### PR TITLE
Fix view image link

### DIFF
--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -33,7 +33,7 @@
                  ng:switch="ctrl.status">
                 <a class="result-editor__status status status--valid"
                    ng:switch-when="ready"
-                   ui:sref="image({imageId: image.data.id})">View image ▸</a>
+                   ui:sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
 
                 <span class="result-editor__status status status--invalid"
                       ng:switch-when="invalid">


### PR DESCRIPTION
Ran a `[^\.]image` on the page to make sure none were missed.
I will make this a point of call.

I wish there was better compilation here.
