### PR TITLE
Usage rights category logging

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -45,7 +45,8 @@ object UsageRights {
 
   implicit val jsonReads: Reads[UsageRights] =
     Reads[UsageRights] { json  =>
-      ((json \ "category").asOpt[String] flatMap {
+      val category = (json \ "category").asOpt[String]
+      (category flatMap {
         case "agency"             => json.asOpt[Agency]
         case "PR Image"           => json.asOpt[PrImage]
         case "handout"            => json.asOpt[Handout]
@@ -59,7 +60,7 @@ object UsageRights {
       })
       .orElse(json.asOpt[NoRights.type])
       .map(JsSuccess(_))
-      .getOrElse(JsError("No such usage rights category"))
+      .getOrElse(JsError(s"No such usage rights category: ${category.getOrElse("None")}"))
     }
 }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/model/UsageRightsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/model/UsageRightsTest.scala
@@ -13,7 +13,8 @@ object TestImage {
 
 class UsageRightsTest extends FunSpec with Matchers {
 
-  val invalidJson = Json.parse("""{ "category": "animated-gif", "fps": "∞" }""")
+  val invalidCategory = "animated-gif"
+  val invalidJson = Json.parse(s"""{ "category": "$invalidCategory", "fps": "∞" }""")
 
   it ("should serialise to JSON correctly") {
     val supplier = "Getty Images"
@@ -76,7 +77,7 @@ class UsageRightsTest extends FunSpec with Matchers {
     }
 
     jsError.errors.headOption.map { case (path, errors) =>
-      errors.head.message should be ("No such usage rights category")
+      errors.head.message should be (s"No such usage rights category: $invalidCategory")
     }
   }
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -25,7 +25,6 @@ object ImageResponse {
   def fileMetaDataUri(id: String) = URI.create(s"${Config.rootUri}/images/$id/fileMetadata")
 
   def create(id: String, esSource: JsValue, withWritePermission: Boolean, included: List[String] = List()): (JsValue, List[Link]) = {
-
     val (image: Image, source: JsValue) = Try {
       val image = esSource.as[Image]
       val source = Json.toJson(image)(
@@ -35,7 +34,7 @@ object ImageResponse {
       (image, source)
     }.recoverWith {
       case e => {
-        Logger.error(s"Failed to read ElasticSearch response into Image object: ${e.getMessage}")
+        Logger.error(s"Failed to read ElasticSearch response ${id} into Image object: ${e.getMessage}")
         Failure(e)
       }
     }.get


### PR DESCRIPTION
As we have indexed some images with `{ "usageRights": { "supplier": "Gonzo" } }` it was failing to parse them.

Reindex will fix this.