### PR TITLE
Fix date filter clearing when pressing return in search field.

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -19,7 +19,10 @@
     <div class="gu-date-range__overlay search__overlay" ng:show="ctrl.showOverlay">
         <h2 class="gu-date-range__overlay__title search__overlay__title">Presets</h2>
         <div class="gu-date-range__overlay__presets">
-            <button class="gu-date-range__overlay__preset__button button" ng:repeat="presetDate in ctrl.guPresetDates" ng:click="setPresetDate(presetDate.value)">
+            <button type="button"
+                    class="gu-date-range__overlay__preset__button button"
+                    ng:repeat="presetDate in ctrl.guPresetDates"
+                    ng:click="setPresetDate(presetDate.value)">
                 {{presetDate.label}}
             </button>
         </div>
@@ -29,19 +32,35 @@
             <span class="gu-date-range__overlay__pikaday__wrapper">
                 <h2 class="gu-date-range__overlay__title search__overlay__title">From</h2>
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--start"/>
-                <button class="gu-date-range__overlay__pikaday__clear button-shy" ng:click="clearStart()">Clear</button>
+                <button type="button"
+                        class="gu-date-range__overlay__pikaday__clear button-shy"
+                        ng:click="clearStart()">
+                    Clear
+                </button>
             </span>
 
             <span class="gu-date-range__overlay__pikaday__wrapper">
                 <h2 class="gu-date-range__overlay__title search__overlay__title">To</h2>
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--end"/>
-                <button class="gu-date-range__overlay__pikaday__clear button-shy" ng:click="clearEnd()">Clear</button>
+                <button type="button"
+                        class="gu-date-range__overlay__pikaday__clear button-shy"
+                        ng:click="clearEnd()">
+                    Clear
+                </button>
             </span>
         </div>
 
         <div class="gu-date-range__overlay__buttons">
-            <button class="gu-date-range__overlay__button__cancel button-shy" ng:click="cancel()">Cancel</button>
-            <button class="gu-date-range__overlay__button__ok button" ng:click="save()">Filter</button>
+            <button type="button"
+                    class="gu-date-range__overlay__button__cancel button-shy"
+                    ng:click="cancel()">
+                Cancel
+            </button>
+            <button type="button"
+                    class="gu-date-range__overlay__button__ok button"
+                    ng:click="save()">
+                Filter
+            </button>
         </div>
     </div>
 


### PR DESCRIPTION
Prevent form submission when the return key is pressed in the search field by setting the `type` of the `button` elements to `button`.

The [form submission spec](http://www.w3.org/TR/html5/forms.html#implicit-submission) is horrible.

> A form element's default button is the first submit button in tree order whose form owner is that form element.
> 
> If the user agent supports letting the user submit a form implicitly (for example, on some platforms hitting the "enter" key while a text field is focused implicitly submits the form), then doing so for a form whose default button has a defined activation behavior must cause the user agent to run synthetic click activation steps on that default button.

We could also use `input[type=button]` rather than `button`s to prevent the default form submission behaviour - from the [Angular docs](https://code.angularjs.org/1.3.15/docs/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action):

> if a form has 2+ input fields and no buttons or input[type=submit] then hitting enter doesn't trigger submit
