### PR TITLE
remove complete jobs from upload jobs list

### DIFF
--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -7,7 +7,8 @@ upload.controller('UploadCtrl',
                   ['$scope', 'uploadManager', 'mediaApi',
                    function($scope, uploadManager, mediaApi) {
 
-    this.latestJob = uploadManager.listUploads().slice(-1)[0];
+    // TODO: Show multiple jobs?
+    this.latestJob = uploadManager.getLatestRunningJob();
 
     // my uploads
     mediaApi.getSession().then(session => {


### PR DESCRIPTION
Fixes #668.

This means that the "Current uploads" section will only show uploads that are currently uploading.
There's more functionality that could be added, but let's see if we need it first.

![reset-jobs](https://cloud.githubusercontent.com/assets/31692/7608222/7c2002f4-f95f-11e4-9282-e11e37facb3e.gif)

Sorry for the slow gif.
