### PR TITLE
Add CF script to create ingestion stack, one per env

### DIFF
--- a/picdar-export/cloud-formation/picdar-export.json
+++ b/picdar-export/cloud-formation/picdar-export.json
@@ -1,0 +1,108 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Picdar Export",
+    "Parameters": {
+        "Stage": {
+            "Description": "Environment name",
+            "Type": "String",
+            "AllowedValues": ["DEV", "TEST", "PROD"],
+            "Default": "PROD"
+        }
+    },
+    "Resources": {
+
+        "PicdarExportGroup": {
+            "Type": "AWS::IAM::Group",
+            "Properties": {
+                "Policies": [{
+                    "PolicyName": "PicdarExportDynamoTablePolicy",
+                    "PolicyDocument": {
+                        "Id": "PicdarExportDynamoTablePolicy",
+                        "Statement": [ {
+                            "Effect": "Allow",
+                            "Action": [ "dynamodb:*" ],
+                            "Resource": [
+                                { "Fn::Join" : [ "", [
+                                    "arn:aws:dynamodb:",
+                                    { "Ref" : "AWS::Region" },
+                                    ":",
+                                    { "Ref" : "AWS::AccountId" },
+                                    ":table/",
+                                    { "Ref" : "PicdarExportDynamoTable" }
+                                ] ] }
+                            ]
+                        } ]
+                    }
+                }, {
+                    "PolicyName": "MetricsPublishingGroup-Policy",
+                    "PolicyDocument": {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [ "cloudwatch:PutMetricData" ],
+                                "Resource": "*"
+                            }
+                        ]
+                    }
+                }]
+            }
+        },
+        "PicdarExportUser": {
+            "Type": "AWS::IAM::User",
+            "Properties": {
+                "Path": "/",
+                "Groups": [ { "Ref": "PicdarExportGroup" } ]
+            }
+        },
+        "PicdarExportCredentials": {
+            "Type": "AWS::IAM::AccessKey",
+            "Properties": {
+                "UserName": { "Ref": "PicdarExportUser" }
+            }
+        },
+
+        "PicdarExportDynamoTable": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "picdarUrn",
+                        "AttributeType": "S"
+                    },
+                    {
+                        "AttributeName": "picdarCreated",
+                        "AttributeType": "S"
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": "picdarUrn",
+                        "KeyType": "HASH"
+                    },
+                    {
+                        "AttributeName": "picdarCreated",
+                        "KeyType": "RANGE"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits" : "30",
+                    "WriteCapacityUnits" : "30"
+                }
+            }
+        }
+
+    },
+    "Outputs": {
+        "PicdarExportDynamoTable": {
+            "Description": "ARN of the DynamoDB table storing Picdar export state",
+            "Value": { "Ref": "PicdarExportDynamoTable" }
+        },
+        "PicdarExportCredentialsId": {
+            "Value": { "Ref": "PicdarExportCredentials" }
+        },
+        "PicdarExportCredentialsSecret": {
+            "Value": { "Fn::GetAtt": [ "PicdarExportCredentials", "SecretAccessKey" ] }
+        }
+    }
+}

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/Config.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/Config.scala
@@ -9,12 +9,12 @@ case class MediaConfig(apiKey: String, loaderUrl: String)
 object Config {
   val properties = Properties.fromPath("/etc/gu/picdar-export.properties")
 
-  val awsAccessId = properties("aws.id")
-  val awsAccessSecret = properties("aws.secret")
+  def awsAccessId(env: String)       = properties(s"aws.$env.id")
+  def awsAccessSecret(env: String)   = properties(s"aws.$env.secret")
+  def picdarExportTable(env: String) = properties(s"aws.$env.picdarexport.table")
 
-  val awsCredentials = new BasicAWSCredentials(awsAccessId, awsAccessSecret)
+  def awsCredentials(env: String) = new BasicAWSCredentials(awsAccessId(env), awsAccessSecret(env))
   val dynamoRegion = Region.getRegion(Regions.EU_WEST_1)
-  val picdarExportTable = properties("aws.picdarexport.table")
 
 
   val picdarDeskUrl      = properties("picdar.desk.url")


### PR DESCRIPTION
The script has to be run manually, I've already created a stack for TEST and for my own DEV environment. Please name your DEV stack better than I did by suffixing it with your login. Will create a PROD one in due course.

The output of the CF script will give you the aws properties you need to configure in your properties file, e.g.

```
aws.dev.id=xxx
aws.dev.secret=xxx
aws.dev.picdarexport.table=xxx-DEV-PicdarExportDynamoTable-xxx
```
