### PR TITLE
Fix upload metrics in ftp-watcher

### DIFF
--- a/ftp-watcher/app/lib/FTPWatcherMetrics.scala
+++ b/ftp-watcher/app/lib/FTPWatcherMetrics.scala
@@ -6,7 +6,10 @@ import com.amazonaws.services.cloudwatch.model.Dimension
 
 object FTPWatcherMetrics extends CloudWatchMetrics(s"$stage/FTPWatcher", metricsAwsCredentials) {
 
-  def incrementUploaded(uploader: String) = uploadedImages.increment(uploadedBy(uploader))
+  def incrementUploaded(uploader: String) =  {
+    uploadedImages.increment(List(uploadedByDimension(uploader)))
+    uploadedImages.increment()
+  }
 
   val retrievingImages = new CountMetric("RetrievingImages")
 
@@ -18,11 +21,6 @@ object FTPWatcherMetrics extends CloudWatchMetrics(s"$stage/FTPWatcher", metrics
 
   def uploadedByDimension(value: String): Dimension =
     new Dimension().withName("UploadedBy").withValue(value)
-
-  def uploadedBy(value: String): List[Dimension] = List(
-    new Dimension().withName("UploadedBy").withValue(value),
-    new Dimension().withName("TotalUploads").withValue("uploads")
-  )
 
   def causedByDimension(thrown: Throwable): Dimension =
     new Dimension().withName("CausedBy").withValue(thrown.getClass.getSimpleName)


### PR DESCRIPTION
Creates a separate dimensionless metric for uploaded images that is an aggregate of all uploads across suppliers.
