### PR TITLE
add commonly used sizing to crops list

### DIFF
--- a/cropper/app/lib/Config.scala
+++ b/cropper/app/lib/Config.scala
@@ -33,6 +33,8 @@ object Config extends CommonPlayAppProperties {
 
   val imagingThreadPoolSize = 4
 
-  val landscapeCropSizingWidths = List(2000, 1000, 500, 140)
+  // FIXME: We don't need this many, but until we save the original, it's sizes
+  // that are currently popular
+  val landscapeCropSizingWidths = List(2000, 1000, 500, 460, 140)
   val portraitCropSizingHeights = List(2000, 1000, 500)
 }


### PR DESCRIPTION
We need to make sure we [store the original](https://github.com/guardian/media-service/issues/303).
This is a hack to get people (Tom Ross) over from the Composer to the Grid.

I'll make it a little project to get the crop working properly (and talk to @paperboyo about colour spaces etc).
