### PR TITLE
Recommended restriction text

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -50,7 +50,7 @@ class NoSuchUsageRightsCategory(category: String) extends RuntimeException(s"no 
 
 trait UsageRightsCategory {
   val name = toString.replace("-", " ").split(" ").map(_.capitalize).mkString(" ")
-  val restrictions: Option[String] = None
+  val recommendedRestrictions: Option[String] = None
 }
 object UsageRightsCategory {
   private val usageRightsCategories =
@@ -90,7 +90,7 @@ case object Screengrab
 case object GuardianWitness
   extends UsageRightsCategory {
     override def toString = "guardian-witness"
-    override val restrictions =
+    override val recommendedRestrictions =
       Some("Images may only be used in association with the assignment, otherwise standard editorial charges apply")
   }
 

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -49,7 +49,7 @@ object EditsApi extends Controller with ArgoHelpers {
   def getUsageRights = Authenticated { usageRightsResponse }
 }
 
-case class CategoryResponse(value: String, name: String, cost: String, restrictions: Option[String] = None)
+case class CategoryResponse(value: String, name: String, cost: String, recommendedRestrictions: Option[String] = None)
 object CategoryResponse {
   // I'd like to have an override of the `apply`, but who nows how you do that
   // with the JSON parsing stuff
@@ -58,7 +58,7 @@ object CategoryResponse {
       value = cat.toString,
       name  = cat.name,
       cost  = UsageRightsConfig.categoryCosts.getOrElse(cat, Pay).toString,
-      restrictions = cat.restrictions
+      recommendedRestrictions = cat.recommendedRestrictions
     )
 
   implicit val categoryResponseWrites: Writes[CategoryResponse] = Json.writes[CategoryResponse]


### PR DESCRIPTION
Sense checking what I am doing here.
Add a `recommendedRestrictions` to stop people filling in the same thing a million times.

Quite easy to add to the UI if we think it'll be useful.

All other categories don't really have fixed restrictions.
Text was supplied by Jo B.
