### PR TITLE
Display usageRights restrictions from image rather than from userMetadata

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -23,7 +23,7 @@
             <div ng:switch-when="conditional"
                  class="image-notice image-info__group cost cost--conditional"
                  title="This image can be used but only within certain restrictions">
-                <b>restricted use:</b> {{ctrl.image.data.usageRights.data.restrictions}}
+                <b>restricted use:</b> {{ctrl.image.data.usageRights.restrictions}}
             </div>
         </div>
 

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -32,7 +32,7 @@
 
                     <div ng:switch-when="conditional"
                          class="cost cost--conditional"
-                         title="{{ctrl.image.data.usageRights.data.restrictions}}">
+                         title="{{ctrl.image.data.usageRights.restrictions}}">
                          <!-- As `conditional` can only be set with usageRights, let's
                          just assume it's here. We might need to revisit this. -->
                         restricted use

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -50,7 +50,7 @@
                 <div ng:switch-when="conditional"
                      class="image-notice image-info__group cost cost--conditional"
                      title="This image can be used but only within certain restrictions">
-                    <b>restricted use:</b> {{ctrl.image.data.usageRights.data.restrictions}}
+                    <b>restricted use:</b> {{ctrl.image.data.usageRights.restrictions}}
                 </div>
             </div>
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -64,7 +64,7 @@
 
                 <div ng:switch-when="conditional"
                      class="cost cost--conditional"
-                     title="{{image.data.usageRights.data.restrictions}}">
+                     title="{{image.data.usageRights.restrictions}}">
                      <!-- As `conditional` can only be set with usageRights, let's
                      just assume it's here. We might need to revisit this. -->
                     restricted


### PR DESCRIPTION
This is necessary now that `restrictions` may appear on the image's `usageRights` but not in the `userMetadata` (if using the `defaultRestrictions` filled in by the API).

cc @jamesgorrie 
