### PR TITLE
Fix jspm version

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "jscs": "^1.13.0",
     "jshint": "^2.5.11",
-    "jspm": "~0.16.0"
+    "jspm": "~0.16.0-beta"
   },
   "scripts": {
     "test": "npm run lint",


### PR DESCRIPTION
The current version causes an error when attempting to install via npm.