### PR TITLE
Fix bug with publication selection in usage-rights-editor

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -120,10 +120,10 @@
                          ng:if="ctrl.imageHasBeenSelected(image)">
                         <input type="checkbox"
                                class="result__select__checkbox"
-                               id="{{::image.data.id}}-result__select__checkbox--select"
+                               id="id-{{::image.data.id}}-result__select__checkbox--select"
                                checked="true"
                                ng:click="ctrl.toggleSelection(image, false)"/>
-                        <label for="{{::image.data.id}}-result__select__checkbox--select"
+                        <label for="id-{{::image.data.id}}-result__select__checkbox--select"
                                class="result__select__checkbox__label">
                             <gr-icon>check_box</gr-icon>
                         </label>
@@ -131,9 +131,9 @@
                     <div class="result__select" ng:if="!ctrl.imageHasBeenSelected(image)">
                         <input type="checkbox"
                                class="result__select__checkbox"
-                               id="{{::image.data.id}}-result__select__checkbox--deselect"
+                               id="id-{{::image.data.id}}-result__select__checkbox--deselect"
                                ng:click="ctrl.toggleSelection(image, true)" />
-                        <label for="{{::image.data.id}}-result__select__checkbox--deselect"
+                        <label for="id-{{::image.data.id}}-result__select__checkbox--deselect"
                                class="result__select__checkbox__label">
                             <gr-icon>check_box</gr-icon>
                         </label>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -84,13 +84,13 @@
                                         <input type="radio"
                                             ng:if="$first && !property.required"
                                             value=""
-                                            id="none-{{property.name}}-radio-list__item"
+                                            id="id-{{::$id}}-none-{{property.name}}-radio-list__item"
                                             ng:checked="!ctrl.model[property.name]"
                                             class="radio-list__circle"
                                             name="{{property.name}}-radio-list" />
                                         <label
                                             ng:if="$first && !property.required"
-                                            for="none-{{property.name}}-radio-list__item"
+                                            for="id-{{::$id}}-none-{{property.name}}-radio-list__item"
                                             class="radio-list__label"
                                             ng:class="{'radio-list--selected': !ctrl.model[property.name]}">
                                             <div class="radio-list__selection-state"></div>
@@ -99,13 +99,13 @@
 
                                         <input type="radio"
                                             value="{{o}}"
-                                            id="{{o}}-{{property.name}}-radio-list__item"
+                                            id="id-{{::$id}}-{{o}}-{{property.name}}-radio-list__item"
                                             class="radio-list__circle"
                                             name="{{property.name}}-radio-list"
                                             ng:required="property.required"
                                             ng:model="ctrl.model[property.name]" />
                                         <label
-                                            for="{{o}}-{{property.name}}-radio-list__item"
+                                            for="id-{{::$id}}-{{o}}-{{property.name}}-radio-list__item"
                                             class="radio-list__label"
                                             ng:class="{'radio-list--selected': ctrl.model[property.name] === o}">
                                             <div class="radio-list__selection-state"></div>


### PR DESCRIPTION
This was preventing choosing the publication for a photographer on the uploads page, because all fake radios had the same ID. This uses the unique scope `$id` to make the ids unique.

Also fixes the other use of dynamic id to produce [valid IDs](http://www.w3.org/TR/REC-html40/types.html#type-name) (i.e. start with letters, not numbers).