### PR TITLE
Introduce a yield to work around Chrome bug causing jCrop race condition

### DIFF
--- a/kahuna/public/js/app.js
+++ b/kahuna/public/js/app.js
@@ -8,6 +8,7 @@ import 'services/api/media-api';
 import 'services/api/media-cropper';
 import 'services/api/loader';
 import 'directives/ui-crop-box';
+import 'util/async';
 import 'pandular/heal';
 
 var apiLink = document.querySelector('link[rel="media-api-uri"]');
@@ -23,6 +24,7 @@ var kahuna = angular.module('kahuna', [
     'ui.router',
     'theseus',
     'pandular.heal',
+    'util.async',
     'kahuna.services.api',
     'kahuna.directives'
 ]);

--- a/kahuna/public/js/directives/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box.js
@@ -17,8 +17,8 @@ controlsDirectives.value('safeApply', function (scope, fn) {
     }
 });
 
-controlsDirectives.directive('uiCropBox', ['$timeout', '$parse', 'safeApply',
-                                           function($timeout, $parse, safeApply) {
+controlsDirectives.directive('uiCropBox', ['$timeout', '$parse', 'safeApply', 'nextTick',
+                                           function($timeout, $parse, safeApply, nextTick) {
 
     // Annoyingly, AngularJS passes us values as strings,
     // so we need to convert them, which can potentially
@@ -64,8 +64,12 @@ controlsDirectives.directive('uiCropBox', ['$timeout', '$parse', 'safeApply',
                 throw new Error('The uiCropBox directive requires an object as parameter');
             }
 
+            // Note: in Chrome there's a bug whereby the image
+            // dimensions aren't properly set when install() is called
+            // immediately, apparently if the image is already in the
+            // browser cache (?).
             // TODO: check if already loaded, in which case call install immediately
-            element.on('load', install);
+            element.on('load', nextTick(install));
 
             function install() {
                 var initialCoords = [

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -1,0 +1,17 @@
+import angular from 'angular';
+
+export var async = angular.module('util.async', []);
+
+/**
+ * Return a lazy function that will yield before calling the input `func`.
+ */
+async.factory('nextTick',
+              ['$timeout',
+               function($timeout) {
+
+    function nextTick(func) {
+        return () => $timeout(func, 0);
+    }
+
+    return nextTick;
+}]);


### PR DESCRIPTION
which in terms results in the image being distorted on the crop screen and the produced crop having incorrect dimensions.

Seemingly only in Chrome, possibly only recently introduced. Also likely related to the fact the images are now cached by the browser.
