### PR TITLE
Copyright supplier ref to metadata

### DIFF
--- a/image-loader/app/lib/imaging/ImageMetadata.scala
+++ b/image-loader/app/lib/imaging/ImageMetadata.scala
@@ -1,7 +1,7 @@
 package lib.imaging
 
 import java.io.File
-
+import com.drew.metadata.icc.{IccDescriptor, IccDirectory}
 import scala.concurrent.{ExecutionContext, Future}
 import com.drew.imaging.ImageMetadataReader
 import com.drew.metadata.iptc.{IptcDescriptor, IptcDirectory}
@@ -23,20 +23,25 @@ object ImageMetadata {
     yield {
       for {
         iptcDir <- Option(metadata.getDirectory(classOf[IptcDirectory]))
-        descriptor = new IptcDescriptor(iptcDir)
+        iptcDescriptor = new IptcDescriptor(iptcDir)
       }
-      yield ImageMetadata(
-        nonEmptyTrimmed(descriptor.getCaptionDescription),
-        nonEmptyTrimmed(descriptor.getByLineDescription),
-        nonEmptyTrimmed(descriptor.getHeadlineDescription),
-        nonEmptyTrimmed(descriptor.getCreditDescription),
-        nonEmptyTrimmed(descriptor.getCopyrightNoticeDescription),
-        nonEmptyTrimmed(descriptor.getSourceDescription),
-        nonEmptyTrimmed(descriptor.getSpecialInstructionsDescription),
-        nonEmptyTrimmed(descriptor.getKeywordsDescription) map (_.split(Array(';', ',')).toList) getOrElse Nil,
-        nonEmptyTrimmed(descriptor.getCityDescription),
-        nonEmptyTrimmed(descriptor.getCountryOrPrimaryLocationDescription)
-      )
+      yield {
+        ImageMetadata(
+          nonEmptyTrimmed(iptcDescriptor.getCaptionDescription),
+          nonEmptyTrimmed(iptcDescriptor.getByLineDescription),
+          nonEmptyTrimmed(iptcDescriptor.getHeadlineDescription),
+          nonEmptyTrimmed(iptcDescriptor.getCreditDescription),
+          nonEmptyTrimmed(iptcDescriptor.getCopyrightNoticeDescription),
+          nonEmptyTrimmed(getIccAlternatve(metadata, IccDirectory.TAG_ICC_TAG_cprt, iptcDescriptor.getCopyrightNoticeDescription)),
+          nonEmptyTrimmed(Option(iptcDescriptor.getOriginalTransmissionReferenceDescription)
+            .getOrElse(iptcDescriptor.getObjectNameDescription)),
+          nonEmptyTrimmed(iptcDescriptor.getSourceDescription),
+          nonEmptyTrimmed(iptcDescriptor.getSpecialInstructionsDescription),
+          nonEmptyTrimmed(iptcDescriptor.getKeywordsDescription) map (_.split(Array(';', ',')).toList) getOrElse Nil,
+          nonEmptyTrimmed(iptcDescriptor.getCityDescription),
+          nonEmptyTrimmed(iptcDescriptor.getCountryOrPrimaryLocationDescription)
+        )
+      }
     }
 
   def dimensions(image: File): Future[Option[Dimensions]] =
@@ -54,9 +59,12 @@ object ImageMetadata {
     Option(nullableStr) map (_.trim) filter (_.nonEmpty)
 
   private def readMetadata(file: File): Future[Metadata] =
-    Future {
-      ImageMetadataReader.readMetadata(file)
-    }
+    Future(ImageMetadataReader.readMetadata(file))
+
+  private def getIccAlternatve(metadata: Metadata, iccTag: Int, alternative: String) =
+    Option(metadata.getDirectory(classOf[IccDirectory])).map { iccDirectory =>
+      new IccDescriptor(iccDirectory).getDescription(iccTag)
+    }.getOrElse(alternative)
 
 }
 
@@ -66,6 +74,8 @@ case class ImageMetadata(
   title: Option[String],
   credit: Option[String],
   copyrightNotice: Option[String],
+  copyright: Option[String],
+  suppliersReference: Option[String],
   source: Option[String],
   specialInstructions: Option[String],
   keywords: List[String],

--- a/image-loader/app/model/Image.scala
+++ b/image-loader/app/model/Image.scala
@@ -34,6 +34,8 @@ object Image {
       (__ \ "title").writeNullable[String] ~
       (__ \ "credit").writeNullable[String] ~
       (__ \ "copyrightNotice").writeNullable[String] ~
+      (__ \ "copyright").writeNullable[String] ~
+      (__ \ "suppliersReference").writeNullable[String] ~
       (__ \ "source").writeNullable[String] ~
       (__ \ "specialInstructions").writeNullable[String] ~
       (__ \ "keywords").write[List[String]] ~


### PR DESCRIPTION
From the logic of David Blishen:
- `suppliersReference = OriginalTransmissionReference || ObjectName`
- `copyrightInformation = Copyright || CopyrightNotice`

This is giving RCS what they need and doesn't change the current structure.
In future I suggest we work with RCS to see if we can make this better, although that will only be after the coup on PicDar.

Test to come soon too.
