### PR TITLE
add email to events that happen in mixpanel

### DIFF
--- a/kahuna/public/js/mixpanel/mixpanel.js
+++ b/kahuna/public/js/mixpanel/mixpanel.js
@@ -32,7 +32,8 @@ mp.factory('mixpanel', ['$window', 'mixpanelEnabled', function($window, mixpanel
 
         // also record browser version alongside each event
         mixpanel.register_once(angular.extend({
-            'Browser version': browser.major
+            'Browser version': browser.major,
+            'Email': email
         }, registerProps));
     }
 


### PR DESCRIPTION
There is no easy way of cross-referencing the People and Event APIs of Mixpanbel without digging into the APIs.

This will allow us to do things like [check who's getting 419 errors](https://mixpanel.com/report/592271/segmentation/#action:segment,arb_event:'Authentication%20error',bool_op:and,chart_analysis_type:linear,chart_type:line,from_date:-29,segfilter:!%28%28filter:%28operand:'401',operator:%3D%3D%29,property:'Error%20code',selected_property_type:number,type:number%29,%28property:Email,selected_property_type:string,type:string%29%29,segment_type:string,to_date:0,type:general,unit:day).
