### PR TITLE
Add title to add label button.

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -1,7 +1,8 @@
 <button class="button-shy"
         ng:class="{'small': ctrl.grSmall}"
         ng:click="ctrl.addLabel()"
-        ng:disabled="ctrl.adding">
+        ng:disabled="ctrl.adding"
+        title="Add label">
     <gr-icon ng:class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span ng:hide="ctrl.grSmall">
         Add<span ng:show="ctrl.adding">ing...</span>


### PR DESCRIPTION
As noted by @paperboyo on https://github.com/guardian/grid/pull/1095#issuecomment-132299692.

Tooltip applies to the Uploads page, Image page and Search page... yay components!

<img width="79" alt="screen shot 2015-08-18 at 20 30 56" src="https://cloud.githubusercontent.com/assets/836140/9340566/51f7040c-45e8-11e5-9645-b1960677d557.png">
