### PR TITLE
Fix total count update

### DIFF
--- a/kahuna/public/templates/search/results.html
+++ b/kahuna/public/templates/search/results.html
@@ -14,10 +14,11 @@
 
         <div class="image-results-count">
             {{totalResults}} matches
-            <button ng:show="newImages.length > 0"
+            <button ng:show="newImagesCount > 0"
                     ng:click="revealNewImages()"
-                    class="image-results-count__new"
-            >{{newImages.length}} new</button>
+                    class="image-results-count__new">
+                {{newImagesCount}} new
+            </button>
         </div>
 
         <ul class="results"


### PR DESCRIPTION
Change the logic to reload the results rather than trying to cleverly splice in the new stuff. If there is more than 50, it wouldn't have worked.
