### PR TITLE
Making the thrall retry amount configurable.

### DIFF
--- a/cloud-formation/dot-properties/README.md
+++ b/cloud-formation/dot-properties/README.md
@@ -70,6 +70,7 @@ PROPERTIES = {
     'panda_aws_key': <PRIVATE_VALUE>,
     'panda_aws_secret': <PRIVATE_VALUE>,
     'cors': <PRIVATE_VALUE>,
+    'thrall_max_retries': <VALUE>
 }
 
 STACK = <CLOUD_FORMATION_NAME_OR_ID>

--- a/cloud-formation/dot-properties/settings/settings.py
+++ b/cloud-formation/dot-properties/settings/settings.py
@@ -12,6 +12,8 @@ INITIAL_PROPERTIES = {
     'panda_domain': '',
     'panda_aws_key': '',
     'panda_aws_secret': '',
+
+    'thrall_max_retries': 10,
 }
 
 AWS_PROFILE_NAME = 'media-service'

--- a/cloud-formation/dot-properties/templates/thrall.properties.template
+++ b/cloud-formation/dot-properties/templates/thrall.properties.template
@@ -3,3 +3,4 @@ aws.secret={{AwsSecret}}
 s3.image.bucket={{ImageBucket}}
 s3.thumb.bucket={{ThumbBucket}}
 sqs.queue.url={{SqsQueueUrl}}
+maxRetries={{thrall_max_retries}}

--- a/thrall/app/lib/Config.scala
+++ b/thrall/app/lib/Config.scala
@@ -1,5 +1,6 @@
 package lib
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
 import com.amazonaws.services.ec2.AmazonEC2Client
 import scalaz.syntax.id._
@@ -35,5 +36,9 @@ object Config extends CommonPlayAppConfig {
 
   // The presence of this identifier prevents deletion
   val persistenceIdentifier = "picdarUrn" // TODO: properties("persistence.identifier")
+
+  val maxRetries = properties("maxRetries").toInt
+
+  val clientConfiguration = new ClientConfiguration().withMaxErrorRetry(maxRetries)
 
 }

--- a/thrall/app/lib/MessageConsumer.scala
+++ b/thrall/app/lib/MessageConsumer.scala
@@ -33,7 +33,7 @@ object MessageConsumer {
     actorSystem.scheduler.scheduleOnce(0.seconds)(processMessages())
 
   lazy val client =
-    new AmazonSQSClient(Config.awsCredentials) <| (_ setEndpoint Config.awsEndpoint)
+    new AmazonSQSClient(Config.awsCredentials, Config.clientConfiguration) <| (_ setEndpoint Config.awsEndpoint)
 
   @tailrec
   def processMessages() {


### PR DESCRIPTION
The SDK [default retry amount is 3](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#DEFAULT_RETRY_POLICY) - set this number from the value of `maxRetries` in `thrall.properties`.

Still using the SDK [default retry conditions](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedRetryPolicies.java#L152).

(contributes to #570).
