### PR TITLE
Inject link to separate resource with full fileMetadata

### DIFF
--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -10,6 +10,7 @@ GET     /images/metadata/:field     controllers.MediaApi.metadataSearch(field: S
 
 # Images
 GET     /images/:id                 controllers.MediaApi.getImage(id: String)
+GET     /images/:id/fileMetadata    controllers.MediaApi.getImageFileMetadata(id: String)
 DELETE  /images/:id                 controllers.MediaApi.deleteImage(id: String)
 
 GET     /images                     controllers.MediaApi.imageSearch


### PR DESCRIPTION
We initially removed it from the image response because it was heavy and not used by the frontend, but it's still useful to have access to the data (I've found myself digging in ES instead, which is lame).

Could add a way to request its expansion in the image response if needed in the future.
