### PR TITLE
Actually send Angular errors to Sentry

### DIFF
--- a/kahuna/public/js/sentry/sentry.js
+++ b/kahuna/public/js/sentry/sentry.js
@@ -3,20 +3,18 @@ import raven from 'raven-js';
 
 export var sentry = angular.module('sentry', []);
 
-// TODO: Add user information
-// TODO: Catch angular errors nicely
-
 sentry.factory('sentryEnabled', ['sentryDsn', function(sentryDsn) {
     return angular.isString(sentryDsn);
 }]);
 
-sentry.factory('sentry', [function() {
-
-    function trigger(errorMessage, extra) {
-        raven.captureException(new Error(errorMessage), { extra });
-    }
-
-    return { trigger };
+// TODO: Alternatively could investigate angular-raven
+sentry.config(['$provide', function ($provide) {
+    $provide.decorator('$exceptionHandler', ['$delegate', function ($delegate) {
+        return function (exception, cause) {
+            $delegate(exception, cause);
+            raven.captureException(exception, cause);
+        };
+    }]);
 }]);
 
 sentry.run(['$rootScope', 'sentryEnabled', 'sentryDsn',


### PR DESCRIPTION
Was having a quick look and it turns out because Angular errors don't bubble to the window, they were never sent to Sentry. Doh.

This code snippet is borrowed from Composer, and tested locally. In theory we could try to use [angular-raven](https://github.com/gdi2290/angular-raven), but in practice it doesn't give us much more than the 7 lines of code below (and more configuration hassle).