### PR TITLE
Add crop time as metadata stored in S3

### DIFF
--- a/cropper/app/controllers/Application.scala
+++ b/cropper/app/controllers/Application.scala
@@ -16,6 +16,8 @@ import com.gu.mediaservice.lib.auth
 import com.gu.mediaservice.lib.auth.{AuthenticatedService, PandaUser, KeyStore}
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 
+import org.joda.time.DateTime
+
 import lib._, Files._
 import model._
 
@@ -55,7 +57,11 @@ object Application extends Controller with ArgoHelpers {
     cropSourceForm.bindFromRequest()(httpRequest).fold(
       errors   => Future.successful(BadRequest(errors.errorsAsJson)),
       cropSrc => {
-        val cropRequest = CropRequest(by = author, specification = cropSrc)
+        val cropRequest = CropRequest(
+          by = author,
+          timeRequested = new DateTime(),
+          specification = cropSrc
+        )
 
         createSizings(cropRequest).map { case (id, sizings) =>
 

--- a/cropper/app/lib/CropStorage.scala
+++ b/cropper/app/lib/CropStorage.scala
@@ -21,6 +21,7 @@ object CropStorage extends S3(Config.imgPublishingCredentials) {
                        "bounds_w" -> w,
                        "bounds_h" -> h,
                        "author" -> request.by,
+                       "date" -> request.timeRequested,
                        "width" -> dimensions.width,
                        "height" -> dimensions.height
                    ) ++ r.map("aspect_ratio" -> _)

--- a/cropper/app/model/CropSource.scala
+++ b/cropper/app/model/CropSource.scala
@@ -2,8 +2,9 @@ package model
 
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import org.joda.time.DateTime
 
-case class CropRequest(by: String, specification: CropSource)
+case class CropRequest(by: String, timeRequested: DateTime, specification: CropSource)
 
 case class Crop(id: String, specification: CropSource, assets: List[CropSizing])
 


### PR DESCRIPTION
Arises from https://github.com/guardian/media-service/pull/292
