### PR TITLE
Validate crop specification against image

### DIFF
--- a/cropper/app/controllers/Application.scala
+++ b/cropper/app/controllers/Application.scala
@@ -86,6 +86,7 @@ object Application extends Controller with ArgoHelpers {
         } recover {
           case InvalidImage => respondError(BadRequest, "invalid-image", InvalidImage.getMessage)
           case MissingSecureSourceUrl => respondError(BadRequest, "no-source-image", MissingSecureSourceUrl.getMessage)
+          case InvalidCropRequest => respondError(BadRequest, "no-source-image", InvalidCropRequest.getMessage)
         }
       }
     )

--- a/cropper/app/controllers/Application.scala
+++ b/cropper/app/controllers/Application.scala
@@ -86,7 +86,7 @@ object Application extends Controller with ArgoHelpers {
         } recover {
           case InvalidImage => respondError(BadRequest, "invalid-image", InvalidImage.getMessage)
           case MissingSecureSourceUrl => respondError(BadRequest, "no-source-image", MissingSecureSourceUrl.getMessage)
-          case InvalidCropRequest => respondError(BadRequest, "no-source-image", InvalidCropRequest.getMessage)
+          case InvalidCropRequest => respondError(BadRequest, "invalid-crop", InvalidCropRequest.getMessage)
         }
       }
     )

--- a/cropper/app/lib/Crops.scala
+++ b/cropper/app/lib/Crops.scala
@@ -55,7 +55,7 @@ object Crops {
 
   def isInvalidCrop(asset: Asset, specification: CropSource): Boolean = {
     asset.dimensions.map { dimensions =>
-      val bounds = specification.bounds;
+      val bounds = specification.bounds
 
       val outOfBounds = bounds.x > dimensions.width || bounds.y > dimensions.height
       val cropTooSmall = bounds.width < 1 || bounds.height < 1

--- a/cropper/app/lib/Crops.scala
+++ b/cropper/app/lib/Crops.scala
@@ -2,12 +2,13 @@ package lib
 
 import scala.concurrent.Future
 import lib.imaging.{ExportOperations, ExportResult}
-import com.gu.mediaservice.model.{Asset, Dimensions, SourceImage, Crop, Bounds}
+import com.gu.mediaservice.model.{Asset, Dimensions, SourceImage, Crop, Bounds, CropSource}
 import java.net.{URI, URL}
 import java.io.File
 
 case object InvalidImage extends Exception("Invalid image cannot be cropped")
 case object MissingSecureSourceUrl extends Exception("Missing secureUrl from source API")
+case object InvalidCropRequest extends Exception("Crop request invalid for image dimesions")
 
 case class MasterCrop(sizing: Future[Asset], file: File, dimensions: Dimensions, aspectRatio: Float)
 
@@ -52,10 +53,24 @@ object Crops {
     else
       Config.landscapeCropSizingWidths.filter(_ <= bounds.width).map(w => Dimensions(w, math.round(w / aspectRatio)))
 
+  def isInvalidCrop(asset: Asset, specification: CropSource): Boolean = {
+    asset.dimensions.map { dimensions =>
+      val bounds = specification.bounds;
+
+      val outOfBounds = bounds.x > dimensions.width || bounds.y > dimensions.height
+      val cropTooSmall = bounds.width < 1 || bounds.height < 1
+      val cropTooBig = bounds.width > dimensions.width || bounds.height > dimensions.height
+
+      outOfBounds || cropTooSmall || cropTooBig
+    } getOrElse true
+  }
+
   def export(apiImage: SourceImage, crop: Crop): Future[ExportResult] = {
     val source    = crop.specification
     val mediaType = "image/jpeg"
     val secureUrl = apiImage.source.secureUrl.getOrElse(throw MissingSecureSourceUrl)
+
+    if(isInvalidCrop(apiImage.source, source)) throw InvalidCropRequest
 
     for {
       sourceFile <- tempFileFromURL(secureUrl, "cropSource", "")


### PR DESCRIPTION
Cropper can be asked to perform impossible crops which can cause it to
behave strangely (500s thrown from im4java as crop fails, endless waits to perform impossibly huge crops).

This changeset validates crop requests against the source image
dimensions before performing a crop. Invalid crops will result in a HTTP
400 Bad Request.