### PR TITLE
Remove relative timestamp.

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -47,14 +47,8 @@
 
     <div class="preview__bottom-bar bottom-bar">
         <div class="bottom-bar__meta">
-            <span ng:if="ctrl.displayAsRelative(image.data.uploadTime)"
-                  class="preview__upload-time">
-                {{ctrl.relativeFormat(image.data.uploadTime)}}
-            </span>
-
-            <span ng:if="!ctrl.displayAsRelative(image.data.uploadTime)"
-                class="preview__upload-time">
-                {{image.data.uploadTime | date:'d/M/yy'}} at {{image.data.uploadTime | date:'HH:mm'}}
+            <span class="preview__upload-time">
+                {{image.data.uploadTime | date:'dd/MM/yy'}} {{image.data.uploadTime | date:'HH:mm'}}
             </span>
 
             <span class="bottom-bar__meta-item preview__has-crops"

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -1,6 +1,4 @@
 import angular from 'angular';
-import moment from 'moment';
-
 import '../analytics/track';
 
 import template from './image.html!text';
@@ -8,15 +6,6 @@ import template from './image.html!text';
 export var image = angular.module('kahuna.preview.image', [
     'analytics.track'
 ]);
-
-image.controller('uiPreviewImageCtrl', [function () {
-    var ctrl = this;
-
-    ctrl.displayAsRelative = dateTime =>
-        moment().diff(moment(dateTime), 'days') < 7;
-
-    ctrl.relativeFormat = uploadTime => moment(uploadTime).fromNow();
-}]);
 
 image.directive('uiPreviewImage', function() {
     return {
@@ -28,9 +17,7 @@ image.directive('uiPreviewImage', function() {
         },
         // extra actions can be transcluded in
         transclude: true,
-        template: template,
-        controller: 'uiPreviewImageCtrl',
-        controllerAs: 'ctrl'
+        template: template
     };
 });
 


### PR DESCRIPTION
[Relative timestamps](https://github.com/guardian/grid/pull/936) aren't helpful on their own. Moving back to full timestamp.