### PR TITLE
Report processing latency of messages in thrall

### DIFF
--- a/thrall/app/lib/ThrallMetrics.scala
+++ b/thrall/app/lib/ThrallMetrics.scala
@@ -17,4 +17,6 @@ object ThrallMetrics extends CloudWatchMetrics(s"$stage/Thrall", awsCredentials)
 
   val failedQueryUpdates = new CountMetric("FailedQueryUpdates")
 
+  val processingLatency = new TimeMetric("ProcessingLatency")
+
 }


### PR DESCRIPTION
Report the latency between when a message is posted to SNS and when it has been applied by thrall, as a new CloudWatch metric.

I've got a suspicion (confirmed by early experiments) that the latency is quite high, and I want to get this in to collect some data before I do the change to use long-polling, so we can compare.
