### PR TITLE
Using icons for pay and restricted images in results.

### DIFF
--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -34,8 +34,9 @@
                  title="restricted use: {{ctrl.image.data.usageRights.restrictions}}">
                 <!-- As `conditional` can only be set with usageRights, let's
                      just assume it's here. We might need to revisit this. -->
-                     <gr-icon>warning</gr-icon><span class="top-bar-item__label"> restricted use
-                         <span class="ico ico--circled ico--help">?</span></span>
+                <gr-icon>flag</gr-icon>
+                <span class="top-bar-item__label">restricted use</span>
+                <gr-icon>help</gr-icon>
             </div>
         </div>
 

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -65,8 +65,7 @@
                 <span class="result-editor__status status status--invalid"
                       ng:switch-when="invalid">
                         Info missing
-                        <span class="ico ico--circled ico--help"
-                              title="You need to add both a credit and description">?</span>
+                    <gr-icon title="You need to add both a credit and description">help</gr-icon>
                 </span>
             </div>
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -72,7 +72,8 @@
             <div class="preview__cost bottom-bar__action" ng:switch="ctrl.states.cost">
                 <div ng:switch-when="pay"
                      class="cost cost--pay">
-                    <gr-icon>attach_money</gr-icon>
+                    <!-- material icons doesn't have a £ icon -->
+                    <span title="pay to use">£</span>
                 </div>
 
                 <div ng:switch-when="conditional"

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -69,7 +69,9 @@
                 image="ctrl.image"
                 disabled="ctrl.selectionMode"></ui-archiver>
 
-            <div class="preview__cost bottom-bar__action" ng:switch="ctrl.states.cost">
+            <div class="preview__cost bottom-bar__action"
+                 ng:if="ctrl.states.cost !== 'free'"
+                 ng:switch="ctrl.states.cost">
                 <div ng:switch-when="pay"
                      class="cost cost--pay">
                     <!-- material icons doesn't have a £ icon -->

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -72,7 +72,7 @@
             <div class="preview__cost bottom-bar__action" ng:switch="ctrl.states.cost">
                 <div ng:switch-when="pay"
                      class="cost cost--pay">
-                    pay
+                    <gr-icon>attach_money</gr-icon>
                 </div>
 
                 <div ng:switch-when="conditional"
@@ -80,7 +80,7 @@
                      title="{{ctrl.image.data.usageRights.restrictions}}">
                      <!-- As `conditional` can only be set with usageRights, let's
                      just assume it's here. We might need to revisit this. -->
-                    restricted
+                    <gr-icon>flag</gr-icon>
                 </div>
             </div>
         </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -218,26 +218,6 @@ a:focus {
     100% { transform: rotateY(360deg); }
 }
 
-.ico {
-    width: 12px;
-    vertical-align: middle;
-    line-height: 12px;
-}
-
-.ico--circled {
-    font-size: 1.2rem;
-    display: inline-block;
-    border: 1px solid white;
-    border-radius: 50%;
-}
-
-.ico--help {
-    cursor: help;
-    text-align: center;
-    padding-left: 1px;
-    margin-left: 2px;
-}
-
 .saving {
     display: inline;
     width: 15px;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -847,6 +847,7 @@ FIXME: what to do with touch devices
 
 .bottom-bar__actions .preview__cost {
     float: right;
+    width: 35px;
 }
 
 


### PR DESCRIPTION
- Pay is a £ character (material icons doesn't have one)
- Restricted is a flag

Also removing `.ico` classes in favour of material icon `help`.

Why? Provides more space for `persisted` icon to go.

![screen shot 2015-07-20 at 12 15 32](https://cloud.githubusercontent.com/assets/836140/8774728/1f5d6aa2-2ed9-11e5-9cee-5c4643168519.png)
