### PR TITLE
Use star SSL cert for media and media-metadata services

### DIFF
--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/UpdateStack.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/UpdateStack.scala
@@ -115,7 +115,7 @@ abstract class StackScript {
       val alertEmail = s"media-service-$stage-alerts@gupage.pagerduty.com".toLowerCase
       val alertActive = stage == Prod
 
-      val kahunaCertArn = getCertArn(s"$domainRoot-rotated")
+      val kahunaCertArn = getCertArn(s"$parentDomain-rotated")
       val mediaApiCertArn = getCertArn(s"api.$domainRoot-rotated")
       val loaderCertArn = getCertArn(s"loader.$domainRoot-rotated")
       val cropperCertArn = getCertArn(s"cropper.$domainRoot-rotated")


### PR DESCRIPTION
Move to *.gutools.co.uk (resp *.test.dev-gutools.co.uk) certificates for domains that match it. This will make it easier (and cheaper) to add services in the future, following the `media-$service.gutools.co.uk` scheme. (Unless we start hating it in the meantime for some good reasons.)

The TEST certificate is signed by the internal Guardian CA, so requires the CA to be installed explicitly. The PROD certificate is of course genuine and publicly signed.
