### PR TITLE
Remove duplicates from search results

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -151,7 +151,7 @@ results.controller('SearchResultsCtrl', [
             ctrl.imagesAll = [];
             ctrl.imagesAll.length = Math.min(images.total, ctrl.maxResults);
 
-            imagesPositions = new Map;
+            imagesPositions = new Map();
 
             checkForNewImages();
 

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -37,6 +37,7 @@ results.controller('SearchResultsCtrl', [
     '$stateParams',
     '$window',
     '$timeout',
+    '$log',
     'delay',
     'onNextEvent',
     'scrollPosition',
@@ -52,6 +53,7 @@ results.controller('SearchResultsCtrl', [
              $stateParams,
              $window,
              $timeout,
+             $log,
              delay,
              onNextEvent,
              scrollPosition,
@@ -93,6 +95,9 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.images = [];
         ctrl.newImagesCount = 0;
+
+        // Map to track image->position and help remove duplicates
+        let imagesPositions;
 
         // FIXME: This is being refreshed by the router.
         // Make it watch a $stateParams collection instead
@@ -146,6 +151,8 @@ results.controller('SearchResultsCtrl', [
             ctrl.imagesAll = [];
             ctrl.imagesAll.length = Math.min(images.total, ctrl.maxResults);
 
+            imagesPositions = new Map;
+
             checkForNewImages();
 
             // Keep track of time of the latest result for all
@@ -170,12 +177,24 @@ results.controller('SearchResultsCtrl', [
             search({offset: start, length: length}).then(images => {
                 // Update imagesAll with newly loaded images
                 images.data.forEach((image, index) => {
-                    // Only set images that were missing from the Array
-                    // FIXME: might be safer to override, but causes
-                    // issues with object identity in the ng:repeat
-                    if (! ctrl.imagesAll[index + start]) {
-                        ctrl.imagesAll[index + start] = image;
+                    const position = index + start;
+                    const imageId = image.data.id;
+
+                    // If image already present in results at a
+                    // different position (result set shifted due to
+                    // items being spliced in or deleted?), get rid of
+                    // item at its previous position to avoid
+                    // duplicates
+                    const existingPosition = imagesPositions.get(imageId);
+                    if (angular.isDefined(existingPosition) &&
+                        existingPosition !== position) {
+                        $log.info(`Detected duplicate image ${imageId}, ` +
+                                  `old ${existingPosition}, new ${position}`);
+                        delete ctrl.imagesAll[existingPosition];
                     }
+
+                    ctrl.imagesAll[position] = image;
+                    imagesPositions.set(imageId, position);
                 });
 
                 // images should not contain any 'holes'


### PR DESCRIPTION
Keep a map of image id -> position, and when we detect an image is being loaded a second time at a different position, delete its former position to only keep the latest one.

This may leave holes or miss images under certain conditions, but at least it should fix the blank results bug so many people have experienced.

Tested locally be removing an image in the result set and scrolling back up from the end. Duplicates correctly detected and removed. I haven't found an easy way to inject out-of-order new images but the logic should hold for that case too.