### PR TITLE
Reword Kahuna "small crop" warning

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -43,8 +43,6 @@ crop.controller('ImageCropCtrl',
         return tooSmall;
     };
 
-    $scope.reloadRoute = () => $state.reload();
-
     $scope.preCrop = () => { $scope.promptToCrop = $scope.imageCropCtrl.cropSizeWarning(); }
 
     $scope.crop = function() {

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -44,11 +44,11 @@
     </div>
 
     <div class="errors">
-        <div class="error" ng:if="promptToCrop">
+        <div class="error" ng:show="promptToCrop">
             This crop is very small and will result in a low-quality image. Are you sure you want to proceed?
             <div class="error__buttons">
                 <button class="error__button button-shy"
-                    ng:click="reloadRoute()"
+                    ng:click="promptToCrop = false"
                     ng:disabled="cropping">
                     back to crop
                 </button>
@@ -57,7 +57,7 @@
                     ng:click="crop()"
                     ng:disabled="cropping">
                     <span ng:show="cropping">cropping</span>
-                    <span ng:hide="cropping">crop anyway</span>
+                    <span ng:hide="cropping">complete this crop</span>
                 </button>
             </div>
         </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -169,6 +169,7 @@ a:focus {
 
 .button--warning {
     background: darkred;
+    box-shadow: 0 2px #640000;
 }
 
 .button--warning:hover {


### PR DESCRIPTION
Addresses [#627](https://github.com/guardian/media-service/issues/627).
- If the crop is large enough, clicking 'crop' will behave as before.
- If the crop is too small, the 'crop' button changes to red.
  - Pressing the red 'crop' button will display the warning message with a 'restart crop' and 'crop anyway' button.
  - Having the user press an extra button to create a small crop will, hopefully, prompt them to use a bigger crop.
- The message banner is positioned absolute to remove the jumpy ui.

![small-crop-message](https://cloud.githubusercontent.com/assets/836140/7255378/d9d6857e-e840-11e4-9c11-b26a6074c7dc.gif)

![small-crop-message-ii](https://cloud.githubusercontent.com/assets/836140/7255393/f0e56686-e840-11e4-8fe0-f4661d2a8f22.gif)
