### PR TITLE
Resolve metadata editor 500s when asked for missing content

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -62,6 +62,17 @@ trait ArgoHelpers extends Results {
     serializeAndWrap(response, errorStatus)
   }
 
+  def respondNotFound(errorMessage: String): Result = {
+    val response = ErrorReponse[Int](
+      errorKey     = "not-found",
+      errorMessage = errorMessage,
+      data         = None,
+      links        = Nil
+    )
+
+    serializeAndWrap(response, Status(404))
+  }
+
 
   private def serializeAndWrap[T](response: T, status: Status)(implicit writes: Writes[T]): Result = {
     val json = Json.toJson(response)

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -131,7 +131,7 @@ object EditsController extends Controller with ArgoHelpers {
       val metadata = (dynamoEntry \ "metadata").as[ImageMetadata]
       respond(metadata)
     } recover {
-      case NoItemFound => respond(false)
+      case NoItemFound => respond(Json.toJson(JsObject(Nil)))
     }
   }
 

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -99,7 +99,9 @@ object EditsController extends Controller with ArgoHelpers {
   def getLabels(id: String) = Authenticated.async {
     dynamo.setGet(id, "labels")
       .map(labelsCollection(id, _))
-      .map {case (uri, labels) => respondCollection(labels)}
+      .map {case (uri, labels) => respondCollection(labels)} recover {
+        case NoItemFound => respond(Array[String]())
+      }
   }
 
   def addLabels(id: String) = Authenticated.async { req =>
@@ -128,6 +130,8 @@ object EditsController extends Controller with ArgoHelpers {
     dynamo.jsonGet(id, "metadata").map { dynamoEntry =>
       val metadata = (dynamoEntry \ "metadata").as[ImageMetadata]
       respond(metadata)
+    } recover {
+      case NoItemFound => respond(false)
     }
   }
 
@@ -141,11 +145,12 @@ object EditsController extends Controller with ArgoHelpers {
     )
   }
 
-
   def getUsageRights(id: String) = Authenticated.async {
     dynamo.jsonGet(id, "usageRights").map { dynamoEntry =>
       val usageRights = (dynamoEntry \ "usageRights").as[UsageRights]
       respond(usageRights)
+    } recover {
+      case NoItemFound => respondNotFound("No usage rights overrides found")
     }
   }
 


### PR DESCRIPTION
Currently a number of metadata-editor endpoints produce 500 errors when asked for non-existent content. This PR changes that behaviour to either 404 or 200 dependent on endpoint.

Output by endpoint is below:

---
https://media-metadata.local.dev-gutools.co.uk/metadata/nope/usage-rights

**HTTP STATUS 404**

Status is 404 as any data indicates full override of existing data.

```json
{
  "errorKey": "not-found",
  "errorMessage": "No usage rights overrides found"
}
```
---
https://media-metadata.local.dev-gutools.co.uk/metadata/nope/archived

Status is 200 as but data empty as archived status is necessarily false if no info available.

**HTTP STATUS 200**
```json
{
  "data": false
}
```
---
https://media-metadata.local.dev-gutools.co.uk/metadata/nope/labels

Status is 200 with data as empty list to mirror full api response for no labels.

**HTTP STATUS 200**
```json
{
  "data": [ ]
}
```
---
https://media-metadata.local.dev-gutools.co.uk/metadata/nope/metadata

Status is 200 as but data empty to mirror full api response for no metadata overrides.

**HTTP STATUS 200**
```json
{
  "data": { }
}
```
