### PR TITLE
Fixing a bug where batch labelling on upload was broken.

### DIFF
--- a/kahuna/public/js/edits/labeller.js
+++ b/kahuna/public/js/edits/labeller.js
@@ -52,8 +52,10 @@ labeller.controller('LabellerCtrl',
     if (Boolean(this.withBatch)) {
         $scope.$on(batchApplyLabelsEvent, (e, labels) => this.addLabels(labels));
 
-        this.batchApplyLabels = () =>
-            $rootScope.$broadcast(batchApplyLabelsEvent, this.labels.data.map(label => label.data));
+        this.batchApplyLabels = () => {
+            const labels = this.image.data.userMetadata.data.labels;
+            $rootScope.$broadcast(batchApplyLabelsEvent, labels.data.map(label => label.data));
+        };
     }
 
 }]);


### PR DESCRIPTION
Bug is due to the directive scope changing with the introduction of the [label service](https://github.com/guardian/media-service/commit/5b6d1dd01ea2b31b7dbc9458c80d7df5923a9068); i.e `this.labels` was `undefined`. :sheep:

:scream: 
