### PR TITLE
Only show actions on image preview on hover

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -35,7 +35,7 @@
             <!-- transclusion point for extra actions -->
             <ng:transclude></ng:transclude>
 
-            <a class="bottom-bar__action"
+            <a class="bottom-bar__action preview__crop"
                title="crop"
                ng:if="image.data.valid"
                ui:sref="crop({ imageId: image.data.id })">✂</a>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -454,9 +454,13 @@ input.search-query__input {
     opacity: .5;
 }
 
-.mark-as-seen {
+.preview .mark-as-seen {
     color: #aaa;
     font-size: 1.6rem;
+    display: none;
+}
+.preview:hover .mark-as-seen {
+    display: inline;
 }
 
 .cost {
@@ -545,6 +549,13 @@ input.search-query__input {
     text-overflow: ellipsis;
     white-space: nowrap;
     margin: 0;
+}
+
+.preview .preview__crop {
+    display: none;
+}
+.preview:hover .preview__crop {
+    display: inline;
 }
 
 /*
@@ -1050,6 +1061,14 @@ FIXME: what to do with touch devices
 /* ==========================================================================
    Archviver
    ========================================================================== */
+
+.preview .archiver {
+    display: none;
+}
+.preview:hover .archiver,
+.preview .archiver--archived {
+    display: inline;
+}
 
 .archiver--archived {
     color: gold;


### PR DESCRIPTION
In a further attempt to reduce the noise on search results, I've changed actions to only be displayed when mousing over the result (similarly to the "pop out" and "add label" actions).
# Before

![screenshot-no-free](https://cloud.githubusercontent.com/assets/36964/6211804/e9be09dc-b5d5-11e4-90f9-c436add2b367.png)
# After

![screenshot-no-actions](https://cloud.githubusercontent.com/assets/36964/6211803/e9bd5d48-b5d5-11e4-9abb-4b58ee7547a3.png)

Any state (archived, has crops) is of course still displayed at all times.

If/when revisiting the UI with a more keyboard-driven approach in mind, this may have to be reviewed.

/cc @alastairjardine 
