### PR TITLE
Replacing "upload" with an icon.

### DIFF
--- a/kahuna/public/js/upload/file-uploader.html
+++ b/kahuna/public/js/upload/file-uploader.html
@@ -9,6 +9,9 @@
                multiple
                ui:file ui:file-change="fileUploader.uploadFiles" />
 
-        <button class="file-uploader__select-files button">upload</button>
+        <button class="file-uploader__select-files button">
+            <i class="material-icons">file_upload</i>
+            <span class="file-uploader__select-files--label">upload</span>
+        </button>
     </div>
 </form>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -165,7 +165,7 @@ button {
     box-sizing: border-box;
     color: white;
     display: block;
-    padding: 5px 20px !important;
+    padding: 5px 20px;
     font-size: 1.4rem;
     position: relative;
 }
@@ -308,7 +308,7 @@ textarea.ng-invalid {
    ========================================================================== */
 
 .top-bar-item {
-    margin-left: 20px;
+    margin-left: 10px;
     vertical-align: middle;
     line-height: 28px;
     display: inline-block;
@@ -518,6 +518,15 @@ input.search-query__input {
     display: none;
 }
 
+.file-uploader__select-files {
+    padding: 5px 10px;
+}
+
+@media screen and (max-width: 1200px) {
+    .file-uploader__select-files--label {
+        display: none;
+    }
+}
 
 /* ==========================================================================
    Results


### PR DESCRIPTION
Results in a (slight) reduction in the break-point from 1044px to 991px.

Before
<img width="251" alt="screen shot 2015-07-09 at 08 59 44" src="https://cloud.githubusercontent.com/assets/836140/8590473/e230d3a8-2618-11e5-86ae-f7b15b676599.png">

After: at > 1200px wide
<img width="239" alt="screen shot 2015-07-09 at 10 38 12" src="https://cloud.githubusercontent.com/assets/836140/8592364/a4119dec-2626-11e5-9915-0a358e6f779e.png">


After: at <=1200px wide
<img width="195" alt="screen shot 2015-07-09 at 08 59 30" src="https://cloud.githubusercontent.com/assets/836140/8590476/e86dd52c-2618-11e5-8113-adb1adf4f454.png">
