### PR TITLE
Don't limit uploadable files based on type (file ext really), too many files have no ext

### DIFF
--- a/kahuna/public/templates/directives/file-uploader.html
+++ b/kahuna/public/templates/directives/file-uploader.html
@@ -6,7 +6,7 @@
         https://github.com/angular/angular.js/issues/1375 -->
         <input class="file-uploader__file"
                name="files" type="file"
-               accept="image/jpg,image/jpeg" multiple
+               multiple
                ui:file ui:file-change="fileUploader.uploadFiles" />
 
         <button class="button file-uploader__select-files"


### PR DESCRIPTION
e.g. from email or downloaded from the web.

That makes them impossible to select which gets in the way.

The server will enforce the mime-type restriction and the user will get an error message:

![screen shot 2014-11-17 at 11 53 44](https://cloud.githubusercontent.com/assets/36964/5073548/a13e6b6a-6e50-11e4-8b07-802e529527f4.png)

Not the prettiest or clearest, but we can improve that next and at least users can upload all files they want.
