### PR TITLE
First pass at metadata editing with permissions.

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -183,6 +183,11 @@ service.factory('editsService',
         });
     }
 
-    return { update, add, on, remove };
+    function canUserEdit(image) {
+        return image.getLink('edits')
+            .then(() => true, () => false);
+    }
+
+    return { update, add, on, remove, canUserEdit };
 
 }]);

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -55,9 +55,9 @@ image.controller('ImageCtrl', [
             ctrl.canBeCropped = croppable;
         });
 
-        // Only specific people should be able to edit metadata.
-        // TODO replace this with actual logic.
-        ctrl.userCanEdit = false;
+        editsService.canUserEdit(image).then(editable => {
+            ctrl.userCanEdit = editable;
+        });
 
         var ignoredMetadata = [
             'title', 'description', 'copyright', 'keywords', 'byline',


### PR DESCRIPTION
User can edit metadata if they uploaded the image.
Note, this is only within the media api, the metadata-editor api needs updating.

Builds on top of [#689](https://github.com/guardian/media-service/pull/689) and [#702](https://github.com/guardian/media-service/pull/702).
