### PR TITLE
Fix stretchy results

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -270,6 +270,7 @@ a:focus {
 .image-result {
     width: 20%;
     min-width: 200px;
+    max-width: 270px;
     flex: 1;
     background: #fff;
     margin: 10px 5px;


### PR DESCRIPTION
Fixes #64 
![stretchy results](https://cloud.githubusercontent.com/assets/31692/5548376/6abf6880-8b67-11e4-80dd-9353f536e130.png)
