### PR TITLE
add photographer to mappings

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -75,15 +75,23 @@ object Mappings {
   // keeping them separate for now until used as such
   val imageUsageRightsMapping = nonDynamicObj(
     "category" -> nonAnalyzedString,
+    "restrictions" -> standardAnalysedString,
     "supplier" -> nonAnalyzedString,
     "suppliersCollection" -> nonAnalyzedString,
-    "restrictions" -> standardAnalysedString
+    "photographer" -> standardAnalysedString,
+    "publication" -> nonAnalyzedString
   )
 
+  // We've had to leave `cost` in here so as to not break re-indexing as some of
+  // our documents have this as a legacy issue.
   val userMetadataUsageRightsMapping = nonDynamicObj(
     "cost" -> nonAnalyzedString,
     "category" -> nonAnalyzedString,
-    "restrictions" -> standardAnalysedString
+    "restrictions" -> standardAnalysedString,
+    "supplier" -> nonAnalyzedString,
+    "suppliersCollection" -> nonAnalyzedString,
+    "photographer" -> standardAnalysedString,
+    "publication" -> nonAnalyzedString
   )
 
 


### PR DESCRIPTION
Breaking up my gargantuan PR.
Adding fields for staff-photography - we'll deprecate one of these soon after I do [this](https://github.com/guardian/grid/issues/793).
