### PR TITLE
Refactor ImageMetadata into common-lib to be shared across services

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -1,0 +1,22 @@
+package com.gu.mediaservice.model
+
+import org.joda.time.DateTime
+
+case class ImageMetadata(
+  dateTaken:           Option[DateTime],
+  description:         Option[String],
+  credit:              Option[String],
+  byline:              Option[String],
+  bylineTitle:         Option[String],
+  title:               Option[String],
+  copyrightNotice:     Option[String],
+  copyright:           Option[String],
+  suppliersReference:  Option[String],
+  source:              Option[String],
+  specialInstructions: Option[String],
+  keywords:            List[String],
+  subLocation:         Option[String],
+  city:                Option[String],
+  state:               Option[String],
+  country:             Option[String]
+)

--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -14,7 +14,7 @@ import lib.play.DigestedFile
 
 import lib.{Config, Notifications}
 import lib.storage.S3ImageStorage
-import lib.imaging.{FileMetadata, MimeTypeDetection, Thumbnailer, ImageMetadata}
+import lib.imaging.{FileMetadata, MimeTypeDetection, Thumbnailer, ImageMetadataConverter}
 import lib.cleanup.MetadataCleaner
 
 import model.{Asset, Image}
@@ -101,7 +101,7 @@ class ImageLoader(storage: ImageStorage) extends Controller with ArgoHelpers {
         uri        <- uriFuture
         dimensions <- dimensionsFuture
         fileMetadata <- fileMetadataFuture
-        metadata    = ImageMetadata.fromFileMetadata(fileMetadata)
+        metadata    = ImageMetadataConverter.fromFileMetadata(fileMetadata)
         cleanMetadata = MetadataCleaner.clean(metadata)
         sourceAsset = Asset(uri, tempFile.length, mimeType, dimensions)
         thumbUri   <- storage.storeThumbnail(id, thumb, mimeType)

--- a/image-loader/app/lib/cleanup/AttributeCreditFromByline.scala
+++ b/image-loader/app/lib/cleanup/AttributeCreditFromByline.scala
@@ -1,7 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
-import lib.Config
+import com.gu.mediaservice.model.ImageMetadata
 
 case class AttributeCreditFromByline(bylines: List[String], credit: String) extends MetadataCleaner {
 

--- a/image-loader/app/lib/cleanup/ByLineCreditReorganise.scala
+++ b/image-loader/app/lib/cleanup/ByLineCreditReorganise.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object ByLineCreditReorganise extends MetadataCleaner {
   type Field = Option[String]

--- a/image-loader/app/lib/cleanup/CapitaliseProperty.scala
+++ b/image-loader/app/lib/cleanup/CapitaliseProperty.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object CapitaliseByline extends MetadataCleaner with CapitalisationFixer {
   // Note: probably not exhaustive list

--- a/image-loader/app/lib/cleanup/CleanRubbishLocation.scala
+++ b/image-loader/app/lib/cleanup/CleanRubbishLocation.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object CleanRubbishLocation extends MetadataCleaner {
 

--- a/image-loader/app/lib/cleanup/CountryCode.scala
+++ b/image-loader/app/lib/cleanup/CountryCode.scala
@@ -3,7 +3,7 @@ package lib.cleanup
 import java.util.Locale
 import play.api.Logger
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object CountryCode extends MetadataCleaner {
 

--- a/image-loader/app/lib/cleanup/DropRedundantTitle.scala
+++ b/image-loader/app/lib/cleanup/DropRedundantTitle.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 
 object DropRedundantTitle extends MetadataCleaner {

--- a/image-loader/app/lib/cleanup/ExtractGuardianCreditFromByline.scala
+++ b/image-loader/app/lib/cleanup/ExtractGuardianCreditFromByline.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object ExtractGuardianCreditFromByline extends MetadataCleaner {
 

--- a/image-loader/app/lib/cleanup/MetadataCleaner.scala
+++ b/image-loader/app/lib/cleanup/MetadataCleaner.scala
@@ -1,7 +1,7 @@
 package lib.cleanup
 
 import lib.Config
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 trait MetadataCleaner {
   def clean(metadata: ImageMetadata): ImageMetadata

--- a/image-loader/app/lib/cleanup/StripCopyrightPrefix.scala
+++ b/image-loader/app/lib/cleanup/StripCopyrightPrefix.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object StripCopyrightPrefix extends MetadataCleaner {
 

--- a/image-loader/app/lib/cleanup/UseCanonicalGuardianCredit.scala
+++ b/image-loader/app/lib/cleanup/UseCanonicalGuardianCredit.scala
@@ -1,6 +1,6 @@
 package lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 object UseCanonicalGuardianCredit extends MetadataCleaner {
 

--- a/image-loader/app/lib/imaging/ImageMetadataConverter.scala
+++ b/image-loader/app/lib/imaging/ImageMetadataConverter.scala
@@ -5,7 +5,9 @@ import org.joda.time.format._
 
 import scala.util.Try
 
-object ImageMetadata {
+import com.gu.mediaservice.model.ImageMetadata
+
+object ImageMetadataConverter {
 
   def fromFileMetadata(fileMetadata: FileMetadata): ImageMetadata =
     ImageMetadata(
@@ -74,21 +76,3 @@ object ImageMetadata {
 //       http://cv.iptc.org/newscodes/subjectcode/
 // TODO: add Coded Character Set ?
 // TODO: add Application Record Version ?
-case class ImageMetadata(
-  dateTaken:           Option[DateTime],
-  description:         Option[String],
-  credit:              Option[String],
-  byline:              Option[String],
-  bylineTitle:         Option[String],
-  title:               Option[String],
-  copyrightNotice:     Option[String],
-  copyright:           Option[String],
-  suppliersReference:  Option[String],
-  source:              Option[String],
-  specialInstructions: Option[String],
-  keywords:            List[String],
-  subLocation:         Option[String],
-  city:                Option[String],
-  state:               Option[String],
-  country:             Option[String]
-)

--- a/image-loader/app/model/Image.scala
+++ b/image-loader/app/model/Image.scala
@@ -5,8 +5,9 @@ import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import org.joda.time.DateTime
 
+import lib.imaging.FileMetadata
 import com.gu.mediaservice.lib.formatting._
-import lib.imaging.{FileMetadata, ImageMetadata}
+import com.gu.mediaservice.model.ImageMetadata
 
 
 case class Image(id: String,

--- a/image-loader/test/scala/lib/cleanup/MetadataHelper.scala
+++ b/image-loader/test/scala/lib/cleanup/MetadataHelper.scala
@@ -1,6 +1,6 @@
 package scala.lib.cleanup
 
-import lib.imaging.ImageMetadata
+import com.gu.mediaservice.model.ImageMetadata
 
 trait MetadataHelper {
   def createImageMetadata(metadata: (String, String)*): ImageMetadata =

--- a/image-loader/test/scala/lib/imaging/ImageMetadataConverterTest.scala
+++ b/image-loader/test/scala/lib/imaging/ImageMetadataConverterTest.scala
@@ -1,14 +1,14 @@
 package scala.lib.imaging
 
-import lib.imaging.{FileMetadata, ImageMetadata}
+import lib.imaging.{FileMetadata, ImageMetadataConverter}
 import org.joda.time.{DateTimeZone, DateTime}
 import org.scalatest.{Matchers, FunSpec}
 
-class ImageMetadataTest extends FunSpec with Matchers {
+class ImageMetadataConverterTest extends FunSpec with Matchers {
 
   it("should return an empty ImageMetadata for empty FileMetadata") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be ('empty)
     imageMetadata.description should be ('empty)
     imageMetadata.credit should be ('empty)
@@ -45,7 +45,7 @@ class ImageMetadataTest extends FunSpec with Matchers {
     ), Map(
       "Copyright" -> "the copyright"
     ), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
 
     imageMetadata.description should be (Some("the description"))
     imageMetadata.credit should be (Some("the credit"))
@@ -65,13 +65,13 @@ class ImageMetadataTest extends FunSpec with Matchers {
 
   it("should fallback to Copyright Notice for copyright field of ImageMetadata if Copyright is missing") {
     val fileMetadata = FileMetadata(Map("Copyright Notice" -> "the copyright notice"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.copyrightNotice should be (Some("the copyright notice"))
   }
 
   it("should fallback to Object Name for suppliersReference field of ImageMetadata if Original Transmission Reference is missing") {
     val fileMetadata = FileMetadata(Map("Object Name" -> "the object name"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.suppliersReference should be (Some("the object name"))
   }
 
@@ -82,49 +82,49 @@ class ImageMetadataTest extends FunSpec with Matchers {
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (2014-12-16T02:23:45+01:00)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "2014-12-16T02:23:45+01:00"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (2014-12-16T02:23+01:00)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "2014-12-16T02:23+01:00"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:00Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 GMT 2014)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 GMT 2014"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 UTC 2014)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 UTC 2014"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 BST 2014)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 BST 2014"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45+01:00").withZone(DateTimeZone.UTC)))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 PDT 2014)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 PDT 2014"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45-08:00").withZone(DateTimeZone.UTC)))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (2014-12-16)") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "2014-12-16"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T00:00:00Z")))
   }
 
   it("should leave the dateTaken field of ImageMetadata empty if IPTC Date Created is not a valid date") {
     val fileMetadata = FileMetadata(Map("Date Created" -> "not a date"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be ('empty)
   }
 
@@ -132,7 +132,7 @@ class ImageMetadataTest extends FunSpec with Matchers {
   it("should populate the dateTaken field of ImageMetadata from EXIF Sub Date/Time Original if present") {
     // Thankfully standard datetime format (albeit weird and with no TZ offset)
     val fileMetadata = FileMetadata(Map(), Map(), Map("Date/Time Original" -> "2014:12:16 01:23:45"), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     // Note: we assume UTC as timezone (not necessarily correct but no way to tell)
     imageMetadata.dateTaken should be (Some(new DateTime("2014-12-16T01:23:45Z")))
   }
@@ -140,7 +140,7 @@ class ImageMetadataTest extends FunSpec with Matchers {
   it("should leave the dateTaken field of ImageMetadata empty if EXIF Sub Date/Time Original is not a valid date") {
     // Thankfully standard datetime format (albeit weird and with no TZ offset)
     val fileMetadata = FileMetadata(Map(), Map(), Map("Date/Time Original" -> "not a date"), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be ('empty)
   }
 
@@ -149,13 +149,13 @@ class ImageMetadataTest extends FunSpec with Matchers {
 
   it("should populate keywords field of ImageMetadata from comma-separated list of keywords") {
     val fileMetadata = FileMetadata(Map("Keywords" -> "Foo,Bar, Baz"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.keywords should be (List("Foo", "Bar", "Baz"))
   }
 
   it("should populate keywords field of ImageMetadata from semi-colon-separated list of keywords") {
     val fileMetadata = FileMetadata(Map("Keywords" -> "Foo;Bar; Baz"), Map(), Map(), Map())
-    val imageMetadata = ImageMetadata.fromFileMetadata(fileMetadata)
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.keywords should be (List("Foo", "Bar", "Baz"))
   }
 


### PR DESCRIPTION
As we will it them in the PicdarExport tool.

Next: the MetadataCleaners...
