### PR TITLE
Allow scrolling through 20k images if no query

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -74,7 +74,11 @@ results.controller('SearchResultsCtrl', [
 
         // Arbitrary limit of number of results; too many and the
         // scrollbar becomes hyper-sensitive
-        ctrl.maxResults = 5000;
+        const searchFilteredLimit = 5000;
+        // When reviewing all images, we accept a degraded scroll
+        // experience to allow seeing around one day's worth of images
+        const searchAllLimit = 20000;
+        ctrl.maxResults = $stateParams.query ? searchFilteredLimit : searchAllLimit;
 
         // If not reloading a previous search, discard any previous
         // state related to the last search


### PR DESCRIPTION
Cap to 20,000 images when browsing results with no search query (i.e. everything). This allows people who want to see everything (typically a handful of picture editors) to browse about one day's worth of images.

For everyone else, we keep the 5,000 image limit whenever there are search terms so as to keep the scrollbar less sensitive.

This seems like the simplest solution to accommodate both use cases.