### PR TITLE
Removing the archive filter from the UI.

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -36,7 +36,7 @@ search.config(['$stateProvider',
     });
 
     $stateProvider.state('search.results', {
-        url: 'search?query&ids&since&nonFree&archived&uploadedBy&until',
+        url: 'search?query&ids&since&nonFree&uploadedBy&until',
         data: {
             title: function(params) {
                 return params.query ? params.query : 'search';

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -56,16 +56,6 @@
             </li>
 
             <li class="search__filter-item">
-                <label class="search__filter">
-                    <input type="checkbox"
-                           ng:true-value="'true'"
-                           ng:false-value="undefined"
-                           ng:model="searchQuery.filter.archived" />
-                    archived
-                </label>
-            </li>
-
-            <li class="search__filter-item">
                 <gu-date-range class="search__filter search__date"
                                gu:start-date="searchQuery.filter.since"
                                gu:end-date="searchQuery.filter.until"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -439,7 +439,7 @@ textarea.ng-invalid {
     }
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 1000px) {
 
     .search__filters-toggle {
         display: inherit;


### PR DESCRIPTION
From user feedback and [a couple of days of stats](https://goo.gl/4dn4ss) the "archived" checkbox filter isn't used.

User's feedback has been that its important to be able to archive images, but searching for just those images isn't useful - scanning down the whole grid and seeing visual indicators is the default use case.

We *could* add it to the advanced query syntax, however given the usage of this filter, I don't think its necessary right now.

As a result, we can break at a smaller screen size!

Haven't removed this query string from the media api, as its used by reaper atm.