### PR TITLE
Correctly set script to groovy when upserting ingested image

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -51,13 +51,13 @@ object ElasticSearch extends ElasticSearchClient {
       .setScript(
         // Note: we merge old and new identifiers (in that order) to make easier to re-ingest
         // images without forwarding any existing identifiers.
-        """ | previousIdentifiers = ctx._source.identifiers;
-            | ctx._source += doc;
-            | if (previousIdentifiers) {
-            |   ctx._source.identifiers += previousIdentifiers;
-            |   ctx._source.identifiers += doc.identifiers;
-            | }
-            |""".stripMargin +
+        """| previousIdentifiers = ctx._source.identifiers;
+           | ctx._source += doc;
+           | if (previousIdentifiers) {
+           |   ctx._source.identifiers += previousIdentifiers;
+           |   ctx._source.identifiers += doc.identifiers;
+           | }
+           |""".stripMargin +
           refreshMetadataScript +
           updateLastModifiedScript,
         scriptType)


### PR DESCRIPTION
Master is failing on TEST because the scriptType is not correctly set to Groovy as it should be for the new upsert script.
