### PR TITLE
add a rex copyright to free

### DIFF
--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -53,7 +53,8 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
     "Press Association Images", "Action Images", "Keystone", "AFP", "Getty Images", "Alamy", "FilmMagic", "WireImage",
     "Pool", "Rex Features", "Allsport", "BFI", "ANSA", "The Art Archive", "Hulton Archive", "Hulton Getty", "RTRPIX",
     "Community Newswire", "THE RONALD GRANT ARCHIVE", "NPA ROTA", "Ronald Grant Archive", "PA WIRE", "AP POOL",
-    "REUTER", "dpa", "BBC", "Allstar Picture Library", "AFP/Getty Images", "AAPIMAGE")
+    "REUTER", "dpa", "BBC", "Allstar Picture Library", "AFP/Getty Images", "AAPIMAGE",
+    "IBL/REX")
 
   // TODO: move to config
   val queriableIdentifiers = Seq("picdarUrn")


### PR DESCRIPTION
This is not a sustainable fix.
REX give the credit as Photographer/Agency/REX - this is shit so I will talk to Jo Blason about it.

I will also write a cleaner to deal with this but this is for a few photos editors need now.
