### PR TITLE
not all images have copyright.

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -187,8 +187,8 @@
                     </span>
                 </dd>
 
-                <dt class="image-info__group--dl__key metadata-line__key">copyright</dt>
-                <dd class="image-info__group--dl__value metadata-line__info"><a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a></dd>
+                <dt ng:if="ctrl.metadata.copyright" class="image-info__group--dl__key metadata-line__key">copyright</dt>
+                <dd ng:if="ctrl.metadata.copyright" class="image-info__group--dl__value metadata-line__info"><a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a></dd>
 
 
                 <dt class="image-info__group--dl__key metadata-line__key">uploaded</dt>


### PR DESCRIPTION
Example image that has errors in console - [https://media.[DOMAIN]./images/3094ca05c200f86129d6b016311e0f9856eab428](https://media.../images/3094ca05c200f86129d6b016311e0f9856eab428) (complete the domain).

```
TypeError: Cannot read property 'replace' of undefined
    at i (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:26:5659)
    at https://media.[DOMAIN].co.uk/assets/js/dist/build.js:26:5742
    at fn (eval at <anonymous> (unknown source), <anonymous>:4:275)
    at p.$eval (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:3:6418)
    at D.link (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:6:18326)
    at re (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:2:5524)
    at m (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:1:31547)
    at s (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:1:27614)
    at s (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:1:27637)
    at s (https://media.[DOMAIN].co.uk/assets/js/dist/build.js:1:27637) <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})" class="ng-binding">
```