### PR TITLE
Kill logging of users with unsupported browsers, use Mixpanel instead

### DIFF
--- a/kahuna/app/controllers/Application.scala
+++ b/kahuna/app/controllers/Application.scala
@@ -17,24 +17,4 @@ object Application extends Controller with PanDomainAuthActions {
     Ok(views.html.main(Config.mediaApiUri, Config.mixpanelToken))
   }
 
-
-  // Temporary (lol) hack to dump a warning in the logs when
-  // we see users with unsupported browser versions
-  val SupportedFirefoxVersion = 31
-  val SupportedChromeVersion  = 37
-  val UaFirefox = """.* Firefox/(\d+).*""".r
-  val UaChrome  = """.* Chrome/(\d+).*""".r
-  def logUnsupportedBrowsers(userAgent: Option[String], user: User) = userAgent foreach {
-    case UaFirefox(version) if version.toInt < SupportedFirefoxVersion =>
-      Logger.warn(s"Seen user ${user.email} with unsupported browser: Firefox v$version")
-    case UaChrome(version)  if version.toInt < SupportedChromeVersion =>
-      Logger.warn(s"Seen user ${user.email} with unsupported browser: Chrome v$version")
-
-    case UaFirefox(_) | UaChrome(_) =>
-      // Ok, supported version of FF or Chrome
-
-    case ua =>
-      Logger.warn(s"Seen user ${user.email} with unsupported browser: $ua")
-  }
-
 }


### PR DESCRIPTION
Now that we log browser version, we should be able to do this in Mixpanel instead.

Haven't found an obvious way to do this, but it seems at least somewhat possible via the Live View perhaps...
