### PR TITLE
Universal newlines

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -49,10 +49,6 @@ image.controller('ImageCtrl', [
         ctrl.isUsefulMetadata = isUsefulMetadata;
         ctrl.cropSelected = cropSelected;
 
-        // This is here as we sometimes get \r from images as they've edited on
-        // MS machines. This way we get the best of both.
-        ctrl.universalNewlines = text => text.replace('\r|\n', '\r\n');
-
         mediaCropper.getCropsFor(image).then(crops => {
             ctrl.crops = crops;
             ctrl.crop = crops.find(crop => crop.id === cropKey);
@@ -162,3 +158,10 @@ image.controller('ImageCtrl', [
             onMetadataUpdateEnd();
         });
     }]);
+
+
+image.filter('universalNewlines', function() {
+    // This is here as we sometimes get \r from images as they've edited on
+    // MS machines. This way we get the best of both.
+    return text => text.replace('\r|\n', '\r\n');
+});

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -82,7 +82,7 @@
                          onbeforesave="ctrl.updateMetadata('description', $data)"
                          e:msd-elastic
                          e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}"
-                         e:form="descriptionEditForm">{{ctrl.universalNewlines(ctrl.metadata.description) || "unknown (click ✎ to add the description)"}}</div>
+                         e:form="descriptionEditForm">{{(ctrl.metadata.description|universalNewlines) || "unknown (click ✎ to add the description)"}}</div>
                 </div>
             </div>
 


### PR DESCRIPTION
Sometimes we get `\r` from the metadata of the image.
This way we display it correctly irrespective of OS, although it will save with whatever your OS decides to use.
