### PR TITLE
using correct property for image validity.

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -15,7 +15,7 @@
         <li>
             <a class="image-action"
                title="crop"
-               ng:if="ctrl.states.valid"
+               ng:if="ctrl.states.isValid"
                ui:sref="crop({ imageId: ctrl.image.data.id })">
                 <gr-icon>crop</gr-icon>
             </a>


### PR DESCRIPTION
Another oops caused by changes in https://github.com/guardian/grid/pull/963.

We render the crop symbol on the search page based on this property.