### PR TITLE
Fix API search for free images

### DIFF
--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -28,8 +28,8 @@ object CostCalculator {
         .orElse(supplierCost)
   }
 
-  def getCategoriesOfCost(costs: List[Cost]): List[Option[UsageRightsCategory]] =
-    categoryCosts.filter { case (_, cost) => costs.contains(cost) }.keys.toList
+  def getCategoriesOfCost(costs: List[Cost]): List[UsageRightsCategory] =
+    categoryCosts.filter { case (_, cost) => costs.contains(cost) }.keys.flatten.toList
 
   private def isFreeSupplier(supplier: String) = freeSuppliers.contains(supplier)
 


### PR DESCRIPTION
I noticed images with `guardian-witness` category (or in fact any category) were not showing in the search results when filtering for free images. This was due to a bug that resulted in this ES query:

``` json
  // ...
  "terms" : {
    "usageRights.category" : [ "Some(screengrab)", "Some(obituary)", "Some(PR Image)", "Some(social-media)", "Some(handout)", "Some(guardian-witness)" ]
  }
```

With the fix:

``` json
  "terms" : {
    "usageRights.category" : [ "screengrab", "guardian-witness", "handout", "social-media", "obituary", "PR Image" ]
  }
```

Lesson: dangerous to use `toString` as part of the API (for `UsageRightsCategory`) as it easily gets substituted with `Object.toString` if the wrong type is passed and gives really wrong results.
