### PR TITLE
Make uploadedBy user's name

### DIFF
--- a/kahuna/app/controllers/Panda.scala
+++ b/kahuna/app/controllers/Panda.scala
@@ -2,12 +2,19 @@ package controllers
 
 import lib.Config
 import play.api.mvc.{Action, Controller}
-import play.api.libs.concurrent.Execution.Implicits._
 import com.gu.mediaservice.lib.auth.PanDomainAuthActions
+import play.api.libs.json.Json
 
 object Panda extends Controller with PanDomainAuthActions {
 
   override lazy val authCallbackBaseUri = Config.rootUri
+
+  def index = Action { implicit request =>
+    readAuthenticatedUser(request).map { authedUser =>
+      Ok(Json.obj("data" -> Json.obj("user" -> Json.obj("fullName" ->
+          s"${authedUser.user.firstName} ${authedUser.user.lastName}"))))
+    }.getOrElse(Unauthorized)
+  }
 
   def doLogin = Action.async { implicit request =>
     sendForAuth

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -11,8 +11,9 @@ GET     /assets/*file               controllers.Assets.at(path="/public", file)
 
 # Panda Login
 
-GET     /oauthCallback        controllers.Panda.oauthCallback
-GET     /logout               controllers.Panda.logout
+GET     /oauthCallback              controllers.Panda.oauthCallback
+GET     /logout                     controllers.Panda.logout
+GET     /panda                      controllers.Panda.index
 
 # Management
 GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck

--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -7,11 +7,13 @@ import 'services/theseus';
 import 'services/api/media-api';
 import 'services/api/media-cropper';
 import 'services/api/loader';
+import 'services/api/panda';
 import 'directives/ui-crop-box';
 
 var apiLink = document.querySelector('link[rel="media-api-uri"]');
 var config = {
-    mediaApiUri: apiLink.getAttribute('href')
+    mediaApiUri: apiLink.getAttribute('href'),
+    pandaUri: '/panda' // TODO: If this looks like a good plan, move to seperate service
 };
 
 var kahuna = angular.module('kahuna', [
@@ -283,8 +285,8 @@ kahuna.controller('ImageCropCtrl',
 }]);
 
 kahuna.controller('UploadCtrl',
-                  ['$q', '$window', 'loaderApi',
-                   function($q, $window, loaderApi) {
+                  ['$q', '$window', 'loaderApi', 'pandaApi',
+                   function($q, $window, loaderApi, pandaApi) {
 
     var ctrl = this; // TODO: No!
 
@@ -316,7 +318,8 @@ kahuna.controller('UploadCtrl',
     }
 
     function uploadFile(file) {
-        return loaderApi.load(new Uint8Array(file));
+        return pandaApi.me()
+            .then(me => loaderApi.load(new Uint8Array(file), me.fullName));
     }
 
     // TODO: Poll to see when images are available and add them

--- a/kahuna/public/js/services/api/loader.js
+++ b/kahuna/public/js/services/api/loader.js
@@ -14,7 +14,7 @@ apiServices.factory('loaderApi',
         return loaderRoot;
     }
 
-    function load(imageData) {
+    function load(imageData, uploadedBy) {
         var options = {
             // We could get the guessed mime-type from the File, but
             // it could be wrong, so might as well just send as data
@@ -23,7 +23,7 @@ apiServices.factory('loaderApi',
             transformRequest: []
         };
         return getLoaderRoot().
-            follow('load', {uploadedBy: 'kahuna'}).
+            follow('load', {uploadedBy: uploadedBy}).
             post(imageData, options);
     }
 

--- a/kahuna/public/js/services/api/panda.js
+++ b/kahuna/public/js/services/api/panda.js
@@ -1,0 +1,16 @@
+import apiServices from 'services/api';
+
+var pandaApi = apiServices.factory('pandaApi',
+                    ['pandaUri', 'theseus.Client',
+                     function(pandaUri, client) {
+
+    var root = client.resource(pandaUri);
+
+    function me() {
+        return root.getData().then(index => index.user);
+    }
+
+    return {
+        me: me
+    };
+}]);


### PR DESCRIPTION
Potentially looking to use auth as a separate service (hence I just created the /panda domain for now).
I was wondering if this could actually potentially exist under `panda.gutools.co.uk` and serve all the tools.

I've re-hijacked the `uploadedBy` as this actually seems to make more sense than `kahuna`.
In the future we could look at making it an object to support multiple fields making it more searchable.
e.g:

``` JSON
"uploadedBy": {
  "method": "uploader",
  "name": "James Gorrie",
  "email": "james.gorrie@thegrauniad.com"
}
// ...
"uploadedBy": {
  "method": "FTP", // or S3 in the future
  "name": "REUTERS"
}
```

I thought this might be over-engineering for now though.
