### PR TITLE
Moving persistence identifier to properties file.

### DIFF
--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -55,4 +55,6 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   // TODO: move to config
   val queriableIdentifiers = Seq("picdarUrn")
+
+  val persistenceIdentifier = properties("persistence.identifier")
 }

--- a/scripts/dot-properties/templates/media-api.properties.template
+++ b/scripts/dot-properties/templates/media-api.properties.template
@@ -7,3 +7,4 @@ auth.keystore.bucket={{KeyBucket}}
 sns.topic.arn={{SnsTopicArn}}
 cors.allowed.origins={{cors}}
 s3.config.bucket={{ConfigBucket}}
+persistence.identifier=picdarUrn

--- a/scripts/dot-properties/templates/thrall.properties.template
+++ b/scripts/dot-properties/templates/thrall.properties.template
@@ -4,3 +4,4 @@ s3.image.bucket={{ImageBucket}}
 s3.thumb.bucket={{ThumbBucket}}
 sqs.queue.url={{SqsQueueUrl}}
 sqs.message.min.frequency={{sqs_message_min_frequency}}
+persistence.identifier=picdarUrn

--- a/thrall/app/lib/Config.scala
+++ b/thrall/app/lib/Config.scala
@@ -34,7 +34,7 @@ object Config extends CommonPlayAppConfig {
       ))
 
   // The presence of this identifier prevents deletion
-  val persistenceIdentifier = "picdarUrn" // TODO: properties("persistence.identifier")
+  val persistenceIdentifier = properties("persistence.identifier")
 
   val healthyMessageRate = properties("sqs.message.min.frequency").toInt
 }


### PR DESCRIPTION
Adding this to the media-api too as we'll need it soon for the archived status work.

Before release:
- [ ] [update CF](https://github.com/guardian/grid-infra/pull/102)