### PR TITLE
Change path to metadata search

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -56,6 +56,8 @@ object MediaApi extends Controller with ArgoHelpers {
     val indexLinks = List(
       Link("search",          searchLinkHref),
       Link("image",           s"$rootUri/images/{id}"),
+      // FIXME: credit is the only field availble for now as it's the only on
+      // that we are indexing as a completion suggestion
       Link("metadata-search", s"$rootUri/suggest/metadata/{field}{?q}"),
       Link("cropper",         cropperUri),
       Link("loader",          loaderUri),


### PR DESCRIPTION
It's not completely true to functionality as you can't have a dynamic `{field}`, but I'd prefer to keep this in for later.

We can work on using the suggest naming when we deprecate the aggregates too if the results come back positive.
