### PR TITLE
Smarter metadata setting.

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -200,10 +200,14 @@ service.factory('editsService',
         keys.delete('keywords');
 
         keys.forEach((key) => {
-            if ((image.data.originalMetadata[key] || image.data.metadata[key]) &&
-                (metadata[key] !== image.data.originalMetadata[key])) {
-
+            if (metadata[key] && !angular.isDefined(image.data.originalMetadata[key])) {
                 diff[key] = metadata[key];
+            } else if (metadata[key] !== image.data.originalMetadata[key] &&
+                image.data.originalMetadata[key] !== undefined) {
+                // if the user has provided an override of '' (e.g. they want remove the title),
+                // angular sets the value in the object to undefined.
+                // We need to use an empty string in the PUT request to obey user input.
+                diff[key] = metadata[key] || '';
             }
         });
 


### PR DESCRIPTION
I misunderstood [this feedback](https://github.com/guardian/media-service/pull/791#discussion_r32032732) and so the changes I made meant that the field had to be known on the image before updating it. This behaviour was wrong as it meant invalid images could not be edited as their missing fields could not be added.
