### PR TITLE
decrease imops quality

### DIFF
--- a/kahuna/public/js/imgops/service.js
+++ b/kahuna/public/js/imgops/service.js
@@ -3,11 +3,12 @@ import angular from 'angular';
 export var imgops = angular.module('kahuna.imgops', []);
 
 imgops.factory('imgops', ['$window', function($window) {
+    var quality = 85;
 
     var getUri = image => {
         var { width: w, height: h } = $window.screen;
 
-        return image.follow('optimised', { w, h, q: 95 }).getUri().catch(() => {
+        return image.follow('optimised', { w, h, q: quality }).getUri().catch(() => {
             return image.source.secureUrl || image.source.file;
         });
     };


### PR DESCRIPTION
It seems that between 9\* - 75% quality, there is not that much difference in quality, especially as we're serving relatively large images (the width / height of the users screen).

I've been conservative and gone with 85 as it seems to be quite a nice sweet spot with filesize.
See below.
95%: 194kb
85%: 97kb
75%: 70kb
#75%

![q75](https://cloud.githubusercontent.com/assets/31692/6750684/e0e8cd14-cef4-11e4-881b-bfa90b33408c.jpeg)
#85%

![q85](https://cloud.githubusercontent.com/assets/31692/6750685/e0f7371e-cef4-11e4-8965-db62be0debcf.jpeg)
#95%

![q95](https://cloud.githubusercontent.com/assets/31692/6750730/45fa8f8a-cef5-11e4-9fc2-1ecdf44709f5.jpeg)
