### PR TITLE
Delete unused legacy userMetadata "rights" - now superseded by "usageRights"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/api/Transformers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/api/Transformers.scala
@@ -28,7 +28,6 @@ class Transformers(services: Services) {
           data ++ Json.obj(
             "archived" -> boolOrFalse(data \ "archived").transform(wrapArchived(id)).get,
             "labels" -> arrayOrEmpty(data \ "labels").transform(wrapLabels(id)).get,
-            "rights" -> arrayOrEmpty(data \ "rights").transform(wrapRights(id)).get,
             "metadata" -> objectOrEmpty(data \ "metadata").transform(wrapMetadata(id)).get,
             "usageRights" -> objectOrEmpty(data \ "usageRights").transform(wrapUsageRights(id)).get
           )
@@ -81,19 +80,4 @@ class Transformers(services: Services) {
       )
     }
 
-  def wrapRights(id: String): Reads[JsObject] =
-    __.read[JsArray].map { rights =>
-      Json.obj(
-        "uri" -> s"$metadataBaseUri/metadata/$id/rights",
-        "data" -> rights.value.map(right => right.transform(wrapRight(id)).get)
-      )
-    }
-
-  def wrapRight(id: String): Reads[JsObject] =
-    __.read[JsString].map { case JsString(right) =>
-      Json.obj(
-        "uri" -> s"$metadataBaseUri/metadata/$id/rights/${encodeUriParam(right)}",
-        "data" -> right
-      )
-    }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonPlayAppProperties.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonPlayAppProperties.scala
@@ -11,6 +11,4 @@ trait CommonPlayAppProperties {
 
   lazy val services = new Services(domainRoot, ssl)
 
-  lazy val freeRights: List[String] = List("handout", "PR image")
-
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -2,7 +2,7 @@
 package com.gu.mediaservice.lib.elasticsearch
 
 import play.api.libs.json.Json.JsValueWrapper
-import play.api.libs.json.{Json}
+import play.api.libs.json.Json
 
 
 object Mappings {
@@ -86,7 +86,6 @@ object Mappings {
     nonDynamicObj(
       "archived"    -> boolean,
       "labels"      -> nonAnalysedList("label"),
-      "rights"      -> nonAnalysedList("right"),
       "metadata"    -> metadataMapping,
       "usageRights" -> usageRightsMapping
     )

--- a/metadata-editor/app/model/edits.scala
+++ b/metadata-editor/app/model/edits.scala
@@ -11,10 +11,9 @@ import play.api.libs.functional.syntax._
 case class Edits(
   archived: Boolean = false,
   labels: List[String] = List(),
-  rights: List[String] = List(),
   metadata: ImageMetadata,
   usageRights: Option[UsageRights] = None
-  )
+)
 
 object Edits {
   type ArchivedEntity = EmbeddedEntity[Boolean]
@@ -25,7 +24,6 @@ object Edits {
   implicit val EditsReads: Reads[Edits] = (
     (__ \ "archived").readNullable[Boolean].map(_ getOrElse false) ~
     (__ \ "labels").readNullable[List[String]].map(_ getOrElse Nil) ~
-    (__ \ "rights").readNullable[List[String]].map(_ getOrElse Nil) ~
     (__ \ "metadata").readNullable[ImageMetadata].map(_ getOrElse emptyMetadata) ~
     (__ \ "usageRights").readNullable[UsageRights]
   )(Edits.apply _)
@@ -33,7 +31,6 @@ object Edits {
   implicit val EditsWrites: Writes[Edits] = (
       (__ \ "archived").write[Boolean] ~
       (__ \ "labels").write[List[String]] ~
-      (__ \ "rights").write[List[String]] ~
       (__ \ "metadata").writeNullable[ImageMetadata].contramap(noneIfEmptyMetadata) ~
       (__ \ "usageRights").writeNullable[UsageRights]
     )(unlift(Edits.unapply))
@@ -42,7 +39,6 @@ object Edits {
   def EditsWritesArgo(id: String): Writes[Edits] = (
       (__ \ "archived").write[ArchivedEntity].contramap(archivedEntity(id, _: Boolean)) ~
       (__ \ "labels").write[SetEntity].contramap(setEntity(id, "labels", _: List[String])) ~
-      (__ \ "rights").write[SetEntity].contramap(setEntity(id, "rights", _: List[String])) ~
       (__ \ "metadata").writeNullable[MetadataEntity].contramap(metadataEntity(id, _: ImageMetadata)) ~
       (__ \ "usageRights").writeNullable[UsageRightsEntity].contramap(usageRightsEntity(id, _: Option[UsageRights]))
     )(unlift(Edits.unapply))

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -10,10 +10,6 @@ GET     /metadata/:id/labels              controllers.Application.getLabels(id: 
 POST    /metadata/:id/labels              controllers.Application.addLabels(id: String)
 DELETE  /metadata/:id/labels/*label       controllers.Application.removeLabel(id: String, label: String)
 
-GET     /metadata/:id/rights              controllers.Application.getRights(id: String)
-POST    /metadata/:id/rights              controllers.Application.addRights(id: String)
-DELETE  /metadata/:id/rights/*right       controllers.Application.removeRight(id: String, right: String)
-
 GET     /metadata/:id/metadata            controllers.Application.getMetadata(id: String)
 PUT     /metadata/:id/metadata            controllers.Application.setMetadata(id: String)
 


### PR DESCRIPTION
This was left around unused but it'd be good to remote for sanity and clarity.

I've checked and no content has "rights" either in TEST or PROD.
