### PR TITLE
Avoid big log files

### DIFF
--- a/elasticsearch/logging.yml
+++ b/elasticsearch/logging.yml
@@ -1,4 +1,4 @@
-rootLogger: DEBUG, file
+rootLogger: INFO, file
 
 logger:
   # log action execution errors for easier debugging


### PR DESCRIPTION
Do not set the logging level to DEBUG to avoid filling log file
