### PR TITLE
Add GzipFilter to all relevant servers to compress our responses

### DIFF
--- a/cropper/app/Global.scala
+++ b/cropper/app/Global.scala
@@ -1,10 +1,11 @@
 import play.api.libs.concurrent.Akka
 import play.api.{Application, GlobalSettings}
 import play.api.mvc.WithFilters
+import play.filters.gzip.GzipFilter
 
 import controllers.{Application => App}
 
-object Global extends WithFilters(CorsFilter) with GlobalSettings {
+object Global extends WithFilters(CorsFilter, new GzipFilter) with GlobalSettings {
 
   override def onStart(app: Application) {
     App.keyStore.scheduleUpdates(Akka.system(app).scheduler)

--- a/image-loader/app/Global.scala
+++ b/image-loader/app/Global.scala
@@ -1,10 +1,11 @@
 import play.api.libs.concurrent.Akka
 import play.api.mvc.WithFilters
 import play.api.{Application, GlobalSettings}
+import play.filters.gzip.GzipFilter
 
 import controllers.{Application => App}
 
-object Global extends WithFilters(CorsFilter) with GlobalSettings {
+object Global extends WithFilters(CorsFilter, new GzipFilter) with GlobalSettings {
 
   override def onStart(app: Application) {
     App.keyStore.scheduleUpdates(Akka.system(app).scheduler)

--- a/kahuna/app/Global.scala
+++ b/kahuna/app/Global.scala
@@ -4,11 +4,12 @@ import com.typesafe.config.ConfigValue
 import play.api.{Logger, Application, GlobalSettings}
 import play.api.mvc.WithFilters
 import play.api.libs.concurrent.Akka
+import play.filters.gzip.GzipFilter
 
 import controllers.Application
 import lib.{Config, ForceHTTPSFilter}
 
-object Global extends WithFilters(ForceHTTPSFilter) with GlobalSettings {
+object Global extends WithFilters(ForceHTTPSFilter, new GzipFilter) with GlobalSettings {
 
   override def beforeStart(app: Application) {
 

--- a/media-api/app/Global.scala
+++ b/media-api/app/Global.scala
@@ -4,9 +4,10 @@ import lib.elasticsearch.ElasticSearch
 import play.api.libs.concurrent.Akka
 import play.api.{Application, GlobalSettings}
 import play.api.mvc.WithFilters
+import play.filters.gzip.GzipFilter
 
 
-object Global extends WithFilters(CorsFilter) with GlobalSettings {
+object Global extends WithFilters(CorsFilter, new GzipFilter) with GlobalSettings {
 
   override def beforeStart(app: Application) {
     ElasticSearch.ensureAliasAssigned()

--- a/metadata-editor/app/Global.scala
+++ b/metadata-editor/app/Global.scala
@@ -1,10 +1,11 @@
 import play.api.libs.concurrent.Akka
 import play.api.{Application, GlobalSettings}
 import play.api.mvc.WithFilters
+import play.filters.gzip.GzipFilter
 
 import controllers.{Application => App}
 
-object Global extends WithFilters(CorsFilter) with GlobalSettings {
+object Global extends WithFilters(CorsFilter, new GzipFilter) with GlobalSettings {
 
   override def onStart(app: Application) {
     App.keyStore.scheduleUpdates(Akka.system(app).scheduler)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -77,6 +77,7 @@ object Build extends Build {
       .enablePlugins(play.PlayScala)
       .dependsOn(lib)
       .settings(commonSettings ++ playArtifactDistSettings ++ playArtifactSettings: _*)
+      .settings(libraryDependencies += filters)
       .settings(magentaPackageName := path)
 
   def playArtifactSettings = Seq(


### PR DESCRIPTION
Noticed up to 8x reduction of payload on an API search response locally.

As a bonus, it also seems to gzip the static assets we serve via Kahuna (/cc @jamespamplin).
