### PR TITLE
use default flex

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -310,7 +310,7 @@ input.ng-invalid {
 }
 
 .result {
-    flex-grow: 1;
+    flex: 1;
     width: 20%;
     min-width: 200px;
     max-width: 270px;


### PR DESCRIPTION
Tested in FF and Chrome.

`flex: 1` set's the default of flex-basis to `0` meaning that it has `0` initial size, so it can squeeze in anywhere, which it couldn't before.

Fixes the odd spacing at the end of the results.
