### PR TITLE
Making the `/usage-rights` endpoint resolve in all cases.

### DIFF
--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -144,8 +144,10 @@ object EditsController extends Controller with ArgoHelpers {
 
   def getUsageRights(id: String) = Authenticated.async {
     dynamo.jsonGet(id, "usageRights").map { dynamoEntry =>
-      val usageRights = (dynamoEntry \ "usageRights").as[UsageRights]
-      respond(usageRights)
+      (dynamoEntry \ "usageRights").asOpt[UsageRights] match {
+        case Some(usageRights: UsageRights) => respond(usageRights)
+        case _ => respond(NoRights)
+      }
     }
   }
 


### PR DESCRIPTION
Stop getting 500s when asking for usage rights when there isn't any. - e.g:

[PROD-metadata-api]/metadata/79472bf085aecb85a2bb50fba591e1ea1cfdf774/usage-rights

Instead, respond with:

```json
{
    "data": {}
}
```