### PR TITLE
Adjust z-index to avoid icons going over top bar

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -310,7 +310,7 @@ textarea.ng-invalid {
 .top-bar-wrapper {
     height: 48px; /* faking we're in the flow */
     position: relative;
-    z-index: 1;
+    z-index: 2;
 }
 
 .top-bar {
@@ -379,7 +379,7 @@ textarea.ng-invalid {
     left: 0;
     right: 0;
     top: 5px;
-    z-index: 1;
+    z-index: 2;
     text-align: center;
 }
 
@@ -1470,7 +1470,7 @@ FIXME: what to do with touch devices
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 1;
+    z-index: 3;
     text-align: center;
 }
 
@@ -1554,7 +1554,7 @@ FIXME: what to do with touch devices
     padding: 10px;
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.5);
     top: calc(100% + 12px);
-    z-index: 2;
+    z-index: 4;
     /* Drop items should win over everything */
 }
 .drop-menu__items--right {


### PR DESCRIPTION
Previously icons were going over the top bar.

![image](https://cloud.githubusercontent.com/assets/36964/8382726/908593f4-1c2c-11e5-9337-8388ab55f3bc.png)
