### PR TITLE
Better mobile and responsive breakpoints

### DIFF
--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -6,6 +6,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title ui:title ui:title-suffix="the grid">the grid</title>
 

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -28,9 +28,9 @@
     <button class="search__filters-toggle"
             type="button"
             ng:click="filtersShown = !filtersShown ">
-        <span ng:show="!filtersShown">▸</span>
-        <span ng:show="filtersShown">▾</span>
-        <gr-icon class="search__filters-toggle__icon">settings</gr-icon>
+        <span ng:show="!filtersShown" class="search__filters-toggle__expander">▸</span>
+        <span ng:show="filtersShown" class="search__filters-toggle__expander">▾</span>
+        <gr-icon class="search__filters-toggle__icon">filter_list</gr-icon>
         <span class="search__filters-toggle__text">search filters</span>
     </button>
 

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -28,8 +28,6 @@
     <button class="search__filters-toggle"
             type="button"
             ng:click="filtersShown = !filtersShown ">
-        <span ng:show="!filtersShown" class="search__filters-toggle__expander">▸</span>
-        <span ng:show="filtersShown" class="search__filters-toggle__expander">▾</span>
         <gr-icon class="search__filters-toggle__icon">filter_list</gr-icon>
         <span class="search__filters-toggle__text">search filters</span>
     </button>

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -30,7 +30,8 @@
             ng:click="filtersShown = !filtersShown ">
         <span ng:show="!filtersShown">▸</span>
         <span ng:show="filtersShown">▾</span>
-        search filters
+        <gr-icon class="search__filters-toggle__icon">settings</gr-icon>
+        <span class="search__filters-toggle__text">search filters</span>
     </button>
 
     <ul class="search__filters" ng:class="filtersShown ? 'search__filters--show' : 'search__filters--hide'">

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -446,7 +446,7 @@ textarea.ng-invalid {
     }
 }
 
-@media screen and (max-width: 550px) {
+@media screen and (max-width: 580px) {
     input.search-query__input {
         width: 130px;
     }
@@ -455,8 +455,8 @@ textarea.ng-invalid {
         display: none;
     }
 
-    .search__filters-toggle__icon {
-        display: inline;
+    .search__filters-toggle__expander {
+        display: none;
     }
     .search__filters-toggle__text {
         display: none;
@@ -467,6 +467,9 @@ textarea.ng-invalid {
 
     .search__filters-toggle {
         display: inherit;
+    }
+    .search__filters-toggle__icon {
+        display: inline;
     }
     .search__filters {
         display: inherit;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -463,7 +463,7 @@ textarea.ng-invalid {
     }
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1030px) {
 
     .search__filters-toggle {
         display: inherit;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -436,10 +436,30 @@ textarea.ng-invalid {
 .search__filters-toggle {
     display: none;
 }
+.search__filters-toggle__icon {
+    display: none;
+}
 
 @media screen and (max-width: 700px) {
     input.search-query__input {
         width: 170px
+    }
+}
+
+@media screen and (max-width: 550px) {
+    input.search-query__input {
+        width: 130px;
+    }
+
+    .search__advanced-toggle {
+        display: none;
+    }
+
+    .search__filters-toggle__icon {
+        display: inline;
+    }
+    .search__filters-toggle__text {
+        display: none;
     }
 }
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -441,18 +441,16 @@ textarea.ng-invalid {
 }
 
 @media screen and (max-width: 700px) {
-    input.search-query__input {
-        width: 170px
+    .search__advanced-toggle {
+        display: none;
     }
 }
 
+/* Note: order matters for cascade ;_; */
 @media screen and (max-width: 580px) {
+    /* fill width */
     input.search-query__input {
-        width: 130px;
-    }
-
-    .search__advanced-toggle {
-        display: none;
+        width: calc(100% - 90px); /* full width - grid logo - filters button */
     }
 
     .search__filters-toggle__expander {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -453,9 +453,6 @@ textarea.ng-invalid {
         width: calc(100% - 90px); /* full width - grid logo - filters button */
     }
 
-    .search__filters-toggle__expander {
-        display: none;
-    }
     .search__filters-toggle__text {
         display: none;
     }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -547,8 +547,9 @@ input.search-query__input {
 }
 
 
-.search__advanced-toggle {
-    margin: 0 10px;
+.search__advanced-toggle,
+.search__filters-container {
+    margin-left: 10px;
 }
 
 .search__date {


### PR DESCRIPTION
Add meta-viewport tag to force viewport to device width (better on mobile), adjust breakpoints and more collapsing so search results are usable on a mobile phone.

Note that other screens (e.g. image preview, cropping) are not really.

# Before

![recorded](https://cloud.githubusercontent.com/assets/36964/9036565/96610d1e-39da-11e5-992d-7d05b392a601.gif)

# After

![recorded](https://cloud.githubusercontent.com/assets/36964/9036534/4f18c1fe-39da-11e5-8acb-edb34eb2b737.gif)


Not sure how scalable this approach to breakpoints is in the long run, but it's an easy win for now and it remains fairly isolated.