### PR TITLE
Strip title if it's a prefix of the description

### DIFF
--- a/image-loader/app/lib/cleanup/DropRedundantTitle.scala
+++ b/image-loader/app/lib/cleanup/DropRedundantTitle.scala
@@ -1,0 +1,18 @@
+package lib.cleanup
+
+import lib.imaging.ImageMetadata
+
+
+object DropRedundantTitle extends MetadataCleaner {
+  override def clean(metadata: ImageMetadata): ImageMetadata = (metadata.title, metadata.description) match {
+    case (Some(title), Some(description)) => metadata.copy(title = cleanTitle(title, description))
+    case _                                => metadata
+  }
+
+  def cleanTitle(title: String, description: String): Option[String] =
+    if (description.startsWith(title)) {
+      None
+    } else {
+      Some(title)
+    }
+}

--- a/image-loader/app/lib/cleanup/MetadataCleaner.scala
+++ b/image-loader/app/lib/cleanup/MetadataCleaner.scala
@@ -13,7 +13,8 @@ object MetadataCleaner {
     CountryCode,
     CapitaliseByline,
     CapitaliseCountry,
-    CapitaliseCity
+    CapitaliseCity,
+    DropRedundantTitle
   )
 
   def clean(inputMetadata: ImageMetadata): ImageMetadata =

--- a/image-loader/test/scala/lib/cleanup/DropRedundantTitleTest.scala
+++ b/image-loader/test/scala/lib/cleanup/DropRedundantTitleTest.scala
@@ -1,0 +1,33 @@
+package scala.lib.cleanup
+
+import org.scalatest.{Matchers, FunSpec}
+import lib.cleanup.DropRedundantTitle
+
+class DropRedundantTitleTest extends FunSpec with Matchers with MetadataHelper {
+
+  it("should be None if no title") {
+    val imageMetadata = createImageMetadata("description" -> "Brief description")
+    DropRedundantTitle.clean(imageMetadata).title should be (None)
+  }
+
+  it("should be the title if no description") {
+    val imageMetadata = createImageMetadata("title" -> "Brief title")
+    DropRedundantTitle.clean(imageMetadata).title should be (Some("Brief title"))
+  }
+
+  it("should be the title if not a prefix of the description") {
+    val imageMetadata = createImageMetadata("title" -> "Brief title", "description" -> "Brief description")
+    DropRedundantTitle.clean(imageMetadata).title should be (Some("Brief title"))
+  }
+
+  it("should be None if exactly the description") {
+    val imageMetadata = createImageMetadata("title" -> "Brief title", "description" -> "Brief title")
+    DropRedundantTitle.clean(imageMetadata).title should be (None)
+  }
+
+  it("should be None if a prefix of the description") {
+    val imageMetadata = createImageMetadata("title" -> "Brief title", "description" -> "Brief title. Also more description.")
+    DropRedundantTitle.clean(imageMetadata).title should be (None)
+  }
+
+}


### PR DESCRIPTION
As I'm working on a tidy up of the metadata panel on the image component, I find it quite annoying when the title is just the description, or an initial portion of the description. Doesn't really help much, so I suggest getting rid of it in the metadata when we detect it's nothing more than a prefix.
