### PR TITLE
Save when changed from original metadata

### DIFF
--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -69,6 +69,7 @@
             class="result-editor__metadata-editor"
             resource="ctrl.image.data.userMetadata.data.metadata"
             metadata="ctrl.image.data.metadata"
+            save-when-changed-from="ctrl.image.data.originalMetadata || ctrl.image.data.metadata"
             image="ctrl.image"
             with-batch="ctrl.withBatch"
         ></ui-required-metadata-editor>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -26,7 +26,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
         // If there has been a change in the metadata, save it as an override
         var cleanMetadata = {};
         Object.keys(ctrl.metadata).forEach(key => {
-            if (ctrl.metadata[key] !== ctrl.originalMetadata[key]) {
+            if (ctrl.metadata[key] !== ctrl.saveWhenChangedFrom[key]) {
                 cleanMetadata[key] = ctrl.metadata[key];
             }
         });
@@ -83,6 +83,7 @@ jobs.directive('uiRequiredMetadataEditor', [function() {
             resource: '=',
             originalMetadata: '=metadata',
             externallyDisabled: '=?disabled',
+            saveWhenChangedFrom: '=',
             // TODO: remove this once we add links to the resources
             image: '=',
             withBatch: '=?'


### PR DESCRIPTION
Problem here was if you try to re-edit your metadata, we compare against the already edited metadata to decide whether to save it or not. This is intentional on the original save to make sure we don't resave / override data. e.g. 
- From file: `byline` = "George Lucas", `credit` = "Lucas Arts"
- Change `credit` from "Lucas arts" => "Georgio Armani"
- Save

Only credit should be sent as an override.

However if we return and change `credit` from "Georgio Armani" => "Georgia Arts", we won't send over the `byline` as it hasn't been changed, thus override the override data with `{ "credit": "Georgia Arts" }` instead of the correct `{ "credit": "Georgia Arts", "byline": "Geirge Lucas" }`.

This probably needs a little reworking, or at least writing down what we are expecting to happen, but this is just attacking a symptom.
