### PR TITLE
Fix query parser to address bugs resulting in no results

### DIFF
--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -54,7 +54,12 @@ class QuerySyntax(val input: ParserInput) extends Parser {
 
 
   // Note: order matters, check for quoted string first
-  def MatchValue = rule { QuotedString ~> Phrase | String ~> Words }
+  def MatchValue = rule {
+    QuotedString ~> Phrase |
+    StringSequence ~> (words => Words(words.mkString(" ")))
+  }
+
+  def StringSequence = rule { oneOrMore(String) separatedBy Whitespace }
 
   def String = rule { capture(Chars) }
 

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -16,36 +16,35 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("should match multiple terms") {
-      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats")), Match(AnyField, Words("dogs"))))
-      // FIXME: or should it be Words("cats dogs") ?
+      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats dogs"))))
     }
 
     it("should match multiple terms separated by multiple whitespace") {
-      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats")), Match(AnyField, Words("dogs"))))
+      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats dogs"))))
     }
 
     it("should match multiple terms including 'in'") {
-      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats")), Match(AnyField, Words("in")), Match(AnyField, Words("dogs"))))
+      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats in dogs"))))
       // FIXME: query results?
     }
 
     it("should match multiple terms including 'by'") {
-      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats")), Match(AnyField, Words("by")), Match(AnyField, Words("dogs"))))
+      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats by dogs"))))
       // FIXME: query results?
     }
 
     it("should match multiple terms including apostrophes") {
-      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's")), Match(AnyField, Words("a")), Match(AnyField, Words("cat"))))
+      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's a cat"))))
       // FIXME: query results?
     }
 
     it("should match multiple terms including commas") {
-      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats,")), Match(AnyField, Words("dogs"))))
+      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats, dogs"))))
       // FIXME: query results?
     }
 
     it("should match multiple terms including single double quotes") {
-      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\"")), Match(AnyField, Words("cats"))))
+      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\" cats"))))
       // FIXME: query results?
     }
 


### PR DESCRIPTION
There were several bugs that resulted in unexpected search results (usually empty), in particular:
- Individual words were being split into separate multiMatch clauses. If any of the words is a stopword (`in`, `the`).
- Apostrophes in words (`Tom's`) weren't correctly parsed.

This should fix all the issues that have been reported so far by @JonnyWeeks.
