### PR TITLE
Add commissioned agency

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -101,7 +101,7 @@ case class Agency(supplier: String, suppliersCollection: Option[String] = None, 
     val name = "Agency"
     val description =
       "Agencies such as Getty, Reuters, Press Association, etc. where " +
-      "subscription fees are paid to access and use pictures."
+      "subscription fees are paid to access and use their pictures."
   }
 object Agency {
  implicit val jsonReads: Reads[Agency] = Json.reads[Agency]
@@ -112,6 +112,26 @@ object Agency {
    (__ \ "restrictions").writeNullable[String]
  )(s => (s.category, s.supplier, s.suppliersCollection, s.restrictions))
 }
+
+
+case class CommissionedAgency(supplier: String, suppliersCollection: Option[String] = None, restrictions: Option[String] = None)
+  extends UsageRights {
+    val category = "commissioned-agency"
+    val defaultCost = Some(Free)
+    val name = "Agency - Commissioned"
+    val description =
+      "Images commissioned and paid for from agencies."
+  }
+object CommissionedAgency {
+ implicit val jsonReads: Reads[Agency] = Json.reads[Agency]
+ implicit val jsonWrites: Writes[Agency] = (
+   (__ \ "category").write[String] ~
+   (__ \ "supplier").write[String] ~
+   (__ \ "suppliersCollection").writeNullable[String] ~
+   (__ \ "restrictions").writeNullable[String]
+ )(s => (s.category, s.supplier, s.suppliersCollection, s.restrictions))
+}
+
 
 case class PrImage(restrictions: Option[String] = None)
   extends UsageRights {
@@ -127,6 +147,7 @@ object PrImage {
   implicit val jsonWrites: Writes[PrImage] = UsageRights.defaultWrites
 }
 
+
 case class Handout(restrictions: Option[String] = None)
   extends UsageRights {
     val category = "handout"
@@ -140,6 +161,7 @@ object Handout {
   implicit val jsonReads: Reads[Handout] = Json.reads[Handout]
   implicit val jsonWrites: Writes[Handout] = UsageRights.defaultWrites
 }
+
 
 case class Screengrab(restrictions: Option[String] = None)
   extends UsageRights {
@@ -226,6 +248,7 @@ object StaffPhotographer {
  )(s => (s.category, s.photographer, s.publication, s.restrictions))
 }
 
+
 case class ContractPhotographer(photographer: String, publication: String, restrictions: Option[String] = None)
   extends UsageRights {
     val category = "contract-photographer"
@@ -244,6 +267,7 @@ object ContractPhotographer {
  )(s => (s.category, s.photographer, s.publication, s.restrictions))
 }
 
+
 case class CommissionedPhotographer(photographer: String, publication: String, restrictions: Option[String] = None)
   extends UsageRights {
     val category = "commissioned-photographer"
@@ -261,6 +285,7 @@ object CommissionedPhotographer {
    (__ \ "restrictions").writeNullable[String]
  )(s => (s.category, s.photographer, s.publication, s.restrictions))
 }
+
 
 case class Pool(restrictions: Option[String] = None)
   extends UsageRights {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -30,6 +30,7 @@ object UsageRights {
   // be good to know though.
   implicit def jsonWrites[T <: UsageRights]: Writes[T] = Writes[T] {
     case o: Agency                   => Agency.jsonWrites.writes(o)
+    case o: CommissionedAgency       => CommissionedAgency.jsonWrites.writes(o)
     case o: PrImage                  => PrImage.jsonWrites.writes(o)
     case o: Handout                  => Handout.jsonWrites.writes(o)
     case o: Screengrab               => Screengrab.jsonWrites.writes(o)
@@ -54,6 +55,7 @@ object UsageRights {
 
       (category flatMap {
         case "agency"                    => json.asOpt[Agency]
+        case "commissioned-agency"       => json.asOpt[CommissionedAgency]
         case "PR Image"                  => json.asOpt[PrImage]
         case "handout"                   => json.asOpt[Handout]
         case "screengrab"                => json.asOpt[Screengrab]

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -43,7 +43,7 @@ object EditsApi extends Controller with ArgoHelpers {
     val usageRightsData =
       List(PrImage(), Handout(), Screengrab(), SocialMedia(), Obituary(), Pool(),
            StaffPhotographer("?", "?"), ContractPhotographer("?", "?"), CommissionedPhotographer("?", "?"),
-           Agency("?")).sortWith(_.name.toLowerCase < _.name.toLowerCase)
+           Agency("?"), CommissionedAgency("?")).sortWith(_.name.toLowerCase < _.name.toLowerCase)
         .map(CategoryResponse.fromUsageRights)
 
     respond(usageRightsData)

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -49,10 +49,7 @@ object UsageRightsProperty {
       UsageRightsProperty("suppliersCollection", "Collection", "string", false)
     )
 
-    case _:CommissionedAgency => List(
-      UsageRightsProperty("supplier", "Supplier", "string", true),
-      UsageRightsProperty("suppliersCollection", "Collection", "string", false)
-    )
+    case _:CommissionedAgency => List(UsageRightsProperty("supplier", "Supplier", "string", true))
     case _ => List()
   }
 

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -48,7 +48,7 @@ object UsageRightsProperty {
       UsageRightsProperty("supplier", "Supplier", "string", true, Some(UsageRightsConfig.freeSuppliers.sortWith(_.toLowerCase < _.toLowerCase))),
       UsageRightsProperty("suppliersCollection", "Collection", "string", false)
     )
-    
+
     case _:CommissionedAgency => List(
       UsageRightsProperty("supplier", "Supplier", "string", true),
       UsageRightsProperty("suppliersCollection", "Collection", "string", false)

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -48,6 +48,11 @@ object UsageRightsProperty {
       UsageRightsProperty("supplier", "Supplier", "string", true, Some(UsageRightsConfig.freeSuppliers.sortWith(_.toLowerCase < _.toLowerCase))),
       UsageRightsProperty("suppliersCollection", "Collection", "string", false)
     )
+    
+    case _:CommissionedAgency => List(
+      UsageRightsProperty("supplier", "Supplier", "string", true),
+      UsageRightsProperty("suppliersCollection", "Collection", "string", false)
+    )
     case _ => List()
   }
 


### PR DESCRIPTION
After chatting to Jo, the conclusion was, "we need a new category".

There's a small realisation that the picture desk don't really care much for taxonomy behind all of this, and a general commissioned category might make more sense, but that is something we can refactor down to if it seems necessary as there is a little.

Saying that - there is still a heavy reliance on the strange  categorisations that Picdar has, that I hope will be less prevalent when people who deal with usage rights use it less.