### PR TITLE
store original metadata mapping onload

### DIFF
--- a/image-loader/app/model/Image.scala
+++ b/image-loader/app/model/Image.scala
@@ -15,7 +15,8 @@ case class Image(id: String,
                  source: Asset,
                  thumbnail: Option[Asset],
                  fileMetadata: FileMetadata,
-                 metadata: ImageMetadata
+                 metadata: ImageMetadata,
+                 originalMetadata: ImageMetadata
 ) {
 
   def asJsValue: JsValue = Json.toJson(this)
@@ -31,7 +32,8 @@ object Image {
                   thumbnail: Asset,
                   fileMetadata: FileMetadata,
                   metadata: ImageMetadata): Image =
-    Image(id, DateTime.now, uploadedBy, source, Some(thumbnail), fileMetadata, metadata)
+    Image(id, DateTime.now, uploadedBy, source, Some(thumbnail),
+          fileMetadata, metadata, metadata)
 
   implicit val IptcMetadataWrites: Writes[ImageMetadata] =
     ((__ \ "description").writeNullable[String] ~
@@ -57,7 +59,8 @@ object Image {
       (__ \ "source").write[Asset] ~
       (__ \ "thumbnail").writeNullable[Asset] ~
       (__ \ "fileMetadata").write[FileMetadata] ~
-      (__ \ "metadata").write[ImageMetadata]
+      (__ \ "metadata").write[ImageMetadata] ~
+      (__ \ "originalMetadata").write[ImageMetadata]
     )(unlift(Image.unapply))
 
 }

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -93,9 +93,6 @@ object ElasticSearch extends ElasticSearchClient {
       // TODO: apply overrides from the original metadata each time?
       .setScript("""
                     if (userMetadata.metadata) {
-                      if (!ctx._source.originalMetadata) {
-                        ctx._source.originalMetadata = ctx._source.metadata;
-                      }
                       ctx._source.metadata += userMetadata.metadata;
                     }
                     ctx._source.userMetadata = userMetadata;


### PR DESCRIPTION
Instigated from @blishen's request from Getty.
I just wondered why we don't just store it on load so that for certain services we can read straight from this (when we return a verbose result from the API).

**Clarity:** if we wanted a hypothetical service to know the original Credit, we would now have to go:

**before**

``` Scala
if (image.originalMetadata) { image.originalMetadata.credit }
else { image.metadata.credit }
```

**after**

``` Scala
image.originalMetadata.credit 
```

All in the name of data consistency.
