### PR TITLE
Listening to the update-end event to update the page on save of metadata.

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -59,6 +59,9 @@ image.controller('ImageCtrl', [
             ctrl.userCanEdit = editable;
         });
 
+        const onMetadataUpdateEnd =
+            editsService.on(image.data.userMetadata.data.metadata, 'update-end', onSave);
+
         var ignoredMetadata = [
             'title', 'description', 'copyright', 'keywords', 'byline',
             'credit', 'subLocation', 'city', 'state', 'country',
@@ -103,6 +106,13 @@ image.controller('ImageCtrl', [
             return editsService.update(image.data.userMetadata.data.metadata, metadata, ctrl.image);
         }
 
+        function onSave () {
+            return ctrl.image.get()
+                .then(newImage => {
+                    ctrl.image = newImage;
+                })
+        }
+
         ctrl.updateMetadata = function (field, value) {
             if (ctrl.metadata[field] === value) {
                 /*
@@ -124,4 +134,8 @@ image.controller('ImageCtrl', [
             return save(changed)
                 .catch(() => 'failed to save (press esc to cancel)');
         };
+
+        $scope.$on('$destroy', () => {
+            onMetadataUpdateEnd();
+        });
     }]);


### PR DESCRIPTION
Primary use case is to show the cost status of the image without having to reload the page after an edit.

![metadata-edit-woo](https://cloud.githubusercontent.com/assets/836140/7653106/392ae79a-fb0b-11e4-9cd0-819400a6d98b.gif)
