### PR TITLE
Add the beginnings of the cost label

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -66,6 +66,26 @@ body {
     padding-bottom: 45px;
 }
 
+.image-result__cost {
+    background-color: darkgrey;
+    border: 2px solid white;
+    border-right: 0;
+    bottom: 36px;
+    color: white;
+    font-size: 0.75rem;
+    padding: 1px 10px;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    vertical-align: middle;
+}
+.image-result__cost--free {
+    background-color: green;
+}
+.image-result__cost--pay {
+    background-color: red;
+}
+
 .image-result__link {
     display: block;
 }

--- a/kahuna/public/templates/search/results.html
+++ b/kahuna/public/templates/search/results.html
@@ -10,6 +10,7 @@
                      ng:src="{{image.data.thumbnail.secureUrl}}"/>
                 <figcaption class="image-result__caption">{{image.data.metadata.title}}</figcaption>
             </figure>
+            <div class="image-result__cost image-result__cost--{{image.data.cost}}" title="{{image.data.cost}} to use">{{image.data.cost}}</div>
         </a>
     </li>
 </ul>


### PR DESCRIPTION
Adding simple text field to image object.
Keeping it in the API to keep it flexible for now.
The list here was taken from PicDar on what the picture desk said was the most used list.

I've used words on the label for now as when talking to the picture desk, apparently there is some confusion to the meaning of red vs green. Sounds odd, but I thought if you started with words to be obvious we could move to icons later.

![cost-label](https://cloud.githubusercontent.com/assets/31692/4204356/b0bd5484-3836-11e4-826d-d6b7901f9427.png)
