### PR TITLE
show crop size in cropper

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -28,6 +28,8 @@ crop.controller('ImageCropCtrl',
         x2: 10000,
         y2: 10000
     };
+    this.cropSize = () => ($scope.coords.x2 - $scope.coords.x1) + ' x ' + ($scope.coords.y2 - $scope.coords.y1);
+
 
     $scope.crop = function() {
         // TODO: show crop

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -1,5 +1,4 @@
 <div class="crop-image">
-
     <div class="top-bar-wrapper">
         <div class="top-bar">
 
@@ -9,6 +8,8 @@
             </div>
 
             <div class="top-bar__actions">
+                <div class="top-bar__item">{{ imageCropCtrl.cropSize() }}</div>
+
                 <label class="top-bar__item">
                     <input type="radio" ng:model="imageCropCtrl.aspect" value="{{landscapeRatio}}" />
                     landscape


### PR DESCRIPTION
As this is going out quite soon and they are going to have comms about cropping / uploading size, I thought it best to get it in now.

The only thing is it's a little misleading due to the crop sizings, so if I crop something at `1001 x 1001` the crop will actually be `1000 x 1000`. Still, it's a nice indicator as to whether you're doing something wrong.

Next - warnings.

![cropsize](https://cloud.githubusercontent.com/assets/31692/5837490/900867e2-a177-11e4-8467-c8876fa789df.png)
