### PR TITLE
make placeholder less in yo' face

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -100,11 +100,11 @@ input[disabled],
 textarea[disabled] {
     color: #666;
 }
-input:disabled::-webkit-input-placeholder,
-textarea:disabled::-webkit-input-placeholder {
+input::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder {
     color: #666;
 }
-input:disabled::-moz-placeholder,
+input::-moz-placeholder,
 textarea:disabled::-moz-placeholder {
     color: #666;
 }


### PR DESCRIPTION
Making the placeholder seem less like input text.
Admittedly it doesn't meet accessibility guidelines - but that's what the labels are for.

---
# Before

![placeholder-before](https://cloud.githubusercontent.com/assets/31692/6233529/81018d70-b6a1-11e4-9d50-12f952b4b0b5.png)
# After

![placeholder-after](https://cloud.githubusercontent.com/assets/31692/6233530/8102b81c-b6a1-11e4-94d0-9433b7901663.png)
