### PR TITLE
Make drag image and crops one data piece

### DIFF
--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -256,6 +256,17 @@ kahuna.filter('asCropsDragData', function() {
     };
 });
 
+// Take an image and return a drag data map of mime-type -> value
+kahuna.filter('asImageAndCropsDragData', ['$filter',
+                                          function($filter) {
+    var extend = angular.extend;
+    return function(image, crops) {
+        return extend(
+            $filter('asImageDragData')(image),
+            $filter('asCropsDragData')(crops));
+    };
+}]);
+
 kahuna.directive('uiHasSpace', function() {
     return {
         restrict: 'A',

--- a/kahuna/public/templates/crop.html
+++ b/kahuna/public/templates/crop.html
@@ -1,17 +1,16 @@
 <!-- TODO: should really be a separate URL -->
-<div class="drag-drop"
-     ng:if="crops"
-     ui:drag-data="{{crops | asCropsDragData}}"
-     ui:drag-image="{{smallestSizingFile}}">
-
-    <!-- Add both image and crop drag data (using nesting) -->
+<div class="drag-drop" ng:if="crops">
     <!-- FIXME: back link, etc -->
 
     <img class="drag-drop__image" ng:src="{{largestSizingFile}}" />
     <div class="drag-drop__handle">Drag me</div>
+
+    <!-- This is used as an image has it's own drag behaviour
+    (using itself as the drag image) in some browsers -->
     <div class="drag-drop__data"
          draggable="true"
-         ui:drag-data="{{image | asImageDragData}}"></div>
+         ui:drag-data="{{image | asImageAndCropsDragData:crops}}"
+         ui:drag-image="{{smallestSizingFile}}"></div>
 </div>
 <div class="crop-image" ng:if="! crops">
     <div class="easel">


### PR DESCRIPTION
Made drag data contain image and crops.

This was causing havoc with the `dragstart` / `dragend` propagation in Chrome (and making the drag unreliable).
