### PR TITLE
Fix remnant window scroll watcher that caused API spam

### DIFF
--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -468,11 +468,12 @@ kahuna.directive('uiNearBottom', ['$window', function($window) {
                 $$window.unbind('scroll', checkScrollNearBottom);
             });
 
+            // Pixel distance from bottom at which we are 'near' it
+            var offset = 200;
             function checkScrollNearBottom(e) {
                 var el = element[0];
 
-                var offset = 200;
-                var nowAt = this.innerHeight + this.scrollY;
+                var nowAt = $window.innerHeight + $window.scrollY;
                 var end = el.scrollHeight + el.offsetTop - offset;
 
                 if (!scrolling && nowAt >= end) {


### PR DESCRIPTION
The nearBottom directive is re-initialised all the time (every character typed, etc), but we never freed the observer on window scroll event. That caused a **lot** of API requests going out all the time for no reason, which would explain why the scrolling wasn't as smooth as it could be.

This solves this issue.

In general, let's remember to unbind any bound events when the directive is destroyed. (I know I always forget...)

I've also replaced the use of `this` for clarity.
