### PR TITLE
Raise max queue size threshold to avoid false positives

### DIFF
--- a/cloud-formation/media-service.json
+++ b/cloud-formation/media-service.json
@@ -1795,7 +1795,7 @@
                 "ActionsEnabled": { "Ref": "AlertActive" },
                 "AlarmDescription": "Thrall queue size excedes threshold",
                 "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-                "Threshold": "10",
+                "Threshold": "60",
                 "Namespace": "AWS/SQS",
                 "MetricName": "ApproximateNumberOfMessagesVisible",
                 "Dimensions": [ { "Name": "QueueName", "Value": "media-service-PROD-Queue-NZYK6W7GPNXZ" } ],


### PR DESCRIPTION
We have seen harmless spikes in the queue size, possibly due to the FTP watcher periodically dying and restarting when the FTP server closes the connection. Either way, it's not worth spamming until the queue grows larger.

![screen shot 2014-11-07 at 17 51 22](https://cloud.githubusercontent.com/assets/36964/4957682/cf8487cc-66a6-11e4-8ef8-67eebd982fd7.png)
