### PR TITLE
Fixes bug where top bar items beneath sub nav

### DIFF
--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
@@ -2,7 +2,7 @@ gr-top-bar {
     display: block;
     height: 50px; /* faking we're in the flow */
     position: relative;
-    z-index: 2;
+    z-index: 3;
 }
 
 gr-top-bar-nav {


### PR DESCRIPTION
Spotted by @jamesgorrie:

Before:
![ohno](https://cloud.githubusercontent.com/assets/953792/9110334/c533ad34-3c34-11e5-9980-d3585592b025.jpeg)

After:
![yup](https://cloud.githubusercontent.com/assets/953792/9110338/cb0bd538-3c34-11e5-824f-073f99b77c7c.jpeg)

