### PR TITLE
Use Stack+App instead of Role to discover other ES nodes

### DIFF
--- a/cloud-formation/media-service.json
+++ b/cloud-formation/media-service.json
@@ -452,7 +452,6 @@
                             "    -e 's,@@STAGE,", { "Ref": "Stage" }, ",g' \\\n",
                             "    -e 's,@@STACK,media-service,g' \\\n",
                             "    -e 's,@@APP,elasticsearch,g' \\\n",
-                            "    -e 's,@@ROLE,media-service-elasticsearch,g' \\\n",
                             "    -e 's,@@ACCESS_KEY,", { "Ref": "HostKeys" }, ",g' \\\n",
                             "    -e 's,@@SECRET_KEY,", { "Fn::GetAtt": [ "HostKeys", "SecretAccessKey" ] }, ",g' \\\n",
                             "    -e 's,@@MIN_MASTER_NODES,", { "Ref": "ElasticsearchMinMasterNodes" }, ",g' \\\n",

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -219,10 +219,8 @@ discovery.zen.minimum_master_nodes: @@MIN_MASTER_NODES
 
 discovery.type: ec2
 
-# FIXME: temporarly use Role for migration purposes
-# discovery.ec2.tag.Stack: "@@STACK"
-# discovery.ec2.tag.App: "@@APP"
-discovery.ec2.tag.Role: "@@ROLE"
+discovery.ec2.tag.Stack: "@@STACK"
+discovery.ec2.tag.App: "@@APP"
 discovery.ec2.tag.Stage: "@@STAGE"
 
 # The gateway allows for persisting the cluster state between full cluster


### PR DESCRIPTION
Penultimate step to retire the deprecated Role tags in our ES instances.

First we need to deploy the new CF script and release this new ES build to TEST and PROD, so that ES hosts use stack and app tags to discover each other and the role tag is unused.
