### PR TITLE
bump version of metadata-extractor to stop images erroring

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   )
 
   val imagingDeps = Seq(
-    "com.drewnoakes" % "metadata-extractor" % "2.6.2",
+    "com.drewnoakes" % "metadata-extractor" % "2.7.0",
     "org.im4java" % "im4java" % "1.4.0"
   )
 


### PR DESCRIPTION
[This issue](https://github.com/drewnoakes/metadata-extractor/issues/29) was resolved by Drew.
Tested on a couple of images that weren't working. They now are. The metadata was also checked and confirmed to be being extracted correctly.
