### PR TITLE
boolFilter for archived field - take 2

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -10,7 +10,7 @@ import org.elasticsearch.index.query.QueryBuilders.matchAllQuery
 import org.elasticsearch.index.engine.VersionConflictEngineException
 import org.elasticsearch.script.ScriptService
 import org.elasticsearch.index.query.QueryBuilders.{filteredQuery, boolQuery, matchQuery}
-import org.elasticsearch.index.query.FilterBuilders.{missingFilter, andFilter}
+import org.elasticsearch.index.query.FilterBuilders.{missingFilter, andFilter, termFilter, boolFilter}
 import org.joda.time.DateTime
 import groovy.json.JsonSlurper
 import _root_.play.api.libs.json._
@@ -70,8 +70,12 @@ object ElasticSearch extends ElasticSearchClient {
       boolQuery.must(matchQuery("_id", id)),
         andFilter(
           missingOrEmptyFilter("exports"),
-          missingOrEmptyFilter("userMetadata.archived"),
-          missingOrEmptyFilter(s"identifiers.$persistenceIdentifier"))
+          missingOrEmptyFilter(s"identifiers.$persistenceIdentifier"),
+          boolFilter.should(
+            missingOrEmptyFilter("userMetadata.archived"),
+            boolFilter.must(termFilter("userMetadata.archived", false))
+          )
+        )
       )
 
     val deleteQuery = client


### PR DESCRIPTION
Take 1 - https://github.com/guardian/grid/pull/1078

Using `boolFilter` on the `archived` field to determine if an image can be deleted.

Executes the following query, where `<IMAGE_ID>` is an existing image id.

[Elastic reference](https://www.elastic.co/guide/en/elasticsearch/guide/current/combining-filters.html#_nesting_boolean_filters).

```sh
curl -XGET 'http://localhost:9200/_search' -d '
{
	"query": {
	  "bool": {
	    "must": {
	      "match": {
	        "_id": {
	          "query": "<IMAGE_ID>",
	          "type": "boolean"
	        }
	      }
	    }
	  }
	},
	"filter": {
	  "and": {
	    "filters": [
	      {
	        "missing": {
	          "field": "exports",
	          "null_value": true,
	          "existence": true
	        }
	      },
	      {
	        "missing": {
	          "field": "identifiers.picdarUrn",
	          "null_value": true,
	          "existence": true
	        }
	      },
	      {
	      	"bool": {
	      		"should": [
	      			{ 
	      				"missing": {
		      				"field": "userMetadata.archived",
		      				"null_value": true,
		      				"existence": true
	      				} 
	      			},
	      			{
	      				"bool": {
	      					"must": [
	      						{ "term": { "userMetadata.archived": false } }
	      					]
	      				}
	      			}
	      		]
	      	}
	      }
	    ]
	  }
	}
}'
```