### PR TITLE
delete image component.

### DIFF
--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.css
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.css
@@ -1,0 +1,21 @@
+.gr-confirm-delete {
+    box-sizing: border-box;
+    min-width: 120px;
+    height: 100%;
+    line-height: inherit;
+    border: 1px solid #888;
+}
+
+.gr-confirm-delete:hover {
+    color: white;
+    background-color: #666666;
+}
+
+.gr-confirm-delete--confirm {
+    color: white;
+    background: red;
+}
+
+.gr-confirm-delete--confirm:hover {
+    background-color: #960000;
+}

--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import './gr-confirm-delete.css!';
 
 export const confirmDelete = angular.module('gr.confirmDelete', []);
 
@@ -6,10 +7,14 @@ confirmDelete.directive('grConfirmDelete', ['$timeout', function($timeout) {
 
     return {
         restrict: 'E',
+        transclude: true,
         template: `
-            <button class="button-ico" type="button" ng:click="showConfirm = true">
-                <span class="confirm" ng:if="showConfirm">Sure?</span>
-                <gr-icon>undo</gr-icon>
+            <button class="gr-confirm-delete" type="button"
+                ng:click="showConfirm = true"
+                ng:class="{'gr-confirm-delete--confirm': showConfirm}">
+                <gr-icon>delete</gr-icon>
+                <ng-transclude ng:if="!showConfirm"></ng-transclude>
+                <span class="gr-confirm-delete__label" ng:if="showConfirm">Confirm delete</span>
             </button>`,
 
         link: function(scope, element, attrs) {

--- a/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
+++ b/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
@@ -1,0 +1,41 @@
+import angular from 'angular';
+import '../gr-confirm-delete/gr-confirm-delete';
+
+export const deleteImage = angular.module('gr.deleteImage', ['gr.confirmDelete']);
+
+deleteImage.controller('grDeleteImageCtrl', ['$rootScope', '$scope', 'mediaApi',
+    function ($rootScope, $scope, mediaApi) {
+        var ctrl = this;
+
+        ctrl.delete = function () {
+            mediaApi.delete(ctrl.image)
+                .then((resp) => {
+                    if (angular.isDefined(ctrl.onSuccess)) {
+                        ctrl.onSuccess(resp);
+                    }
+                })
+                .catch((err) => {
+                    if (angular.isDefined(ctrl.onError)) {
+                        ctrl.onError(err);
+                    }
+                });
+        };
+}]);
+
+deleteImage.directive('grDeleteImage', [function () {
+    return {
+        restrict: 'E',
+        template: `
+            <gr-confirm-delete class="gr-delete-image" gr-on-confirm="ctrl.delete()">
+                <span class="gr-delete-image__label">Delete</span>
+            </gr-confirm-delete>`,
+        controller: 'grDeleteImageCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true,
+        scope: {
+            image: '=',
+            onSuccess: '=?',
+            onError: '=?'
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
+++ b/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
@@ -3,23 +3,22 @@ import '../gr-confirm-delete/gr-confirm-delete';
 
 export const deleteImage = angular.module('gr.deleteImage', ['gr.confirmDelete']);
 
-deleteImage.controller('grDeleteImageCtrl', ['$rootScope', '$scope', 'mediaApi',
-    function ($rootScope, $scope, mediaApi) {
-        var ctrl = this;
+deleteImage.controller('grDeleteImageCtrl', ['mediaApi', function (mediaApi) {
+    var ctrl = this;
 
-        ctrl.delete = function () {
-            mediaApi.delete(ctrl.image)
-                .then((resp) => {
-                    if (angular.isDefined(ctrl.onSuccess)) {
-                        ctrl.onSuccess(resp);
-                    }
-                })
-                .catch((err) => {
-                    if (angular.isDefined(ctrl.onError)) {
-                        ctrl.onError(err);
-                    }
-                });
-        };
+    ctrl.delete = function () {
+        mediaApi.delete(ctrl.image)
+            .then((resp) => {
+                if (angular.isDefined(ctrl.onSuccess)) {
+                    ctrl.onSuccess(resp);
+                }
+            })
+            .catch((err) => {
+                if (angular.isDefined(ctrl.onError)) {
+                    ctrl.onError(err);
+                }
+            });
+    };
 }]);
 
 deleteImage.directive('grDeleteImage', [function () {

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -3,13 +3,15 @@ import angular from 'angular';
 import '../image/service';
 import '../edits/service';
 import '../analytics/track';
+import '../components/gr-delete-image/gr-delete-image';
 
 var image = angular.module(
         'kahuna.image.controller',
         [
             'kahuna.edits.service',
             'gr.image.service',
-            'analytics.track'
+            'analytics.track',
+            'gr.deleteImage'
         ]
 );
 
@@ -17,6 +19,7 @@ image.controller('ImageCtrl', [
     '$rootScope',
     '$scope',
     '$state',
+    '$window',
     'onValChange',
     'image',
     'mediaApi',
@@ -31,6 +34,7 @@ image.controller('ImageCtrl', [
     function ($rootScope,
               $scope,
               $state,
+              $window,
               onValChange,
               image,
               mediaApi,
@@ -176,16 +180,15 @@ image.controller('ImageCtrl', [
                 });
         };
 
-        ctrl.delete = function() {
-            // TODO: use inline confirmation as per other tools
-            const msg = 'Are you sure you want to delete this image from the Grid?';
-            const confirmed = window.confirm(msg);
-            if (confirmed) {
-                mediaApi.delete(image).then(() => {
-                    window.alert('The image will be deleted shortly');
-                    // Can't stay on the page of a deleted image
-                    $state.go('search');
-                });
+        ctrl.onDeleteSuccess = function () {
+            $state.go('search');
+        };
+
+        ctrl.onDeleteError = function (err) {
+            if (err.body.errorKey === 'image-not-found') {
+                $state.go('search');
+            } else {
+                $window.alert(err.body.errorMessage);
             }
         };
 

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -8,11 +8,11 @@
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
-        <button class="top-bar-item"
-                ng:if="ctrl.canBeDeleted"
-                ng:click="ctrl.delete()">
-            <gr-icon>delete</gr-icon><span class="top-bar-item__label">delete</span>
-        </button>
+        <gr-delete-image class="top-bar-item top-bar-item--filled"
+                         ng:if="ctrl.canBeDeleted"
+                         image="ctrl.image"
+                         on-success="ctrl.onDeleteSuccess" on-error="ctrl.onDeleteError">
+        </gr-delete-image>
 
         <a class="top-bar-item" href="{{ ctrl.image.data.source | assetFile }}" download target="_blank">
             <gr-icon>file_download</gr-icon><span class="top-bar-item__label">download</span>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1137,12 +1137,6 @@ FIXME: what to do with touch devices
     text-align: left;
 }
 
-.result-editor__delete-image {
-    display: flex;
-    justify-content: flex-end;
-    font-size: 1.4rem;
-}
-
 /* ==========================================================================
    Full Image / crop
    ========================================================================== */
@@ -1691,10 +1685,6 @@ FIXME: what to do with touch devices
     margin-bottom: 10px;
     padding-bottom: 20px;
     border-bottom: 1px dashed #999;
-}
-
-.upload-result .gr-confirm-delete {
-    padding: 0 10px;
 }
 
 .upload-result:hover .image-actions {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -311,6 +311,11 @@ textarea.ng-invalid {
     background-color: transparent;
 }
 
+.top-bar-item .gr-confirm-delete {
+    border: none;
+    padding: 0 10px;
+}
+
 .user-actions {
     margin-right: -10px;
     padding: 0 5px;
@@ -342,8 +347,14 @@ textarea.ng-invalid {
 }
 
 @media screen and (max-width: 800px) {
-    .top-bar-item__label {
+    .top-bar-item__label,
+    .top-bar-item .gr-delete-image__label,
+    .top-bar-item .gr-confirm-delete__label {
         display: none;
+    }
+
+    .top-bar-item .gr-confirm-delete {
+        min-width: inherit;
     }
 }
 
@@ -1126,6 +1137,12 @@ FIXME: what to do with touch devices
     text-align: left;
 }
 
+.result-editor__delete-image {
+    display: flex;
+    justify-content: flex-end;
+    font-size: 1.4rem;
+}
+
 /* ==========================================================================
    Full Image / crop
    ========================================================================== */
@@ -1676,6 +1693,10 @@ FIXME: what to do with touch devices
     border-bottom: 1px dashed #999;
 }
 
+.upload-result .gr-confirm-delete {
+    padding: 0 10px;
+}
+
 .upload-result:hover .image-actions {
     display: block;
 }
@@ -1970,4 +1991,10 @@ ui-archiver .archiver:hover {
 
 .full-width {
     width: 100%;
+}
+
+.right {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
 }


### PR DESCRIPTION
Reusing `gr-confirm-delete` to show a confirm message before performing a delete on an image.

In first instance, adding this to the preview page:

![delete-image](https://cloud.githubusercontent.com/assets/836140/9200161/6866234e-403e-11e5-87f0-e801458eb491.gif)

cc @alastairjardine 
