### PR TITLE
Document uploader:_ filter in advanced search help

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -102,6 +102,15 @@
     </dl>
     <dl class="advanced-search-example">
         <dt class="advanced-search-example__inputs">
+            <kbd class="advanced-search-example__input">uploader:jonny.weeks@guardian.co.uk</kbd>
+            <kbd class="advanced-search-example__input">uploader:getty</kbd>
+        </dt>
+        <dd>
+            Search the person (email) or agency (folder) who uploaded the image.
+        </dd>
+    </dl>
+    <dl class="advanced-search-example">
+        <dt class="advanced-search-example__inputs">
             <kbd class="advanced-search-example__input">"New York City"</kbd>
             <kbd class="advanced-search-example__input">credit:"Getty Images"</kbd>
         </dt>


### PR DESCRIPTION
Add `uploader:...` filter to the list so it is discoverable.

![screenshot-doc-uploader](https://cloud.githubusercontent.com/assets/36964/7271225/e9de584a-e8d9-11e4-9996-f32aab8a0e91.png)
