### PR TITLE
Show placeholders while items are lazy loading

### DIFF
--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table-placeholder.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table-placeholder.js
@@ -1,0 +1,34 @@
+import angular from 'angular';
+
+export var lazyTableCell = angular.module('gu.lazyTablePlaceholder', [
+    'rx.helpers'
+]);
+
+lazyTableCell.directive('guLazyTablePlaceholder',
+                        ['subscribe$',
+                         function(subscribe$) {
+    return {
+        restrict: 'A',
+        require: '^guLazyTable',
+        // Limit DOM weight by only transcluding the content of this
+        // element iff it is visible.
+        link: function(scope, element, attrs, ctrl) {
+            const index = scope.$eval(attrs.guLazyTablePlaceholder);
+            const position$ = ctrl.getCellPosition$(index);
+            subscribe$(scope, position$,
+                       ({top, left, width, height}) => {
+                // use applyAsync rather than rx.safeApply to batch
+                // all cell's updates together
+                scope.$applyAsync(() => {
+                    element.css({
+                        position: 'absolute',
+                        top:    top    + 'px',
+                        left:   left   + 'px',
+                        width:  width  + 'px',
+                        height: height + 'px'
+                    });
+                });
+            });
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -97,7 +97,8 @@ lazyTable.controller('GuLazyTableCtrl', [function() {
         // Placeholders
         const placeholderExtraCount$ = mult$(columns$, preloadedRows$);
         const placeholderRangeStart$ = max$(sub$(loadedRangeStart$, placeholderExtraCount$), 0);
-        const placeholderRangeEnd$ = min$(add$(loadedRangeEnd$, placeholderExtraCount$), itemsCount$);
+        const placeholderRangeEnd$ = min$(add$(loadedRangeEnd$, placeholderExtraCount$),
+                                          itemsCount$);
 
         const placeholderIndexes$ = combine$(
             items$, placeholderRangeStart$, placeholderRangeEnd$,

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -10,8 +10,8 @@ import './gu-lazy-table-cell';
 
 import {
     combine$,
-    add$, sub$, mult$, div$,
-    floor$, ceil$, max$
+    add$, sub$, mult$, div$, mod$,
+    floor$, ceil$, max$, min$
 } from './observable-utils';
 
 
@@ -122,8 +122,8 @@ lazyTable.controller('GuLazyTableCtrl', [function() {
         const loadedHeight$ = mult$(preloadedRows$, height$);
 
         return (index) => {
-            const top$    = mult$(floor$(columns$.map(col => index / col)), height$);
-            const left$   = mult$(columns$.map(col => index % col), width$);
+            const top$    = mult$(floor$(div$(index, columns$)), height$);
+            const left$   = mult$(mod$(index, columns$), width$);
 
             const bottom$ = add$(top$, height$);
             const display$ = combine$(top$, bottom$, loadedHeight$,

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -100,12 +100,12 @@ lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
         const placeholderExtraCount$ = mult$(columns$, preloadedRows$);
         const placeholderRangeStart$ = max$(sub$(loadedRangeStart$, placeholderExtraCount$), 0);
         const placeholderRangeEnd$ = min$(add$(loadedRangeEnd$, placeholderExtraCount$),
-                                          itemsCount$);
+                                          sub$(itemsCount$, 1));
 
         const placeholderIndexes$ = combine$(
             placeholderRangeStart$, placeholderRangeEnd$,
             (placeholderRangeStart, placeholderRangeEnd) => {
-                let indexes = range(placeholderRangeStart, placeholderRangeEnd - 1);
+                let indexes = range(placeholderRangeStart, placeholderRangeEnd);
                 return Array.from(indexes);
             }
         );

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -8,6 +8,7 @@ let {addResizeListener, removeResizeListener} = elementResize;
 import './rx-helpers';
 import './gu-lazy-table-cell';
 import './gu-lazy-table-placeholder';
+import '../../util/seq';
 
 import {
     combine$,
@@ -19,7 +20,8 @@ import {
 export var lazyTable = angular.module('gu.lazyTable', [
     'gu.lazyTableCell',
     'gu.lazyTablePlaceholder',
-    'rx.helpers'
+    'rx.helpers',
+    'util.seq'
 ]);
 
 
@@ -47,7 +49,7 @@ function findLastIndexFrom(array, item, fromIndex) {
 }
 
 
-lazyTable.controller('GuLazyTableCtrl', [function() {
+lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
     let ctrl = this;
 
     ctrl.init = function({items$, preloadedRows$, cellHeight$, cellMinWidth$,
@@ -101,13 +103,10 @@ lazyTable.controller('GuLazyTableCtrl', [function() {
                                           itemsCount$);
 
         const placeholderIndexes$ = combine$(
-            items$, placeholderRangeStart$, placeholderRangeEnd$,
-            (items, placeholderRangeStart, placeholderRangeEnd) => {
-                let indexes = [];
-                for (let i = placeholderRangeStart; i < placeholderRangeEnd; i++) {
-                    indexes.push(i);
-                }
-                return indexes;
+            placeholderRangeStart$, placeholderRangeEnd$,
+            (placeholderRangeStart, placeholderRangeEnd) => {
+                let indexes = range(placeholderRangeStart, placeholderRangeEnd - 1);
+                return Array.from(indexes);
             }
         );
 

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -115,27 +115,34 @@ lazyTable.controller('GuLazyTableCtrl', [function() {
 
         // Mutations needed here to access streams in this closure ;_;
 
-        // Share subscriptions to these streams between all cells that
-        // register to getItemPosition$
+        // Share subscriptions to these streams between all cells and
+        // placeholders that register to their position
 
-        // TODO: share shareReplay between the two
+        const itemsShared$          = items$.shareReplay(1);
+        const cellWidthShared$      = cellWidth$.shareReplay(1);
+        const cellHeightShared$     = cellHeight$.shareReplay(1);
+        const columnsShared$        = columns$.shareReplay(1);
+        const preloadedRowsShared$  = preloadedRows$.shareReplay(1);
+        const viewportTopShared$    = viewportTop$.shareReplay(1);
+        const viewportBottomShared$ = viewportBottom$.shareReplay(1);
+
         ctrl.getItemPosition$ = createGetItemPosition$({
-            items$:          items$.shareReplay(1),
-            cellWidth$:      cellWidth$.shareReplay(1),
-            cellHeight$:     cellHeight$.shareReplay(1),
-            columns$:        columns$.shareReplay(1),
-            preloadedRows$:  preloadedRows$.shareReplay(1),
-            viewportTop$:    viewportTop$.shareReplay(1),
-            viewportBottom$: viewportBottom$.shareReplay(1)
+            items$:          itemsShared$,
+            cellWidth$:      cellWidthShared$,
+            cellHeight$:     cellHeightShared$,
+            columns$:        columnsShared$,
+            preloadedRows$:  preloadedRowsShared$,
+            viewportTop$:    viewportTopShared$,
+            viewportBottom$: viewportBottomShared$
         });
 
         ctrl.getCellPosition$ = createGetCellPosition$({
-            cellWidth$:      cellWidth$.shareReplay(1),
-            cellHeight$:     cellHeight$.shareReplay(1),
-            columns$:        columns$.shareReplay(1),
-            preloadedRows$:  preloadedRows$.shareReplay(1),
-            viewportTop$:    viewportTop$.shareReplay(1),
-            viewportBottom$: viewportBottom$.shareReplay(1)
+            cellWidth$:      cellWidthShared$,
+            cellHeight$:     cellHeightShared$,
+            columns$:        columnsShared$,
+            preloadedRows$:  preloadedRowsShared$,
+            viewportTop$:    viewportTopShared$,
+            viewportBottom$: viewportBottomShared$
         });
 
         return {

--- a/kahuna/public/js/components/gu-lazy-table/observable-utils.js
+++ b/kahuna/public/js/components/gu-lazy-table/observable-utils.js
@@ -2,20 +2,37 @@ import Rx from 'rx';
 
 export const combine$ = Rx.Observable.combineLatest;
 
+function combine2$(a$, b$, resultSelector) {
+    if (a$ instanceof Rx.Observable) {
+        if (b$ instanceof Rx.Observable) {
+            return combine$(a$, b$, resultSelector);
+        } else {
+            return a$.map(a => resultSelector(a, b$));
+        }
+    } else {
+        if (b$ instanceof Rx.Observable) {
+            return b$.map(b => resultSelector(a$, b));
+        } else {
+            return Rx.Observable.return(resultSelector(a$, b$));
+        }
+    }
+}
+
+
 export function add$(a$, b$) {
-    return combine$(a$, b$, (a, b) => a + b);
+    return combine2$(a$, b$, (a, b) => a + b);
 }
 export function sub$(a$, b$) {
-    return combine$(a$, b$, (a, b) => a - b);
+    return combine2$(a$, b$, (a, b) => a - b);
 }
 export function mult$(a$, b$) {
-    return combine$(a$, b$, (a, b) => a * b);
+    return combine2$(a$, b$, (a, b) => a * b);
 }
 export function div$(a$, b$) {
-    return combine$(a$, b$, (a, b) => a / b);
+    return combine2$(a$, b$, (a, b) => a / b);
 }
 export function mod$(a$, b$) {
-    return combine$(a$, b$, (a, b) => a % b);
+    return combine2$(a$, b$, (a, b) => a % b);
 }
 export function round$(s$) {
     return s$.map(Math.round);
@@ -26,9 +43,9 @@ export function floor$(s$) {
 export function ceil$(s$) {
     return s$.map(Math.ceil);
 }
-export function max$(s$, n) {
-    return s$.map(x => Math.max(x, n));
+export function max$(s$, n$) {
+    return combine2$(s$, n$, (x, n) => Math.max(x, n));
 }
-export function min$(s$, n) {
-    return s$.map(x => Math.min(x, n));
+export function min$(s$, n$) {
+    return combine2$(s$, n$, (x, n) => Math.min(x, n));
 }

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -1,10 +1,12 @@
 import angular from 'angular';
 
 import '../services/preview-selection';
+import '../util/seq';
 import '../components/gu-lazy-table/gu-lazy-table';
 
 export var results = angular.module('kahuna.search.results', [
     'kahuna.services.selection',
+    'util.seq',
     'gu.lazyTable'
 ]);
 
@@ -22,6 +24,7 @@ results.controller('SearchResultsCtrl', [
     '$timeout',
     'mediaApi',
     'selectionService',
+    'range',
     function($rootScope,
              $scope,
              $state,
@@ -29,7 +32,8 @@ results.controller('SearchResultsCtrl', [
              $window,
              $timeout,
              mediaApi,
-             selection) {
+             selection,
+             range) {
 
         const ctrl = this;
 
@@ -167,12 +171,6 @@ results.controller('SearchResultsCtrl', [
             }));
         }
 
-
-        function* range (start, end) {
-            for (let i = start; i <= end; i += 1) {
-                yield i;
-            }
-        }
 
         ctrl.selectedImages = selection.selectedImages;
 

--- a/kahuna/public/js/util/seq.js
+++ b/kahuna/public/js/util/seq.js
@@ -1,0 +1,9 @@
+import angular from 'angular';
+
+export var seq = angular.module('util.seq', []);
+
+seq.value('range', function* range(start, end) {
+    for (let i = start; i <= end; i += 1) {
+        yield i;
+    }
+});

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -569,6 +569,13 @@ input.search-query__input {
     background: #393939;
 }
 
+.result-placeholder {
+    position: relative;
+    border: solid 5px #333;
+    box-sizing: border-box;
+    background: #393939;
+}
+
 .result__select input[type=checkbox] {
     visibility: hidden;
 }


### PR DESCRIPTION
Note: the merge target for this PR is the base infinite-scroll branch.

Placeholders are positioned with the same formula as cells, and we show [as many extra rows of placeholders](https://github.com/guardian/grid/compare/sc-infinite-scroll...sc-infinite-scroll+placeholders-bis?expand=1#diff-e67d7a61b905b41b4f3d88c228e1ef95R98) as we preload beyond the viewport. For example, the preloaded-rows attribute is currently 4, so we load 4 rows of results before and after the current viewport; that means we should 8 rows of placeholders before and after the current viewport. This is to make it harder to scroll where there are no placeholders.

Jumping further down can still briefly reveal an area with no placeholder, but that's just a performance trade-off and it's acceptable imo.