### PR TITLE
Add new AP credit

### DIFF
--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -63,6 +63,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
     "Alamy",
     "Allsport",
     "Allstar Picture Library",
+    "ASSOCIATED PRESS",
     "Associated Press",
     "BBC",
     "BFI",


### PR DESCRIPTION
I would argue that it's the wrong capitilisation - [but it's how quite a few are coming in](https://media.gutools.co.uk/search?query=credit:%22ASSOCIATED%20PRESS%22&nonFree=true).

Anything with the [correct capitilisation](https://media.gutools.co.uk/search?query=credit:%22Associated%20Press%22) has been uploaded by us.
