### PR TITLE
Set searchbox size

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -190,7 +190,7 @@ a:focus {
 
 .search__query {
     padding: 5px 10px;
-    width: 20%;
+    width: 200px;
 }
 
 


### PR DESCRIPTION
A little better and fixes a FF bug.
# before

![searchobox-b](https://cloud.githubusercontent.com/assets/31692/5163241/11096cfe-73c1-11e4-87b5-e438b02639fb.png)
# after

![searchbox-a](https://cloud.githubusercontent.com/assets/31692/5163240/10e8d886-73c1-11e4-9ed9-69011f46b2c5.png)
