### PR TITLE
Rename JSPM env var to avoid conflict

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "test": "npm run lint",
     "lint": "jscs public/js/ && jshint public/js --exclude public/js/dist/build.js",
-    "ci": "jspm config registries.github.auth `echo -n JSPM_GITHUB_AUTH_USERNAME:$JSPM_GITHUB_AUTH_TOKEN | base64`",
+    "ci": "jspm config registries.github.auth `echo -n JSPM_GITHUB_AUTH_USERNAME:$JSPM_GITHUB_AUTH_PASSTOKEN | base64`",
     "dist": "jspm bundle js/main public/js/dist/build.js -m --inject",
     "undist": "jspm unbundle && rm -f public/js/dist/build.js*"
   },


### PR DESCRIPTION
`JSPM_GITHUB_AUTH_PASSTOKEN` is used in latest jspm to include the hashed user+token, rather than just the token. This avoid this conflicts by renaming the env var so we can use either version.