### PR TITLE
don't analyse the source

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -55,7 +55,7 @@ object Mappings {
       "copyright" -> standardAnalysedString,
       "copyrightNotice" -> standardAnalysedString,
       "suppliersReference" -> standardAnalysedString,
-      "source" -> standardAnalysedString,
+      "source" -> nonAnalyzedString,
       "specialInstructions" -> nonAnalyzedString,
       "keywords" -> nonAnalysedList("keyword"),
       "subLocation" -> standardAnalysedString,


### PR DESCRIPTION
We'll have to do a reindex.
I wanted to use this to aggregate the sources for autocomplete, so I'll do it after.

Definitely worth reviewing our mappings before import of the library where reindexing will not be as cheap.
