### PR TITLE
Make infinite scrolling more reliable

### DIFF
--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -262,7 +262,7 @@ kahuna.directive('uiHitBottom', function() {
                 var bottomPos = element[0].scrollTop + element[0].clientHeight;
                 var viewHeight = element[0].scrollHeight;
                 scope.$apply(function() {
-                    scope[attrs.uiHitBottom] = bottomPos === viewHeight;
+                    scope[attrs.uiHitBottom] = bottomPos >= viewHeight;
                 });
             });
         }


### PR DESCRIPTION
Looks like sometimes we're "beyond" the bottom of the viewport somehow. This ensures we always fetch more when we reach the bottom (or beyond)
