### PR TITLE
Bump base AMIs in provisioning script to latest

### DIFF
--- a/cloud-formation/provisioning.json
+++ b/cloud-formation/provisioning.json
@@ -27,11 +27,6 @@
             "sudo mkdir -p /root/aws-cfn-bootstrap-latest",
             "sudo tar xvfz /root/aws-cfn-bootstrap-latest.tar.gz --strip-components=1 -C /root/aws-cfn-bootstrap-latest",
 
-            "# TODO: Remove hack when PBR is ready",
-            "# we force the version of PBR here with pip as v0.10.3 breaks",
-            "# see: https://forums.aws.amazon.com/thread.jspa?messageID=590567#590567",
-            "sudo easy_install pip",
-            "sudo pip install pbr==0.10.2",
             "sudo easy_install /root/aws-cfn-bootstrap-latest/"
         ]
     }]


### PR DESCRIPTION
This should hopefully speed up our deploys a lot.

Also remove pbr hack (I noticed pbr got upgraded since the issue, but to be tested in a real deploy).
