### PR TITLE
Em metadata list styling

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -233,7 +233,7 @@
                 full metadata
             </button>
 
-            <table ng:show="metadataExpanded" class="metadata">
+            <table ng:show="metadataExpanded" class="metadata metadata-line">
                 <tbody class="metadata__body">
                     <tr ng:repeat="(key, value) in ctrl.metadata" ng:if="ctrl.isUsefulMetadata(key)">
                         <th class="metadata-line__key">{{key}}</th>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -237,7 +237,7 @@
                 <tbody class="metadata__body">
                     <tr ng:repeat="(key, value) in ctrl.metadata" ng:if="ctrl.isUsefulMetadata(key)">
                         <th class="metadata-line__key">{{key}}</th>
-                        <td>{{value}}</td>
+                        <td class="metadata-line__info">{{value}}</td>
                     </tr>
                 </tbody>
             </table>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1197,9 +1197,6 @@ FIXME: what to do with touch devices
 .metadata-line__key {
     font-weight: bold;
     color: #999;
-}
-
-.image-info__group--list .metadata-line__key {
     padding-right: 20px;
     vertical-align: top;
     text-align: left;


### PR DESCRIPTION
Corrects styling of the metadata shown when you click "Show full metadata"; makes padding consistent with metadata list which is always displayed.  