### PR TITLE
Upload lastModified time when indexing export or metadata override

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -13,7 +13,6 @@ import org.elasticsearch.script.ScriptService
 import org.elasticsearch.index.query.QueryBuilders.{filteredQuery, boolQuery, matchQuery}
 import org.elasticsearch.index.query.FilterBuilders.{missingFilter, andFilter}
 import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
 import groovy.json.JsonSlurper
 import _root_.play.api.libs.json._
 


### PR DESCRIPTION
Currently the lastModified time is only bumped when an image is re-uploaded. It should also be updated when exports or metadata overrides are indexed by thrall.

Likely related to #292 (record time of crop).
