### PR TITLE
Correctly parse queries that include Unicode chars, accents, etc

### DIFF
--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -1,9 +1,6 @@
 package lib.querysyntax
 
-import scala.util.Try
-
 import org.joda.time.DateTime
-import org.joda.time.format.{DateTimeFormatter, DateTimeFormat}
 import org.parboiled2._
 
 class QuerySyntax(val input: ParserInput) extends Parser {
@@ -128,7 +125,21 @@ class QuerySyntax(val input: ParserInput) extends Parser {
   def NotDoubleQuote = rule { oneOrMore(noneOf(DoubleQuote)) }
 
   def Whitespace = rule { oneOrMore(' ') }
-  def Chars      = rule { oneOrMore(CharPredicate.Visible) }
+  def Chars = rule { oneOrMore(visibleChars) }
+
+
+  // Note: this is a somewhat arbitrarily list of common Unicode ranges that we
+  // expect people to want to use (e.g. Latin1 accented characters, curly quotes, etc).
+  // This is likely not exhaustive and will need reviewing in the future.
+  val latin1SupplementSubset = CharPredicate('\u00a1' to '\u00ff')
+  val latin1ExtendedA = CharPredicate('\u0100' to '\u017f')
+  val latin1ExtendedB = CharPredicate('\u0180' to '\u024f')
+  val generalPunctuation = CharPredicate('\u2010' to '\u203d')
+  val latin1ExtendedAdditional = CharPredicate('\u1e00' to '\u1eff')
+  val extraVisibleCharacters = latin1SupplementSubset ++ latin1ExtendedA ++ latin1ExtendedB ++ generalPunctuation
+
+  val visibleChars = CharPredicate.Visible ++ extraVisibleCharacters
+
 }
 
 // TODO:

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -11,6 +11,13 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter {
       Parser.run("cats") should be (List(Match(AnyField, Words("cats"))))
     }
 
+    it("should match single terms with accents") {
+      Parser.run("séb") should be (List(Match(AnyField, Words("séb"))))
+    }
+    it("should match single terms with curly apostrophe") {
+      Parser.run("l’apostrophe") should be (List(Match(AnyField, Words("l’apostrophe"))))
+    }
+
     it("should ignore surrounding whitespace") {
       Parser.run(" cats ") should be (List(Match(AnyField, Words("cats"))))
     }


### PR DESCRIPTION
Fixes https://github.com/guardian/media-service/issues/516

It turns out the problem was not Elasticsearch but our query parser. Parboiled2 isn't very culturally open-minded and `CharPredicate.Visible` doesn't include a lot of things that it ideally should, such as accented characters from Latin1 or extended, non-ASCII punctuation, etc.

This fixes the characters matched in a slightly ad-hoc way, but I don't know of a better way to deal with wide ranges of Unicode characters.

cc @paperboyo 
