### PR TITLE
Revert "add commonly used sizing to crops list"

### DIFF
--- a/cropper/app/lib/Config.scala
+++ b/cropper/app/lib/Config.scala
@@ -33,8 +33,6 @@ object Config extends CommonPlayAppProperties {
 
   val imagingThreadPoolSize = 4
 
-  // FIXME: We don't need this many, but until we save the original, it's sizes
-  // that are currently popular
-  val landscapeCropSizingWidths = List(2000, 1000, 500, 460, 140)
+  val landscapeCropSizingWidths = List(2000, 1000, 500, 140)
   val portraitCropSizingHeights = List(2000, 1000, 500)
 }


### PR DESCRIPTION
This reverts commit 12c213c4fc08f3337b7d9af523261f2e8a2b157b.

I'll talk to Tom to find out why he's using 460 images.
