### PR TITLE
Disable the label hyperlink when in selection mode.

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -44,7 +44,9 @@
     <div class="preview__info" ng:if="! ctrl.hideInfo">
         <div class="flex-container">
             <ui-labeller-compact class="preview__labeller"
-                                 image="ctrl.image"></ui-labeller-compact>
+                                 image="ctrl.image"
+                                 disabled="ctrl.selectionMode">
+            </ui-labeller-compact>
             <span class="flex-spacer"></span>
             <gr-add-label ng:if="!ctrl.selectionMode"
                           image="ctrl.image"


### PR DESCRIPTION
Currently, labels remain clickable when in selection mode - clicking a label when you're in selection mode performs a search and thus cancels your selected images. This stops that - clicking on a label will select/deselect the image.