### PR TITLE
Remove Egyptian

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -3,22 +3,6 @@
    ========================================================================== */
 
 @font-face {
-    font-family: "Guardian Text Egyptian Web";
-    src: url("fonts/GuardianTextEgyptianWeb-Regular.woff2") format("woff2"),
-         url("fonts/GuardianTextEgyptianWeb-Regular.woff") format("woff");
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-}
-@font-face {
-    font-family: "Guardian Text Egyptian Web";
-    src: url("fonts/GuardianTextEgyptianWeb-Bold.woff2") format("woff2"),
-         url("fonts/GuardianTextEgyptianWeb-Bold.woff") format("woff");
-    font-weight: bold;
-    font-style: normal;
-    font-stretch: normal;
-}
-@font-face {
     font-family: "Guardian Agate Sans Web";
     src: url("fonts/GuardianAgateSans1Web-Regular.woff2") format("woff2"),
          url("fonts/GuardianAgateSans1Web-Regular.woff") format("woff");
@@ -45,7 +29,7 @@
 }
 
 html {
-    font: 62.5%/1.5 "Guardian Text Egyptian Web", Georgia;
+    font: 62.5%/1.5 "Guardian Agate Sans Web", Georgia;
 }
 
 body {
@@ -81,6 +65,14 @@ a {
     color: #00adee;
 }
 
+input,
+option,
+textarea,
+button {
+    font-family: "Guardian Agate Sans Web", Helvetica, Arial;
+    font-size: 1.4rem;
+}
+
 input[type="text"],
 textarea {
     background-color: #444;
@@ -111,7 +103,6 @@ button {
     cursor: pointer;
     color: inherit;
     font-size: inherit;
-    font-family: "Guardian Agate Sans Web", Helvetica, Arial;
 }
 
 .button {
@@ -123,8 +114,7 @@ button {
     color: white;
     display: block;
     padding: 5px 20px !important;
-    font-family: "Guardian Text Egyptian Web", Georgia;
-    font-size: 1.6rem;
+    font-size: 1.4rem;
     position: relative;
 }
 .button:hover {
@@ -239,7 +229,7 @@ a:focus {
 
 .logout {
     color: inherit;
-    font-size: 1.2rem;
+    font-size: 1.3rem;
 }
 
 
@@ -411,7 +401,7 @@ a:focus {
 }
 
 .preview__info {
-    font-size: 1.2rem;
+    font-size: 1.3rem;
     padding-left: 10px;
     margin: 5px 0;
 }
@@ -618,7 +608,7 @@ a:focus {
 
 .labels {
     display: inline-block;
-    font-size: 1.2rem;
+    font-size: 1.3rem;
 }
 
 .label {


### PR DESCRIPTION
As suggested by @paperboyo.

I am inclined to agree that it looks quite a bit neater and doesn't necessitate us to theorise which font is for what. Simpler.

File size obviously drops too.

Happy to close PR if you think this is something we shouldn't be looking at.

---
## results before

![f-egypt](https://cloud.githubusercontent.com/assets/31692/5934564/07e1b4c0-a6c9-11e4-8526-79c824a91f14.png)
## results after

![f-agate](https://cloud.githubusercontent.com/assets/31692/5934562/07ca2f1c-a6c9-11e4-8615-729de6be3a24.png)

---
## upload before

![f-agypt-upload](https://cloud.githubusercontent.com/assets/31692/5934563/07e18112-a6c9-11e4-80ec-b313dfa042f6.png)
## upload after

![f-agate-upload](https://cloud.githubusercontent.com/assets/31692/5934561/07b7ee42-a6c9-11e4-834a-d275d3af6656.png)
