### PR TITLE
Don't allow or try deleting images with a picdarUrn

### DIFF
--- a/cloud-formation/media-service.json
+++ b/cloud-formation/media-service.json
@@ -1388,7 +1388,7 @@
                         "MEDIA_API=https://", { "Fn::GetAtt": ["MediaApiLoadBalancer", "DNSName"] } ,"\n",
 
                         "cat > /home/media-service/reaper.sh <<EOF\n",
-                        "curl -k --silent \"$MEDIA_API/images?until=20.days&length=100&hasExports=false&archived=false\" ",
+                        "curl -k --silent \"$MEDIA_API/images?until=20.days&length=100&hasExports=false&archived=false&missingIdentifier=picdarUrn\" ",
                         " -H 'X-Gu-Media-Key: reaper-5c928132116656580ede0417e7cc1c5b' ",
                         " | python /home/media-service/extract_uris.py ",
                         " | xargs curl -k --silent -X DELETE -H 'X-Gu-Media-Key: reaper-5c928132116656580ede0417e7cc1c5b' \n",

--- a/thrall/app/lib/Config.scala
+++ b/thrall/app/lib/Config.scala
@@ -33,4 +33,7 @@ object Config extends CommonPlayAppConfig {
         "App"   -> Seq(elasticsearchApp)
       ))
 
+  // The presence of this identifier prevents deletion
+  val persistenceIdentifier = "picdarUrn" // TODO: properties("persistence.identifier")
+
 }

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -25,6 +25,8 @@ object ImageNotDeletable extends Throwable("Image cannot be deleted")
 
 object ElasticSearch extends ElasticSearchClient {
 
+  import Config.persistenceIdentifier
+
   val host = Config.elasticsearchHost
   val port = Config.int("es.port")
   val cluster = Config("es.cluster")
@@ -46,7 +48,8 @@ object ElasticSearch extends ElasticSearchClient {
       boolQuery.must(matchQuery("_id", id)),
         andFilter(
           missingOrEmptyFilter("exports"),
-          missingOrEmptyFilter("userMetadata.archived"))
+          missingOrEmptyFilter("userMetadata.archived"),
+          missingOrEmptyFilter(s"identifiers.$persistenceIdentifier"))
       )
 
     val deleteQuery = client


### PR DESCRIPTION
- Don't make reaper request deletion of images with a picdarUrn.
- Don't let thrall delete images with a picdarUrn.

In the future, we may want to allow deletion (manually), but for now this is safer.
