### PR TITLE
Automatically resolve PagerDuty alerts if alarm is OK

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -137,13 +137,27 @@
                 </span>
             </div>
 
+
             <div class="image-info__wrap metadata-line image-info__credit">
                 <button class="image-info__edit"
                         ng:if="ctrl.userCanEdit"
                         ng:click="creditEditForm.$show()"
                         ng:hide="creditEditForm.$visible">✎</button>
                 credit
-                <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
+                <gr:datalist
+                    class="image-info--editor__input"
+                    gr:search="ctrl.metadataSearch('credit', q)">
+
+                    <input type="text"
+                        class="image-info__credit"
+                        required
+                        gr:datalist-input
+                        ng:model="ctrl.metadata.credit"
+                        ng:change="ctrl.save()"
+                        ng:model-options="{ updateOn: 'gr:datalist:update blur' }" />
+                </gr:datalist>
+
+               <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
                       editable-text="ctrl.metadata.credit"
                       onbeforesave="ctrl.updateMetadataField('credit', $data)"
                       e:form="creditEditForm"

--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -18,6 +18,7 @@ export var grPanel = angular.module('grPanel', [
 grPanel.controller('GrPanel', [
     '$scope',
     '$window',
+    'mediaApi',
     'selectionService',
     'labelService',
     'archiveService',
@@ -26,6 +27,7 @@ grPanel.controller('GrPanel', [
     function (
         $scope,
         $window,
+        mediaApi,
         selection,
         labelService,
         archiveService,
@@ -34,9 +36,16 @@ grPanel.controller('GrPanel', [
 
         var ctrl = this;
 
+
         ctrl.selectedImages = selection.selectedImages;
         ctrl.hasMultipleValues = (val) => Array.isArray(val);
         ctrl.clear = selection.clear;
+
+        ctrl.metadataSearch = (field, q) => {
+            return mediaApi.metadataSearch(field,  { q }).then(resource => {
+                return resource.data.map(d => d.key);
+            });
+        };
 
         $scope.$watch(() => selection.getMetadata(), onValChange(newMetadata => {
             ctrl.rawMetadata = newMetadata;


### PR DESCRIPTION
If a service is back in a healthy state, the PagerDuty alert should automatically be resolved.

To do this, we may need to use the proper CloudWatch/PagerDuty integration as described in:

https://www.pagerduty.com/docs/guides/aws-cloudwatch-integration-guide/
