### PR TITLE
Allow service to delete from media api

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -88,6 +88,7 @@ object MediaApi extends Controller with ArgoHelpers {
           case _ => permissionStore.hasPermission(permission, user.email)
         }
       }
+      case service: AuthenticatedService => Future.successful(true)
       case _ => Future.successful(false)
     }
   }

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -88,7 +88,7 @@ object MediaApi extends Controller with ArgoHelpers {
           case _ => permissionStore.hasPermission(permission, user.email)
         }
       }
-      case service: AuthenticatedService => Future.successful(true)
+      case _: AuthenticatedService => Future.successful(true)
       case _ => Future.successful(false)
     }
   }


### PR DESCRIPTION
In order for reaper or other machine authed services to delete from the media api we need to allow that.