### PR TITLE
Extract any "Helmut Schon for the Guardian" byline to a clean byline/Guardian credit

### DIFF
--- a/image-loader/app/lib/cleanup/ExtractGuardianCreditFromByline.scala
+++ b/image-loader/app/lib/cleanup/ExtractGuardianCreditFromByline.scala
@@ -1,0 +1,16 @@
+package lib.cleanup
+
+import lib.imaging.ImageMetadata
+
+object ExtractGuardianCreditFromByline extends MetadataCleaner {
+
+  val BylineForTheGuardian = """(?i)(.+) for the (Guardian|Observer)[.]?""".r
+
+  override def clean(metadata: ImageMetadata): ImageMetadata = metadata.byline match {
+    case Some(BylineForTheGuardian(byline, org)) => {
+      val orgName = org.toLowerCase.capitalize
+      metadata.copy(byline = Some(byline), credit = Some(s"The $orgName"))
+    }
+    case _ => metadata
+  }
+}

--- a/image-loader/app/lib/cleanup/MetadataCleaner.scala
+++ b/image-loader/app/lib/cleanup/MetadataCleaner.scala
@@ -12,6 +12,7 @@ object MetadataCleaner {
     CleanRubbishLocation,
     StripCopyrightPrefix,
     UseCanonicalGuardianCredit,
+    ExtractGuardianCreditFromByline,
     CountryCode,
     CapitaliseByline,
     CapitaliseCountry,

--- a/image-loader/test/scala/lib/cleanup/ExtractGuardianCreditFromBylineTest.scala
+++ b/image-loader/test/scala/lib/cleanup/ExtractGuardianCreditFromBylineTest.scala
@@ -1,0 +1,50 @@
+package scala.lib.cleanup
+
+import lib.cleanup.ExtractGuardianCreditFromByline
+import org.scalatest.{FunSpec, Matchers}
+
+class ExtractGuardianCreditFromBylineTest extends FunSpec with Matchers with MetadataHelper {
+
+  it("should not infer any credit from a plain byline") {
+    val metadata = createImageMetadata("byline" -> "Helmut Schon", "credit" -> "Getty Images")
+    val mappedMetadata = ExtractGuardianCreditFromByline.clean(metadata)
+    mappedMetadata.byline should be (Some("Helmut Schon"))
+    mappedMetadata.credit should be (Some("Getty Images"))
+  }
+
+  it("should extract a Guardian credit from a 'for the Guardian' byline") {
+    val metadata = createImageMetadata("byline" -> "Helmut Schon for the Guardian")
+    val mappedMetadata = ExtractGuardianCreditFromByline.clean(metadata)
+    mappedMetadata.byline should be (Some("Helmut Schon"))
+    mappedMetadata.credit should be (Some("The Guardian"))
+  }
+
+  it("should extract a Guardian credit from a 'for The GUARDIAN' byline with bad capitalisation") {
+    val metadata = createImageMetadata("byline" -> "Helmut Schon for The GUARDIAN")
+    val mappedMetadata = ExtractGuardianCreditFromByline.clean(metadata)
+    mappedMetadata.byline should be (Some("Helmut Schon"))
+    mappedMetadata.credit should be (Some("The Guardian"))
+  }
+
+  it("should extract a Guardian credit from a 'for the Guardian.' byline with trailing dot") {
+    val metadata = createImageMetadata("byline" -> "Helmut Schon for the Guardian.")
+    val mappedMetadata = ExtractGuardianCreditFromByline.clean(metadata)
+    mappedMetadata.byline should be (Some("Helmut Schon"))
+    mappedMetadata.credit should be (Some("The Guardian"))
+  }
+
+  it("should extract a Guardian credit from a 'for the Guardian' byline and override any existing one") {
+    val metadata = createImageMetadata("byline" -> "Helmut Schon for the Guardian", "credit" -> "Whatever")
+    val mappedMetadata = ExtractGuardianCreditFromByline.clean(metadata)
+    mappedMetadata.byline should be (Some("Helmut Schon"))
+    mappedMetadata.credit should be (Some("The Guardian"))
+  }
+
+  it("should extract an Observer credit from a 'for the Observer' byline and override any existing one") {
+    val metadata = createImageMetadata("byline" -> "Helmut Schon for the Observer", "credit" -> "Whatever")
+    val mappedMetadata = ExtractGuardianCreditFromByline.clean(metadata)
+    mappedMetadata.byline should be (Some("Helmut Schon"))
+    mappedMetadata.credit should be (Some("The Observer"))
+  }
+
+}


### PR DESCRIPTION
Also works for the Observer.

We know that images may have this metadata, or else it may have been entered like this in Picdar Library.

This means we'll likely need to run something like these cleaners when ingesting metadata overrides from the Picdar Library.
