### PR TITLE
[wip] update labels on thumbnail when batch edited.

### DIFF
--- a/kahuna/public/js/edits/labeller.js
+++ b/kahuna/public/js/edits/labeller.js
@@ -11,11 +11,15 @@ export var labeller = angular.module('kahuna.edits.labeller', [
 ]);
 
 labeller.controller('LabellerCtrl',
-                  ['$rootScope', '$scope', '$window', '$timeout', 'labelService',
-                   function($rootScope, $scope, $window, $timeout, labelService) {
+                  ['$rootScope', '$scope', '$window', '$timeout', 'labelService', 'onValChange',
+                   function($rootScope, $scope, $window, $timeout, labelService, onValChange) {
 
     var ctrl = this;
     ctrl.labels = ctrl.image.data.userMetadata.data.labels;
+
+    $scope.$watch(() => ctrl.image.data.userMetadata.data.labels, onValChange(labels => {
+        ctrl.labels = labels;
+    }));
 
     function saveFailed() {
         $window.alert('Something went wrong when saving, please try again!');


### PR DESCRIPTION
WIP because I need to work out if we can get rid of the [root event](https://github.com/guardian/grid/blob/master/kahuna/public/js/services/label.js#L15).

before (the blank frame is the page being manually refreshed)
![before](https://cloud.githubusercontent.com/assets/836140/9262900/7f784d86-4210-11e5-8966-973f921c4f6a.gif)

after
![after](https://cloud.githubusercontent.com/assets/836140/9262902/8344964a-4210-11e5-9973-b95f3bc160f8.gif)