### PR TITLE
Add placeholder to usage rights restrictions box

### DIFF
--- a/kahuna/public/js/edits/usage-rights-editor.html
+++ b/kahuna/public/js/edits/usage-rights-editor.html
@@ -36,6 +36,7 @@
         <textarea class="ure__restrictions-text"
                   msd-elastic
                   name="restrictions"
+                  placeholder="{{ctrl.restrictionsPlaceholder()}}"
                   ng:required="ctrl.category.cost === 'conditional'"
                   ng:model="ctrl.restrictions"
                   ng:disabled="ctrl.isDisabled()"></textarea>

--- a/kahuna/public/js/edits/usage-rights-editor.js
+++ b/kahuna/public/js/edits/usage-rights-editor.js
@@ -33,16 +33,25 @@ usageRightsEditor.controller('UsageRightsEditorCtrl',
             del();
         }
     };
+
     ctrl.isDisabled = () => ctrl.saving;
+
     ctrl.isNotEmpty = () => !angular.equals(ctrl.resource.data, {});
+
     ctrl.getCost = () => {
         // TODO: Can we move this to the server
         if (ctrl.restrictions) { return 'conditional'; }
 
         return ctrl.category && ctrl.category.cost;
     };
+
     ctrl.pluraliseCategory = () => ctrl.category.name +
         (ctrl.category.name.toLowerCase().endsWith('image') ? 's' : ' images');
+
+    ctrl.restrictionsPlaceholder = () => ctrl.getCost() === 'conditional' ?
+        'e.g. Use in relation to the Windsor Triathlon only' :
+        'Adding restrictions will mark this image as restricted. '+
+        'Leave blank if there aren\'t any.';
 
     function setCategories(cats) {
         ctrl.categories = cats;


### PR DESCRIPTION
I noticed that some of the free categories have now got `none` or `no restrictions` in the restrictions box.

Not a massively elegant solution - but I think it'll be better than having the restrictions box togllable if you are on a free category, whilst not on another...

I can then track to see if this stops it.
