### PR TITLE
Add USA Today Sports as a Reuters credit

### DIFF
--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -81,6 +81,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
     "REUTERS",
     "Reuters",
     "RTRPIX",
+    "USA Today Sports", // via Reuters too
     // REX
     "Rex Features",
     "Ronald Grant Archive",


### PR DESCRIPTION
Confirmed by Jo that it's "free" under our Reuters contract
