### PR TITLE
Appalling hack to avoid jcrop.gif 404s

### DIFF
--- a/kahuna/app/controllers/Application.scala
+++ b/kahuna/app/controllers/Application.scala
@@ -1,10 +1,8 @@
 package controllers
 
 import play.api.mvc.Controller
-import play.api.Logger
 import lib.Config
 import com.gu.mediaservice.lib.auth.PanDomainAuthActions
-import com.gu.pandomainauth.model.User
 
 // TODO: retire Panda entirely from kahuna, let the JS app and the APIs manage auth
 
@@ -18,6 +16,11 @@ object Application extends Controller with PanDomainAuthActions {
       Config.watUri,
       Config.mixpanelToken,
       Config.sentryDsn))
+  }
+
+  // FIXME: Hack to serve asset under the erroneous URL it is requested at
+  def hackJcropGif(ignored: String) = {
+    Assets.at(path="/public", file="jspm_packages/github/tapmodo/Jcrop@0.9.12/css/Jcrop.gif")
   }
 
 }

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -21,3 +21,9 @@ GET     /session                    controllers.Panda.session
 # Management
 GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+
+
+# HACK: appalling workaround to serve this image asset from the erroneous URL it is requested at,
+#       due to a shortcoming in the SystemJS plugin-css build process:
+#       https://github.com/systemjs/plugin-css/issues/52
+GET     /images/$id<[0-9a-z]+>/jspm_packages/github/tapmodo/Jcrop@0.9.12/css/Jcrop.gif controllers.Application.hackJcropGif(id)


### PR DESCRIPTION
It really pains me to write this but not quite as much as getting erroneous alarms on kahuna. Hopefully can get this fixed in the CSS plugin soon.