### PR TITLE
catch errors from panda lib and respond to client

### DIFF
--- a/kahuna/app/controllers/Panda.scala
+++ b/kahuna/app/controllers/Panda.scala
@@ -3,12 +3,19 @@ package controllers
 import lib.Config
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
-import com.gu.mediaservice.lib.auth.PanDomainAuthActions
+import com.gu.mediaservice.lib.auth.{ArgoErrorResponses, PanDomainAuthActions}
 import com.gu.pandomainauth.model.AuthenticatedUser
+import com.gu.pandomainauth.service.GoogleAuthException
 
-object Panda extends Controller with PanDomainAuthActions {
+import scala.concurrent.Future
+import scala.util.{Success, Try, Failure}
+
+object Panda extends Controller
+  with PanDomainAuthActions
+  with ArgoErrorResponses {
 
   override lazy val authCallbackBaseUri = Config.rootUri
+  def loginUri: String = Config.loginUri
 
   def session = Action { implicit request =>
     readAuthenticatedUser(request).map { case AuthenticatedUser(user, _, _, _, _) =>
@@ -31,7 +38,16 @@ object Panda extends Controller with PanDomainAuthActions {
   }
 
   def oauthCallback = Action.async { implicit request =>
-    processGoogleCallback()
+    // We use the `Try` here as the `GoogleAuthException` are thrown before we
+    // get to the asynchronicity of the `Future` it returns.
+    Try(processGoogleCallback) match {
+      case Success(result) => result
+      case Failure(error) => Future.successful(error match {
+        // This is when session session args are missing
+        case e: GoogleAuthException =>
+          respondError(BadRequest, "missing-session-parameters", e.getMessage, loginLinks)
+      })
+    }
   }
 
   def logout = Action { implicit request =>

--- a/kahuna/app/lib/Config.scala
+++ b/kahuna/app/lib/Config.scala
@@ -7,6 +7,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val properties = Properties.fromPath("/etc/gu/kahuna.properties")
 
+  val loginUri: String = services.loginUri
   val rootUri: String = services.kahunaBaseUri
   val mediaApiUri: String = services.apiBaseUri
 


### PR DESCRIPTION
Fixes #750.

[Catch errors from the Panda client](https://github.com/guardian/pan-domain-authentication/blob/90a15dbc56d6bd160f8805c81fc6fca00c04afc4/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala#L112) and respond appropriately.

e.g. response:

``` JSON
{
  "errorKey": "missing-session-parameters",
  "errorMessage": "missing anti forgery token",
  "links": [
    {
      "rel": "login",
      "href": "https://media.local.dev-gutools.co.uk/login"
    }
  ]
}
```
