### PR TITLE
Retire no longer used 'update-image-metadata' thrall processor

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -116,21 +116,6 @@ object ElasticSearch extends ElasticSearchClient {
       .executeAndLog(s"updating exports on image $id")
       .incrementOnFailure(conflicts) { case e: VersionConflictEngineException => true }
 
-  def updateImageMetadata(id: String, metadata: JsValue)(implicit ex: ExecutionContext): Future[UpdateResponse] =
-    prepareImageUpdate(id)
-      .setScriptParams(Map(
-        "metadata" -> asGroovy(metadata),
-        "lastModified" -> asGroovy(JsString(currentIsoDateString))
-      ).asJava)
-      // replace metadata, then merge in edits
-      .setScript(
-        "ctx._source.originalMetadata = metadata;" +
-          refreshMetadataScript +
-          updateLastModifiedScript,
-        scriptType)
-      .executeAndLog(s"updating image metadata on image $id")
-      .incrementOnFailure(conflicts) { case e: VersionConflictEngineException => true }
-
   def applyImageMetadataOverride(id: String, metadata: JsValue)(implicit ex: ExecutionContext): Future[UpdateResponse] =
     prepareImageUpdate(id)
       .setScriptParams(Map(

--- a/thrall/app/lib/MessageConsumer.scala
+++ b/thrall/app/lib/MessageConsumer.scala
@@ -51,8 +51,6 @@ object MessageConsumer {
       case "delete-image"               => deleteImage
       case "update-image        "       => indexImage
       case "update-image-exports"       => updateImageExports
-      // TODO: deprecate once media-api no longer sends this
-      case "update-image-metadata"      => updateImageMetadata
       case "update-image-user-metadata" => updateImageUserMetadata
     }
 
@@ -71,9 +69,6 @@ object MessageConsumer {
 
   def updateImageExports(exports: JsValue): Future[UpdateResponse] =
     withImageId(exports)(id => ElasticSearch.updateImageExports(id, exports \ "data"))
-
-  def updateImageMetadata(metadata: JsValue): Future[UpdateResponse] =
-    withImageId(metadata)(id => ElasticSearch.updateImageMetadata(id, metadata \ "data"))
 
   def updateImageUserMetadata(metadata: JsValue): Future[UpdateResponse] =
     withImageId(metadata)(id => ElasticSearch.applyImageMetadataOverride(id, metadata \ "data"))


### PR DESCRIPTION
Was only use for image reindex and now superseded (since a good week back) by `"update-image"`.
