### PR TITLE
Resume vertical position when navigating back to search results

### DIFF
--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -297,6 +297,7 @@ lazyTable.directive('guLazyTable', ['$window', 'observe$',
                 // with other cell rendering updates
                 scope.$applyAsync(() => {
                     element.css('height', viewHeight + 'px');
+                    scope.$emit('gu-lazy-table:height-changed', viewHeight);
                 });
             });
         }

--- a/kahuna/public/js/services/scroll-position.js
+++ b/kahuna/public/js/services/scroll-position.js
@@ -3,8 +3,8 @@ import angular from 'angular';
 var scrollPosService = angular.module('kahuna.services.scroll-position', []);
 
 scrollPosService.factory('scrollPosition',
-                         ['$window', '$q', 'delay',
-                          function ($window, $q, delay) {
+                         ['$window',
+                          function ($window) {
 
     // The saved scroll top position
     let positionTop;

--- a/kahuna/public/js/services/scroll-position.js
+++ b/kahuna/public/js/services/scroll-position.js
@@ -1,0 +1,45 @@
+import angular from 'angular';
+
+var scrollPosService = angular.module('kahuna.services.scroll-position', []);
+
+scrollPosService.factory('scrollPosition',
+                         ['$window', '$q', 'delay',
+                          function ($window, $q, delay) {
+
+    // The saved scroll top position
+    let positionTop;
+
+    // The original context where the position was saved
+    let originalContext;
+
+    function save(currentContext) {
+        originalContext = currentContext;
+        // Accommodate Chrome & Firefox
+        positionTop = document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function resume(currentContext) {
+        if (angular.equals(currentContext, originalContext)) {
+            $window.scrollTo(0, positionTop);
+        }
+    }
+
+    function getSaved() {
+        return positionTop;
+    }
+
+    function clear() {
+        positionTop = undefined;
+        originalContext = undefined;
+    }
+
+    return {
+        save,
+        resume,
+        getSaved,
+        clear
+    };
+}]);
+
+
+export default scrollPosService;

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -84,3 +84,16 @@ async.factory('apiPoll', ['poll', function(poll) {
 
     return func => poll(func, pollFrequency, pollTimeout);
 }]);
+
+
+// Return a promise resolved the next time the event is fired on the scope
+async.factory('onNextEvent', ['$q', function($q) {
+
+    function onNextEvent(scope, event) {
+        const defer = $q.defer();
+        const unregister = scope.$on(event, defer.resolve);
+        return defer.promise.finally(unregister);
+    }
+
+    return onNextEvent;
+}]);


### PR DESCRIPTION
As long requested and wished for.

Bit fiddly due to browser scrolling being slightly odd, but works well enough.

Demo: https://i.imgur.com/sn4rH7F.gif

## Known issue

Scroll down the default search, click on an image to preview it, then click on the Home/Grid button. One would expect to get back at the top of the results, but the view is actually scrolled down to the previous position.

Note that the Home/Grid button correctly shows the top of the results for any other search than the default.