### PR TITLE
Load non moving results

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -277,11 +277,15 @@ results.controller('SearchResultsCtrl', [
         function search({until, since, offset, length} = {}) {
             // FIXME: Think of a way to not have to add a param in a million places to add it
 
+            // If we have a lastSearch time we should always respect it.
+            // The reason for this is that we should never be looking into the future, of our
+            // initial search so that we are returning an immutable / identical set, just in
+            // at different offsets. An example would be search for "today", we would first search
+            // for 2015-08-10T23:00:00, get the latest result and then search for that time.
             // Default explicit until/since to $stateParams
             if (angular.isUndefined(until)) {
-                // if we have a `lastSearchTime`, use that instead of `$stateParams` so that if the
-                // stateParams.until was in the future, we're not loading a mutating set of results.
                 until = lastSearchFirstResultTime || $stateParams.until;
+                console.log('until', until)
             }
             if (angular.isUndefined(since)) {
                 since = $stateParams.since;

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -222,7 +222,7 @@ results.controller('SearchResultsCtrl', [
         function checkForNewImages() {
             $timeout(() => {
                 const latestTime = lastSearchFirstResultTime;
-                // Blank any 'until' parameter to look for new images
+                // Use explicit `until`, or blank it to find new images
                 search({since: latestTime, length: 0, until: $stateParams.until || null}).then(resp => {
                     // FIXME: minor assumption that only the latest
                     // displayed image is matching the uploadTime

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -281,20 +281,17 @@ results.controller('SearchResultsCtrl', [
 
             // Default explicit until/since to $stateParams
             if (angular.isUndefined(until)) {
-                // if `until` is later than the last search time, we should use the latter
-                // to make sure we're not loading in a mutating / updating result list
-                const untilDate = new Date($stateParams.until);
-                const lastSearchDate = new Date(lastSearchFirstResultTime);
-
-                if (untilDate > lastSearchDate) {
-                    until = lastSearchFirstResultTime;
-                } else {
-                    until = $stateParams.until || lastSearchFirstResultTime;
-                }
+                until = $stateParams.until || lastSearchFirstResultTime;
             }
             if (angular.isUndefined(since)) {
                 since = $stateParams.since;
             }
+
+            // if `until` is later than the last search time, we should use the latter
+            // to make sure we're not loading in a mutating / updating result list
+            const untilDate = new Date(until);
+            const lastSearchDate = new Date(lastSearchFirstResultTime);
+            const notFutureUntil = untilDate > lastSearchDate ? lastSearchFirstResultTime : until;
 
             return mediaApi.search($stateParams.query, angular.extend({
                 ids:        $stateParams.ids,
@@ -302,7 +299,7 @@ results.controller('SearchResultsCtrl', [
                 // The nonFree state param is the inverse of the free API param
                 free:       $stateParams.nonFree === 'true' ? undefined: true,
                 uploadedBy: $stateParams.uploadedBy,
-                until:      until,
+                until:      notFutureUntil,
                 since:      since,
                 offset:     offset,
                 length:     length,

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -273,17 +273,24 @@ results.controller('SearchResultsCtrl', [
             return $stateParams.query || '*';
         }
 
-
         function search({until, since, offset, length} = {}) {
             // FIXME: Think of a way to not have to add a param in a million places to add it
 
-            // If we have a lastSearch time we should always respect it.
-            // The reason for this is that we should never be looking into the future, of our
-            // initial search so that we are returning an immutable / identical set, just in
-            // at different offsets. An example would be search for "today", we would first search
-            // for 2015-08-10T23:00:00, get the latest result and then search for that time.
-            // `until` Is only ever sent over explicitly when we are asking for new images.
-            // Default explicit until/since to $stateParams
+            /*
+             * @param `until` can have three values:
+             *
+             * - `null`      => Don't send over a date, which will default to `now()` on the server.
+             *                  Used in `checkForNewImages` with no until in `stateParams` to search
+             *                  for the new image count
+             *
+             * - `string`    => Override the use of `stateParams` or `lastSearchFirstResultTime`.
+             *                  Used in `checkForNewImages` when a `stateParams.until` is set.
+             *
+             * - `undefined` => Default. We then use the `lastSearchFirstResultTime` if available to
+             *                  make sure we aren't loading any new images into the result set and
+             *                  `checkForNewImages` deals with that. If it's the first search, we
+             *                  will use `stateParams.until` if available.
+             */
             if (angular.isUndefined(until)) {
                 until = lastSearchFirstResultTime || $stateParams.until;
             }

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -281,7 +281,16 @@ results.controller('SearchResultsCtrl', [
 
             // Default explicit until/since to $stateParams
             if (angular.isUndefined(until)) {
-                until = $stateParams.until || lastSearchFirstResultTime;
+                // if `until` is later than the last search time, we should use the latter
+                // to make sure we're not loading in a mutating / updating result list
+                const untilDate = new Date($stateParams.until);
+                const lastSearchDate = new Date(lastSearchFirstResultTime);
+
+                if (untilDate > lastSearchDate) {
+                    until = lastSearchFirstResultTime;
+                } else {
+                    until = $stateParams.until || lastSearchFirstResultTime;
+                }
             }
             if (angular.isUndefined(since)) {
                 since = $stateParams.since;

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -281,17 +281,13 @@ results.controller('SearchResultsCtrl', [
 
             // Default explicit until/since to $stateParams
             if (angular.isUndefined(until)) {
-                until = $stateParams.until || lastSearchFirstResultTime;
+                // if we have a `lastSearchTime`, use that instead of `$stateParams` so that if the
+                // stateParams.until was in the future, we're not loading a mutating set of results.
+                until = lastSearchFirstResultTime || $stateParams.until;
             }
             if (angular.isUndefined(since)) {
                 since = $stateParams.since;
             }
-
-            // if `until` is later than the last search time, we should use the latter
-            // to make sure we're not loading in a mutating / updating result list
-            const untilDate = new Date(until);
-            const lastSearchDate = new Date(lastSearchFirstResultTime);
-            const notFutureUntil = untilDate > lastSearchDate ? lastSearchFirstResultTime : until;
 
             return mediaApi.search($stateParams.query, angular.extend({
                 ids:        $stateParams.ids,
@@ -299,7 +295,7 @@ results.controller('SearchResultsCtrl', [
                 // The nonFree state param is the inverse of the free API param
                 free:       $stateParams.nonFree === 'true' ? undefined: true,
                 uploadedBy: $stateParams.uploadedBy,
-                until:      notFutureUntil,
+                until:      until,
                 since:      since,
                 offset:     offset,
                 length:     length,

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -223,9 +223,7 @@ results.controller('SearchResultsCtrl', [
             $timeout(() => {
                 const latestTime = lastSearchFirstResultTime;
                 // Blank any 'until' parameter to look for new images
-                // TODO: if a manual until was set (e.g. using date
-                // picker), don't check for new images until now
-                search({since: latestTime, length: 0, until: null}).then(resp => {
+                search({since: latestTime, length: 0, until: $stateParams.until || null}).then(resp => {
                     // FIXME: minor assumption that only the latest
                     // displayed image is matching the uploadTime
                     ctrl.newImagesCount = resp.total - 1;

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -282,10 +282,10 @@ results.controller('SearchResultsCtrl', [
             // initial search so that we are returning an immutable / identical set, just in
             // at different offsets. An example would be search for "today", we would first search
             // for 2015-08-10T23:00:00, get the latest result and then search for that time.
+            // `until` Is only ever sent over explicitly when we are asking for new images.
             // Default explicit until/since to $stateParams
             if (angular.isUndefined(until)) {
                 until = lastSearchFirstResultTime || $stateParams.until;
-                console.log('until', until)
             }
             if (angular.isUndefined(since)) {
                 since = $stateParams.since;


### PR DESCRIPTION
Makes sure we're not loading in a mutating set of results.

~~e.g. When we search for today we're search for `2015-08-10T23:00:00` which will be having images added to it.~~

# before
__Search for a data rage__ =>
search between `2015-08-10T23:00:00.000Z` - `2015-08-11T22:59:59.999Z`

__scroll__
search between `2015-08-10T23:00:00.000Z` - `2015-08-11T22:59:59.999Z`

# after
__Search for a data rage__ =>
search between `2015-08-10T23:00:00.000Z` - `2015-08-11T22:59:59.999Z`

__scroll__
search between `2015-08-10T23:00:00.000Z` - `lastSearchFirstResultTime`