### PR TITLE
[wip] Remove `None` from usage rights publication list.

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -61,30 +61,13 @@
                             <div class="radio-list" ng:switch-when="false">
                                 <div class="radio-list__item"
                                     ng:repeat="o in property.options">
-
-                                    <input type="radio"
-                                        ng:if="$first && !property.required"
-                                        value=""
-                                        id="none-{{property.name}}-radio-list__item"
-                                        ng:checked="!ctrl.model[property.name]"
-                                        class="radio-list__circle"
-                                        name="{{property.name}}-radio-list" />
-                                    <label
-                                        ng:if="$first && !property.required"
-                                        for="none-{{property.name}}-radio-list__item"
-                                        class="radio-list__label"
-                                        ng:class="{'radio-list--selected': !ctrl.model[property.name]}">
-                                        <div class="radio-list__selection-state"></div>
-                                        <div class="radio-list__label-value">None</div>
-                                    </label>
-
                                     <input type="radio"
                                         value="{{o}}"
                                         id="{{o}}-{{property.name}}-radio-list__item"
                                         class="radio-list__circle"
                                         name="{{property.name}}-radio-list"
-                                        ng:required="property.required"
-                                        ng:model="ctrl.model[property.name]" />
+                                        ng:model="ctrl.model[property.name]"
+                                        required/>
                                     <label
                                         for="{{o}}-{{property.name}}-radio-list__item"
                                         class="radio-list__label"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -97,7 +97,7 @@
                         ng:model="ctrl.model[property.name]"
                         ng:required="property.required"
                         ng:options="o for o in ctrl.getOptionsFor(property)">
-                        <option value="">None</option>
+                        <option value="" disabled>None</option>
                     </select>
 
                 </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1081,11 +1081,11 @@ FIXME: what to do with touch devices
 .image-info__group {
     padding: 10px;
     border-bottom: 1px solid #565656;
-} 
+}
 
 .image-info:last-child .image-info__group{
     border-bottom: none;
-}   
+}
 
 .image-info__group table {
     border-collapse: collapse;
@@ -1200,7 +1200,6 @@ FIXME: what to do with touch devices
 .image-info__usage-rights {
     width: 100%;
     box-sizing: border-box;
-    font-weight: bold;
     color: #999;
 }
 
@@ -1744,7 +1743,9 @@ ui-archiver .archiver:hover {
 .form-label {
     display: flex;
 }
-
+.form-label__text {
+    font-weight: bold;
+}
 .form-label__error,
 .form-label__notice {
     font-size: 1.2rem;


### PR DESCRIPTION
`None` is not a valid value - its was copied over when moving from a select to radio buttons.