### PR TITLE
brighten has crops logo

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -27,7 +27,7 @@
             <span class="preview__upload-time">{{image.data.uploadTime | date:'HH:mm'}}</span>
 
             <span class="bottom-bar__meta-item preview__has-crops"
-                  title="this image has crops"
+                  title="This image has crops"
                   ng:if="image | hasExportsOfType:'crop'">⌍⌎</span>
         </div>
         <div class="bottom-bar__actions">

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -492,8 +492,7 @@ FIXME: what to do with touch devices
     margin-right: 10px;
 }
 
-.preview__upload-time,
-.preview__has-crops {
+.preview__upload-time {
     font-size: 1.2rem;
     color: #999;
 }
@@ -501,6 +500,7 @@ FIXME: what to do with touch devices
 .preview__has-crops {
     letter-spacing: -4px;
     cursor: help;
+    font-size: 1.2rem;
 }
 
 .preview__bottom-bar {


### PR DESCRIPTION
Thinking it might be time to try and add material design icons.
I am hesitant as it's a large repo and might slow build times, but I'll give it a go.
## before

![hascrops-dark](https://cloud.githubusercontent.com/assets/31692/6076930/74bb622a-ade1-11e4-9623-186165f702a8.png)
## after

![hascrops-light](https://cloud.githubusercontent.com/assets/31692/6076931/74cae5f6-ade1-11e4-92c5-c14e9fafa861.png)
