### PR TITLE
Simple CloudWatch alarms when ingestion goes wrong

### DIFF
--- a/cloud-formation/media-service.json
+++ b/cloud-formation/media-service.json
@@ -63,6 +63,14 @@
             "Description": "Root domain (suffix) for all deployed services",
             "Type": "String"
         },
+        "AlertEmail": {
+            "Description": "Email to send CloudWatch alerts to",
+            "Type": "String"
+        },
+        "AlertActive": {
+            "Description": "Whether to send CloudWatch alerts to the AlertEmail",
+            "Type": "String"
+        },
         "PandaDomain": {
             "Description": "Master domain the app cookie is set and shared on",
             "Type": "String"
@@ -1503,6 +1511,50 @@
             "Type": "AWS::IAM::AccessKey",
             "Properties": {
                 "UserName": { "Ref": "MetricsPublishingUser" }
+            }
+        },
+
+        "AlertingTopic": {
+            "Type": "AWS::SNS::Topic",
+            "Properties": {
+                "DisplayName": { "Fn::Join" : [ "-", [ { "Ref": "Stage" },"Alerts"]] },
+                "Subscription": [{
+                    "Endpoint": { "Ref": "AlertEmail" },
+                    "Protocol": "email"
+                }]
+            }
+        },
+
+        "IngestedImagesAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ActionsEnabled": { "Ref": "AlertActive" },
+                "AlarmDescription": "Not seen any image ingested by thrall for more than a threshold",
+                "ComparisonOperator": "LessThanThreshold",
+                "Threshold": "1",
+                "Namespace": "PROD/Thrall",
+                "MetricName": "IndexedImages",
+                "Period": "60",
+                "EvaluationPeriods": "3",
+                "Statistic": "Sum",
+                "AlarmActions": [ { "Ref": "AlertingTopic" } ]
+            }
+        },
+
+        "ThrallQueueSizeAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ActionsEnabled": { "Ref": "AlertActive" },
+                "AlarmDescription": "Thrall queue size excedes threshold",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "Threshold": "10",
+                "Namespace": "AWS/SQS",
+                "MetricName": "ApproximateNumberOfMessagesVisible",
+                "Dimensions": [ { "Name": "QueueName", "Value": "media-service-PROD-Queue-NZYK6W7GPNXZ" } ],
+                "Period": "60",
+                "EvaluationPeriods": "1",
+                "Statistic": "Average",
+                "AlarmActions": [ { "Ref": "AlertingTopic" } ]
             }
         }
 

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/UpdateStack.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/UpdateStack.scala
@@ -116,6 +116,9 @@ abstract class StackScript {
         case _    => s"$stage.dev-gutools.co.uk".toLowerCase
       }
 
+      val alertEmail = "media-service-$stage@gupage.pagerduty.com".toLowerCase
+      val alertActive = stage == Prod
+
       val kahunaCertArn = getCertArn(s"$domainRoot-rotated")
       val mediaApiCertArn = getCertArn(s"api.$domainRoot-rotated")
       val loaderCertArn = getCertArn(s"loader.$domainRoot-rotated")
@@ -155,6 +158,8 @@ abstract class StackScript {
           param("ImageOriginHostname", imgOriginHostname),
           param("ImageEdgeHostname", imgEdgeHostname),
           param("DomainRoot", domainRoot),
+          param("AlertEmail", alertEmail),
+          param("AlertActive", alertActive.toString),
           param("PandaDomain", pandaDomain),
           param("PandaAwsKey",  pandaAwsKey),
           param("PandaAwsSecret", pandaAwsSecret)


### PR DESCRIPTION
Sends alarms to PagerDuty when:
- Not seen any image ingested for 3 minutes
- More than 10 items in the queue
