### PR TITLE
Retire "your past 50 uploads" from the upload screen

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -50,7 +50,7 @@
             <li class="search__filter-item">
                 <label class="search__filter">
                     <input type="checkbox"
-                           ng:model="searchQuery.filter.uploadedByMe" />
+                           ng:model="searchQuery.pseudoFilter.uploadedByMe" />
                     your uploads
                 </label>
             </li>

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -7,6 +7,7 @@
     <gr-top-bar-actions>
         <a ng:controller="SessionCtrl"
            ui:sref="search.results({uploadedBy: user.email, nonFree: true})"
+           gr:track-click="Your recent uploads button"
            class="top-bar-item"
            title="your uploads">
             <gr-icon>photo_library</gr-icon>

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -5,7 +5,10 @@
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
-        <a class="top-bar-item" ui:sref="upload" title="your recent uploads">
+        <a ng:controller="SessionCtrl"
+           ui:sref="search.results({uploadedBy: user.email, nonFree: true})"
+           class="top-bar-item"
+           title="your uploads">
             <gr-icon>photo_library</gr-icon>
             <span class="top-bar-item__label">your recent uploads</span>
         </a>

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -4,15 +4,9 @@ import '../edits/image-editor';
 var upload = angular.module('kahuna.upload.controller', ['kahuna.edits.imageEditor']);
 
 upload.controller('UploadCtrl',
-                  ['$scope', 'uploadManager', 'mediaApi',
-                   function($scope, uploadManager, mediaApi) {
+                  ['uploadManager',
+                   function(uploadManager) {
 
     // TODO: Show multiple jobs?
     this.latestJob = uploadManager.getLatestRunningJob();
-
-    // my uploads
-    mediaApi.getSession().then(session => {
-        var uploadedBy = session.user.email;
-        mediaApi.search('', { uploadedBy }).then(resource => this.myUploads = resource);
-    });
 }]);

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -17,29 +17,6 @@
 
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
     </section>
-
-
-    <section class="section" ng:if="ctrl.myUploads.data.length > 0">
-        <h2 class="section-heading">Your past 50 uploads</h2>
-
-        <ul>
-            <li ng:repeat="result in ctrl.myUploads.data" class="upload-result">
-                <ui-image-editor image="result"></ui-image-editor>
-            </li>
-        </ul>
-
-        <p ng:controller="SessionCtrl">
-            <a class="coloured-link" ui:sref="search.results({uploadedBy: user.email})">View all your uploads.</a>
-        </p>
-    </section>
-
-    <div class="upload-yours"
-       ng:if="ctrl.myUploads.data.length === 0">
-        <p>You haven't uploaded anything yet.</p>
-        <p>Either drag 'n drop an image onto this screen or click the blue
-        upload button in the top right hand corner to get your images on
-        the Grid.</p>
-    </div>
 </div>
 
 <dnd-uploader></dnd-uploader>


### PR DESCRIPTION
This also changes the "your recent uploads" link to simply load up your uploads (no free filter) in the search results. Happy to debate whether we still want that link for a while to get people used to this new flow, or whether to retire it altogether.

![recorded](https://cloud.githubusercontent.com/assets/36964/9043850/7c0b487c-3a10-11e5-955d-571fd726cf8a.gif)

This is just one piece of the puzzle, I still think we can work on the uploads screen to make it clearer that images are immediately uploaded and it's a transient panel.

/cc @alastairjardine 