### PR TITLE
Show delete button on image page if allowed

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -27,7 +27,7 @@
       "rx-angular": "npm:rx-angular@^0.0.14",
       "rx-dom": "npm:rx-dom@^6.0.0",
       "text": "github:systemjs/plugin-text@^0.0.2",
-      "theseus": "npm:theseus@~0.4.1",
+      "theseus": "npm:theseus@~0.5.0",
       "theseus-angular": "npm:theseus-angular@^0.3.0",
       "ua-parser-js": "npm:ua-parser-js@0.7.3"
     },

--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -34,7 +34,7 @@ System.config({
     "rx-angular": "npm:rx-angular@0.0.14",
     "rx-dom": "npm:rx-dom@6.0.0",
     "text": "github:systemjs/plugin-text@0.0.2",
-    "theseus": "npm:theseus@0.4.1",
+    "theseus": "npm:theseus@0.5.0",
     "theseus-angular": "npm:theseus-angular@0.3.0",
     "traceur": "github:jmcriffey/bower-traceur@0.0.90",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.90",
@@ -196,9 +196,9 @@ System.config({
       "angular": "github:angular/bower-angular@1.4.3",
       "any-http-angular": "npm:any-http-angular@0.1.0",
       "any-promise-angular": "npm:any-promise-angular@0.1.1",
-      "theseus": "npm:theseus@0.4.1"
+      "theseus": "npm:theseus@0.5.0"
     },
-    "npm:theseus@0.4.1": {
+    "npm:theseus@0.5.0": {
       "uri-templates": "npm:uri-templates@0.1.7"
     },
     "npm:ua-parser-js@0.7.3": {

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -16,6 +16,7 @@ var image = angular.module(
 image.controller('ImageCtrl', [
     '$rootScope',
     '$scope',
+    '$state',
     'onValChange',
     'image',
     'mediaApi',
@@ -29,6 +30,7 @@ image.controller('ImageCtrl', [
 
     function ($rootScope,
               $scope,
+              $state,
               onValChange,
               image,
               mediaApi,
@@ -130,6 +132,10 @@ image.controller('ImageCtrl', [
         }
 
         function updateAbilities(image) {
+            mediaApi.canDelete(image).then(deletable => {
+                ctrl.canBeDeleted = deletable;
+            });
+
             mediaCropper.canBeCropped(image).then(croppable => {
                 ctrl.canBeCropped = croppable;
             });
@@ -168,6 +174,17 @@ image.controller('ImageCtrl', [
                      */
                     return 'failed to save (press esc to cancel)';
                 });
+        };
+
+        ctrl.delete = function() {
+            const confirmed = window.confirm('Are you sure you want to delete this image from the Grid?');
+            if (confirmed) {
+                mediaApi.delete(image).then(() => {
+                    window.alert('The image will be deleted shortly!');
+                    // Can't stay on the page of a deleted image
+                    $state.go('search');
+                });
+            }
         };
 
         $scope.$on('$destroy', function() {

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -177,6 +177,7 @@ image.controller('ImageCtrl', [
         };
 
         ctrl.delete = function() {
+            // TODO: use inline confirmation as per other tools
             const confirmed = window.confirm('Are you sure you want to delete this image from the Grid?');
             if (confirmed) {
                 mediaApi.delete(image).then(() => {

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -8,6 +8,12 @@
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
+        <button class="top-bar-item"
+                ng:if="ctrl.canBeDeleted"
+                ng:click="ctrl.delete()">
+            <gr-icon>delete</gr-icon><span class="top-bar-item__label">delete</span>
+        </button>
+
         <a class="top-bar-item" href="{{ ctrl.image.data.source | assetFile }}" download target="_blank">
             <gr-icon>file_download</gr-icon><span class="top-bar-item__label">download</span>
         </a>

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -40,11 +40,22 @@ apiServices.factory('mediaApi',
         return root.follow('metadata-search', { field, q }).get();
     }
 
+    // TODO: move to separate service (refactored imageService?)
+    function canDelete(image) {
+        return image.getLink('delete');
+    }
+
+    function delete_(image) {
+        return image.perform('delete');
+    }
+
     return {
         root,
         search,
         find,
         getSession,
-        metadataSearch
+        metadataSearch,
+        delete: delete_,
+        canDelete
     };
 }]);

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -42,7 +42,7 @@ apiServices.factory('mediaApi',
 
     // TODO: move to separate service (refactored imageService?)
     function canDelete(image) {
-        return image.getLink('delete');
+        return image.getAction('delete').then(action => !! action);
     }
 
     function delete_(image) {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -148,8 +148,7 @@ object MediaApi extends Controller with ArgoHelpers {
           canUserDeleteImage(request, source) map { canDelete =>
             if (canDelete) {
               Notifications.publish(Json.obj("id" -> id), "delete-image")
-              // TODO: use respond
-              Accepted.as(ArgoMediaType)
+              Accepted
             } else {
               ImageDeleteForbidden
             }


### PR DESCRIPTION
This allows a handful of allowed people to delete images without the clunky "Delete from Grid" bookmarklet.

![image](https://cloud.githubusercontent.com/assets/36964/9033876/35de3618-39c3-11e5-8792-58dc00401bf6.png)

This feature makes use of the new `actions` in the argo responses :fireworks: 