### PR TITLE
Allow upstart to respawn elasticsearch process

### DIFF
--- a/elasticsearch/elasticsearch.conf
+++ b/elasticsearch/elasticsearch.conf
@@ -17,7 +17,7 @@ limit nproc 4096 4096
 console output
 
 # automatically restart if the process dies
-# respawn
+respawn
 
 script
   bin/elasticsearch -f


### PR DESCRIPTION
Being a copy-cat after seeing the same in content-api's [399](https://github.com/guardian/content-api/pull/399), in case this ever applies to us. :cat2: 
