### PR TITLE
Match up es.cluster name between services and ES config itself

### DIFF
--- a/media-api/conf/application.conf
+++ b/media-api/conf/application.conf
@@ -3,7 +3,7 @@ application.langs="en"
 session.httpOnly=false
 session.secure=true
 
-es.cluster = "media-api"
+es.cluster = "media-service"
 es.host = "localhost"
 es.port = 9300
 

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -122,7 +122,7 @@ abstract class EsScript {
   // FIXME: Get from config (no can do as Config is coupled to Play)
   final val esApp   = "elasticsearch"
   final val esPort = 9300
-  final val esCluster = "media-api"
+  final val esCluster = "media-service"
 
   def log(msg: String) = System.out.println(s"[Reindexer]: $msg")
 

--- a/thrall/conf/application.conf
+++ b/thrall/conf/application.conf
@@ -1,6 +1,6 @@
 application.langs="en"
 
-es.cluster = "media-api"
+es.cluster = "media-service"
 es.host = "localhost"
 es.port = 9300
 


### PR DESCRIPTION
My hope is for this to reduce noise in logs like:

```
2015-08-05 15:26:07,283 - [WARN] - from org.elasticsearch.client.transport in elasticsearch[Justine Hammer][generic][T#1] 
[Justine Hammer] node null not part of the cluster Cluster [media-api], ignoring...
```

Will want to triple check effect on TEST first.