### PR TITLE
Flatten Staff Photographer config

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -1,39 +1,39 @@
 package com.gu.mediaservice.lib.config
 
 object MetadataConfig {
-
-  // TODO: Move this list into an admin-managed repository
-  // Mapping of credit->byline for metadata cleanup
-  val creditBylineMap = Map(
-    "The Guardian" -> List(
-      "Christopher Thomond",
-      "Sean Smith",
-      "David Levene",
-      "David Sillitoe",
-      "Eamonn Mccabe",
-      "Felicity Cloake",
-      "Frank Baron",
-      "Graeme Robertson",
-      "Graham Turner",
-      "Linda Nylind",
-      "Martin Argles",
-      "Martin Godwin",
-      "Mike Bowers",
-      "Murdo Macleod",
-      "Sarah Lee",
-      "Tom Jenkins",
-      "Tristram Kenton"
-    ),
-    "The Observer" -> List(
-      "Andy Hall",
-      "Antonio Olmos",
-      "Catherine Shaw",
-      "Gary Calton",
-      "Karen Robinson",
-      "Katherine Anne Rose",
-      "Richard Saker",
-      "Sophia Evans",
-      "Suki Dhanda"
+  object StaffPhotographers {
+    val store = Map(
+      "Christopher Thomond" -> "The Guardian",
+      "Sean Smith"          -> "The Guardian",
+      "David Levene"        -> "The Guardian",
+      "David Sillitoe"      -> "The Guardian",
+      "Eamonn Mccabe"       -> "The Guardian",
+      "Felicity Cloake"     -> "The Guardian",
+      "Frank Baron"         -> "The Guardian",
+      "Graeme Robertson"    -> "The Guardian",
+      "Graham Turner"       -> "The Guardian",
+      "Linda Nylind"        -> "The Guardian",
+      "Martin Argles"       -> "The Guardian",
+      "Martin Godwin"       -> "The Guardian",
+      "Mike Bowers"         -> "The Guardian",
+      "Murdo Macleod"       -> "The Guardian",
+      "Sarah Lee"           -> "The Guardian",
+      "Tom Jenkins"         -> "The Guardian",
+      "Tristram Kenton"     -> "The Guardian",
+      "Andy Hall"           -> "The Observer",
+      "Antonio Olmos"       -> "The Observer",
+      "Catherine Shaw"      -> "The Observer",
+      "Gary Calton"         -> "The Observer",
+      "Karen Robinson"      -> "The Observer",
+      "Katherine Anne Rose" -> "The Observer",
+      "Richard Saker"       -> "The Observer",
+      "Sophia Evans"        -> "The Observer",
+      "Suki Dhanda"         -> "The Observer"
     )
-  )
+
+    val creditBylineMap = store.groupBy(_._2).map(o => o._1 -> o._2.keys.toList)
+    val list = store.keys.toList
+
+    def getOrganisation(name: String): Option[String] = store.get(name)
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -31,9 +31,12 @@ object MetadataConfig {
       "Suki Dhanda"         -> "The Observer"
     )
 
-    val creditBylineMap = store.groupBy(_._2).map(o => o._1 -> o._2.keys.toList)
+    val creditBylineMap = store
+      .groupBy(_ match { case (photographer, publication) => publication })
+      .map(_ match { case (publication, photographers) => publication -> photographers.keys.toList })
+
     val list = store.keys.toList
 
-    def getOrganisation(name: String): Option[String] = store.get(name)
+    def getPublication(name: String): Option[String] = store.get(name)
   }
 }

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -11,7 +11,7 @@ import lib.Config
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
 import com.gu.mediaservice.lib.resource.FutureResources._
 import com.gu.mediaservice.lib.cleanup.{SupplierProcessors, MetadataCleaners}
-import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.lib.config.MetadataConfig.StaffPhotographers
 import com.gu.mediaservice.lib.formatting._
 
 import lib.storage.ImageStore
@@ -20,7 +20,7 @@ import com.gu.mediaservice.model._
 case class ImageUpload(uploadRequest: UploadRequest, image: Image)
 case object ImageUpload {
 
-  val metadataCleaners = new MetadataCleaners(MetadataConfig.creditBylineMap)
+  val metadataCleaners = new MetadataCleaners(StaffPhotographers.creditBylineMap)
 
   def fromUploadRequest(uploadRequest: UploadRequest): Future[ImageUpload] = {
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -27,7 +27,7 @@ import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model._
 import com.gu.mediaservice.lib.formatting.{printDateTime, parseDateFromQuery}
 import com.gu.mediaservice.lib.cleanup.{SupplierProcessors, MetadataCleaners}
-import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.lib.config.MetadataConfig.StaffPhotographers
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.api.Transformers
@@ -127,7 +127,7 @@ object MediaApi extends Controller with ArgoHelpers {
   }
 
   def cleanImage(id: String) = Authenticated.async {
-    val metadataCleaners = new MetadataCleaners(MetadataConfig.creditBylineMap)
+    val metadataCleaners = new MetadataCleaners(StaffPhotographers.creditBylineMap)
 
     ElasticSearch.getImageById(id) map {
       case Some(source) => {

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/cleanup/MetadataOverrides.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/cleanup/MetadataOverrides.scala
@@ -3,13 +3,13 @@ package com.gu.mediaservice.picdarexport.lib.cleanup
 import scala.language.reflectiveCalls
 
 import com.gu.mediaservice.lib.cleanup.MetadataCleaners
-import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.lib.config.MetadataConfig.StaffPhotographers
 import com.gu.mediaservice.model.{FileMetadata, ImageMetadata}
 
 
 object MetadataOverrides {
 
-  val metadataCleaners = new MetadataCleaners(MetadataConfig.creditBylineMap)
+  val metadataCleaners = new MetadataCleaners(StaffPhotographers.creditBylineMap)
 
   def getOverrides(current: ImageMetadata, picdarOverrides: ImageMetadata): Option[ImageMetadata] = {
     // Strip any Picdar-specific metadata artifacts


### PR DESCRIPTION
This change is to make it easier to write a staff photographer parser for usage rights.

The config is moved closed to a "flat representation" as might be loaded from an external source, in order that it can be more flexibly manipulated for various uses.