### PR TITLE
Revert "Update ftp-watcher stack and app names too"

### DIFF
--- a/ftp-watcher/conf/deploy.json
+++ b/ftp-watcher/conf/deploy.json
@@ -1,8 +1,8 @@
 {
-    "defaultStacks": ["media-service"],
     "packages": {
         "ftp-watcher": {
             "type": "executable-jar-webapp",
+            "apps": [ "mediaservice::ftpwatcher" ],
             "data": {
                 "port": "8080",
                 "healthcheck_paths": [ "/health-check" ],


### PR DESCRIPTION
Use the old names because websys is reluctant to let stack and app names contain hyphens in puppet config for GC2 hosts. This means the names will be inconsistent with the EC2 stack, but so be it.
