### PR TITLE
Adding more precision to the dimensions by using Math.round

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -28,8 +28,9 @@ crop.controller('ImageCropCtrl',
         x2: 10000,
         y2: 10000
     };
-    var cropWidth = () => $scope.coords.x2 - $scope.coords.x1;
-    var cropHeight = () => $scope.coords.y2 - $scope.coords.y1;
+
+    var cropWidth = () => Math.round($scope.coords.x2 - $scope.coords.x1);
+    var cropHeight = () => Math.round($scope.coords.y2 - $scope.coords.y1);
     this.cropSize = () => cropWidth() + ' x ' + cropHeight();
     this.cropSizeWarning = () => cropWidth() < 500;
 
@@ -39,8 +40,8 @@ crop.controller('ImageCropCtrl',
         var coords = {
             x: $scope.coords.x1,
             y: $scope.coords.y1,
-            width:  $scope.coords.x2 - $scope.coords.x1,
-            height: $scope.coords.y2 - $scope.coords.y1
+            width:  cropWidth(),
+            height: cropHeight()
         };
 
         var ratio;

--- a/kahuna/public/js/directives/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box.js
@@ -99,10 +99,10 @@ controlsDirectives.directive('uiCropBox', ['$timeout', '$parse', 'safeApply', 'n
                 // (e.g. redraw after aspect changed) or not (user
                 // interaction)
                 safeApply(scope, function() {
-                    scope.coords.x1 = parseInt(c.x, 10);
-                    scope.coords.y1 = parseInt(c.y, 10);
-                    scope.coords.x2 = parseInt(c.x2, 10);
-                    scope.coords.y2 = parseInt(c.y2, 10);
+                    scope.coords.x1 = c.x;
+                    scope.coords.y1 = c.y;
+                    scope.coords.x2 = c.x2;
+                    scope.coords.y2 = c.y2;
                 });
             }
 


### PR DESCRIPTION
Some effort into addressing [#199](https://github.com/guardian/media-service/issues/199).

It looks like there is an issue with jcrop in general; I've created [this](https://akash1810.github.io/jcrop-playground/) to demonstrate why. JCrop appears to have an issue calculating the dimensions of a crop when on the edge of the image (look at the width and height rows below).

I'll raise a PR to the JCrop project if/when I find and fix it.

![jcrop](https://cloud.githubusercontent.com/assets/836140/6923014/1ad9253e-d7c7-11e4-913d-86f4df4917ac.gif)
