### PR TITLE
Revert "Fix query parser to address bugs resulting in no results"

### DIFF
--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -16,44 +16,10 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("should match multiple terms") {
-      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats dogs"))))
+      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats")), Match(AnyField, Words("dogs"))))
     }
 
-    it("should match multiple terms separated by multiple whitespace") {
-      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats dogs"))))
-    }
-
-    it("should match multiple terms including 'in'") {
-      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats in dogs"))))
-      // FIXME: query results?
-    }
-
-    it("should match multiple terms including 'by'") {
-      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats by dogs"))))
-      // FIXME: query results?
-    }
-
-    it("should match multiple terms including apostrophes") {
-      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's a cat"))))
-      // FIXME: query results?
-    }
-
-    it("should match multiple terms including commas") {
-      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats, dogs"))))
-      // FIXME: query results?
-    }
-
-    it("should match multiple terms including single double quotes") {
-      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\" cats"))))
-      // FIXME: query results?
-    }
-
-    // it("should match multiple terms including '#' character") {
-    //   // FIXME: gets caught as label; exclude numeric?
-    //   Parser.run("the #1 cat") should be (List(Match(AnyField, Words("the")), Match(AnyField, Words("#1")), Match(AnyField, Words("cat"))))
-    // }
-
-    it("should match a quoted phrase") {
+    it("should match quoted terms") {
       Parser.run(""""cats dogs"""") should be (List(Match(AnyField, Phrase("cats dogs"))))
     }
 


### PR DESCRIPTION
Reverts guardian/media-service#679

It seems that the results are now matching too many things (rather than none), due to the [terms](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html) query only requiring that _any_ of the terms matches rather than all. There are certainly ways around it, but we basically need to make the query a little stricter.
