### PR TITLE
Aggregate uploadedBy stats in ftp-watcher

### DIFF
--- a/ftp-watcher/app/lib/FTPWatcher.scala
+++ b/ftp-watcher/app/lib/FTPWatcher.scala
@@ -125,7 +125,7 @@ class FTPWatcher(host: String, user: String, password: String) {
         \/.right(path)
       }
       upload.onFinish {
-        case None      => uploadedImages.increment(List(uploadedByDimension(uploadedBy)))
+        case None      => incrementUploaded(uploadedBy)
         case Some(err) => failedUploads.increment(List(causedByDimension(err)))
       }.handle {
         case NonFatal(err) => \/.left(FailedUpload(path))

--- a/ftp-watcher/app/lib/FTPWatcherMetrics.scala
+++ b/ftp-watcher/app/lib/FTPWatcherMetrics.scala
@@ -6,6 +6,8 @@ import com.amazonaws.services.cloudwatch.model.Dimension
 
 object FTPWatcherMetrics extends CloudWatchMetrics(s"$stage/FTPWatcher", metricsAwsCredentials) {
 
+  def incrementUploaded(uploader: String) = uploadedImages.increment(uploadedBy(uploader))
+
   val retrievingImages = new CountMetric("RetrievingImages")
 
   val retrievedImages = new CountMetric("RetrievedImages")
@@ -16,6 +18,11 @@ object FTPWatcherMetrics extends CloudWatchMetrics(s"$stage/FTPWatcher", metrics
 
   def uploadedByDimension(value: String): Dimension =
     new Dimension().withName("UploadedBy").withValue(value)
+
+  def uploadedBy(value: String): List[Dimension] = List(
+    new Dimension().withName("UploadedBy").withValue(value),
+    new Dimension().withName("TotalUploads").withValue("uploads")
+  )
 
   def causedByDimension(thrown: Throwable): Dimension =
     new Dimension().withName("CausedBy").withValue(thrown.getClass.getSimpleName)


### PR DESCRIPTION
This adds a dimension to those recorded by the `ftp-watcher` which is the total uploads.

This will allow us to alarm more reliably in cases where the `ftp-watcher` is not uploading images.
