### PR TITLE
Bump metadata-extractor, use fixed helper

### DIFF
--- a/image-loader/app/lib/imaging/FileMetadata.scala
+++ b/image-loader/app/lib/imaging/FileMetadata.scala
@@ -37,9 +37,7 @@ object FileMetadata {
   def exportDirectory[T <: Directory](metadata: Metadata, directoryClass: Class[T]): Map[String, String] =
     Option(metadata.getDirectory(directoryClass)) map { directory =>
       directory.getTags.
-        // TODO: change to tag.hasTagName() once a minor issue has been fixed:
-        // https://github.com/drewnoakes/metadata-extractor/pull/78
-        filter(tag => directory.hasTagName(tag.getTagType)).
+        filter(tag => tag.hasTagName()).
         flatMap { tag =>
           nonEmptyTrimmed(tag.getDescription) map { value => tag.getTagName -> value }
         }.toMap

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   )
 
   val imagingDeps = Seq(
-    "com.drewnoakes" % "metadata-extractor" % "2.7.1",
+    "com.drewnoakes" % "metadata-extractor" % "2.7.2",
     "org.im4java" % "im4java" % "1.4.0"
   )
 


### PR DESCRIPTION
Also fixes some local issues I've got with the previous version, possibly dirty Ivy cache though.
