### PR TITLE
Locking metadata panel doesn't in older versions of Chrome

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -624,7 +624,7 @@ input.search-query__input {
 }
 
 .results--panel-locked {
-    width: calc(100%- 284px);
+    width: calc(100% - 290px);
 }
 
 .results--left {


### PR DESCRIPTION
Older versions of chrome don't like the %- inside the css calc