### PR TITLE
Show 'pay to use' warning on image preview too

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -29,6 +29,11 @@
     <div class="image-details">
 
         <div class="image-info">
+            <div ng:if="image.data.cost == 'pay'"
+                 class="image-info__group cost cost--{{image.data.cost}}">
+                pay to use
+            </div>
+
             <div class="image-info__group">
                 <h2 ng:if="image.data.metadata.title" class="image-info__title">{{image.data.metadata.title}}</h2>
 


### PR DESCRIPTION
Until now, the search results were the only place where the user would be warned of the cost of an image. This adds a visual indicator on the image preview page to repeat the warning.

![screenshot-pay-preview](https://cloud.githubusercontent.com/assets/36964/6212166/f56916e2-b5d9-11e4-89fa-998a444eec01.png)

Rationale: It is possible that people email each other image preview links, in which case they might end up using an image without knowing it was "pay to use" in the search results. The warning is located near the crop button so hopefully it cannot be overlooked. We could add even more friction in the future, although I think we may want to perfect the free/pay detection first.

Note that in theory, a user may get a link to the crop page, where the "pay to use" flag still isn't shown. We don't have any metrics on this (would be nice to add), but I am not aware that this is a common scenario, unlike links to individual images being sent around. We could add to the other page if necessary.

/cc @alastairjardine 
