### PR TITLE
Use long polling in thrall

### DIFF
--- a/thrall/app/lib/MessageConsumer.scala
+++ b/thrall/app/lib/MessageConsumer.scala
@@ -36,7 +36,8 @@ object MessageConsumer {
 
   def processMessages() {
     // Pull 1 message at a time to avoid starvation
-    // Wait for maximum duration (20s) as per doc recommendation
+    // Wait for maximum duration (20s) as per doc recommendation:
+    // http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html
     for (msg <- poll(waitTime = 20, maxMessages = 1)) {
       val future = for {
         message <- Future(extractSNSMessage(msg) getOrElse sys.error("Invalid message structure (not via SNS?)"))


### PR DESCRIPTION
Update SQS consumer to use long polling (waits up to 20s to pull 1 new message).

In my local experiments, this significantly reduced the processing latency of messages. Not sure about throughput.
