### PR TITLE
add invalid upload count

### DIFF
--- a/kahuna/public/js/search/controller.js
+++ b/kahuna/public/js/search/controller.js
@@ -1,0 +1,6 @@
+import angular from 'angular';
+import '../upload/invalid-upload-count';
+
+var search = angular.module('kahuna.search.controller', ['kahuna.upload.invalidUploadCount']);
+
+search.controller('SearchController', [function() {}]);

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 
+import './controller';
 import './query';
 import './results';
 import '../preview/image';
@@ -9,6 +10,7 @@ import searchResultsTemplate from './results.html!text';
 
 
 export var search = angular.module('kahuna.search', [
+    'kahuna.search.controller',
     'kahuna.search.query',
     'kahuna.search.results',
     'kahuna.preview.image'

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -4,7 +4,10 @@
         <search-query class="top-bar__nav"></search-query>
 
         <div class="top-bar__actions">
-            <a class="top-bar__item" ui:sref="upload">your uploads</a>
+            <a class="top-bar__item your-uploads" ui:sref="upload">
+                your uploads
+                <ui-invalid-upload-count class="your-uploads__invalid"></ui-invalid-upload-count>
+            </a>
             <file-uploader class="top-bar__item"></file-uploader>
         </div>
     </div>

--- a/kahuna/public/js/upload/invalid-upload-count.html
+++ b/kahuna/public/js/upload/invalid-upload-count.html
@@ -1,0 +1,1 @@
+<div class="invalid-upload-count">{{ctrl.total}} invalid</div>

--- a/kahuna/public/js/upload/invalid-upload-count.js
+++ b/kahuna/public/js/upload/invalid-upload-count.js
@@ -1,0 +1,23 @@
+import angular from 'angular';
+import template from './invalid-upload-count.html!text';
+
+export var count = angular.module('kahuna.upload.invalidUploadCount', []);
+
+count.controller('InvalidUploadCountCtrl', ['mediaApi', function(mediaApi) {
+    mediaApi.getSession().then(session => {
+        mediaApi.search('', { uploadedBy: session.user.email, valid: false }).then(images => {
+            this.total = images.total;
+        });
+    });
+}]);
+
+
+count.directive('uiInvalidUploadCount', [function() {
+    return {
+        restrict: 'E',
+        controller: 'InvalidUploadCountCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true,
+        template: template
+    };
+}]);

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -856,6 +856,22 @@ textarea.ng-invalid {
     text-decoration: underline;
 }
 
+.your-uploads {
+    position: relative;
+}
+
+.your-uploads__invalid {
+    background: red;
+    color: white;
+    position: absolute;
+    top: -6px;
+    right: -8px;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 2px;
+}
+
+
 /* ==========================================================================
    jCrop
    ========================================================================== */


### PR DESCRIPTION
Just a thought.
A way to make sure people are keeping up to date with what they're doing.

Also based on a conversation with Joanna about them uploading images and just putting gumpf in so they can use the image quicker.

**Next:**
- add a filter to the `your uploads` section to see only your invalid uploads to amend them?

![invalid-uploads](https://cloud.githubusercontent.com/assets/31692/6047137/9701c290-ac9f-11e4-96c5-d8b74b1b9776.png)
