### PR TITLE
Store uploadTime on S3 object for original image

### DIFF
--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -5,13 +5,14 @@ import java.io.File
 import play.api.libs.concurrent.Execution.Implicits._
 import scala.concurrent.Future
 
-import lib.imaging.{FileMetadataReader, MimeTypeDetection, Thumbnailer}
+import lib.imaging.{FileMetadataReader, Thumbnailer}
 import lib.Config
 
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
 import com.gu.mediaservice.lib.resource.FutureResources._
 import com.gu.mediaservice.lib.cleanup.{SupplierProcessors, MetadataCleaners}
 import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.lib.formatting._
 
 import lib.storage.ImageStore
 import com.gu.mediaservice.model._
@@ -63,7 +64,10 @@ case object ImageUpload {
     uploadRequest.id,
     uploadRequest.tempFile,
     uploadRequest.mimeType,
-    Map("uploaded_by" -> uploadRequest.uploadedBy) ++ uploadRequest.identifiersMeta
+    Map(
+      "uploaded_by" -> uploadRequest.uploadedBy,
+      "upload_time" -> printDateTime(uploadRequest.uploadTime)
+    ) ++ uploadRequest.identifiersMeta
   )
   def storeThumbnail(uploadRequest: UploadRequest, thumbFile: File) = ImageStore.storeThumbnail(
     uploadRequest.id,


### PR DESCRIPTION
Otherwise the S3 object does not have all the information necessary to idempotently re-load the image (esp. if it has somehow been lost from the ES index). This is particularly important for Library images, although it is true for all.

There is a related tech debt entry of retro-filling that information on existing images.
