### PR TITLE
Add images to a bucket

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/PlayJsonHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/PlayJsonHelpers.scala
@@ -1,11 +1,13 @@
 package com.gu.mediaservice.lib.json
 
-import play.api.libs.json.{JsResult, JsPath}
-import play.api.data.validation.ValidationError
+import scala.PartialFunction.condOpt
+
+import play.api.libs.json._
 import play.api.Logger
+import play.api.libs.json.JsString
 
 
-object PlayJsonHelpers {
+trait PlayJsonHelpers {
 
   def logParseErrors(parseResult: JsResult[_]): Unit =
     parseResult.fold(
@@ -14,4 +16,12 @@ object PlayJsonHelpers {
       },
       _ => ())
 
+  def string(v: JsValue): Option[String] =
+    condOpt(v) { case JsString(s) => s }
+
+  def array(v: JsValue): Option[List[JsValue]] =
+    condOpt(v) { case JsArray(vs) => vs.toList }
+
 }
+
+object PlayJsonHelpers extends PlayJsonHelpers

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/package.scala
@@ -1,0 +1,4 @@
+package com.gu.mediaservice.lib
+
+
+package object json extends PlayJsonHelpers

--- a/integration/src/main/scala/com/gu/mediaservice/integration/TestHarness.scala
+++ b/integration/src/main/scala/com/gu/mediaservice/integration/TestHarness.scala
@@ -20,8 +20,8 @@ trait TestHarness {
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
-  lazy val config = Discovery.discoverConfig("media-service-TEST") getOrElse sys.error("Could not find stack")
-  //val config = Config(new java.net.URL("http://localhost:9000/"), new java.net.URL("http://localhost:9002/"))
+  //lazy val config = Discovery.discoverConfig("media-service-TEST") getOrElse sys.error("Could not find stack")
+  val config = Config(new java.net.URL("http://localhost:9000/"), new java.net.URL("http://localhost:9002/"))
 
   implicit val ctx: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor)
@@ -48,10 +48,10 @@ trait TestHarness {
     WS.url(config.deleteIndexEndpoint).post()
   }
 
-  def retrying[A](desc: String, attempts: Int = 5, sleep: Duration = 3.seconds)(f: => A): A = {
+  def retrying[A](desc: String, attempts: Int = 10, sleep: Duration = 3.seconds)(f: => A): A = {
     def iter(n: Int, f: => Try[A]): Try[A] =
       if (n <= 0) {
-        log.error(s"\"$desc\" failed after $attempts attempts")
+        log.error(s""""$desc" failed after $attempts attempts""")
         f
       }
       else f.orElse {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -1,5 +1,8 @@
 package controllers
 
+import scala.concurrent.Future
+import scala.util.Try
+
 import play.api.mvc._
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json._
@@ -9,7 +12,6 @@ import scalaz.syntax.std.function2._
 import com.gu.mediaservice.lib.formatting.parseDateFromQuery
 import lib.elasticsearch.ElasticSearch
 import lib.{Notifications, Config, S3Client}
-import scala.util.Try
 
 
 object MediaApi extends Controller {
@@ -29,6 +31,16 @@ object MediaApi extends Controller {
   def deleteImage(id: String) = Action {
     Notifications.publish(Json.obj("id" -> id), "delete-image")
     Accepted
+  }
+
+  def addImageToBucket(id: String) = Action { request =>
+    val bucket = request.body.asText
+    bucket match {
+      case Some(b) =>
+        Notifications.publish(Json.obj("id" -> id, "bucket" -> bucket), "add-image-to-bucket")
+        Accepted
+      case None => BadRequest
+    }
   }
 
   def imageSearch = Action.async { request =>

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -33,7 +33,7 @@ object ElasticSearch extends ElasticSearchClient {
     val search = prepareImagesSearch.setQuery(query)
       .setFilter(filters.date(params.fromDate, params.toDate)) |> sorts.parseFromRequest(params.orderBy)
     for (s <- params.size) search.setSize(s)
-    for (res <- search.executeAndLog("Image search query"))
+    for (res <- search.executeAndLog("image search"))
     yield res.getHits.hits.toList flatMap (h => h.sourceOpt map (h.id -> _))
   }
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -7,6 +7,7 @@ GET     /                           controllers.MediaApi.index
 
 # Images
 GET     /image/:id                  controllers.MediaApi.getImage(id: String)
+POST    /image/:id/buckets          controllers.MediaApi.addImageToBucket(id: String)
 DELETE  /image/:id                  controllers.MediaApi.deleteImage(id: String)
 
 GET     /images                     controllers.MediaApi.imageSearch


### PR DESCRIPTION
Media API gains an endpoint `/image/:id/buckets`. POSTing a string to this endpoint raises a message to instruct the thralls (queue workers) to add the image to the named bucket.
