### PR TITLE
Hardcode jspm version to beta.3 as beta.6 seems to cause issues

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "jscs": "^1.13.0",
     "jshint": "^2.5.11",
-    "jspm": "~0.16.0-beta"
+    "jspm": "0.16.0-beta.3"
   },
   "scripts": {
     "test": "npm run lint",


### PR DESCRIPTION
beta.6 is likely the cause of auth issues observed on our CI server:

```
[13:04:51][Step 1/1] warn Error on getPackageConfig for github:angular-ui/bootstrap-bower
[13:04:51][Step 1/1]      Unauthorized response for GitHub API.
[13:04:51][Step 1/1]      Use jspm registry config github to reconfigure the credentials, or update them in your ~/.netrc file.
[13:04:51][Step 1/1] 
[13:04:51][Step 1/1] warn Error on getPackageConfig for github:jmcriffey/bower-traceur
[13:04:51][Step 1/1]      Unauthorized response for GitHub API.
[13:04:51][Step 1/1]      Use jspm registry config github to reconfigure the credentials, or update them in your ~/.netrc file.
etc
```
(even though credentials are indeed set)

Also some odd errors locally:

```
warn github:monospaced/angular-elastic@2.5.0 dependency installs skipped as it's a GitHub package with no registry property set.
     If the dependencies aren't needed ignore this message. Alternatively use the npm registry version at jspm install npm:angular-elastic@^2.5.0 instead.

warn github:christopherthielen/ui-router-extras@0.0.14 dependency installs skipped as it's a GitHub package with no registry property set.
     If the dependencies aren't needed ignore this message. Alternatively use the npm registry version at jspm install npm:ui-router-extras@^0.0.14 instead.
```

Hardcode to known working version in the meantime.

Will try to reproduce and open a JSPM issue after this is fixed here.

cc @guybedford