### PR TITLE
Fixes to image-loader following refactoring

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Asset.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Asset.scala
@@ -8,14 +8,9 @@ import com.gu.mediaservice.lib.aws.S3Object
 case class Asset(file: URI, size: Long, mimeType: Option[String], dimensions: Option[Dimensions], secureUrl: Option[URL] = None)
 object Asset {
 
-  def fromS3Object(s3Object: S3Object): Asset = {
+  def fromS3Object(s3Object: S3Object, dimensions: Option[Dimensions]): Asset = {
     val userMetadata   = s3Object.metadata.userMetadata
     val objectMetadata = s3Object.metadata.objectMetadata
-
-    val dimensions     = for {
-      width <- userMetadata.get("width").map(_.toInt)
-      height <-userMetadata.get("height").map(_.toInt)
-    } yield Dimensions(width, height)
 
     Asset(
       s3Object.uri,


### PR DESCRIPTION
The https://github.com/guardian/media-service/pull/519 refactoring broke a few things, which this PR fixes, including:
- Original image uploaded as thumbnail
- Operations weren't running in parallel anymore
- Dimensions of source/thumbnail were read from S3 metadata, but weren't there, so were always missing in indexed image entry
