### PR TITLE
Rename Your uploads to Your recent uploads for clarity

### DIFF
--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -4,7 +4,7 @@
         <search-query class="top-bar__nav"></search-query>
 
         <div class="top-bar__actions">
-            <a class="top-bar__item" ui:sref="upload">your uploads</a>
+            <a class="top-bar__item" ui:sref="upload">your recent uploads</a>
             <file-uploader class="top-bar__item"></file-uploader>
         </div>
 


### PR DESCRIPTION
We always felt it was awkward to have two "your uploads" on the search screen and this is a minor improvement.

![screenshot-recent-uploads](https://cloud.githubusercontent.com/assets/36964/7271256/0daa4a04-e8da-11e4-8a6e-db32d27be839.png)
