### PR TITLE
Force state reload on upload, in case already on upload state

### DIFF
--- a/kahuna/public/js/upload/file-uploader.js
+++ b/kahuna/public/js/upload/file-uploader.js
@@ -16,7 +16,8 @@ fileUploader.controller('FileUploaderCtrl',
         // Queue up files for upload and go to the upload state to
         // show progress
         uploadManager.upload(files);
-        $state.go('upload');
+        // Force reload, in case we're already in that state
+        $state.go('upload', {}, {reload: true});
     }
 }]);
 


### PR DESCRIPTION
There is currently a bug in that the Upload button on the upload screen appears not to work. This is because the state transition to the upload screen doesn't occur because we're already there. Forcing the reload fixes the issue.
