### PR TITLE
Whitelist some tools URLs for CORS

### DIFF
--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/UpdateStack.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/UpdateStack.scala
@@ -155,12 +155,18 @@ abstract class StackScript {
         case _    => None
       }
 
-      val corsAllowedOrigins = stage match {
+      val toolsOrigins = List(
+        "http://media-wat.gutools.co.uk",
+        "https://media-wat.local.dev-gutools.co.uk"
+      )
+      val composerOrigins = stage match {
         case Prod => List("https://composer.gutools.co.uk")
         case _    =>
           List("local", "code", "qa", "release").
             map(env => s"https://composer.$env.dev-gutools.co.uk")
+
       }
+      val corsAllowedOrigins = composerOrigins ++ toolsOrigins
 
       lib.Stack(
         stage,


### PR DESCRIPTION
Specifically to let extra tools talk to the APIs over CORS.
