### PR TITLE
Add AAP to list of free providers

### DIFF
--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -52,6 +52,6 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
     "Press Association Images", "Action Images", "Keystone", "AFP", "Getty Images", "Alamy", "FilmMagic", "WireImage",
     "Pool", "Rex Features", "Allsport", "BFI", "ANSA", "The Art Archive", "Hulton Archive", "Hulton Getty", "RTRPIX",
     "Community Newswire", "THE RONALD GRANT ARCHIVE", "NPA ROTA", "Ronald Grant Archive", "PA WIRE", "AP POOL",
-    "REUTER", "dpa", "BBC", "Allstar Picture Library", "AFP/Getty Images")
+    "REUTER", "dpa", "BBC", "Allstar Picture Library", "AFP/Getty Images", "AAPIMAGE")
 
 }


### PR DESCRIPTION
Checked with Robert Hahn and it is indeed OK to use for all offices and even the paper.

The only thing to note is that our daily quota is fairly low (25 / day), so ideally we should incentivise people not too use too many, esp from non-AUS offices, so that we don't hit or go over the quota. Something to come in the future though...

/cc @blishen 
