### PR TITLE
Add 'ci' npm script to setup github token

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "test": "npm run lint",
     "lint": "jshint public/js --exclude public/js/dist/build.js",
-    "ci": "jspm config endpoints.github.auth $JSPM_GITHUB_AUTH_TOKEN",
+    "ci": "jspm config endpoints.github.auth `echo -n JSPM_GITHUB_AUTH_USERNAME:$JSPM_GITHUB_AUTH_TOKEN | base64`",
     "dist": "jspm bundle js/main public/js/dist/build.js -m --inject",
     "undist": "jspm unbundle"
   },


### PR DESCRIPTION
The ci script will be added to our TC script.

This way we should hopefully avoid any more Github rate limiting error when using jspm.

Needs #585 merged first to get the latest jspm.
