### PR TITLE
Labels weren't being correctly sync'd into the Media API anymore

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -66,6 +66,8 @@ object ElasticSearch extends ElasticSearchClient {
       .setScriptParams(Map(
         "userMetadata" -> asGroovy(metadata)
       ).asJava)
+      // TODO: if metadata not set, should undo overrides?
+      // TODO: apply overrides from the original metadata each time?
       .setScript("""
                     if (userMetadata.metadata) {
                       if (!ctx._source.originalMetadata) {


### PR DESCRIPTION
Caused by work on metadata overrides.

This makes the userMetadata indexing code gracefully handle the absence of metadata overrides.

Still some work needed for correct behaviour when removing overrides, but this is not currently possible via the UI so not a blocker.
