### PR TITLE
Fix image fade-in

### DIFF
--- a/kahuna/public/js/directives/gr-image-fade-on-load.js
+++ b/kahuna/public/js/directives/gr-image-fade-on-load.js
@@ -16,7 +16,7 @@ imageFade.directive('grImageFadeOnLoad',
             // If not loaded after animationThreshold, hide and wait
             // until loaded to fade in
             $timeout(() => {
-                if (! isLoaded) {
+                if (! isLoaded()) {
                     hide();
                     whenLoaded().finally(reveal);
                 }
@@ -31,7 +31,7 @@ imageFade.directive('grImageFadeOnLoad',
                 const defer = $q.defer();
 
                 // already loaded
-                if (isLoaded) {
+                if (isLoaded()) {
                     defer.resolve();
                 } else {
                     // wait until loaded/error

--- a/kahuna/public/js/directives/gr-image-fade-on-load.js
+++ b/kahuna/public/js/directives/gr-image-fade-on-load.js
@@ -38,8 +38,8 @@ imageFade.directive('grImageFadeOnLoad',
                     element.bind('load', defer.resolve);
                     element.bind('error', defer.reject);
 
-                    // free listeners
-                    scope.$on('$destroy', () => {
+                    // free listeners once observed
+                    defer.promise.finally(() => {
                         element.unbind('load', defer.resolve);
                         element.unbind('error', defer.reject);
                     });

--- a/kahuna/public/js/directives/gr-image-fade-on-load.js
+++ b/kahuna/public/js/directives/gr-image-fade-on-load.js
@@ -50,13 +50,15 @@ imageFade.directive('grImageFadeOnLoad',
 
             function hide() {
                 element.css({
-                    opacity: 0,
-                    transition: `opacity ${animationDuration}ms ease-out`
+                    opacity: 0
                 });
             }
 
             function reveal() {
-                element.css({opacity: 1});
+                element.css({
+                    opacity: 1,
+                    transition: `opacity ${animationDuration}ms ease-out`
+                });
             }
 
         }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -28,15 +28,6 @@
          url("fonts/MaterialIcons-Regular.woff") format('woff');
 }
 
-@keyframes fadeIn {
-    0%   { opacity: 0; }
-    100% { opacity: 1; }
-}
-@-webkit-keyframes fadeIn {
-    0%   { opacity: 0; }
-    100% { opacity: 1; }
-}
-
 @keyframes spin {
     from   { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
@@ -619,8 +610,6 @@ input.search-query__input {
 .results {
     display: flex;
     flex-wrap: wrap;
-    animation: fadeIn .25s;
-    -webkit-animation: fadeIn .25s;
 }
 
 .results--left {


### PR DESCRIPTION
The fade-in directive wasn't actually working. This fixes it.

It also removes the existing initial fading in of search results, to avoid having two layers of fading in.

Note: images still only fade in if they are not preloaded faster enough (50ms, typically from browser cache).