### PR TITLE
Add lastModified datetime to image

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -95,6 +95,7 @@ object Mappings {
           "exports" -> exportsMapping,
           "uploadTime" -> dateFormat,
           "uploadedBy" -> nonAnalyzedString,
+          "lastModified" -> dateFormat,
           "identifiers" -> dynamicObj
         ),
         "dynamic_templates" -> Json.arr(Json.obj(

--- a/image-loader/app/model/Image.scala
+++ b/image-loader/app/model/Image.scala
@@ -13,6 +13,7 @@ import com.gu.mediaservice.model.ImageMetadata
 case class Image(id: String,
                  uploadTime: DateTime,
                  uploadedBy: String,
+                 lastModified: Option[DateTime],
                  identifiers: Map[String, String],
                  source: Asset,
                  thumbnail: Option[Asset],
@@ -36,7 +37,7 @@ object Image {
              thumbnail: Asset,
              fileMetadata: FileMetadata,
              metadata: ImageMetadata): Image =
-    Image(id, uploadTime, uploadedBy, identifiers, source, Some(thumbnail),
+    Image(id, uploadTime, uploadedBy, Some(uploadTime), identifiers, source, Some(thumbnail),
       fileMetadata, metadata, metadata)
 
   implicit val FileMetadataWrites: Writes[FileMetadata] = Json.writes[FileMetadata]
@@ -45,6 +46,7 @@ object Image {
     (__ \ "id").write[String] ~
       (__ \ "uploadTime").write[String].contramap(printDateTime) ~
       (__ \ "uploadedBy").write[String] ~
+      (__ \ "lastModified").writeNullable[String].contramap(printOptDateTime) ~
       (__ \ "identifiers").write[Map[String, String]] ~
       (__ \ "source").write[Asset] ~
       (__ \ "thumbnail").writeNullable[Asset] ~


### PR DESCRIPTION
Currently just set to the same value as `uploadTime`.

In the future, it will get updated more correctly whenever the image is touched.

To do next:
- [x] Update the mappings in TEST and PROD before this goes out
- [x] Add an item to the tech debt to back-populate the field with the same value as `uploadTime` (done: https://github.com/guardian/grid-infra/pull/20)
- [x] Discuss if we also want a "lastModifiedBy"? (opened as https://github.com/guardian/media-service/issues/539)
- [x] Stop updating `uploadTime` when re-indexing an existing image (#538)
- [x] Update the `lastModified` value when indexing exports or metadata (opened as https://github.com/guardian/media-service/issues/540)
