### PR TITLE
Better cost calculating taking no category into account

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -5,7 +5,6 @@ import com.gu.mediaservice.model._
 object UsageRightsConfig {
 
   val categoryCosts: Map[Option[UsageRightsCategory], Cost] = Map(
-    None                  -> Pay,
     Some(Handout)         -> Free,
     Some(Screengrab)      -> Free,
     Some(PrImage)         -> Conditional,

--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -20,7 +20,7 @@ object CostCalculator {
 
   def getCost(usageRights: ImageUsageRights): Option[Cost] = {
       val restricted  : Option[Cost] = usageRights.restrictions.map(r => Conditional)
-      val categoryCost: Option[Cost] = usageRights.category.flatMap(cat => getCost(Some(cat)))
+      val categoryCost: Option[Cost] = getCost(usageRights.category)
       val supplierCost: Option[Cost] = getCost(usageRights.supplier, usageRights.suppliersCollection)
 
       restricted
@@ -53,7 +53,6 @@ object CostCalculator {
   private def isFreeCredit(credit: String) = freeCreditList.contains(credit)
   private def isFreeSource(source: String) = freeSourceList.contains(source)
   private def isPaySource(source: String)  = payGettySourceList.contains(source)
-
 
 
   // This function is just used until we have deprecated the old model completely

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -1,7 +1,7 @@
 package lib.usagerights
 
-import com.gu.mediaservice.model.{Free, Handout, Conditional, ImageUsageRights}
-import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}
+import com.gu.mediaservice.model._
+import org.scalatest.{FunSpec, Matchers}
 
 class CostCalculatorTest extends FunSpec with Matchers {
 
@@ -24,15 +24,11 @@ class CostCalculatorTest extends FunSpec with Matchers {
       cost should be (Some(Conditional))
     }
 
-    it("should be conditional if there are restrictions") {
-      val usageRights = ImageUsageRights(restrictions = Some("Restrictions"))
-      val cost = CostCalculator.getCost(usageRights)
-
-      cost should be (Some(Conditional))
-    }
-
     it("should be free with a free supplier") {
-      val usageRights = ImageUsageRights(supplier = Some("Getty Images"))
+      val usageRights = ImageUsageRights(
+        category = Some(Agency),
+        supplier = Some("Getty Images")
+      )
       val cost = CostCalculator.getCost(usageRights)
 
       cost should be (Some(Free))
@@ -40,6 +36,7 @@ class CostCalculatorTest extends FunSpec with Matchers {
 
     it("should not be free with a free supplier but excluded collection") {
       val usageRights = ImageUsageRights(
+        category = Some(Agency),
         supplier = Some("Getty Images"),
         suppliersCollection = Some("Anadolu")
       )
@@ -47,6 +44,5 @@ class CostCalculatorTest extends FunSpec with Matchers {
 
       cost should be (None)
     }
-
   }
 }


### PR DESCRIPTION
I think the holes are starting to show with having `None` as a category.
I imagine there might have to be some movement in the model of having a `NoRights` type, but I'd like to get this out to use first.
