### PR TITLE
show no usage rights only to images that initially don't have any

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -73,7 +73,9 @@
 
     <div class="ure__bar">
 
-        <gr-confirm-delete gr:on-confirm="ctrl.remove()"></gr-confirm-delete>
+        <gr-confirm-delete
+            ng:if="ctrl.category.value"
+            gr:on-confirm="ctrl.remove()"></gr-confirm-delete>
 
         <button class="ure__action button-ico" type="button" ng:click="ctrl.cancel()"
             title="close usage rights overrides">


### PR DESCRIPTION
We only show no rights on images that don't have them to start with to stop the confusion of the interface defaulting to say PR Image.

This will disappear when we have reindexed and allow the override of no-rights.