### PR TITLE
Bump theseus to 0.3.2

### DIFF
--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -23,7 +23,7 @@ System.config({
     "pandular": "npm:pandular@0.1.5",
     "raven-js": "github:getsentry/raven-js@1.1.18",
     "text": "github:systemjs/plugin-text@0.0.2",
-    "theseus": "npm:theseus@0.3.1",
+    "theseus": "npm:theseus@0.3.2",
     "theseus-angular": "npm:theseus-angular@0.2.3",
     "ua-parser-js": "npm:ua-parser-js@0.7.3",
     "github:angular-ui/ui-router@0.2.13": {
@@ -65,9 +65,9 @@ System.config({
       "angular": "github:angular/bower-angular@1.3.15",
       "any-http-angular": "npm:any-http-angular@0.1.0",
       "any-promise-angular": "npm:any-promise-angular@0.1.1",
-      "theseus": "npm:theseus@0.3.1"
+      "theseus": "npm:theseus@0.3.2"
     },
-    "npm:theseus@0.3.1": {
+    "npm:theseus@0.3.2": {
       "uri-templates": "npm:uri-templates@0.1.5"
     },
     "npm:ua-parser-js@0.7.3": {


### PR DESCRIPTION
Avoids noisy errors when loading image preview for invalid image (see https://github.com/guardian/media-service/pull/596).
