### PR TITLE
use imagemagick scale instead of resize

### DIFF
--- a/cropper/app/lib/imaging/Conversion.scala
+++ b/cropper/app/lib/imaging/Conversion.scala
@@ -18,7 +18,7 @@ object Conversion {
     val op = new IMOperation
     op.addImage(source.getAbsolutePath)
       op.crop(w, h, x, y)
-      op.resize(dimensions.width, dimensions.height)
+      op.scale(dimensions.width, dimensions.height)
       op.colorspace("RGB")
       op.addImage(dest.getAbsolutePath)
     for {


### PR DESCRIPTION
Cropping is taking ages.
This, locally, improves cropping speed from `3-4000ms` to `+-500ms`.

[There is a more detailed explanation here](http://www.imagemagick.org/Usage/resize/).

Here are two images:
![a](https://cloud.githubusercontent.com/assets/31692/5394832/0ce57452-813a-11e4-8746-b1a4b64af7be.jpg)
![b](https://cloud.githubusercontent.com/assets/31692/5394831/0ce29f52-813a-11e4-8465-936a42e2a16c.jpg)
