### PR TITLE
set usage rights on picdar import

### DIFF
--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
@@ -431,6 +431,8 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
         |       +ingest <dev|test|prod> [dateLoaded] [range]
         |       +override <dev|test|prod> [dateLoaded] [range]
         |       +clear  <dev|test|prod> [dateLoaded]
+        |
+        |       +rights:fetch  <dev|test|prod> <desk|library> [dateLoaded] [range]
       """.stripMargin
     )
   }

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
@@ -406,6 +406,16 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
       fetchRights(env, system)
     }
 
+    case "+rights:fetch" :: env :: system :: Nil => terminateAfter {
+      fetchRights(env, system)
+    }
+    case "+rights:fetch" :: env :: system :: date :: Nil => terminateAfter {
+      fetchRights(env, system, parseDateRange(date))
+    }
+    case "+rights:fetch" :: env :: system :: date :: rangeStr :: Nil => terminateAfter {
+      fetchRights(env, system, parseDateRange(date), parseQueryRange(rangeStr))
+    }
+
     case _ => println(
       """
         |usage: :count-loaded    <dev|test|prod> [dateLoaded]


### PR DESCRIPTION
Thinking there might only be one more step - read media API, decide who's rights to keep, and if it's picdars, post them as an override to the edits API.
