### PR TITLE
Fix broken builds

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -65,9 +65,10 @@ object Build extends Build {
     .libraryDependencies(awsDeps ++ commonsNetDeps)
 
   val picdarExport = project("picdar-export")
+    .enablePlugins(play.PlayScala)
     .settings(sbtassembly.Plugin.assemblySettings: _*)
     .settings(assemblyMergeSettings: _*)
-    .libraryDependencies(playDeps ++ playWsDeps)
+    .libraryDependencies(playDeps)
 
   @deprecated
   val devImageLoader = project("dev-image-loader")
@@ -98,7 +99,6 @@ object Build extends Build {
     mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) => {
       case f if f.startsWith("org/apache/lucene/index/") => MergeStrategy.first
       case "play/core/server/ServerWithStop.class" => MergeStrategy.first
-      case "play.plugins" => MergeStrategy.first
       case "ehcache.xml" => MergeStrategy.first
       case x => old(x)
     }}


### PR DESCRIPTION
It's not particularly obvious how this change in the Build (specifically the mergeStrategy) broke the ability of the different services to accept requests with API keys, but bisecting the issue helped narrow down the possible causes.

Lesson: always redeploy master to TEST and PROD after changes, even if they seem unrelated, as they might not be and leaving it too long makes it harder to identify the source of the issue. Would be nice to get something like goo to do this more easily.
