### PR TITLE
Rework 'click to edit' text.

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -66,10 +66,10 @@
                         blur="submit"
                         onbeforesave="ctrl.updateMetadata('title', $data)"
                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}"
-                        e:form="titleEditForm">{{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}</h2>
+                        e:form="titleEditForm">{{ctrl.metadata.title}}</h2>
                 </div>
 
-                <div class="image-info__wrap">
+                <div class="image-info__wrap" ng:if="ctrl.metadata.description || ctrl.userCanEdit">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="descriptionEditForm.$show()"
@@ -95,7 +95,7 @@
                     </span>
                 </div>
 
-                <div class="image-info__byline image-info__wrap metadata-line">
+                <div class="image-info__byline image-info__wrap metadata-line" ng:if="ctrl.metadata.byline || ctrl.userCanEdit">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="bylineEditForm.$show()"
@@ -118,7 +118,7 @@
                     </span>
                 </div>
 
-                <div class="image-info__credit image-info__wrap metadata-line">
+                <div class="image-info__credit image-info__wrap metadata-line" ng:if="ctrl.metadata.credit || ctrl.userCanEdit">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="creditEditForm.$show()"


### PR DESCRIPTION
When image has no byline, if the user doesn't have edit permission, then no html is rendered. If the user does have edit permission, then the 'click to edit' message is rendered and the icon appears on hover.

When image has a byline, if the user doesn't have edit permission, then the byline is rendered. If the user does have edit permissions, then the edit icon appears on hover.
