### PR TITLE
Add rights as Entity in image API response

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/api/Transformers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/api/Transformers.scala
@@ -25,6 +25,7 @@ class Transformers(services: Services) {
           data ++ Json.obj(
             "archived" -> boolOrFalse(data \ "archived").transform(wrapArchived(id)).get,
             "labels" -> arrayOrEmpty(data \ "labels").transform(wrapLabels(id)).get,
+            "rights" -> arrayOrEmpty(data \ "rights").transform(wrapRights(id)).get,
             "metadata" -> objectOrEmpty(data \ "metadata").transform(wrapMetadata(id)).get
           )
         )
@@ -59,6 +60,22 @@ class Transformers(services: Services) {
     __.read[JsString].map { case JsString(label) =>
       Json.obj(
         "uri" -> s"$metadataBaseUri/metadata/$id/labels/$label",
+        "data" -> label
+      )
+    }
+
+  def wrapRights(id: String): Reads[JsObject] =
+    __.read[JsArray].map { rights =>
+      Json.obj(
+        "uri" -> s"$metadataBaseUri/metadata/$id/rights",
+        "data" -> rights.value.map(right => right.transform(wrapRight(id)).get)
+      )
+    }
+
+  def wrapRight(id: String): Reads[JsObject] =
+    __.read[JsString].map { case JsString(label) =>
+      Json.obj(
+        "uri" -> s"$metadataBaseUri/metadata/$id/rights/$label",
         "data" -> label
       )
     }


### PR DESCRIPTION
I know we're not meant to be using these weird wrappers - but it seems like it's going to be quite a refactor to move to the Argo types.

This is needed for the rights management.
