### PR TITLE
Fixing issue where a missing field is not treated correctly.

### DIFF
--- a/kahuna/public/js/services/preview-selection.js
+++ b/kahuna/public/js/services/preview-selection.js
@@ -14,13 +14,18 @@ selectionService.factory('selectionService', ['$q', 'editsService', function ($q
         var metadata = {};
         var cost = new Set();
 
-        for (let image of selectedImages) {
-            Object.keys(image.data.metadata).forEach((key) => {
+        var allFields = [];
+        selectedImages.forEach(img => allFields = allFields.concat(Object.keys(img.data.metadata)));
+
+        var uniqueFields = new Set(allFields);
+
+        selectedImages.forEach(image => {
+            uniqueFields.forEach((key) => {
                 metadata[key] = metadata[key] || new Set();
                 metadata[key].add(image.data.metadata[key]);
             });
             cost.add(image.data.cost);
-        }
+        });
         return {
             metadata: metadata,
             cost: cost


### PR DESCRIPTION
In a selection of images, its not guaranteed that all images have the same metadata fields, e.g. some may not have a title. `allFields` is the set of all unique metadata fields in the selection of images. Now, we loop over `allFields` to find the corresponding value or undefined for an image.

For example, if there are two images selected and one has a title and the other doesn't, the `metadata` object now looks like `{"title": Set {"title 1", undefined}` rather then `{"title: Set {"title 1"}`. As we switch on the size of `metadata`, we now correctly display "Multiple Titles" rather than "title 1".
