### PR TITLE
add restricted usage rights to image preview

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -39,9 +39,18 @@
                  class="image-info__group cost cost--pay">
                 invalid (missing metadata)
             </div>
-            <div ng:if="ctrl.image.data.valid && ctrl.image.data.cost == 'pay'"
-                 class="image-info__group cost cost--pay">
-                pay to use
+
+            <div ng:if="ctrl.image.data.valid" ng:switch="ctrl.image.data.cost">
+                <div ng:switch-when="pay"
+                     class="image-info__group status cost cost--pay">
+                    pay to use
+                </div>
+
+                <div ng:switch-when="conditional"
+                     class="image-info__group cost cost--conditional"
+                     title="This image can be used but only within certain restrictions">
+                    <b>restricted:</b> {{ctrl.image.data.userMetadata.data.usageRights.data.restrictions}}
+                </div>
             </div>
 
             <div class="image-info__group">

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -824,6 +824,7 @@ FIXME: what to do with touch devices
 
 .image-info__group {
     margin-bottom: 5px;
+    padding: 10px;
 }
 
 .image-info__title {


### PR DESCRIPTION
There is a question of whether we show that it's been overriden with free to use or pay to use, but we can address that later.

![restricted preview](https://cloud.githubusercontent.com/assets/31692/7201976/a193f86a-e505-11e4-9484-b0d9700909a4.png)
