### PR TITLE
Upgrade panda library to 0.2.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,8 +26,8 @@ object Dependencies {
   val awsDeps = Seq("com.amazonaws" % "aws-java-sdk" % "1.9.24")
 
   val pandaDeps = Seq(
-    ("com.gu" %% "pan-domain-auth-core" % "0.2.6") exclude ("xpp3", "xpp3") exclude("com.google.guava", "guava-jdk5"),
-    ("com.gu" %% "pan-domain-auth-play" % "0.2.6")
+    ("com.gu" %% "pan-domain-auth-core" % "0.2.7") exclude ("xpp3", "xpp3") exclude("com.google.guava", "guava-jdk5"),
+    ("com.gu" %% "pan-domain-auth-play" % "0.2.7")
   )
 
   val scalazDeps = Seq(


### PR DESCRIPTION
This new version drops the new cookie for the upcoming asymmetric auth. The old cookie is still issued and used for verification.