### PR TITLE
Don't require <base>; affects IE9, but who cares

### DIFF
--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -3,8 +3,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <!-- Added for: https://docs.angularjs.org/error/$location/nobase -->
-    <base href="/" />
 
     <title ui:title ui:title-suffix="the grid">the grid</title>
     <link rel="media-api-uri" href="@mediaApiUri" />

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -59,7 +59,7 @@ kahuna.config(['$locationProvider',
                function($locationProvider) {
 
     // Use real URLs (with History API) instead of hashbangs
-    $locationProvider.html5Mode(true).hashPrefix('!');
+    $locationProvider.html5Mode({enabled: true, requireBase: false});
 }]);
 
 kahuna.config(['$urlRouterProvider',


### PR DESCRIPTION
Alternative solution to the `<base>` tag, as per https://docs.angularjs.org/error/$location/nobase

Seems nicer to me, YMMV?
