### PR TITLE
Reduce polling for new images from 5s to 15s to reduce load

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -59,7 +59,7 @@ results.controller('SearchResultsCtrl', [
         });
 
 
-        const pollingPeriod = 5 * 1000; // ms
+        const pollingPeriod = 15 * 1000; // ms
 
         // FIXME: this will only add up to 50 images (search capped)
         function checkForNewImages() {


### PR DESCRIPTION
Bit needlessly aggressive, let's see if we can lighten the load on the API with that change.
