### PR TITLE
Fix leaking and errors on image update

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -76,7 +76,7 @@ grPanel.controller('GrPanel', [
             editsApi.getUsageRightsCategories().then((cats) => {
                 var categoryCode = ctrl.usageRights.reduce((m, o) => {
                     return (m == o.data.category) ? o.data.category : 'multiple categories';
-                }, ctrl.usageRights[0].data.category);
+                }, ctrl.usageRights[0] && ctrl.usageRights[0].data.category);
 
                 var usageCategory = cats.find(cat => cat.value === categoryCode);
                 ctrl.usageCategory = usageCategory ? usageCategory.name : categoryCode;

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -139,7 +139,7 @@ image.controller('ImageCtrl', [
             });
         }
 
-        $rootScope.$on('image-updated', (e, updatedImage) => {
+        const freeUpdateListener = $rootScope.$on('image-updated', (e, updatedImage) => {
             ctrl.image = updatedImage;
             ctrl.usageRights = imageService(ctrl.image).usageRights;
             ctrl.setUsageCategory(ctrl.usageCategories, ctrl.usageRights.data.category);
@@ -169,4 +169,8 @@ image.controller('ImageCtrl', [
                     return 'failed to save (press esc to cancel)';
                 });
         };
+
+        $scope.$on('$destroy', function() {
+            freeUpdateListener();
+        });
     }]);

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -11,14 +11,16 @@ export var image = angular.module('kahuna.preview.image', [
 ]);
 
 image.controller('uiPreviewImageCtrl', [
+    '$scope',
     '$rootScope',
     'imageService',
     function (
+        $scope,
         $rootScope,
         imageService) {
     var ctrl = this;
 
-    $rootScope.$on('image-updated', (e, updatedImage) => {
+    const freeUpdateListener = $rootScope.$on('image-updated', (e, updatedImage) => {
         if (ctrl.image.data.id === updatedImage.data.id) {
             ctrl.states = imageService(updatedImage).states;
             ctrl.image = updatedImage;
@@ -27,6 +29,10 @@ image.controller('uiPreviewImageCtrl', [
     });
 
     ctrl.states = imageService(ctrl.image).states;
+
+    $scope.$on('$destroy', function() {
+        freeUpdateListener();
+    });
 }]);
 
 image.directive('uiPreviewImage', function() {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -287,7 +287,7 @@ results.controller('SearchResultsCtrl', [
             }
         };
 
-        $rootScope.$on('image-updated', (e, updatedImage, oldImage) => {
+        const freeUpdateListener = $rootScope.$on('image-updated', (e, updatedImage, oldImage) => {
             var index = ctrl.images.findIndex(i => i.data.id === updatedImage.data.id);
             if (index !== -1) {
                 ctrl.images[index] = updatedImage;
@@ -306,6 +306,7 @@ results.controller('SearchResultsCtrl', [
         });
 
         $scope.$on('$destroy', function() {
+            freeUpdateListener();
             selection.clear();
         });
     }

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -299,7 +299,7 @@ results.controller('SearchResultsCtrl', [
                 }
             }
 
-            var indexAll = ctrl.imagesAll.findIndex(i => i.data.id === updatedImage.data.id);
+            var indexAll = ctrl.imagesAll.findIndex(i => i && i.data.id === updatedImage.data.id);
             if (indexAll !== -1) {
                 ctrl.imagesAll[indexAll] = updatedImage;
             }


### PR DESCRIPTION
1. We should always free global listeners in controllers.
2. imagesAll can contain holes (`undefined`) so we need to protect against it (else we're seeing `Cannot read property 'data' of undefined`)