### PR TITLE
track users browser version

### DIFF
--- a/kahuna/public/js/analytics/track.js
+++ b/kahuna/public/js/analytics/track.js
@@ -45,7 +45,7 @@ track.run(['$window', 'mixpanel', 'mixpanelToken', 'track', 'mediaApi', 'trackin
     // Set the browser and OS version for every tracked event
     var props = {
         // Note: Browser and Operating System already tracked by Mixpanel
-        'Browser Version': browser.major,
+        'Browser Version': browser.major
         // Disabling 'os.version' as it seems to be buggy (returns 'Chromium' !?)
         // 'Operating System Version': os.version
     };

--- a/kahuna/public/js/mixpanel/mixpanel.js
+++ b/kahuna/public/js/mixpanel/mixpanel.js
@@ -2,6 +2,7 @@
 /* global mixpanel */
 import angular from 'angular';
 import './snippet';
+import UAParser from 'ua-parser-js';
 
 export var mp = angular.module('mixpanel', []);
 
@@ -9,7 +10,9 @@ export var mp = angular.module('mixpanel', []);
  * This module is to allow the rest of the app to include mixpanel as a dependency
  * and not have to deal with the global `var`.
  */
-mp.factory('mixpanel', function() {
+mp.factory('mixpanel', ['$window', function($window) {
+    var ua      = new UAParser($window.navigator.userAgent);
+    var browser = ua.getBrowser();
 
     function init(mixpanelToken, id, { firstName, lastName, email }, registerProps = {}) {
         mixpanel.init(mixpanelToken);
@@ -19,7 +22,8 @@ mp.factory('mixpanel', function() {
         mixpanel.people.set({
             '$first_name': firstName,
             '$last_name': lastName,
-            '$email': email
+            '$email': email,
+            'Browser version': browser.major
         });
         mixpanel.register(registerProps);
     }
@@ -32,4 +36,4 @@ mp.factory('mixpanel', function() {
         init: init,
         track: track
     };
-});
+}]);


### PR DESCRIPTION
Track the browser version against a user.
This is handy if we'd like to notify them that they're using an old browser.

We can use [Mixpanel's notifications](https://mixpanel.com/notifications/) (normally to sell you stuff) if they trigger a browser vender + browser version > ?.
