### PR TITLE
Let errors thrown in request handlers bubble up instead of catching them in auth

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -48,12 +48,13 @@ case class Authenticated(keyStore: KeyStore, authCallbackBaseUri: String)
 
   type RequestHandler[A] = AuthenticatedRequest[A, Principal] => Future[Result]
 
-  case object NotAuthenticated extends Exception
+  class AuthException extends Exception
+  case object NotAuthenticated extends AuthException
 
 
   // Try to auth by API key, and failing that, with Panda
   override def invokeBlock[A](request: Request[A], block: RequestHandler[A]): Future[Result] =
-    authByKey(request, block) recoverWith { case _ => authByPanda(request, block) }
+    authByKey(request, block) recoverWith { case _: AuthException => authByPanda(request, block) }
 
 
   // API Key authentication


### PR DESCRIPTION
This should let us see actual errors in the image-loader so we can fix them
