### PR TITLE
Hide description, source and copyright from metadata fields

### DIFF
--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -163,6 +163,10 @@ kahuna.controller('ImageCtrl',
         $scope.image = image;
     });
 
+    var ignoredMetadata = ['description', 'source', 'copyright'];
+    $scope.isUsefulMetadata = function(metadataKey) {
+        return ignoredMetadata.indexOf(metadataKey) === -1;
+    };
 }]);
 
 kahuna.controller('ImageCropCtrl',

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -314,7 +314,7 @@ a:focus {
 
 .metadata {
     font-family: "Guardian Agate Sans 1 Web";
-    font-size: 1.3rem;
+    margin-top: 15px;
 }
 
 .metadata__heading {
@@ -322,6 +322,10 @@ a:focus {
     font-weight: bold;
     margin-bottom: 5px;
     text-align: left;
+}
+
+.metadata__body {
+    font-size: 1.3rem;
 }
 
 .metadata__key {

--- a/kahuna/public/templates/image.html
+++ b/kahuna/public/templates/image.html
@@ -10,8 +10,8 @@
 
         <table class="metadata">
             <caption class="metadata__heading">Metadata</caption>
-            <tbody>
-            <tr ng:repeat="(key, value) in image.data.metadata">
+            <tbody class="metadata__body">
+            <tr ng:repeat="(key, value) in image.data.metadata" ng:if="isUsefulMetadata(key)">
                 <th class="metadata__key">{{key}}</td>
                 <td>{{value}}</td>
             </tr>


### PR DESCRIPTION
They are not useful anyway.

Couldn't find a way to insert a filter in the ngRepeat for that so just hiding for now.
