### PR TITLE
Add spacing before expander arrow in date range

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.css
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.css
@@ -13,6 +13,7 @@
 
 .gu-date-range__display__icon__toggle {
     float: right;
+    margin-left: 5px;
 }
 
 .gu-date-range__overlay__pikaday {


### PR DESCRIPTION
Fixes tragic lack of spacing.

# Before

![image](https://cloud.githubusercontent.com/assets/36964/8774371/369ecfe8-2ed5-11e5-86e5-a81a86ff532f.png)

# After
![image](https://cloud.githubusercontent.com/assets/36964/8774369/289fac00-2ed5-11e5-898d-23759f3e81f2.png)
