### PR TITLE
only capitilise on more than one word

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CapitaliseProperty.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CapitaliseProperty.scala
@@ -59,7 +59,8 @@ trait CapitalisationFixer {
 
   // FIXME: is there no more efficient way of partial matching a regexp on a string?
   val notNumbersOrSlash = """[^/0-9]+"""
-  def looksLikeAName(s: String): Boolean = s.matches(notNumbersOrSlash)
+  def looksLikeAName(s: String): Boolean =
+    s.matches(notNumbersOrSlash) && s.split("\\s+").length > 1
 
   def isAllUpperCase(s: String): Boolean = s == s.toUpperCase
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/CapitaliseBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/CapitaliseBylineTest.scala
@@ -5,6 +5,10 @@ import org.scalatest.{FunSpec, Matchers}
 
 class CapitaliseBylineTest extends FunSpec with Matchers with MetadataHelper {
 
+  it("should not apply capitilisation to single words") {
+    expectUnchanged("PA")
+  }
+
   it("should not change a correctly capitalised name") {
     expectUnchanged("James Gorrie")
   }


### PR DESCRIPTION
So PA doesn't become Pa.
