### PR TITLE
Show filename (if any) on image preview page

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -201,6 +201,18 @@
                     </span>
                 </dd>
 
+                <dt ng:if="ctrl.image.data.uploadInfo.filename"
+                    class="image-info__group--dl__key metadata-line__key">
+                    filename
+                </dt>
+                <dd ng:if="ctrl.image.data.uploadInfo.filename"
+                    class="image-info__group--dl__value metadata-line__info"
+                    title="{{ctrl.image.data.uploadInfo.filename}}">
+                    <span class="metadata-line__info">
+                        {{ctrl.image.data.uploadInfo.filename}}
+                    </span>
+                </dd>
+
                 <dt ng:if="!ctrl.crop" class="image-info__group--dl__key metadata-line__key">dimensions</dt>
                 <dd ng:if="!ctrl.crop" class="image-info__group--dl__value metadata-line__info">
                     <span class="metadata-line__info">{{ctrl.dimensions.width}} &times; {{ctrl.dimensions.height}}</span>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -196,8 +196,12 @@
                     <span class="metadata-line__info">
                         {{ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm'}}
                     </span>
+                </dd>
+
+                <dt class="image-info__group--dl__key metadata-line__key">uploader</dt>
+                <dd class="image-info__group--dl__value metadata-line__info">
                     <span class="metadata-line__info">
-                        (<a ui:sref="search.results({query: (ctrl.image.data.uploadedBy | queryFilter:'uploader')})">{{ctrl.image.data.uploadedBy | stripEmailDomain}}</a>)
+                        <a ui:sref="search.results({query: (ctrl.image.data.uploadedBy | queryFilter:'uploader')})">{{ctrl.image.data.uploadedBy | stripEmailDomain}}</a>
                     </span>
                 </dd>
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1210,6 +1210,9 @@ FIXME: what to do with touch devices
 .image-info__group--dl__value {
     flex-basis: 60%;
     position: relative;
+    /* cut long words */
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .image-info__group--dl__key--panel {


### PR DESCRIPTION
Note:
* Also split out uploader onto its own row
* Filename gets cropped with an ellipsis if too long. The full name is revealed as a hover tooltip.

![image](https://cloud.githubusercontent.com/assets/36964/9175476/decc081c-3f7d-11e5-8fea-e7e2ababc203.png)
