### PR TITLE
Clear the selection on search result scope destroy.

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -192,5 +192,9 @@ results.controller('SearchResultsCtrl', [
                 selection.add(updatedImage);
             }
         });
+
+        $scope.$on('$destroy', function() {
+            selection.clear();
+        });
     }
 ]);


### PR DESCRIPTION
Ensures that the selection is cleared on navigation/state change.
