### PR TITLE
Fix silly typo in thrall message consumer

### DIFF
--- a/thrall/app/lib/MessageConsumer.scala
+++ b/thrall/app/lib/MessageConsumer.scala
@@ -49,7 +49,7 @@ object MessageConsumer {
     PartialFunction.condOpt(subject) {
       case "image"                      => indexImage
       case "delete-image"               => deleteImage
-      case "update-image        "       => indexImage
+      case "update-image"               => indexImage
       case "update-image-exports"       => updateImageExports
       // TODO: deprecate once media-api no longer sends this
       case "update-image-metadata"      => updateImageMetadata


### PR DESCRIPTION
Was preventing (rare and manual) image reindex message from being applied.
