### PR TITLE
Ignoring drag events initiated from Grid

### DIFF
--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -145,9 +145,14 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply',
 
                 event.preventDefault();
 
-                if (isDraggingFromGrid(event)) {
-                    // noop - probably didn't mean to drop on Grid too
-                } else if (files.length > 0) {
+                if (! isDraggingFromGrid(event)) {
+                    performDropAction(files, uri);
+                }
+                scope.$apply(deactivate);
+            }
+
+            function performDropAction(files, uri) {
+                if (files.length > 0) {
                     ctrl.uploadFiles(files);
                 } else if (ctrl.isWitnessUri(uri)) {
                     ctrl.importing = true;
@@ -158,7 +163,6 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply',
                     $window.alert('You must drop valid files or ' +
                                   'GuardianWitness URLs to upload them');
                 }
-                scope.$apply(deactivate);
             }
 
             function clean() {


### PR DESCRIPTION
Currently, dragging an image from the Grid (e.g. from search results) triggers the drop zone, even though we never want to drop a Grid image onto the Grid. This disables the drop zone or any subsequent actions when dragging from the Grid (detected by presence of Grid drag data)
