### PR TITLE
Fixes to alarm monitoring setup

### DIFF
--- a/cloud-formation/media-service.json
+++ b/cloud-formation/media-service.json
@@ -1799,7 +1799,9 @@
                 "Threshold": "60",
                 "Namespace": "AWS/SQS",
                 "MetricName": "ApproximateNumberOfMessagesVisible",
-                "Dimensions": [ { "Name": "QueueName", "Value": { "Ref": "Queue" } } ],
+                "Dimensions": [
+                    { "Name": "QueueName", "Value": { "Fn::GetAtt": ["Queue", "QueueName"] } }
+                ],
                 "Period": "60",
                 "EvaluationPeriods": "1",
                 "Statistic": "Average",


### PR DESCRIPTION
- Ensure alarm is triggered when no images are ingested, by also sending an alarm when there is not enough data (which is the state the alarm gets in if nothing is ingested)
- Fix TEST alarms to point to TEST data, not PROD

The second fix means these alarms will always be in an "Insufficient Data" state, which isn't very pretty, but their actions should be disabled by default. In the future, we could fix by either feeding a few images to the TEST stack regularly, or just finding other ways to declare them.
