### PR TITLE
remove extra event emission again.

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -251,7 +251,8 @@ service.factory('editsService',
 
         var changed = getMetadataDiff(image, proposedMetadata);
 
-        return update(image.data.userMetadata.data.metadata, changed, image);
+        return update(image.data.userMetadata.data.metadata, changed, image)
+            .then(() => image.get());
     }
 
     function batchUpdateMetadataField (images, field, value) {

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -251,13 +251,7 @@ service.factory('editsService',
 
         var changed = getMetadataDiff(image, proposedMetadata);
 
-        return update(image.data.userMetadata.data.metadata, changed, image)
-            .then(() => {
-                return image.get().then(updatedImage => {
-                    $rootScope.$emit('image-updated', updatedImage, image);
-                    return updatedImage;
-                });
-            });
+        return update(image.data.userMetadata.data.metadata, changed, image);
     }
 
     function batchUpdateMetadataField (images, field, value) {


### PR DESCRIPTION
See https://github.com/guardian/grid/pull/1019.

We use the image resource that's returned in `then` [here](https://github.com/guardian/grid/blob/master/kahuna/public/js/image/controller.js#L156), so https://github.com/guardian/grid/pull/1019 wasn't entirely correct!

We should probably unify the way we use the `update` function - either listen to an event, or use the promise (the batch editing uses the promise).