### PR TITLE
Make select elements full width in usage rights editor.

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -12,6 +12,7 @@
         <!-- We reset the model here else properties remain attached to the\
         model, even though they don't exist in the form -->
         <select
+            class="full-width"
             ng:model="ctrl.category"
             ng:disabled="ctrl.saving"
             ng:options="category as category.name for category in ctrl.categories track by category.value"
@@ -92,6 +93,7 @@
                             </div>
 
                             <select
+                                class="full-width"
                                 name="{{ property.name }}"
                                 ng:switch-when="true"
                                 ng:model="ctrl.model[property.name]"
@@ -102,6 +104,7 @@
                     </div>
 
                     <select
+                        class="full-width"
                         name="{{ property.name }}"
                         ng:if="property.optionsMap"
                         ng:model="ctrl.model[property.name]"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1752,10 +1752,14 @@ ui-archiver .archiver:hover {
    text-align: center;
    border: 1px solid #555;
 }
-.radio-list__circle:checked + .radio-list__label { 
+.radio-list__circle:checked + .radio-list__label {
    background-color:#666;
    border: 1px solid #777;
 }
 .radio-list__circle {
    display: none;
+}
+
+.full-width {
+    width: 100%;
 }


### PR DESCRIPTION
Because its a bit jumpy.

Before:
![full-width](https://cloud.githubusercontent.com/assets/836140/8983911/cf69043a-36c5-11e5-8003-9a569ad009d7.gif)

After:
![screen shot 2015-07-30 at 14 17 41](https://cloud.githubusercontent.com/assets/836140/8983914/d5c2028c-36c5-11e5-92ac-c5449fef2165.png)
