### PR TITLE
add filename to image case class

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -117,6 +117,7 @@ object Mappings {
           "uploadedBy" -> nonAnalyzedString,
           "lastModified" -> dateFormat,
           "identifiers" -> dynamicObj,
+          "filename" -> nonAnalyzedString,
           "suggestMetadataCredit" -> simpleSuggester
         ),
         "dynamic_templates" -> Json.arr(Json.obj(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -98,6 +98,11 @@ object Mappings {
       "usageRights" -> usageRightsMapping
     )
 
+  val uploadInfo =
+    nonDynamicObj(
+      "filename" -> nonAnalyzedString
+    )
+
   val imageMapping: String =
     Json.stringify(Json.obj(
       "image" -> Json.obj(
@@ -117,7 +122,7 @@ object Mappings {
           "uploadedBy" -> nonAnalyzedString,
           "lastModified" -> dateFormat,
           "identifiers" -> dynamicObj,
-          "filename" -> nonAnalyzedString,
+          "uploadInfo" -> uploadInfo,
           "suggestMetadataCredit" -> simpleSuggester
         ),
         "dynamic_templates" -> Json.arr(Json.obj(

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -11,6 +11,7 @@ case class Image(
   uploadedBy:          String,
   lastModified:        Option[DateTime],
   identifiers:         Map[String, String],
+  filename:            Option[String],
   source:              Asset,
   thumbnail:           Option[Asset],
   fileMetadata:        FileMetadata,
@@ -35,6 +36,7 @@ object Image {
       (__ \ "uploadedBy").read[String] ~
       (__ \ "lastModified").readNullable[String].map(parseOptDateTime) ~
       (__ \ "identifiers").readNullable[Map[String, String]].map(_ getOrElse Map()) ~
+      (__ \ "filename").readNullable[String] ~
       (__ \ "source").read[Asset] ~
       (__ \ "thumbnail").readNullable[Asset] ~
       (__ \ "fileMetadata").readNullable[FileMetadata].map(_ getOrElse FileMetadata()) ~
@@ -52,6 +54,7 @@ object Image {
       (__ \ "uploadedBy").write[String] ~
       (__ \ "lastModified").writeNullable[String].contramap(printOptDateTime) ~
       (__ \ "identifiers").write[Map[String, String]] ~
+      (__ \ "filename").writeNullable[String] ~
       (__ \ "source").write[Asset] ~
       (__ \ "thumbnail").writeNullable[Asset] ~
       (__ \ "fileMetadata").write[FileMetadata] ~

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -11,7 +11,7 @@ case class Image(
   uploadedBy:          String,
   lastModified:        Option[DateTime],
   identifiers:         Map[String, String],
-  filename:            Option[String],
+  uploadInfo:          UploadInfo,
   source:              Asset,
   thumbnail:           Option[Asset],
   fileMetadata:        FileMetadata,
@@ -36,7 +36,7 @@ object Image {
       (__ \ "uploadedBy").read[String] ~
       (__ \ "lastModified").readNullable[String].map(parseOptDateTime) ~
       (__ \ "identifiers").readNullable[Map[String, String]].map(_ getOrElse Map()) ~
-      (__ \ "filename").readNullable[String] ~
+      (__ \ "uploadInfo").readNullable[UploadInfo].map(_ getOrElse UploadInfo()) ~
       (__ \ "source").read[Asset] ~
       (__ \ "thumbnail").readNullable[Asset] ~
       (__ \ "fileMetadata").readNullable[FileMetadata].map(_ getOrElse FileMetadata()) ~
@@ -54,7 +54,7 @@ object Image {
       (__ \ "uploadedBy").write[String] ~
       (__ \ "lastModified").writeNullable[String].contramap(printOptDateTime) ~
       (__ \ "identifiers").write[Map[String, String]] ~
-      (__ \ "filename").writeNullable[String] ~
+      (__ \ "uploadInfo").write[UploadInfo] ~
       (__ \ "source").write[Asset] ~
       (__ \ "thumbnail").writeNullable[Asset] ~
       (__ \ "fileMetadata").write[FileMetadata] ~

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UploadInfo.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UploadInfo.scala
@@ -1,0 +1,10 @@
+package com.gu.mediaservice.model
+
+import play.api.libs.json.Json
+
+case class UploadInfo(filename: Option[String] = None)
+
+object UploadInfo {
+  implicit val jsonWrites = Json.writes[UploadInfo]
+  implicit val jsonReads = Json.reads[UploadInfo]
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
@@ -17,7 +17,7 @@ trait MetadataHelper {
       uploadedBy = "tester",
       lastModified = None,
       identifiers = Map(),
-      filename = None,
+      uploadInfo = UploadInfo(),
       source = Asset(URI.create("http://example.com/image.jpg"), Some(0), None, None),
       thumbnail = None,
       fileMetadata = FileMetadata(),

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
@@ -17,6 +17,7 @@ trait MetadataHelper {
       uploadedBy = "tester",
       lastModified = None,
       identifiers = Map(),
+      filename = None,
       source = Asset(URI.create("http://example.com/image.jpg"), Some(0), None, None),
       thumbnail = None,
       fileMetadata = FileMetadata(),

--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -114,7 +114,7 @@ class ImageLoader extends Controller with ArgoHelpers {
 
     Logger.info(s"Received ${uploadRequestDescription(uploadRequest)}")
 
-    val supportedMimeType = Config.supportedMimeTypes.contains(mimeType_)
+    val supportedMimeType = Config.supportedMimeTypes.contains(Some(mimeType_))
 
     if (supportedMimeType) storeFile(uploadRequest) else unsupportedTypeError(uploadRequest)
   }

--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -45,8 +45,8 @@ class ImageLoader extends Controller with ArgoHelpers {
   val indexResponse = {
     val indexData = Map("description" -> "This is the Loader Service")
     val indexLinks = List(
-      Link("load",   s"$rootUri/images{?uploadedBy,identifiers,uploadTime}"),
-      Link("import", s"$rootUri/imports{?uri,uploadedBy,identifiers,uploadTime}")
+      Link("load",   s"$rootUri/images{?uploadedBy,identifiers,uploadTime,filename}"),
+      Link("import", s"$rootUri/imports{?uri,uploadedBy,identifiers,uploadTime,filename}")
     )
     respond(indexData, indexLinks)
   }

--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -114,7 +114,7 @@ class ImageLoader extends Controller with ArgoHelpers {
 
     Logger.info(s"Received ${uploadRequestDescription(uploadRequest)}")
 
-    val supportedMimeType = Config.supportedMimeTypes.contains(Some(mimeType_))
+    val supportedMimeType = Config.supportedMimeTypes.exists(Some(_) == mimeType_)
 
     if (supportedMimeType) storeFile(uploadRequest) else unsupportedTypeError(uploadRequest)
   }

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -85,6 +85,7 @@ case object ImageUpload {
       uploadRequest.uploadedBy,
       Some(uploadRequest.uploadTime),
       uploadRequest.identifiers,
+      uploadRequest.filename,
       source,
       Some(thumbnail),
       fileMetadata,

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -85,7 +85,7 @@ case object ImageUpload {
       uploadRequest.uploadedBy,
       Some(uploadRequest.uploadTime),
       uploadRequest.identifiers,
-      uploadRequest.filename,
+      uploadRequest.uploadInfo,
       source,
       Some(thumbnail),
       fileMetadata,

--- a/image-loader/app/model/UploadRequest.scala
+++ b/image-loader/app/model/UploadRequest.scala
@@ -10,7 +10,8 @@ case class UploadRequest(
   mimeType: Option[String],
   uploadTime: DateTime,
   uploadedBy: String,
-  identifiers: Map[String, String]
+  identifiers: Map[String, String],
+  filename: Option[String]
 ) {
   val identifiersMeta = identifiers.map { case (k,v) => (s"identifier!$k", v) }.toMap
 }

--- a/image-loader/app/model/UploadRequest.scala
+++ b/image-loader/app/model/UploadRequest.scala
@@ -1,6 +1,7 @@
 package model
 
 import java.io.File
+import com.gu.mediaservice.model.UploadInfo
 import org.joda.time.DateTime
 
 
@@ -11,7 +12,7 @@ case class UploadRequest(
   uploadTime: DateTime,
   uploadedBy: String,
   identifiers: Map[String, String],
-  filename: Option[String]
+  uploadInfo: UploadInfo
 ) {
   val identifiersMeta = identifiers.map { case (k,v) => (s"identifier!$k", v) }.toMap
 }

--- a/image-loader/conf/routes
+++ b/image-loader/conf/routes
@@ -1,5 +1,5 @@
 GET     /                           controllers.Application.index
-POST    /images                     controllers.Application.loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String])
+POST    /images                     controllers.Application.loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename = Option[String])
 POST    /imports                    controllers.Application.importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String])
 
 # Management

--- a/image-loader/conf/routes
+++ b/image-loader/conf/routes
@@ -1,6 +1,6 @@
 GET     /                           controllers.Application.index
-POST    /images                     controllers.Application.loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename = Option[String])
-POST    /imports                    controllers.Application.importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String])
+POST    /images                     controllers.Application.loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
+POST    /imports                    controllers.Application.importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
 
 # Management
 GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -147,6 +147,7 @@ object ImageResponse {
     (__ \ "uploadedBy").write[String] ~
     (__ \ "lastModified").writeNullable[DateTime] ~
     (__ \ "identifiers").write[Map[String,String]] ~
+    (__ \ "filename").writeNullable[String] ~
     (__ \ "source").write[Asset] ~
     (__ \ "thumbnail").writeNullable[Asset] ~
     (__ \ "fileMetadata").write[FileMetadataEntity]

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -147,7 +147,7 @@ object ImageResponse {
     (__ \ "uploadedBy").write[String] ~
     (__ \ "lastModified").writeNullable[DateTime] ~
     (__ \ "identifiers").write[Map[String,String]] ~
-    (__ \ "filename").writeNullable[String] ~
+    (__ \ "uploadInfo").write[UploadInfo] ~
     (__ \ "source").write[Asset] ~
     (__ \ "thumbnail").writeNullable[Asset] ~
     (__ \ "fileMetadata").write[FileMetadataEntity]


### PR DESCRIPTION
Fixes #1004.
Saving the filename if it's there.

Should we be doing:

```JavaScript
{
  "uploadInfo": {
    "filename": "thingamajig.jpg"
  }
}
```