### PR TITLE
only run filter if value exists

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -52,7 +52,7 @@
                 <div ng:if="image.data.metadata.byline || image.data.metadata.credit"
                      class="metadata-line">
                     by
-                    <span class="metadata-line__info" ng:show="image.data.metadata.byline">
+                    <span class="metadata-line__info" ng:if="image.data.metadata.byline">
                         <a ui:sref="search.results({query: (image.data.metadata.byline | queryFilter:'by')})">{{image.data.metadata.byline}}</a>
                     </span>
                     <span class="metadata-line__info" ng:hide="image.data.metadata.byline">


### PR DESCRIPTION
This is throwing an error.

If byline is missing, an error is thrown (can't replace on undefined).

All the other metadata fields are protected by an `if` so `queryFilter` doesn't break.
I thought it best t guard here and not [the filter](https://github.com/guardian/media-service/blob/master/kahuna/public/js/search/query-filter.js#L6).

Another solution would be to force a string, which would be messy. i.e:
`image.data.metadata.byline || '' | queryFilter:'by'`.
