### PR TITLE
Fix bug where metadata edits were ignoring already applied edits.

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -201,7 +201,7 @@ service.factory('editsService',
 
         keys.forEach((key) => {
             if ((image.data.originalMetadata[key] || image.data.metadata[key]) &&
-                (metadata[key] !== image.data.metadata[key])) {
+                (metadata[key] !== image.data.originalMetadata[key])) {
 
                 diff[key] = metadata[key];
             }


### PR DESCRIPTION
Compare against `originalMetadata` rather than `metadata`. The `metadata` object contains the applied changes so doing a diff against it will not include an already existing edit.
Comparing against `originalMetadata` ensures any existing edit always gets sent in the PUT request.

For example:

Edit 1:
Title changes from "Title One" to "Title Two".

Edit 2:
Description changes from "Description One" to "Description Two".

Comparing against `image.data.metadata` means the payload of Edit 2 would be: `{"description": "Description Two"}` instead of `{"title": "Title Two", "description": "Description Two"}`.

The PUT request to the metadata-api requires the full metadata edit to be sent each time; maybe we could change this to a PATCH request?
