### PR TITLE
Strip empty values '' from metadata

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -164,6 +164,9 @@ object ElasticSearch extends ElasticSearchClient {
     """| ctx._source.metadata = ctx._source.originalMetadata;
        | if (ctx._source.userMetadata && ctx._source.userMetadata.metadata) {
        |   ctx._source.metadata += ctx._source.userMetadata.metadata;
+       |   // Get rid of "" values
+       |   def nonEmptyKeys = ctx._source.metadata.findAll { it.value != "" }.collect { it.key }
+       |   ctx._source.metadata = ctx._source.metadata.subMap(nonEmptyKeys)
        | }
     """.stripMargin
 


### PR DESCRIPTION
Fixes https://github.com/guardian/media-service/issues/753 by removing any empty string value from the `metadata` map after it has been computed.

Not the world's most elegant piece of code, but it has to be in Groovy to apply within the update "transaction".
