### PR TITLE
Fixes 'cd is not a command' error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-x-terminal-emulator -T elasticsearch -e "cd elasticsearch; ./dev-start.sh" &
+x-terminal-emulator -T elasticsearch -e '/bin/bash -c "cd elasticsearch; ./dev-start.sh"' &
 x-terminal-emulator -T media-api     -e "sbt 'project media-api'    'run 9001'" &
 x-terminal-emulator -T thrall        -e "sbt 'project thrall'       'run 9002'" &
 x-terminal-emulator -T image-loader  -e "sbt 'project image-loader' 'run 9003'" &
@@ -8,4 +8,4 @@ x-terminal-emulator -T ftp-loader    -e "sbt 'project ftp-watcher'  'run 9004'" 
 x-terminal-emulator -T kahuna        -e "sbt 'project kahuna'       'run 9005'" &
 x-terminal-emulator -T cropper       -e "sbt 'project cropper'      'run 9006'" &
 x-terminal-emulator -T metadata-editor -e "sbt 'project metadata-editor' 'run 9007'" &
-x-terminal-emulator -T imgops        -e "cd imgops; ./dev-start.sh" &
+x-terminal-emulator -T imgops        -e '/bin/bash -c "cd imgops; ./dev-start.sh"' &


### PR DESCRIPTION
Passes command for imgops and elasticsearch to bash so "cd" is interpreted as a command.