### PR TITLE
Limit cache of static assets to 60s, rather than 1h

### DIFF
--- a/kahuna/conf/application.conf
+++ b/kahuna/conf/application.conf
@@ -3,3 +3,7 @@ application.langs="en"
 
 session.httpOnly=false
 session.secure=true
+
+# Quick hack
+# TODO: rely on URL cache busting instead
+assets.defaultCache="public, max-age=60"


### PR DESCRIPTION
Copied from workflow.

Just a dirty fix.
