### PR TITLE
add 'crown copyright' usage rights category

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -41,6 +41,7 @@ object UsageRights {
     case o: ContractPhotographer     => ContractPhotographer.jsonWrites.writes(o)
     case o: CommissionedPhotographer => CommissionedPhotographer.jsonWrites.writes(o)
     case o: Pool                     => Pool.jsonWrites.writes(o)
+    case o: CrownCopyright           => CrownCopyright.jsonWrites.writes(o)
     case o: NoRights.type            => NoRights.jsonWrites.writes(o)
   }
 
@@ -66,6 +67,7 @@ object UsageRights {
         case "contract-photographer"     => json.asOpt[ContractPhotographer]
         case "commissioned-photographer" => json.asOpt[CommissionedPhotographer]
         case "pool"                      => json.asOpt[Pool]
+        case "crown-copyright"           => json.asOpt[CrownCopyright]
         case _                           => None
       })
       .orElse(supplier.flatMap(_ => json.asOpt[Agency]))
@@ -301,4 +303,19 @@ case class Pool(restrictions: Option[String] = None)
 object Pool {
  implicit val jsonReads: Reads[Pool] = Json.reads[Pool]
  implicit val jsonWrites: Writes[Pool] = UsageRights.defaultWrites
+}
+
+
+case class CrownCopyright(restrictions: Option[String] = None)
+  extends UsageRights {
+    val category = "crown-copyright"
+    val defaultCost = Some(Free)
+    val name = "Crown Copyright"
+    val description =
+      "Crown copyright covers material created by civil servants, ministers and government " +
+      "departments and agencies, including the MOD."
+  }
+object CrownCopyright {
+ implicit val jsonReads: Reads[CrownCopyright] = Json.reads[CrownCopyright]
+ implicit val jsonWrites: Writes[CrownCopyright] = UsageRights.defaultWrites
 }

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -43,7 +43,7 @@ object EditsApi extends Controller with ArgoHelpers {
     val usageRightsData =
       List(PrImage(), Handout(), Screengrab(), SocialMedia(), Obituary(), Pool(),
            StaffPhotographer("?", "?"), ContractPhotographer("?", "?"), CommissionedPhotographer("?", "?"),
-           Agency("?"), CommissionedAgency("?")).sortWith(_.name.toLowerCase < _.name.toLowerCase)
+           Agency("?"), CommissionedAgency("?"), CrownCopyright()).sortWith(_.name.toLowerCase < _.name.toLowerCase)
         .map(CategoryResponse.fromUsageRights)
 
     respond(usageRightsData)


### PR DESCRIPTION
There are 750+ images from picdar with this set from the copyright groups.
There are still more being added (there's a few from 2015).

This means it's needed for legacy and present-day.