### PR TITLE
Fix 'free to use' filter not working if initially unset (on)

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -12,7 +12,7 @@
              when the option is off -->
             <input type="checkbox"
                    ng:model="searchQuery.nonFree"
-                   ng:true-value="null"
+                   ng:true-value="undefined"
                    ng:false-value="true"
                    ng:checked="{{!searchQuery.nonFree}}" />
             free to use


### PR DESCRIPTION
Steps to reproduce:
1. Load kahuna
2. Untick free to use filter

Expected:
3. Updates URL and search

Actual:
3. Nothing

Toggling the checkbox back off and on again then works. This is apparently due to the `null` value used in the view.

Can we try and follow Crockford's advice to only use `undefined` as "zero-value" (and never use `null`)?
