### PR TITLE
fix label link on compact labeller

### DIFF
--- a/kahuna/public/js/edits/labeller-compact.html
+++ b/kahuna/public/js/edits/labeller-compact.html
@@ -4,7 +4,7 @@
         <li class="label"
             ng:repeat="label in ctrl.labels.data">
             <a class="label__link"
-               ui:sref="search.results({query: label.data})">{{label.data}}</a>
+               ui:sref="search.results({query: (label.data | queryLabelFilter)})">{{label.data}}</a>
         </li>
     </ul>
 


### PR DESCRIPTION
Just noticed it wasn't using the shiny new grammar.
