### PR TITLE
stop filtering on cost in usageRights

### DIFF
--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -64,13 +64,7 @@ trait SearchFilters extends ImageFields {
   // We're showing `Conditional` here too as we're considering them potentially
   // free. We could look into sending over the search query as a cost filter
   // that could take a comma seperated list e.g. `cost=free,conditional`.
-  val freeUsageRightsOverrideFilter = List(Free, Conditional).map(_.toString).toNel.map(filters.terms(editsField(usageRightsField("cost")), _))
-  val freeUsageRightsCategoryFilter = CostCalculator.getCategoriesOfCost(Free).map(_.toString).toNel.map(filters.terms(usageRightsField("category"), _))
-
-  val freeUsageRightsFilter = (freeUsageRightsOverrideFilter, freeUsageRightsCategoryFilter) match {
-    case (Some(freeUsageRightsOverride), Some(freeUsageRightsCategory)) => Some(filters.or(freeUsageRightsOverride, freeUsageRightsCategory))
-    case (freeUsageRightsOverrideOpt,    freeUsageRightsCategoryOpt)    => freeUsageRightsOverrideOpt orElse freeUsageRightsCategoryOpt
-  }
+  val freeUsageRightsFilter = CostCalculator.getCategoriesOfCost(List(Free, Conditional)).map(_.toString).toNel.map(filters.terms(usageRightsField("category"), _))
 
   val freeFilter = (freeMetadataFilter, freeUsageRightsFilter) match {
     case (Some(freeMetadata), Some(freeUsageRights)) => Some(filters.or(freeMetadata, freeUsageRights))

--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -25,8 +25,8 @@ object CostCalculator {
       categoryCost.orElse(supplierCost)
   }
 
-  def getCategoriesOfCost(cost: Cost): List[UsageRightsCategory] =
-    categoryCosts.filter(_._2 == cost).keys.toList
+  def getCategoriesOfCost(costs: List[Cost]): List[UsageRightsCategory] =
+    categoryCosts.filter { case (_, cost) => costs.contains(cost) }.keys.toList
 
   private def isFreeSupplier(supplier: String) = freeSuppliers.contains(supplier)
 


### PR DESCRIPTION
One last bit that was left out on the deprecation of `cost`.
