### PR TITLE
remove extra event emission.

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -254,7 +254,6 @@ service.factory('editsService',
         return update(image.data.userMetadata.data.metadata, changed, image)
             .then(() => {
                 return image.get().then(updatedImage => {
-                    $rootScope.$emit('image-updated', updatedImage, image);
                     return updatedImage;
                 });
             });

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -251,12 +251,7 @@ service.factory('editsService',
 
         var changed = getMetadataDiff(image, proposedMetadata);
 
-        return update(image.data.userMetadata.data.metadata, changed, image)
-            .then(() => {
-                return image.get().then(updatedImage => {
-                    return updatedImage;
-                });
-            });
+        return update(image.data.userMetadata.data.metadata, changed, image);
     }
 
     function batchUpdateMetadataField (images, field, value) {


### PR DESCRIPTION
Fixes https://github.com/guardian/grid/issues/1015.

As of https://github.com/guardian/grid/commit/4423078cec5109430ebeb0ac676407203c6e0642#diff-17227494f078d3840f7fa4a485a88e2fR112 we're emitting the `image-updated` event in the `update` function.

Firing it again in `updateMetadataField` causes [this](https://github.com/guardian/grid/issues/1015) behaviour.