### PR TITLE
Couple of UI changes from user feedback.

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -32,7 +32,3 @@
 .panel__content {
     clear: both;
 }
-
-.panel__bottom .panel__close{
-    width: 100%;
-}

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -2,8 +2,10 @@
     class="panel panel--side panel--right image-details">
 
     <div class="panel__top">
-        <h1 class="panel__title">Metadata ({{ctrl.selectedImages.size}} image<span ng:if="ctrl.selectedImages.size > 1">s</span>)</h1>
-        <button class="panel__close" ng:click="ctrl.clear()" title="Clear selection and close">x</button>
+        <h1 class="panel__title">{{ctrl.selectedImages.size}} image<span ng:if="ctrl.selectedImages.size > 1">s</span> selected</h1>
+        <button class="panel__close" ng:click="ctrl.clear()" title="Clear selection and close">
+            <i class="material-icons">close</i>
+        </button>
     </div>
 
     <div class="panel__content">
@@ -171,9 +173,5 @@
             </div>
         </div>
 
-    </div>
-
-    <div class="panel__bottom">
-        <button class="panel__close button-shy" ng:click="ctrl.clear()">clear selection</button>
     </div>
 </div>


### PR DESCRIPTION
- Removing "clear selection" button; the "X" is enough.
- Updating "X" to material design close icon (woo!). For consistency, we should use the same icon as Workflow, however some work needs to be done to make them usable across products, e.g icon font generation.
- Rewording panel title from "Metadata (X images)" to "X images selected".

From
![screen shot 2015-06-17 at 15 10 10](https://cloud.githubusercontent.com/assets/836140/8209085/f995a310-1502-11e5-9292-f03b69838edf.png)

To
![screen shot 2015-06-17 at 15 09 47](https://cloud.githubusercontent.com/assets/836140/8209097/07649168-1503-11e5-8573-81c1f06f6a16.png)
