### PR TITLE
Updating thrall health check end-point

### DIFF
--- a/scripts/dot-properties/settings/settings.py
+++ b/scripts/dot-properties/settings/settings.py
@@ -12,6 +12,7 @@ INITIAL_PROPERTIES = {
     'panda_domain': '',
     'panda_aws_key': '',
     'panda_aws_secret': '',
+    'sqs_heartbeat_message_min_frequency': 5,
 }
 
 AWS_PROFILE_NAME = 'media-service'

--- a/scripts/dot-properties/templates/thrall.properties.template
+++ b/scripts/dot-properties/templates/thrall.properties.template
@@ -3,3 +3,4 @@ aws.secret={{AwsSecret}}
 s3.image.bucket={{ImageBucket}}
 s3.thumb.bucket={{ThumbBucket}}
 sqs.queue.url={{SqsQueueUrl}}
+sqs.heartbeat.message.min.frequency={{sqs_heartbeat_message_min_frequency}}

--- a/thrall/app/controllers/HealthCheck.scala
+++ b/thrall/app/controllers/HealthCheck.scala
@@ -1,17 +1,32 @@
 package controllers
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{Result, Action, Controller}
 import play.api.libs.concurrent.Execution.Implicits._
-import lib.{MessageConsumer, ElasticSearch}
+import lib.{Config, MessageConsumer, ElasticSearch}
 import com.gu.mediaservice.syntax._
 
 object HealthCheck extends Controller {
 
   def healthCheck = Action.async {
+    elasticHealth map {
+      case r: Result => sqsHealth
+      case _ => ServiceUnavailable("ES is not healthy")
+    }
+  }
+
+  def elasticHealth = {
     ElasticSearch.client.prepareSearch().setSize(0)
       .executeAndLog("Health check")
       .filter(_ => ! MessageConsumer.actorSystem.isTerminated)
-      .map(_ => Ok("OK"))
+      .map(_ => Ok("ES is healthy"))
   }
 
+  def sqsHealth = {
+    val lastHeartBeat = MessageConsumer.lastHeartBeat.get
+
+    if (lastHeartBeat.plusMinutes(Config.heartRate).isBeforeNow)
+      ServiceUnavailable(s"Heart has not beat since $lastHeartBeat")
+    else
+      Ok("SQS is healthy")
+  }
 }

--- a/thrall/app/lib/Config.scala
+++ b/thrall/app/lib/Config.scala
@@ -36,4 +36,5 @@ object Config extends CommonPlayAppConfig {
   // The presence of this identifier prevents deletion
   val persistenceIdentifier = "picdarUrn" // TODO: properties("persistence.identifier")
 
+  val heartRate = properties("sqs.heartbeat.message.min.frequency").toInt
 }


### PR DESCRIPTION
Updating thrall health check end-point to report unhealthy if:

- Not processed a heartbeat message from SQS since last health check.
- Not processed a heartbeat message in `heartRate` minutes.

Where `heartRate` is the value of `sqs.heatbeat.message.min.frequency` in `thrall.properties` (5 minutes ATM).

Before release:
- [ ] [Apply CF update](https://github.com/guardian/grid-infra/pull/97) to send heartbeats.