### PR TITLE
Enforce content-length on image-loader

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/BodyParsers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/BodyParsers.scala
@@ -9,7 +9,7 @@ import scala.util.{Left, Right, Either}
 import play.api.libs.iteratee.Iteratee
 import play.api.mvc.BodyParser
 import play.api.mvc.Results.Status
-
+import play.api.Logger
 
 case class DigestedFile(file: File, digest: String)
 
@@ -22,17 +22,26 @@ object BodyParsers {
 
   def digestedFile(to: File)(implicit ex: ExecutionContext): BodyParser[DigestedFile] =
     BodyParser("digested file, to=" + to) { request => {
-      Iteratee.fold[Array[Byte], (MessageDigest, FileOutputStream)]((MessageDigest.getInstance("SHA-1"), new FileOutputStream(to))) {
-        case ((md, os), data) =>
+      Iteratee.fold[Array[Byte], (MessageDigest, FileOutputStream)](
+        (MessageDigest.getInstance("SHA-1"), new FileOutputStream(to))) {
+
+        case ((md, os), data) => {
           md.update(data)
           os.write(data)
+
           (md, os)
+        }
+
       }.map { case (md, os) =>
         os.close()
-
-        request.headers.get("Content-Length").foldLeft[Either[Status, DigestedFile]](Left(Status(411))) { (_,expectedContentLength) =>
-          if(to.length==expectedContentLength.toInt) Right(DigestedFile(to, md.digest))
-          else Left(Status(400))
+        request.headers.get("Content-Length").foldLeft[Either[Status, DigestedFile]](Left(Status(411))) {
+          (_,expectedContentLength) => {
+            if(to.length==expectedContentLength.toInt) Right(DigestedFile(to, md.digest))
+            else {
+              Logger.info("Received file does not match specified 'Content-Length'")
+              Left(Status(400))
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes the issue with the `image-loader` accepting truncated images by enforcing the `Content-Length` header. This results in:
- 400 if Content-Length is incorrect.
- 411 if Content-Length is missing
