### PR TITLE
Let users know what kinds of files are supported

### DIFF
--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -73,7 +73,7 @@ class ImageLoader(storage: ImageStorage) extends Controller with ArgoHelpers {
     } else {
       val mimeTypeName = mimeType getOrElse "none detected"
       Logger.info(s"Rejected file, id: $id, uploadedBy: $uploadedBy_, because the mime-type is not supported ($mimeTypeName). return 415")
-      Future(UnsupportedMediaType(Json.obj("errorMessage" -> s"Unsupported mime-type: $mimeTypeName")))
+      Future(UnsupportedMediaType(Json.obj("errorMessage" -> s"Unsupported mime-type: $mimeTypeName. Supported: ${Config.supportedMimeTypes.mkString(", ")}")))
     }
 
     future.onComplete(_ => tempFile.delete())


### PR DESCRIPTION
When a user uploads a PNG, let them know they can upload JPEG.
