### PR TITLE
Fix malformed HTML that caused desc to be hidden in results

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -14,7 +14,7 @@
 
     <div class="preview__info" ng:if="! hideInfo">
         <ui-labeller-compact class="preview__labeller"
-                             labels="image.data.userMetadata.data.labels"></ui-labeller>
+                             labels="image.data.userMetadata.data.labels"></ui-labeller-compact>
 
         <p class="preview__description">{{image.data.metadata.description || image.data.metadata.title}}</p>
     </div>


### PR DESCRIPTION
Minor issue reported by Jonny.

It'd be nice to have an HTML validator running on our templates to catch such issues.
