### PR TITLE
Pass Content-Length on upload to suppress warning and possibly improve performance

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -34,6 +34,7 @@ class S3(credentials: AWSCredentials) {
       mimeType.foreach(metadata.setContentType)
       cacheControl.foreach(metadata.setCacheControl)
       metadata.setUserMetadata(meta.asJava)
+      metadata.setContentLength(file.length)
       val req = new PutObjectRequest(bucket, id, new FileInputStream(file), metadata)
       client.putObject(req)
       objectUrl(bucket, id)


### PR DESCRIPTION
Before:

```
2015-01-21 16:53:00,382 [play-akka.actor.default-dispatcher-5] INFO  GUUID= application:93 - Received file, id: b2a26f78deef7ef9c99be3f09f954df509d6c082, uploadedBy: seb.cevey@guardian.co.uk, uploadTime: 2015-01-21T16:53:00.381Z
2015-01-21 16:53:00,397 [pool-12-thread-1] WARN  GUUID= c.a.services.s3.AmazonS3Client:1381 - No content length specified for stream data.  Stream contents will be buffered in memory and could result in out of memory errors.
2015-01-21 16:53:00,785 [pool-12-thread-2] WARN  GUUID= c.a.services.s3.AmazonS3Client:1381 - No content length specified for stream data.  Stream contents will be buffered in memory and could result in out of memory errors.
2015-01-21 16:53:02,352 [play-akka.actor.default-dispatcher-5] INFO  GUUID= application:93 - Published message: {MessageId: 62389238-0c83-51f1-a62f-df01d72d7478}
```

After:

```
2015-01-21 16:48:35,386 [play-akka.actor.default-dispatcher-2] INFO  GUUID= application:93 - Received file, id: b2a26f78deef7ef9c99be3f09f954df509d6c082, uploadedBy: seb.cevey@guardian.co.uk, uploadTime: 2015-01-21T16:48:35.386Z
2015-01-21 16:48:36,203 [play-akka.actor.default-dispatcher-2] INFO  GUUID= application:93 - Published message: {MessageId: 304df052-6773-5d10-af75-bd6bbdd70e13}
```

The docs hint at a memory performance, so I wonder if this will speed up the upload response time.
