### PR TITLE
Add Grid logo as 'Home' link at the top-right of every screen

### DIFF
--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
@@ -20,7 +20,10 @@ topBar.directive('grTopBarNav', [function() {
     return {
         restrict: 'E',
         transclude: true,
-        template: `<ng:transclude></ng:transclude>`
+        // Annoying to have to hardcode root route here, but only
+        // way I found to clear $stateParams from uiRouter...
+        template: `<a href="/search" class="home-link">Home</a>
+                   <ng:transclude></ng:transclude>`
     };
 }]);
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -322,6 +322,16 @@ textarea.ng-invalid {
     padding: 0px 5px;
 }
 
+.home-link {
+    text-indent: -9999px;
+    width: 24px;
+    height: 24px;
+    background: url(/assets/images/grid-logo-32.png) no-repeat center;
+    margin-right: 10px;
+    vertical-align: top;
+    float: left;
+}
+
 .logout {
     color: inherit;
     font-size: 1.3rem;


### PR DESCRIPTION
(Sorry for the PR spam, clearing some of my local branches before the BFG...)

This adds the current Grid logo/favicon @akemitakagi made as "home" link, as per every website on the Internet ever. This can also serves as an "escape" to reset any search query.

![capture-2015-07-04t22 43 59](https://cloud.githubusercontent.com/assets/36964/8509487/46d466f4-229e-11e5-91cb-8416228a1cb2.gif)
