### PR TITLE
Using correct metadataBaseUri.

### DIFF
--- a/metadata-editor/app/lib/EditsResponse.scala
+++ b/metadata-editor/app/lib/EditsResponse.scala
@@ -16,7 +16,7 @@ object EditsResponse {
   type MetadataEntity = EmbeddedEntity[ImageMetadata]
   type UsageRightsEntity = EmbeddedEntity[UsageRights]
 
-  val metadataBaseUri = Config.services
+  val metadataBaseUri = Config.services.metadataBaseUri
 
   // the types are in the arguments because of a whining scala compiler
   def editsResponseWrites(id: String): Writes[Edits] = (


### PR DESCRIPTION
`entityUri` uses `metadataBaseUri` to string format; `metadataBaseUri` should be the uri rather than a `Services` object.

This meant the URI in the response for [labels](https://media-metadata.test.dev-gutools.co.uk/metadata/1ed36b44cef9e3070cd198fc97c6903214b3a8c5/labels), for example, looked like:

``` json
{
"length": 1,
  "data": [
    {
      "uri": "com.gu.mediaservice.lib.config.Services@3d7b6196/metadata/1ed36b44cef9e3070cd198fc97c6903214b3a8c5/labels/test",
      "data": "test"
    }
  ]
}
```

i.e. the result of calling `toString` on Config.services.

rather than

``` json
{
"length": 1,
  "data": [
    {
      "uri": "https://media-metadata.test.dev-gutools.co.uk/metadata/1ed36b44cef9e3070cd198fc97c6903214b3a8c5/labels/test",
      "data": "test"
    }
  ]
}
```
