### PR TITLE
Revert "bump version of nmetadata-extractor to stop images erroring"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   )
 
   val imagingDeps = Seq(
-    "com.drewnoakes" % "metadata-extractor" % "2.7.0",
+    "com.drewnoakes" % "metadata-extractor" % "2.6.2",
     "org.im4java" % "im4java" % "1.4.0"
   )
 


### PR DESCRIPTION
This reverts commit b9ffb52d66cf4aa82c7781a07f24dc8fbe489c88.
