### PR TITLE
Convert DataTransfer types to Array to fix FF bug

### DIFF
--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -113,7 +113,9 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply',
 
             function isDraggingFromGrid(event) {
                 const dataTransfer = event.originalEvent.dataTransfer;
-                return dataTransfer.types.indexOf(gridImageMimeType) !== -1;
+                // Convert as FF uses DOMStringList and Chrome an Array
+                const types = Array.from(dataTransfer.types);
+                return types.indexOf(gridImageMimeType) !== -1;
             }
 
             function over(event) {


### PR DESCRIPTION
Convert `types` of `DataTransfer` as FF uses DOMStringList and Chrome an Array :-/

Should fix:
https://app.getsentry.com/the-guardian/the-grid/group/70343364/
https://app.getsentry.com/the-guardian/the-grid/group/70343365/

Sentry BFF forever :sparkling_heart: 
