### PR TITLE
Change label text hide breakpoint

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -374,7 +374,7 @@ textarea.ng-invalid {
     padding: 10px;
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 800px) {
     .top-bar-item__label {
         display: none;
     }
@@ -621,7 +621,7 @@ input.search-query__input {
     padding: 5px 10px;
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 800px) {
     .file-uploader__select-files--label {
         display: none;
     }
@@ -1562,7 +1562,7 @@ FIXME: what to do with touch devices
    Archviver
    ========================================================================== */
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 800px) {
     .archiver__label {
         display: none;
     }


### PR DESCRIPTION
Changes the label text breakpoint to a smaller width.

This changes accommodates the embedded version of the grid in Composer:

![crop](https://cloud.githubusercontent.com/assets/953792/8743744/6e69854e-2c69-11e5-8886-cd1355c87e34.gif)
