### PR TITLE
`gr-add-label` component.

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.css
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.css
@@ -1,0 +1,8 @@
+gr-add-label .button-shy {
+    box-shadow: none;
+}
+
+gr-add-label .small {
+    border: none;
+    padding: 0;
+}

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -1,0 +1,9 @@
+<button class="button-shy"
+        ng:class="{'small': ctrl.grSmall}"
+        ng:click="ctrl.addLabel()"
+        ng:disabled="ctrl.adding">
+    <gr-icon ng:class="{'spin': ctrl.adding}">add_box</gr-icon>
+    <span ng:hide="ctrl.grSmall">
+        Add<span ng:show="ctrl.adding">ing...</span>
+    </span>
+</button>

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -1,0 +1,54 @@
+import angular from 'angular';
+
+import '../../services/label';
+
+import './gr-add-label.css!';
+import template from './gr-add-label.html!text';
+
+export var addLabel = angular.module('gr.addLabel', [
+    'kahuna.services.label'
+]);
+
+addLabel.controller('GrAddLabelCtrl', ['$window', 'labelService',
+    function ($window, labelService) {
+        function saveFailed() {
+            $window.alert("Something went wrong when saving, please try again!");
+        }
+
+        let ctrl = this;
+
+        ctrl.addLabel = () => {
+            let label = ($window.prompt('Enter a label:') || '').trim();
+            if (label) {
+                ctrl.addLabels([label]);
+            }
+        };
+
+        ctrl.addLabels = labels => {
+            ctrl.adding = true;
+
+            labelService.add(ctrl.image, labels)
+                .then(image => {
+                    ctrl.image = image;
+                })
+                .catch(saveFailed)
+                .finally(() => {
+                    ctrl.adding = false;
+                });
+        };
+    }
+]);
+
+addLabel.directive('grAddLabel', [function () {
+    return {
+        restrict: 'E',
+        scope: {
+            image: '=',
+            grSmall: '=?'
+        },
+        controller: 'GrAddLabelCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true,
+        template: template
+    };
+}]);

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -12,7 +12,7 @@ export var addLabel = angular.module('gr.addLabel', [
 addLabel.controller('GrAddLabelCtrl', ['$window', 'labelService',
     function ($window, labelService) {
         function saveFailed() {
-            $window.alert("Something went wrong when saving, please try again!");
+            $window.alert('Something went wrong when saving, please try again!');
         }
 
         let ctrl = this;

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -118,7 +118,11 @@
         </div>
 
         <div class="result-editor__labeller-container">
-            <span class="result-editor__label">Labels</span>
+            <span class="result-editor__label flex-container">
+                Labels
+                <span class="flex-spacer"></span>
+                <gr-add-label image="ctrl.image" gr-small="true"></gr-add-label>
+            </span>
             <ui-labeller
                 class="result-editor__labeller"
                 image="ctrl.image"

--- a/kahuna/public/js/edits/labeller-compact.html
+++ b/kahuna/public/js/edits/labeller-compact.html
@@ -1,26 +1,16 @@
-<div class="labeller" ng:if="!ctrl.disabled">
+<div class="labeller">
     <ul class="labels"
         ng:if="ctrl.labels.data.length > 0">
         <li class="label"
             ng:repeat="label in ctrl.labels.data">
+
+            <span ng:if="ctrl.disabled">{{label.data}}</span>
+
             <a class="label__link"
-               ui:sref="search.results({query: (label.data | queryLabelFilter)})">{{label.data}}</a>
-        </li>
-    </ul>
-
-    <button class="labeller__add"
-            ng:click="ctrl.addLabel()"
-            ng:disabled="ctrl.adding">
-
-        <span ng:class="{ 'labeller__add-spin': ctrl.adding }">+</span>
-    </button>
-</div>
-
-<div class="labeller" ng:if="ctrl.disabled">
-    <ul class="labels"
-        ng:if="ctrl.labels.data.length > 0">
-        <li class="label" ng:repeat="label in ctrl.labels.data">
-            {{label.data}}
+               ng:if="!ctrl.disabled"
+               ui:sref="search.results({query: (label.data | queryLabelFilter)})">
+                {{label.data}}
+            </a>
         </li>
     </ul>
 </div>

--- a/kahuna/public/js/edits/labeller.html
+++ b/kahuna/public/js/edits/labeller.html
@@ -9,18 +9,11 @@
 
             <button class="label__remove"
                     title="Remove label"
-                    ng:click="ctrl.removeLabel(label.data)">x</button>
+                    ng:click="ctrl.removeLabel(label.data)">
+                <gr-icon>close</gr-icon>
+            </button>
         </li>
     </ul>
-
-    <div class="labeller__placeholder"
-         ng:if="ctrl.labels.data.length == 0">No labels</div>
-
-    <button class="button-shy labeller__add-button"
-          ng:click="ctrl.addLabel()"
-          ng:disabled="ctrl.adding">
-        Add<span ng:show="ctrl.adding">ing…</span>
-    </button>
 
     <span ng:if="ctrl.withBatch" class="labeller__apply-all">
         <button

--- a/kahuna/public/js/edits/labeller.js
+++ b/kahuna/public/js/edits/labeller.js
@@ -4,6 +4,7 @@ import templateCompact from './labeller-compact.html!text';
 
 import '../search/query-filter';
 import '../services/label';
+import '../components/gr-add-label/gr-add-label';
 
 export var labeller = angular.module('kahuna.edits.labeller', [
     'kahuna.search.filters.query',
@@ -11,23 +12,19 @@ export var labeller = angular.module('kahuna.edits.labeller', [
 ]);
 
 labeller.controller('LabellerCtrl',
-                  ['$rootScope', '$scope', '$window', '$timeout', 'labelService',
-                   function($rootScope, $scope, $window, $timeout, labelService) {
-
+                  ['$rootScope', '$scope', '$window', '$timeout', 'labelService', 'onValChange',
+                   function($rootScope, $scope, $window, $timeout, labelService, onValChange) {
     var ctrl = this;
+
+    $scope.$watch(() => ctrl.image.data.userMetadata.data.labels, onValChange(newLabels => {
+        ctrl.labels = newLabels;
+    }));
+
     ctrl.labels = ctrl.image.data.userMetadata.data.labels;
 
     function saveFailed() {
         $window.alert('Something went wrong when saving, please try again!');
     }
-
-    ctrl.addLabel = () => {
-        // Prompt for a label and add if not empty
-        var label = ($window.prompt('Enter a label:') || '').trim();
-        if (label) {
-            ctrl.addLabels([label]);
-        }
-    };
 
     ctrl.addLabels = labels => {
         ctrl.adding = true;
@@ -42,7 +39,6 @@ labeller.controller('LabellerCtrl',
                 ctrl.adding = false;
             });
     };
-
 
     ctrl.labelsBeingRemoved = new Set();
     ctrl.removeLabel = label => {

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -4,6 +4,7 @@ import '../image/service';
 import '../edits/service';
 import '../analytics/track';
 import '../components/gr-delete-image/gr-delete-image';
+import '../components/gr-add-label/gr-add-label';
 
 var image = angular.module(
         'kahuna.image.controller',
@@ -11,7 +12,8 @@ var image = angular.module(
             'kahuna.edits.service',
             'gr.image.service',
             'analytics.track',
-            'gr.deleteImage'
+            'gr.deleteImage',
+            'gr.addLabel'
         ]
 );
 

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -249,10 +249,15 @@
 
     <div class="image-info">
         <dl class="image-info__group">
-            <dt class="image-info__heading image-info__heading--first">Labels</dt>
+            <dt class="image-info__heading image-info__heading--first">
+                <div class="flex-container">
+                    Labels
+                    <div class="flex-spacer"></div>
+                    <gr-add-label image="ctrl.image"></gr-add-label>
+                </div>
+            </dt>
             <dd class="image-info__group--fixed-panel">
-                <ui-labeller image="ctrl.image">
-                </ui-labeller>
+                <ui-labeller image="ctrl.image"></ui-labeller>
             </dd>
         </dl>
     </div>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -44,10 +44,12 @@
     <div class="preview__info" ng:if="! ctrl.hideInfo">
         <div class="flex-container">
             <ui-labeller-compact class="preview__labeller"
-                                 image="ctrl.image"
-                                 disabled="ctrl.selectionMode"></ui-labeller-compact>
+                                 image="ctrl.image"></ui-labeller-compact>
             <span class="flex-spacer"></span>
-            <gr-add-label image="ctrl.image" gr-small="true"></gr-add-label>
+            <gr-add-label ng:if="!ctrl.selectionMode"
+                          image="ctrl.image"
+                          gr-small="true">
+            </gr-add-label>
         </div>
 
         <!-- Ensure contents in P to maintain height -->

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -42,9 +42,13 @@
     </span>
 
     <div class="preview__info" ng:if="! ctrl.hideInfo">
-        <ui-labeller-compact class="preview__labeller"
-                             image="ctrl.image"
-                             disabled="ctrl.selectionMode"></ui-labeller-compact>
+        <div class="flex-container">
+            <ui-labeller-compact class="preview__labeller"
+                                 image="ctrl.image"
+                                 disabled="ctrl.selectionMode"></ui-labeller-compact>
+            <span class="flex-spacer"></span>
+            <gr-add-label image="ctrl.image" gr-small="true"></gr-add-label>
+        </div>
 
         <!-- Ensure contents in P to maintain height -->
         <p class="preview__description">{{ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;'}}</p>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -4,10 +4,12 @@ import '../analytics/track';
 import template from './image.html!text';
 
 import '../image/service';
+import '../components/gr-add-label/gr-add-label';
 
 export var image = angular.module('kahuna.preview.image', [
     'gr.image.service',
-    'analytics.track'
+    'analytics.track',
+    'gr.addLabel'
 ]);
 
 image.controller('uiPreviewImageCtrl', [

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -247,6 +247,36 @@ a:focus {
     -webkit-animation-timing-function: linear;
 }
 
+.spin {
+    animation-name: spin;
+    animation-duration: 500ms;
+    animation-iteration-count: infinite;
+    animation-timing-function: ease-out;
+
+    -webkit-animation-name: spin;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-duration: 500ms;
+    -webkit-animation-timing-function: ease-out;
+}
+
+.full-width {
+    width: 100%;
+}
+
+.right {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
+.flex-container {
+    display: flex;
+}
+
+.flex-spacer {
+    flex-grow: 1;
+}
+
 /* ==========================================================================
    Generics
    ========================================================================== */
@@ -703,9 +733,12 @@ input.search-query__input {
 .result:hover .result__select,
 .result:hover .preview__fade,
 .result:hover .image-actions,
-.result:hover .labeller__add,
 .result:hover .archiver {
     display: block;
+}
+
+.result:hover gr-add-label {
+    display: inline-block;
 }
 
 .result:hover {
@@ -949,7 +982,13 @@ input.search-query__input {
 FIXME: this is a little targeted
 FIXME: what to do with touch devices
 */
-.preview .labeller__add {
+
+.preview__labeller {
+    width: calc(100% - 20px);
+    display: inline-block;
+}
+
+.preview gr-add-label {
     display: none;
 }
 
@@ -1121,8 +1160,13 @@ FIXME: what to do with touch devices
     width: 100%;
     margin-top: 5px;
 }
+
+.result-editor__labeller-container gr-add-label {
+    font-size: 1.3rem;
+    padding-right: 10px;
+}
+
 .result-editor__label {
-    display: inline-block;
     width: 100px;
 }
 
@@ -1500,38 +1544,6 @@ FIXME: what to do with touch devices
 .label--partial button:active gr-icon {
     background-color: #CFCFCF;
     color: #333;
-}
-
-.labeller__placeholder {
-    color: #999;
-}
-
-.labeller__add {
-    padding: 0 5px;
-    color: #00adee;
-}
-
-.labeller__add-button {
-    margin-left: 10px;
-}
-
-.image-info__group--fixed-panel .labeller__add-button{
-    height: 20px;
-    box-shadow: none;
-}
-
-
-
-.labeller__add-spin {
-    animation-name: spin;
-	animation-duration: 500ms;
-	animation-iteration-count: infinite;
-	animation-timing-function: ease-out;
-
-    -webkit-animation-name: spin;
-    -webkit-animation-iteration-count: infinite;
-    -webkit-animation-duration: 500ms;
-    -webkit-animation-timing-function: ease-out;
 }
 
 .labeller__apply-all {
@@ -1983,14 +1995,4 @@ ui-archiver .archiver:hover {
 
 .radio-list__label-value {
     padding: 5px 10px;
-}
-
-.full-width {
-    width: 100%;
-}
-
-.right {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
 }


### PR DESCRIPTION
Standalone button to add labels to an image.

I had this in a branch for a while, and after this was reported:

![picture 496](https://cloud.githubusercontent.com/assets/836140/9273331/bfdcecec-4283-11e5-9e2c-37def3193dc0.png)

I thought I might as well finish up the work as it fixes the issue by moving the Add button next to the field label (see https://github.com/guardian/grid/issues/993 for an artist's impression).

Here's how it looks now:

# Preview
![add-label-preview](https://cloud.githubusercontent.com/assets/836140/9273376/2aeeacf0-4284-11e5-9c8a-b541d69bb0de.gif)

# Uploads
![add-label-current-uploads](https://cloud.githubusercontent.com/assets/836140/9273391/5bb98058-4284-11e5-9d63-e8410d122b37.gif)

# Image Page
![add-label-image](https://cloud.githubusercontent.com/assets/836140/9273448/b364fd96-4284-11e5-8c6c-00762cca46db.gif)

