### PR TITLE
Add tracking on recent uploads button clicks

### DIFF
--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -5,7 +5,10 @@
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
-        <a class="top-bar-item" ui:sref="upload" title="your recent uploads">
+        <a ui:sref="upload"
+           gr:track-click="Your recent uploads button"
+           class="top-bar-item"
+           title="your recent uploads">
             <gr-icon>photo_library</gr-icon>
             <span class="top-bar-item__label">your recent uploads</span>
         </a>


### PR DESCRIPTION
I'm still feeling like being overly cautious about releasing #1024 (retire 50 recent uploads), so this adds tracking on the recent uploads button so we can see how much it's actually being used.