### PR TITLE
Decouple auth from initial asset load (trigger login via JS, not kahuna page load)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/ArgoErrorResponses.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/ArgoErrorResponses.scala
@@ -4,10 +4,10 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 
 trait ArgoErrorResponses extends ArgoHelpers {
-  def loginUri: String
+  def loginUriTemplate: String
 
   val loginLinks = List(
-    Link("login", loginUri)
+    Link("login", loginUriTemplate)
   )
 
   // Panda errors

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -24,7 +24,8 @@ case class PandaUser(email: String, firstName: String, lastName: String, avatarU
 
 case class AuthenticatedService(name: String) extends Principal
 
-class PandaAuthenticated(loginUri_ : String, authCallbackBaseUri_ : String)
+
+class PandaAuthenticated(loginUriTemplate_ : String, authCallbackBaseUri_ : String)
     extends ActionBuilder[({ type R[A] = AuthenticatedRequest[A, Principal] })#R]
     with PanDomainAuthActions {
 
@@ -43,11 +44,11 @@ class PandaAuthenticated(loginUri_ : String, authCallbackBaseUri_ : String)
 
   object ArgoAuthAction extends AbstractApiAuthAction with ArgoErrorResponses {
     // FIXME: for some reason an initialisation order issue causes this to be null if not lazy >:-(
-    lazy val loginUri = loginUri_
+    lazy val loginUriTemplate = loginUriTemplate_
   }
 }
 
-case class AuthenticatedUpload(keyStore: KeyStore, loginUri: String, authCallbackBaseUri: String) extends AuthenticatedBase {
+case class AuthenticatedUpload(keyStore: KeyStore, loginUriTemplate: String, authCallbackBaseUri: String) extends AuthenticatedBase {
 
   override def invokeBlock[A](request: Request[A], block: RequestHandler[A]): Future[Result] = {
     val DigestedFile(tempFile, id) = request.body
@@ -59,11 +60,11 @@ case class AuthenticatedUpload(keyStore: KeyStore, loginUri: String, authCallbac
 
 }
 
-case class Authenticated(keyStore: KeyStore, loginUri: String, authCallbackBaseUri: String) extends AuthenticatedBase
+case class Authenticated(keyStore: KeyStore, loginUriTemplate: String, authCallbackBaseUri: String) extends AuthenticatedBase
 trait AuthenticatedBase extends ActionBuilder[({ type R[A] = AuthenticatedRequest[A, Principal] })#R] with ArgoErrorResponses {
 
   val keyStore: KeyStore
-  val loginUri: String
+  val loginUriTemplate: String
   val authCallbackBaseUri: String
 
   type RequestHandler[A] = AuthenticatedRequest[A, Principal] => Future[Result]
@@ -102,7 +103,7 @@ trait AuthenticatedBase extends ActionBuilder[({ type R[A] = AuthenticatedReques
 
   // Panda authentication
 
-  val pandaAuth = new PandaAuthenticated(loginUri, authCallbackBaseUri)
+  val pandaAuth = new PandaAuthenticated(loginUriTemplate, authCallbackBaseUri)
 
   def authByPanda[A](request: Request[A], block: RequestHandler[A]): Future[Result] =
     pandaAuth.invokeBlock(request, block)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -22,7 +22,7 @@ class Services(domainRoot: String, ssl: Boolean) {
   val metadataBaseUri = baseUri(metadataHost)
   val imgopsBaseUri  = baseUri(imgopsHost)
 
-  val loginUri = s"$kahunaBaseUri/login"
+  val loginUriTemplate = s"$kahunaBaseUri/login{?redirectUri}"
 
   def baseUri(host: String) = {
     val protocol = if (ssl) "https" else "http"

--- a/cropper/app/controllers/Application.scala
+++ b/cropper/app/controllers/Application.scala
@@ -27,10 +27,10 @@ import lib._, Files._
 
 object Application extends Controller with ArgoHelpers {
 
-  import Config.{rootUri, loginUri, kahunaUri}
+  import Config.{rootUri, loginUriTemplate, kahunaUri}
 
   val keyStore = new KeyStore(Config.keyStoreBucket, Config.awsCredentials)
-  val Authenticated = auth.Authenticated(keyStore, loginUri, kahunaUri)
+  val Authenticated = auth.Authenticated(keyStore, loginUriTemplate, kahunaUri)
 
   val mediaApiKey = keyStore.findKey("cropper").getOrElse(throw new Error("Missing cropper API key in key bucket"))
 

--- a/cropper/app/lib/Config.scala
+++ b/cropper/app/lib/Config.scala
@@ -26,7 +26,7 @@ object Config extends CommonPlayAppProperties {
 
   val rootUri = services.cropperBaseUri
   val kahunaUri = services.kahunaBaseUri
-  val loginUri = services.loginUri
+  val loginUriTemplate = services.loginUriTemplate
 
   val corsAllAllowedOrigins = List(services.kahunaBaseUri)
 

--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -34,12 +34,12 @@ object Application extends ImageLoader
 
 class ImageLoader extends Controller with ArgoHelpers {
 
-  import Config.{rootUri, loginUri}
+  import Config.{rootUri, loginUriTemplate}
 
   val keyStore = new KeyStore(Config.keyStoreBucket, Config.awsCredentials)
 
-  val Authenticated = auth.Authenticated(keyStore, loginUri, rootUri)
-  val AuthenticatedUpload = auth.AuthenticatedUpload(keyStore, loginUri, rootUri)
+  val Authenticated = auth.Authenticated(keyStore, loginUriTemplate, rootUri)
+  val AuthenticatedUpload = auth.AuthenticatedUpload(keyStore, loginUriTemplate, rootUri)
 
 
   val indexResponse = {

--- a/image-loader/app/lib/Config.scala
+++ b/image-loader/app/lib/Config.scala
@@ -27,7 +27,7 @@ object Config extends CommonPlayAppProperties {
 
   val rootUri = services.loaderBaseUri
   val apiUri = services.apiBaseUri
-  val loginUri = services.loginUri
+  val loginUriTemplate = services.loginUriTemplate
 
   lazy val corsAllAllowedOrigins: List[String] = List(services.kahunaBaseUri)
 

--- a/kahuna/app/controllers/Application.scala
+++ b/kahuna/app/controllers/Application.scala
@@ -1,16 +1,11 @@
 package controllers
 
-import play.api.mvc.Controller
+import play.api.mvc.{Action, Controller}
 import lib.Config
-import com.gu.mediaservice.lib.auth.PanDomainAuthActions
 
-// TODO: retire Panda entirely from kahuna, let the JS app and the APIs manage auth
+object Application extends Controller {
 
-object Application extends Controller with PanDomainAuthActions {
-
-  override lazy val authCallbackBaseUri = Config.rootUri
-
-  def index(ignored: String) = AuthAction { req =>
+  def index(ignored: String) = Action { req =>
     Ok(views.html.main(
       Config.mediaApiUri,
       Config.watUri,

--- a/kahuna/app/controllers/Panda.scala
+++ b/kahuna/app/controllers/Panda.scala
@@ -39,11 +39,11 @@ object Panda extends Controller
     }
   }
 
-  // Trigger the auth cycle and return a dummy page
-  // Typically used for automatically re-auth'ing in the background
-  def doLogin = AuthAction { req =>
-    // Note: returning NoContent as iframe content seems to make browsers unhappy
-    Ok("logged in")
+  // Trigger the auth cycle
+  // If a redirectUri is provided, redirect the browser there once auth'd,
+  // else return a dummy page (e.g. for automatically re-auth'ing in the background)
+  def doLogin(redirectUri: Option[String] = None) = AuthAction { req =>
+    redirectUri map (Redirect(_)) getOrElse Ok("logged in")
   }
 
   def oauthCallback = Action.async { implicit request =>

--- a/kahuna/app/controllers/Panda.scala
+++ b/kahuna/app/controllers/Panda.scala
@@ -5,6 +5,8 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
 import com.gu.mediaservice.lib.auth.{ArgoErrorResponses, PanDomainAuthActions}
 import com.gu.pandomainauth.model._
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.service.GoogleAuthException
 
 import scala.concurrent.Future
@@ -12,11 +14,14 @@ import scala.util.{Success, Try, Failure}
 
 object Panda extends Controller
   with PanDomainAuthActions
+  with ArgoHelpers
   with ArgoErrorResponses {
 
   override lazy val authCallbackBaseUri = Config.rootUri
-  def loginUri: String = Config.loginUri
+  override lazy val loginUriTemplate    = Config.loginUriTemplate
 
+
+  // FIXME: how to use usual Authenticated action helper for this? separate Controller?
   def session = Action { implicit request =>
     extractAuth(request) match {
       case Authenticated(AuthenticatedUser(user, _, _, _, _)) =>

--- a/kahuna/app/controllers/Panda.scala
+++ b/kahuna/app/controllers/Panda.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.net.URI
+
 import lib.Config
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
@@ -20,6 +22,7 @@ object Panda extends Controller
   override lazy val authCallbackBaseUri = Config.rootUri
   override lazy val loginUriTemplate    = Config.loginUriTemplate
 
+  import Config.domainRoot
 
   // FIXME: how to use usual Authenticated action helper for this? separate Controller?
   def session = Action { implicit request =>
@@ -44,11 +47,24 @@ object Panda extends Controller
     }
   }
 
+
+  def isOwnDomainAndSecure(uri: URI): Boolean = {
+    uri.getHost.endsWith(domainRoot) && uri.getScheme == "https"
+  }
+  def isValidDomain(inputUri: String): Boolean = {
+    Try(URI.create(inputUri)).filter(isOwnDomainAndSecure).isSuccess
+  }
+
+
   // Trigger the auth cycle
   // If a redirectUri is provided, redirect the browser there once auth'd,
   // else return a dummy page (e.g. for automatically re-auth'ing in the background)
+  // FIXME: validate redirectUri before doing the auth
   def doLogin(redirectUri: Option[String] = None) = AuthAction { req =>
-    redirectUri map (Redirect(_)) getOrElse Ok("logged in")
+    redirectUri map {
+      case uri if isValidDomain(uri) => Redirect(uri)
+      case _ => Ok("logged in (not redirecting to external redirectUri)")
+    } getOrElse Ok("logged in")
   }
 
   def oauthCallback = Action.async { implicit request =>

--- a/kahuna/app/lib/Config.scala
+++ b/kahuna/app/lib/Config.scala
@@ -7,9 +7,10 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val properties = Properties.fromPath("/etc/gu/kahuna.properties")
 
-  val loginUri: String = services.loginUri
   val rootUri: String = services.kahunaBaseUri
   val mediaApiUri: String = services.apiBaseUri
+
+  val loginUriTemplate = services.loginUriTemplate
 
   val keyStoreBucket: String = properties("auth.keystore.bucket")
   val mixpanelToken: Option[String] = properties.get("mixpanel.token").filterNot(_.isEmpty)

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -13,7 +13,7 @@ GET     /assets/*file               controllers.Assets.at(path="/public", file)
 # Panda Login
 # TODO: Think about moving this to a separate service
 
-GET     /login                      controllers.Panda.doLogin
+GET     /login                      controllers.Panda.doLogin(redirectUri: Option[String])
 GET     /oauthCallback              controllers.Panda.oauthCallback
 GET     /logout                     controllers.Panda.logout
 GET     /session                    controllers.Panda.session

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -30,7 +30,8 @@
       "text": "github:systemjs/plugin-text@^0.0.2",
       "theseus": "npm:theseus@~0.5.0",
       "theseus-angular": "npm:theseus-angular@^0.3.0",
-      "ua-parser-js": "npm:ua-parser-js@0.7.3"
+      "ua-parser-js": "npm:ua-parser-js@0.7.3",
+      "uri-templates": "npm:uri-templates@0.1.5"
     },
     "devDependencies": {
       "traceur": "github:jmcriffey/bower-traceur@0.0.90",

--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -40,6 +40,7 @@ System.config({
     "traceur": "github:jmcriffey/bower-traceur@0.0.90",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.90",
     "ua-parser-js": "npm:ua-parser-js@0.7.3",
+    "uri-templates": "npm:uri-templates@0.1.5",
     "github:angular-ui/ui-router@0.2.15": {
       "angular": "github:angular/bower-angular@1.4.3"
     },
@@ -231,4 +232,3 @@ System.config({
     }
   }
 });
-

--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -215,6 +215,11 @@ System.config({
     "npm:ua-parser-js@0.7.3": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
+    "npm:uri-templates@0.1.5": {
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:uri-templates@0.1.7": {
       "path": "github:jspm/nodelibs-path@0.1.0",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0",
@@ -232,3 +237,4 @@ System.config({
     }
   }
 });
+

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -41,9 +41,9 @@ object MediaApi extends Controller with ArgoHelpers {
 
   val commonTransformers = new Transformers(Config.services)
 
-  import Config.{rootUri, cropperUri, loaderUri, metadataUri, kahunaUri, loginUri}
+  import Config.{rootUri, cropperUri, loaderUri, metadataUri, kahunaUri, loginUriTemplate}
 
-  val Authenticated = auth.Authenticated(keyStore, loginUri, Config.kahunaUri)
+  val Authenticated = auth.Authenticated(keyStore, loginUriTemplate, Config.kahunaUri)
 
 
   val searchParamList = List("q", "ids", "offset", "length", "orderBy",

--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -45,7 +45,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
   lazy val loaderUri: String = services.loaderBaseUri
   lazy val metadataUri: String = services.metadataBaseUri
   lazy val imgopsUri: String = services.imgopsBaseUri
-  lazy val loginUri: String = services.loginUri
+  lazy val loginUriTemplate: String = services.loginUriTemplate
 
   private lazy val corsAllowedOrigins = properties.getOrElse("cors.allowed.origins", "").split(",").toList
   lazy val corsAllAllowedOrigins: List[String] =

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -14,10 +14,10 @@ import lib.Config
 
 object EditsApi extends Controller with ArgoHelpers {
 
-  import Config.{rootUri, loginUri, kahunaUri, keyStoreBucket, awsCredentials}
+  import Config.{rootUri, loginUriTemplate, kahunaUri, keyStoreBucket, awsCredentials}
 
   val keyStore = new KeyStore(keyStoreBucket, awsCredentials)
-  val Authenticated = auth.Authenticated(keyStore, loginUri, kahunaUri)
+  val Authenticated = auth.Authenticated(keyStore, loginUriTemplate, kahunaUri)
 
     // TODO: add links to the different responses esp. to the reference image
   val indexResponse = {

--- a/metadata-editor/app/lib/Config.scala
+++ b/metadata-editor/app/lib/Config.scala
@@ -22,7 +22,7 @@ object Config extends CommonPlayAppProperties {
 
   val rootUri = services.metadataBaseUri
   val kahunaUri = services.kahunaBaseUri
-  val loginUri = services.loginUri
+  val loginUriTemplate = services.loginUriTemplate
 
   val corsAllAllowedOrigins = List(services.kahunaBaseUri)
 }


### PR DESCRIPTION
As a step toward a simpler setup where the Angular app (incl. `index.html` page) is served statically rather than behind a Play controller that enforces auth. The need for auth'ing is instead detected by a probe API call that, if failed with a 401, triggers a redirect to the login link provided in the response (with the current page URL set as `redirectUri`).

This will lead to a brief flash of the page loading before the user is sent for auth the first time (when they don't have a valid panda cookie), but that's actually quite rare. Most of the time the auth just expires and is refreshed in the background.

If this code works, I'm keen to move it to our libraries so it can be reused.

**Notes**
* This would make a few of our `meta` configuration public, including Mixpanel token, Sentry DSN and wat page URL. The main one I'd suggest protecting is the Sentry DSN; we could expose it in the API instead. Not sure about Mixpanel, as it's nice to have it in the page as early as possible to report errors even if other things are broken. The wat page I'm not too fussed about, it's nice to be able to statically extract it from scripts imho.
* This leaves us more vulnerable to faulty browser settings (the infamous Third-party cookies setting preventing transparent re-auth in the background). Refreshing the page would no longer fix the issue automatically, although that may not be such a bad thing to identify misconfigured browsers as constantly having to reload the page isn't really a great UX. Something to keep an eye on.