### PR TITLE
add padding onto metadata inputs

### DIFF
--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -12,6 +12,7 @@
                 ng:controller="DescriptionPlaceholderCtrl"
                 ng:change="ctrl.save()"
                 ng:model-options="{updateOn: 'default blur', debounce: { default: 500, blur: 0 }}"
+                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
             ></textarea>
 
             <button
@@ -34,6 +35,7 @@
                 ng:model="ctrl.metadata.byline"
                 ng:change="ctrl.save()"
                 ng:model-options="{updateOn: 'default blur', debounce: { default: 500, blur: 0 }}"
+                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
             />
 
             <button

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1150,6 +1150,10 @@ FIXME: what to do with touch devices
     display: inline-block;
     flex-grow: 1;
 }
+.job-info--editor__input--with-batch {
+    padding-right: 25px;
+}
+
 .job-info--editor__input--description {
     height: 4em;
 }
@@ -1211,10 +1215,11 @@ FIXME: what to do with touch devices
 
 .job-editor__apply-to-all {
     position: absolute;
-    right: 5px;
+    /* These positions are so that we don't overlay the input borders */
+    right: 1px;
     top: 1px;
     z-index: 1;
-    padding-left: 5px;
+    padding: 0 5px;
     background: #444;
 }
 


### PR DESCRIPTION
Adding padding to the right of the inputs on the required metadata fields so you can see what you're editing.

I've left it off the credit field as it's a bit of a headache as we've applied the styles to inputs directly (doh!).
Credits should never really be that long - and batch application will be changing soon I think.
