### PR TITLE
check for image before loading data

### DIFF
--- a/kahuna/public/templates/crop.html
+++ b/kahuna/public/templates/crop.html
@@ -1,5 +1,5 @@
 <div class="crop-image">
-    <div class="easel">
+    <div class="easel" ng:if="image.data">
         <div class="easel__canvas">
             <img class="easel__image easel__image--with-space"
                  ng:src="{{image.data.source | assetFile}}"


### PR DESCRIPTION
[Live bug (view console)](https://media.gutools.co.uk/images/40d3c760a02e3f8911546d055db18bb0e310eeca/crop)

As image.data is async - we need to wait till we have the image information.
Otherwise we are sending a dead asset to the [`assetFile`](https://github.com/guardian/media-service/blob/master/kahuna/public/js/app.js#L430) filter.
I feel this is cleaner and more semantic than putting a check in the `assetFile` filter.
