### PR TITLE
Bump core logger to info level to get more data

### DIFF
--- a/cropper/conf/application.conf
+++ b/cropper/conf/application.conf
@@ -3,3 +3,16 @@ application.langs="en"
 
 session.httpOnly=false
 session.secure=true
+
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
+
+# Root logger:
+logger.root=INFO
+
+# Logger used by the framework:
+logger.play=INFO
+
+# Logger provided to your application:
+logger.application=DEBUG

--- a/ftp-watcher/conf/application.conf
+++ b/ftp-watcher/conf/application.conf
@@ -1,0 +1,12 @@
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
+
+# Root logger:
+logger.root=INFO
+
+# Logger used by the framework:
+logger.play=INFO
+
+# Logger provided to your application:
+logger.application=DEBUG

--- a/image-loader/conf/application.conf
+++ b/image-loader/conf/application.conf
@@ -2,7 +2,7 @@ application.secret="vimh`x4d<NHaOg4@BnwFIg[y0<;[_KhVF=0:n^9]Q0SjFVJ38LC[k`KDwGjA
 application.langs="en"
 
 # Root logger:
-logger.root=ERROR
+logger.root=INFO
 
 # Logger used by the framework:
 logger.play=INFO

--- a/kahuna/conf/application.conf
+++ b/kahuna/conf/application.conf
@@ -7,3 +7,16 @@ session.secure=true
 # Quick hack
 # TODO: rely on URL cache busting instead
 assets.defaultCache="public, max-age=60"
+
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
+
+# Root logger:
+logger.root=INFO
+
+# Logger used by the framework:
+logger.play=INFO
+
+# Logger provided to your application:
+logger.application=DEBUG

--- a/media-api/conf/application.conf
+++ b/media-api/conf/application.conf
@@ -13,7 +13,7 @@ es.port = 9300
 # You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
 
 # Root logger:
-logger.root=ERROR
+logger.root=INFO
 
 # Logger used by the framework:
 logger.play=INFO

--- a/metadata-editor/conf/application.conf
+++ b/metadata-editor/conf/application.conf
@@ -3,3 +3,16 @@ application.langs="en"
 
 session.httpOnly=false
 session.secure=true
+
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
+
+# Root logger:
+logger.root=INFO
+
+# Logger used by the framework:
+logger.play=INFO
+
+# Logger provided to your application:
+logger.application=DEBUG

--- a/thrall/conf/application.conf
+++ b/thrall/conf/application.conf
@@ -10,7 +10,7 @@ es.port = 9300
 # You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
 
 # Root logger:
-logger.root=ERROR
+logger.root=INFO
 
 # Logger used by the framework:
 logger.play=INFO


### PR DESCRIPTION
Should be esp useful for ftp-watcher, which uses the core SL4F logger more than the others (which rely on the Play logger more), and to help diagnose why it dies every once in a while.
