### PR TITLE
Fill 'credit' in for Getty if they didn't

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -105,7 +105,9 @@ object GettyParser extends ImageProcessor {
   def apply(image: Image): Image = image.fileMetadata.getty.isEmpty match {
     // Only images supplied by Getty have getty fileMetadata
     case false => image.copy(
-      usageRights = image.usageRights.copy(supplier = Some("Getty Images"), suppliersCollection = image.metadata.source)
+      usageRights = image.usageRights.copy(supplier = Some("Getty Images"), suppliersCollection = image.metadata.source),
+      // Set a default "credit" for when Getty is too lazy to provide one
+      metadata    = image.metadata.copy(credit = Some(image.metadata.credit.getOrElse("Getty Images")))
     )
     case true => image
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -157,6 +157,13 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.credit should be(Some("AFP/Getty"))
       processedImage.metadata.source should be(Some("AFP"))
     }
+
+    it("should use 'Getty Images' as credit if missing from the file metadata") {
+      val image = createImageFromMetadata()
+      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "lol.jpg")))
+      val processedImage = applyProcessors(gettyImage)
+      processedImage.metadata.credit should be(Some("Getty Images"))
+    }
   }
 
 


### PR DESCRIPTION
About 5000 Getty Images images in PROD are missing any `credit`, which makes them invalid. This does Getty's job for them by filling the field if they forgot to do so themselves.

This was identified by Jo yesterday, should be easy to reindex these images retroactively.
