### PR TITLE
Add credit suggester to mapping

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -13,6 +13,12 @@ object Mappings {
   val snowballAnalysedString = Json.obj("type" -> "string", "analyzer" -> "snowball")
   val standardAnalysedString = Json.obj("type" -> "string", "analyzer" -> "standard")
 
+  val simpleSuggester = Json.obj(
+    "type" -> "completion",
+    "index_analyzer" -> "simple",
+    "search_analyzer" -> "simple"
+  )
+
   val integer = Json.obj("type" -> "integer")
   val boolean = Json.obj("type" -> "boolean")
   val dateFormat = Json.obj("type" -> "date")
@@ -44,25 +50,23 @@ object Mappings {
       "dimensions" -> dimensionsMapping
     )
 
-  val metadataMapping = Json.obj(
-    "properties" -> Json.obj(
-      "dateTaken" -> dateFormat,
-      "description" -> snowballAnalysedString,
-      "byline" -> standardAnalysedString,
-      "bylineTitle" -> standardAnalysedString,
-      "title" -> snowballAnalysedString,
-      "credit" -> nonAnalyzedString,
-      "copyright" -> standardAnalysedString,
-      "copyrightNotice" -> standardAnalysedString,
-      "suppliersReference" -> standardAnalysedString,
-      "source" -> nonAnalyzedString,
-      "specialInstructions" -> nonAnalyzedString,
-      "keywords" -> nonAnalysedList("keyword"),
-      "subLocation" -> standardAnalysedString,
-      "city" -> standardAnalysedString,
-      "state" -> standardAnalysedString,
-      "country" -> standardAnalysedString
-    )
+  val metadataMapping = nonDynamicObj(
+    "dateTaken" -> dateFormat,
+    "description" -> snowballAnalysedString,
+    "byline" -> standardAnalysedString,
+    "bylineTitle" -> standardAnalysedString,
+    "title" -> snowballAnalysedString,
+    "credit" -> nonAnalyzedString,
+    "copyright" -> standardAnalysedString,
+    "copyrightNotice" -> standardAnalysedString,
+    "suppliersReference" -> standardAnalysedString,
+    "source" -> nonAnalyzedString,
+    "specialInstructions" -> nonAnalyzedString,
+    "keywords" -> nonAnalysedList("keyword"),
+    "subLocation" -> standardAnalysedString,
+    "city" -> standardAnalysedString,
+    "state" -> standardAnalysedString,
+    "country" -> standardAnalysedString
   )
 
 
@@ -101,6 +105,10 @@ object Mappings {
       "usageRights" -> userMetadataUsageRightsMapping
     )
 
+  val suggesters = nonDynamicObj(
+    "credit" -> simpleSuggester
+  )
+
   val imageMapping: String =
     Json.stringify(Json.obj(
       "image" -> Json.obj(
@@ -119,7 +127,8 @@ object Mappings {
           "uploadTime" -> dateFormat,
           "uploadedBy" -> nonAnalyzedString,
           "lastModified" -> dateFormat,
-          "identifiers" -> dynamicObj
+          "identifiers" -> dynamicObj,
+          "suggesters" -> suggesters
         ),
         "dynamic_templates" -> Json.arr(Json.obj(
           "stored_json_object_template" -> Json.obj(


### PR DESCRIPTION
Adding [suggesters](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html) to Elastic.

Just trying to figure out where to put them - given the way they're queried differently, it seems nicer to have a namespaceish type thing to them.

This way we land up with an index looking something like:

`image.metadata.credit.suggest`
`image.suggest.metadata.credit`
`image.suggest.credit`

Trying to think of the shape of the API which might define this bettter. Thinking maybe:
`api.media/images/metadata/credit/suggest`
**OR**
`api.media/suggest/metadata/credit`
**OR**
`api.media/images/suggest/credit`

Thoughts?
