### PR TITLE
Use correct cluster name in thrall and media-api conf.

### DIFF
--- a/media-api/conf/application.conf
+++ b/media-api/conf/application.conf
@@ -3,7 +3,7 @@ application.langs="en"
 session.httpOnly=false
 session.secure=true
 
-es.cluster = "media-api"
+es.cluster = "media-service"
 es.host = "localhost"
 es.port = 9300
 

--- a/thrall/conf/application.conf
+++ b/thrall/conf/application.conf
@@ -1,6 +1,6 @@
 application.langs="en"
 
-es.cluster = "media-api"
+es.cluster = "media-service"
 es.host = "localhost"
 es.port = 9300
 


### PR DESCRIPTION
Cluster name matches the one defined in the [ES yaml](https://github.com/guardian/grid/blob/master/elasticsearch/elasticsearch.yml#L6).

The logs for thrall and media-api no longer report `node null not part of the cluster Cluster [media-api], ignoring`

(Not entirely sure how these services were working when referencing a cluster that was different from elasticsearch?!?!)