### PR TITLE
Fix metadata edit erroring when no change has been made.

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -87,9 +87,11 @@ image.controller('ImageCtrl', [
         ctrl.updateMetadataField = function (field, value) {
             return editsService.updateMetadataField(image, field, value)
                 .then((updatedImage) => {
-                    ctrl.image = updatedImage;
-                    updateAbilities(updatedImage);
-                    track.success('Metadata edit', { field: field });
+                    if (updatedImage) {
+                        ctrl.image = updatedImage;
+                        updateAbilities(updatedImage);
+                        track.success('Metadata edit', { field: field });
+                    }
                 })
                 .catch(() => {
                     track.failure('Metadata edit', { field: field });


### PR DESCRIPTION
Noted by Sarah Gilbert (via @blishen).

> Edit metadata  - edit two fields at once and it all goes Pete Tong.
> Steps to reproduce are easy. On a picture page - click one edit pencil, and then another on a different field.

Proceed iff [`editsService.updateMetadataField`](https://github.com/guardian/media-service/blob/master/kahuna/public/js/edits/service.js#L214)'s Promise returns anything but false.

Per [xeditible docs](http://vitalets.github.io/angular-xeditable/#onbeforesave), returning a Promise that resolves to false means "success but no change", i.e. a cancelled edit. So we should only update state if the Promise is not false.
