### PR TITLE
add redimentary 'mark as seen' controls

### DIFF
--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -51,6 +51,7 @@ kahuna.config(['$stateProvider', '$urlRouterProvider',
             }
         }
     });
+
     $stateProvider.state('image', {
         url: '/images/:imageId?crop',
         templateUrl: templatesDirectory + '/image.html',
@@ -73,8 +74,8 @@ kahuna.controller('SearchQueryCtrl',
 
     // a little annoying as the params are returned as strings
     $scope.free = $stateParams.free !== 'false';
-    $scope.query = $stateParams.query || '';
-    $scope.since = $stateParams.since || '';
+    $scope.query = $stateParams.query;
+    $scope.since = $stateParams.since;
 
     // Update state from search filters (skip initialisation step)
     $scope.$watch('query', function(query, oldQuery) {
@@ -120,6 +121,19 @@ kahuna.controller('SearchResultsCtrl',
     $scope.freeImageFilter = function(image) {
        return $stateParams.free === 'false' || image.data.cost === 'free';
     };
+
+    $scope.getLastImageUploadTime = function() {
+        return $scope.images[0].data.uploadTime;
+    };
+
+    var seenSince = localStorage.getItem('search.seenSince');
+    $scope.imageHasBeenSeen = function(image) {
+        return image.data.uploadTime <= seenSince;
+    };
+
+    $scope.$watch(() => localStorage.getItem('search.seenSince'), function() {
+        seenSince = localStorage.getItem('search.seenSince');
+    });
 
     function addImages() {
         // TODO: stop once reached the end
@@ -387,6 +401,29 @@ kahuna.directive('uiTitle', function($rootScope) {
                        + ' | ' + attrs.uiTitleSuffix;
 
                   element.text(title);
+            });
+        }
+    };
+});
+
+/**
+ * omitting uiLocalStoreVal will remove the item from localStorage
+ */
+kahuna.directive('uiLocalstore', function() {
+    return {
+        restrict: 'A',
+        scope: {
+            value: '&uiLocalstoreVal'
+        },
+        link: function(scope, element, attrs) {
+            element.bind('click', function() {
+                var val = scope.value();
+                if (val) {
+                    localStorage.setItem(attrs.uiLocalstore, scope.value());
+                } else {
+                    localStorage.removeItem(attrs.uiLocalstore);
+                }
+                scope.$apply();
             });
         }
     };

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -62,29 +62,42 @@ a {
     background: #00adee;
     border-radius: 2px;
     box-shadow: 0 2px #00729c;
+    box-sizing: border-box;
     color: white;
     display: block;
     padding: 5px 20px !important;
     font-family: "Guardian Egyptian Text";
     font-size: 1.6rem;
+    position: relative;
 }
 .button:hover {
     background: #008fc5;
 }
 .button:active {
     box-shadow: none;
-    background: #1a7d91; /* 25% darken */
+    top: 2px;
 }
 .button:focus,
 a:focus {
-    box-shadow: none;
     outline: 2px solid rgba(255, 255, 255, 0.5);
-    outline-offset: 1px;
+    outline-offset: -3px;
 }
 .button[disabled] {
     background-color: #999;
     box-shadow: 0 2px #666;
     color: #ccc;
+}
+
+.button--shy {
+    padding: 2px 5px;
+    color: #333;
+    background: transparent;
+    box-shadow: 0 2px #efefef;
+    border: 1px solid #efefef;
+    border-bottom: 0;
+}
+.button--shy:hover {
+    background: #efefef;
 }
 
 
@@ -140,11 +153,7 @@ a:focus {
    Search
    ========================================================================== */
 .search {
-    position: fixed;
     background-color: #ccc;
-    top: 0;
-    left: 0;
-    right: 0;
     padding: 10px;
     font-family: "Guardian Agate Sans 1 Web";
 }
@@ -169,11 +178,22 @@ a:focus {
     display: flex;
     flex-wrap: wrap;
     position: fixed;
-    top: 50px;
+    top: 100px;
     bottom: 0;
     left: 0;
     right: 0;
     overflow-y: auto; /* Vertically scrollable */
+}
+
+.results-controls {
+    background: white;
+    padding: 10px;
+    box-shadow: 0px 1px 5px #999;
+}
+
+.results__control {
+    display: inline;
+    margin-right: 5px;
 }
 
 .image-result {
@@ -184,6 +204,9 @@ a:focus {
     margin: 10px 5px;
     position: relative;
     padding-bottom: 65px;
+}
+.image-result--seen {
+    opacity: .5;
 }
 
 .image-result__link {

--- a/kahuna/public/templates/search/results.html
+++ b/kahuna/public/templates/search/results.html
@@ -1,7 +1,19 @@
+<div class="results-controls">
+    <button type="button"
+        class="button results__control"
+        ui:localstore="search.seenSince"
+        ui:localstore-val="getLastImageUploadTime()">I've seen these</button>
+
+    <button type="button"
+        class="button button--shy results__control"
+        ui:localstore="search.seenSince">Clear</button>
+</div>
 <ul class="results"
     ui:near-bottom="nearBottom"
     ui:has-space="hasSpace">
-    <li class="image-result" ng:repeat="image in images | filter:freeImageFilter" ng:hide="{{image.hide}}">
+    <li class="image-result"
+        ng:repeat="image in images | filter:freeImageFilter"
+        ng:class="{ 'image-result--seen': imageHasBeenSeen(image) }">
         <a class="image-result__link"
            title="{{image.data.metadata.title}}"
            ng:href="/images/{{image.data.id}}"


### PR DESCRIPTION
Very simple and only works on blank search.

Let's see what they think, assuming the next thing to add would be search specific, or perhaps only do this when search is blank.

Let's release then ask.

(the double click in the gif was the gif recorder being crap)
![markasseen](https://cloud.githubusercontent.com/assets/31692/4556579/edffd2a4-4eca-11e4-944d-4db826c34ff8.gif)
