### PR TITLE
[wip] Dulling down the archive status.

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -68,10 +68,10 @@
 
 .batch-archive--all-archived .metadata-line,
 .batch-archive--mixed .metadata-line .material-icons {
-    color: gold;
+    color: #ccc;
 }
 
 .batch-archive__archive:hover,
 .batch-archive__unarchive:hover {
-    color: gold;
+    color: white;
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1560,8 +1560,12 @@ FIXME: what to do with touch devices
     display: block;
 }
 
-.archiver--archived {
-    color: gold;
+ui-archiver {
+    color: #ccc;
+}
+
+ui-archiver .archiver:hover {
+    color: white;
 }
 
 


### PR DESCRIPTION
Following https://github.com/guardian/grid/pull/978, the presence of the icon is a strong enough indicator.

![archive-colour](https://cloud.githubusercontent.com/assets/836140/8856436/d9780bfa-3162-11e5-80c8-e01d4a15ea4f.gif)

The hover state is also the same as the other items in the top bar too:

![archive-colour-ii](https://cloud.githubusercontent.com/assets/836140/8856442/e0678f6c-3162-11e5-8369-31065881823b.gif)
