### PR TITLE
hide scrollbar on labels

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -727,11 +727,15 @@ FIXME: what to do with touch devices
     min-height: 20px;
     font-size: 1.3rem;
     display: flex;
+    overflow: hidden;
 }
 
 .labels {
     overflow-x: scroll;
     white-space: nowrap;
+}
+.labels::-webkit-scrollbar {
+    display: none;
 }
 
 .label {


### PR DESCRIPTION
[Stolen from frontend](https://github.com/guardian/frontend/blob/f26d4cbaa9bc75019d246afbda06f60ba29c8d2b/static/src/stylesheets/module/nav/_navigation.scss#L466). I need to test on Firefox Windows / Linux.
