### PR TITLE
Centre thumbnails on upload page.

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1083,6 +1083,7 @@ FIXME: what to do with touch devices
 .result-editor__img,
 .result-editor__img-link {
     display: block;
+    margin: 0 auto;
 }
 
 .result-editor__editor {


### PR DESCRIPTION
Most thumbnails are centred, already, this is for the odd vertical image:

Before:
![screen shot 2015-08-12 at 09 45 40](https://cloud.githubusercontent.com/assets/836140/9220022/403adcf4-40d7-11e5-9b66-e9d93545da95.png)

After:
![screen shot 2015-08-12 at 09 45 25](https://cloud.githubusercontent.com/assets/836140/9220024/45153e86-40d7-11e5-9c7a-b77a2f79370d.png)
