### PR TITLE
Add time to backup name

### DIFF
--- a/elasticsearch/scripts/run-s3-snapshot-backup.sh
+++ b/elasticsearch/scripts/run-s3-snapshot-backup.sh
@@ -4,6 +4,6 @@ MASTER=$(curl -s http://localhost:9200/_cat/master?h=ip)
 MY_IP=$(curl -s http://instance-data/latest/meta-data/local-ipv4)
 
 if [ $MY_IP = $MASTER ]; then
-    DATE=$(date +%Y-%m-%d)
+    DATE=$(date +%Y-%m-%d-%T)
     curl -s -XPUT http://localhost:9200/_snapshot/s3/${DATE}?wait_for_completion=true
 fi


### PR DESCRIPTION
Allows sub-day backups to made.

Current 15 minute backups don't work as backup names are not unique.

Should be deployed before https://github.com/guardian/grid-infra/pull/40
