### PR TITLE
Rolling our own OptionalMapping.

### DIFF
--- a/metadata-editor/app/controllers/Application.scala
+++ b/metadata-editor/app/controllers/Application.scala
@@ -228,24 +228,26 @@ object Application extends Controller with ArgoHelpers {
   // JSON combinators
   val metadataForm: Form[ImageMetadata] = Form(
     single("data" -> mapping(
-      "dateTaken" -> optional(jodaDate),
-      "description" -> optional(text),
-      "credit" -> optional(text),
-      "byline" -> optional(text),
-      "bylineTitle" -> optional(text),
-      "title" -> optional(text),
-      "copyrightNotice" -> optional(text),
-      "copyright" -> optional(text),
-      "suppliersReference" -> optional(text),
-      "source" -> optional(text),
-      "specialInstructions" -> optional(text),
+      "dateTaken" -> trueOptional(jodaDate),
+      "description" -> trueOptional(text),
+      "credit" -> trueOptional(text),
+      "byline" -> trueOptional(text),
+      "bylineTitle" -> trueOptional(text),
+      "title" -> trueOptional(text),
+      "copyrightNotice" -> trueOptional(text),
+      "copyright" -> trueOptional(text),
+      "suppliersReference" -> trueOptional(text),
+      "source" -> trueOptional(text),
+      "specialInstructions" -> trueOptional(text),
       "keywords" -> default(list(text), List()),
-      "subLocation" -> optional(text),
-      "city" -> optional(text),
-      "state" -> optional(text),
-      "country" -> optional(text)
+      "subLocation" -> trueOptional(text),
+      "city" -> trueOptional(text),
+      "state" -> trueOptional(text),
+      "country" -> trueOptional(text)
     )(ImageMetadata.apply)(ImageMetadata.unapply))
   )
+
+  def trueOptional[T](mapping: Mapping[T]) = TrueOptionalMapping(mapping)
 
   val booleanForm: Form[Boolean] = Form(
      single("data" -> boolean)

--- a/metadata-editor/app/lib/TrueOptionalMapping.scala
+++ b/metadata-editor/app/lib/TrueOptionalMapping.scala
@@ -1,0 +1,87 @@
+/*
+Lifted from https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/data/Form.scala
+
+Why? To address this issue: https://github.com/playframework/playframework/issues/4346
+ */
+
+package lib
+
+import play.api.data.validation.Constraint
+import play.api.data.{FormError, Mapping}
+
+case class TrueOptionalMapping[T](wrapped: Mapping[T], val constraints: Seq[Constraint[Option[T]]] = Nil) extends Mapping[Option[T]] {
+
+  override val format: Option[(String, Seq[Any])] = wrapped.format
+
+  /**
+   * The field key.
+   */
+  val key = wrapped.key
+
+  /**
+   * Constructs a new Mapping based on this one, by adding new constraints.
+   *
+   * For example:
+   * {{{
+   *   import play.api.data._
+   *   import validation.Constraints._
+   *
+   *   Form("phonenumber" -> text.verifying(required) )
+   * }}}
+   *
+   * @param constraints the constraints to add
+   * @return the new mapping
+   */
+  def verifying(addConstraints: Constraint[Option[T]]*): Mapping[Option[T]] = {
+    this.copy(constraints = constraints ++ addConstraints.toSeq)
+  }
+
+  /**
+   * Binds this field, i.e. constructs a concrete value from submitted data.
+   *
+   * @param data the submitted data
+   * @return either a concrete value of type `T` or a set of error if the binding failed
+   */
+  def bind(data: Map[String, String]): Either[Seq[FormError], Option[T]] = {
+    data.keys.filter(p => p == key || p.startsWith(key + ".") || p.startsWith(key + "[")).map(k => data.get(k)).collect { case Some(v) => v }.headOption.map { _ =>
+      wrapped.bind(data).right.map(Some(_))
+    }.getOrElse {
+      Right(None)
+    }.right.flatMap(applyConstraints)
+  }
+
+  /**
+   * Unbinds this field, i.e. transforms a concrete value to plain data.
+   *
+   * @param value the value to unbind
+   * @return the plain data
+   */
+  def unbind(value: Option[T]): Map[String, String] = {
+    value.map(wrapped.unbind).getOrElse(Map.empty)
+  }
+
+  /**
+   * Unbinds this field, i.e. transforms a concrete value to plain data, and applies validation.
+   *
+   * @param value the value to unbind
+   * @return the plain data and any errors in the plain data
+   */
+  def unbindAndValidate(value: Option[T]): (Map[String, String], Seq[FormError]) = {
+    val errors = collectErrors(value)
+    value.map(wrapped.unbindAndValidate).map(r => r._1 -> (r._2 ++ errors)).getOrElse(Map.empty -> errors)
+  }
+
+  /**
+   * Constructs a new Mapping based on this one, adding a prefix to the key.
+   *
+   * @param prefix the prefix to add to the key
+   * @return the same mapping, with only the key changed
+   */
+  def withPrefix(prefix: String): Mapping[Option[T]] = {
+    copy(wrapped = wrapped.withPrefix(prefix))
+  }
+
+  /** Sub-mappings (these can be seen as sub-keys). */
+  val mappings: Seq[Mapping[_]] = wrapped.mappings
+
+}


### PR DESCRIPTION
Play's OptionalMapping performs a filteNot(_.isEmpty) which treats an empty string as None.
We want to store the empty string as a metadata override; storing null will effectively delete the override and revert to system metadata.

Addresses [this](https://github.com/playframework/playframework/issues/4346).
