### PR TITLE
Set kahuna log level to INFO

### DIFF
--- a/kahuna/conf/application.conf
+++ b/kahuna/conf/application.conf
@@ -13,7 +13,7 @@ assets.defaultCache="public, max-age=60"
 # You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
 
 # Root logger:
-logger.root=WARN
+logger.root=INFO
 
 # Logger used by the framework:
 logger.play=INFO


### PR DESCRIPTION
I noticed logs were not showing up on kahuna, and this was due to the log level being too high.
