### PR TITLE
correcting `panel__content` height.

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -20,16 +20,8 @@
     right: -290px;
     transition: right 0.1s;
 }
-.panel__top,
-.panel__bottom {
-    padding: 10px;
-}
-
-.panel__bottom {
-    height: 40px;
-}
-
 .panel__top {
+    padding: 10px;
     font-size: 18px;
     height: 20px;
 }
@@ -46,7 +38,7 @@
 
 .panel__content {
     clear: both;
-    height: calc(100% - 60px - 60px); /* 60px panel__top, 60px panel__bottom */
+    height: calc(100% - 40px); /* panel__top  (20px height, 20px padding) */
     overflow: auto;
 }
 


### PR DESCRIPTION
`panel-bottom` housed the cancel button, which has been promoted to the toolbar, can get rid of that class now.

(big gifs because recorded on retina screen :cry:)

before
![before](https://cloud.githubusercontent.com/assets/836140/9110605/e2febd7a-3c36-11e5-904d-5ea633750dc7.gif)

after
![after](https://cloud.githubusercontent.com/assets/836140/9110607/e6eb3062-3c36-11e5-983a-387f587378a4.gif)
