### PR TITLE
non dynamic object are now strict

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -19,7 +19,7 @@ object Mappings {
 
   val dynamicObj = Json.obj("type" -> "object", "dynamic" -> true)
 
-  def nonDynamicObj(obj: (String, JsValueWrapper)*) = Json.obj("type" -> "object", "dynamic" -> false, "properties" -> Json.obj(obj:_*))
+  def nonDynamicObj(obj: (String, JsValueWrapper)*) = Json.obj("type" -> "object", "dynamic" -> "strict", "properties" -> Json.obj(obj:_*))
 
   def nonAnalysedList(indexName: String) = Json.obj("type" -> "string", "index" -> "not_analyzed", "index_name" -> indexName)
 


### PR DESCRIPTION
After reading [the docs](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/dynamic-mapping.html) a [little closer](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-object-type.html#_dynamic) `false` just ignores the questionable field. This, I would assume, is silly and dangerous.

I've tested running the migration locally and on TEST and everything still indexes well including:
- [x] Metadata updates
- [x] archive updates
- [x] label updates
- [x] export updates
- [x] original image index
