### PR TITLE
remove cost from usageCost everywhere

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -58,10 +58,10 @@ object ElasticSearch extends ElasticSearchClient {
            |   ctx._source.identifiers += doc.identifiers;
            | }
            |""".stripMargin +
+          removeCostFromUserUsageRights +
           refreshEditsScript +
           updateLastModifiedScript +
-          addToSuggestersScript +
-          removeCostFromUserUsageRights,
+          addToSuggestersScript,
         scriptType)
       .executeAndLog(s"Indexing image $id")
       .incrementOnSuccess(indexedImages)}


### PR DESCRIPTION
We now remove cost in both place but also make sure that we're removing it before updating the edits.
All this will be removed once we reindex.
