### PR TITLE
add failed deletions to cloudwatch metrics

### DIFF
--- a/thrall/app/lib/ThrallMetrics.scala
+++ b/thrall/app/lib/ThrallMetrics.scala
@@ -9,6 +9,8 @@ object ThrallMetrics extends CloudWatchMetrics(s"$stage/Thrall", awsCredentials)
 
   val deletedImages = new CountMetric("DeletedImages")
 
+  val failedDeletedImages = new CountMetric("FailedDeletedImages")
+
   val conflicts = new CountMetric("ElasticSearch/Conflicts")
 
 }


### PR DESCRIPTION
We should never really see this metric unless someone tries to manually delete an image through the API and it doesn't meet the requirements. If thrall's API query is wrong though - this will flag it pretty quickly.
