### PR TITLE
Expose delete argo action on images that can be deleted

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -11,11 +11,13 @@ trait ArgoHelpers extends Results {
 
   val ArgoMediaType = "application/vnd.argo+json"
 
-  // FIXME: DSL to append links?
-  def respond[T](data: T, links: List[Link] = Nil)(implicit writes: Writes[T]): Result = {
+  // FIXME: DSL to append links and actions?
+  def respond[T](data: T, links: List[Link] = Nil, actions: List[Action] = Nil)
+                (implicit writes: Writes[T]): Result = {
     val response = EntityReponse(
-      data  = data,
-      links = links
+      data    = data,
+      links   = links,
+      actions = actions
     )
 
     serializeAndWrap(response, Ok)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/Action.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/Action.scala
@@ -1,0 +1,20 @@
+package com.gu.mediaservice.lib.argo.model
+
+import java.net.URI
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+
+// TODO: add specification of parameters and body structure, mimeType
+case class Action(name: String, href: URI, method: String)
+
+object Action {
+
+  implicit val actionWrites: Writes[Action] = (
+    (__ \ "name").write[String] ~
+      (__ \ "href").write[String].contramap((_: URI).toString) ~
+      (__ \ "method").write[String]
+    )(unlift(Action.unapply))
+
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/EmbeddedEntity.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/EmbeddedEntity.scala
@@ -11,7 +11,8 @@ import com.gu.mediaservice.lib.argo.WriteHelpers
 case class EmbeddedEntity[T](
   uri: URI,
   data: Option[T],
-  links: List[Link] = Nil
+  links: List[Link] = Nil,
+  actions: List[Action] = Nil
 )
 
 object EmbeddedEntity extends WriteHelpers {
@@ -19,7 +20,8 @@ object EmbeddedEntity extends WriteHelpers {
   implicit def embeddedEntityWrites[T: Writes]: Writes[EmbeddedEntity[T]] = (
     (__ \ "uri").write[String].contramap((_: URI).toString) ~
       (__ \ "data").writeNullable[T] ~
-      (__ \ "links").writeNullable[List[Link]].contramap(someListOrNone[Link])
+      (__ \ "links").writeNullable[List[Link]].contramap(someListOrNone[Link]) ~
+      (__ \ "actions").writeNullable[List[Action]].contramap(someListOrNone[Action])
     )(unlift(EmbeddedEntity.unapply[T]))
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/EntityReponse.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/EntityReponse.scala
@@ -11,7 +11,8 @@ import com.gu.mediaservice.lib.argo.WriteHelpers
 case class EntityReponse[T](
   uri: Option[URI] = None,
   data: T,
-  links: List[Link] = Nil
+  links: List[Link] = Nil,
+  actions: List[Action] = Nil
 )
 
 object EntityReponse extends WriteHelpers {
@@ -19,7 +20,8 @@ object EntityReponse extends WriteHelpers {
   implicit def entityResponseWrites[T: Writes]: Writes[EntityReponse[T]] = (
     (__ \ "uri").writeNullable[String].contramap((_: Option[URI]).map(_.toString)) ~
       (__ \ "data").write[T] ~
-      (__ \ "links").writeNullable[List[Link]].contramap(someListOrNone[Link])
+      (__ \ "links").writeNullable[List[Link]].contramap(someListOrNone[Link]) ~
+      (__ \ "actions").writeNullable[List[Action]].contramap(someListOrNone[Action])
     )(unlift(EntityReponse.unapply[T]))
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
@@ -66,6 +66,7 @@ class KeyStore(bucket: String, credentials: AWSCredentials) extends BaseStore[St
 object PermissionType extends Enumeration {
   type PermissionType = Value
   val EditMetadata = Value("editMetadata")
+  val DeleteImage  = Value("deleteImage")
 }
 
 class PermissionStore(bucket: String, credentials: AWSCredentials) extends BaseStore[PermissionType, List[String]](bucket, credentials) {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -27,7 +27,7 @@ object ImageResponse {
   // TODO: move this as a method of Image (fiddly due to dep on Config)
   def imageIsPersisted(image: Image) = {
     image.identifiers.contains(Config.persistenceIdentifier) ||
-      image.exports.length > 0 ||
+      image.exports.nonEmpty ||
       image.userMetadata.exists(_.archived)
   }
 


### PR DESCRIPTION
Expose a hypermedia affordance to declaratively describe a delete action on images, using an experimental extension to the argo media-type (`"actions"` property on resource entities).

By default, a user can only delete their own uploaded images if they haven't been persisted. A new `deleteImage` permission list has been added to list users who can delete any non-persisted image.

This will allow the UI(s) to know when to expose a 'Delete' button on an image.

Example (used both in search results and individual image):

``` json
{  
   "data":{  
      "id":"1ef04f13576e87a053ddd3decbef2cf4e2f21f02",
      "uploadTime":"2015-07-09T15:04:11Z",
     [...]
      "valid":true,
      "cost":"free",
      "persisted":false
   },
   "links":[  
      {  
         "rel":"crops",
         "href":"https://cropper.grid.com/crops/1ef04f13576e87a053ddd3decbef2cf4e2f21f02"
      },
      [...]
   ],
   "actions":[  
      {  
         "name":"delete",
         "href":"https://api.media.grid.com/images/1ef04f13576e87a053ddd3decbef2cf4e2f21f02",
         "method":"DELETE"
      }
   ]
}
```

Note that there is no support for this in theseus yet, but preliminary tests seem to indicate that the extra data doesn't break existing clients.