### PR TITLE
make controls appear at same time

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -857,7 +857,15 @@ FIXME: what to do with touch devices
 }
 .bottom-bar__action {
     color: inherit;
-    display: inline-block;
+    display: block;
+}
+
+.bottom-bar__actions ui-archiver {
+    float: left;
+}
+
+.bottom-bar__actions .preview__cost {
+    float: right;
 }
 
 
@@ -1556,7 +1564,7 @@ FIXME: what to do with touch devices
 }
 
 .preview .archiver--archived {
-    display: inline;
+    display: block;
 }
 
 .archiver--archived {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -671,6 +671,24 @@ input.search-query__input {
 
 .result:hover .result__select,
 .result:hover .preview__fade,
+.result:hover .image-actions,
+.result:hover .labeller__add,
+.result:hover .archiver {
+    display: block;
+}
+
+.result:hover {
+    border-color: #404040;
+}
+
+.result:hover .preview {
+    background-color: #404040;
+}
+
+.result--selected:hover .preview__fade {
+    display: none;
+}
+
 .result__select--selected {
     display: initial;
 }
@@ -784,27 +802,12 @@ input.search-query__input {
     margin: 0;
 }
 
-.preview .preview__crop {
-    display: none;
-}
-
-.preview:hover {
-    background-color: #404040;
-}
-
-.preview:hover .preview__crop {
-    display: inline;
-}
-
 /*
 FIXME: this is a little targeted
 FIXME: what to do with touch devices
 */
 .preview .labeller__add {
-    visibility: hidden;
-}
-.preview:hover .labeller__add {
-    visibility: visible;
+    display: none;
 }
 
 .preview__upload-time {
@@ -863,9 +866,6 @@ FIXME: what to do with touch devices
    ========================================================================== */
 .image-actions-container .image-actions {
     display: none;
-}
-.image-actions-container:hover .image-actions {
-    display: block;
 }
 
 .image-actions {
@@ -1209,7 +1209,8 @@ FIXME: what to do with touch devices
     box-sizing: border-box;
 }
 .image-crop--selected,
-.result--selected {
+.result--selected,
+.result--selected:hover {
     border-color: #00adee;
 }
 
@@ -1233,7 +1234,7 @@ FIXME: what to do with touch devices
    Labeller
    ========================================================================== */
 .labeller {
-    min-height: 20px;
+    height: 25px;
     font-size: 1.3rem;
     display: flex;
     overflow: hidden;
@@ -1553,7 +1554,7 @@ FIXME: what to do with touch devices
 .preview .archiver {
     display: none;
 }
-.preview:hover .archiver,
+
 .preview .archiver--archived {
     display: inline;
 }


### PR DESCRIPTION
Moving `.preview:hover` rules to `.result:hover` so that controls now all appear at the same time.

Before:
![hover-before](https://cloud.githubusercontent.com/assets/836140/8747592/6f78adde-2c8c-11e5-884c-14c87175e942.gif)

After:
![hover-after](https://cloud.githubusercontent.com/assets/836140/8747608/7407a21a-2c8c-11e5-8581-67910aad7930.gif)