### PR TITLE
Only show 'pay' sign, not 'free' (implied)

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -44,8 +44,9 @@
                          archived="image.data.userMetadata.data.archived"></ui-archiver>
 
             <div class="bottom-bar__action">
-                <div class="cost cost--{{image.data.cost}}">
-                {{image.data.cost}}
+                <div ng:if="image.data.cost == 'pay'"
+                     class="cost cost--{{image.data.cost}}">
+                    pay
                 </div>
             </div>
         </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -466,9 +466,6 @@ input.search-query__input {
     text-align: center;
     vertical-align: middle;
 }
-.cost--free {
-    background-color: green;
-}
 .cost--pay {
     background-color: red;
 }


### PR DESCRIPTION
Remove the shrieking "free to use" sign, only keep the "pay" one. In practice, most of the time people should be searching with the filter to only show free anyway, so the sign is just noise. Even when not, it seems better to only highlight images that you have to pay for.
# Before

![screenshot-free](https://cloud.githubusercontent.com/assets/36964/6210957/c38ed77c-b5cc-11e4-8d0d-11bdbdb97394.png)
# After

![screenshot-no-free](https://cloud.githubusercontent.com/assets/36964/6210956/c38d9b3c-b5cc-11e4-998c-827da0a70bc3.png)

In a future version we may be able to make the "pay to use" even more clear.

Roger suggested this and I already had plans to do it.

/cc @alastairjardine 
