### PR TITLE
Put Role back in ES hosts to ease migration

### DIFF
--- a/cloud-formation/media-service.json
+++ b/cloud-formation/media-service.json
@@ -377,6 +377,11 @@
                         "Key": "App",
                         "Value": "elasticsearch",
                         "PropagateAtLaunch": "true"
+                    },
+                    {
+                        "Key": "Role",
+                        "Value": "media-service-elasticsearch",
+                        "PropagateAtLaunch": "true"
                     }
                 ]
             }
@@ -447,6 +452,7 @@
                             "    -e 's,@@STAGE,", { "Ref": "Stage" }, ",g' \\\n",
                             "    -e 's,@@STACK,media-service,g' \\\n",
                             "    -e 's,@@APP,elasticsearch,g' \\\n",
+                            "    -e 's,@@ROLE,media-service-elasticsearch,g' \\\n",
                             "    -e 's,@@ACCESS_KEY,", { "Ref": "HostKeys" }, ",g' \\\n",
                             "    -e 's,@@SECRET_KEY,", { "Fn::GetAtt": [ "HostKeys", "SecretAccessKey" ] }, ",g' \\\n",
                             "    -e 's,@@MIN_MASTER_NODES,", { "Ref": "ElasticsearchMinMasterNodes" }, ",g' \\\n",

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -219,8 +219,10 @@ discovery.zen.minimum_master_nodes: @@MIN_MASTER_NODES
 
 discovery.type: ec2
 
-discovery.ec2.tag.Stack: "@@STACK"
-discovery.ec2.tag.App: "@@APP"
+# FIXME: temporarly use Role for migration purposes
+# discovery.ec2.tag.Stack: "@@STACK"
+# discovery.ec2.tag.App: "@@APP"
+discovery.ec2.tag.Role: "@@ROLE"
 discovery.ec2.tag.Stage: "@@STAGE"
 
 # The gateway allows for persisting the cluster state between full cluster


### PR DESCRIPTION
We can remove it again once all ES hosts have the correct Stack/App tags _too_.
