### PR TITLE
icon label directive to reduce css repetition

### DIFF
--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
@@ -12,9 +12,8 @@ confirmDelete.directive('grConfirmDelete', ['$timeout', function($timeout) {
             <button class="gr-confirm-delete" type="button"
                 ng:click="showConfirm = true"
                 ng:class="{'gr-confirm-delete--confirm': showConfirm}">
-                <gr-icon>delete</gr-icon>
-                <ng-transclude ng:if="!showConfirm"></ng-transclude>
-                <span class="gr-confirm-delete__label" ng:if="showConfirm">Confirm delete</span>
+                <gr-icon-label ng:if="!showConfirm" gr-icon="delete">Delete</gr-icon-label>
+                <gr-icon-label ng:if="showConfirm" gr-icon="delete">Confirm Delete</gr-icon-label>
             </button>`,
 
         link: function(scope, element, attrs) {

--- a/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
+++ b/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
@@ -25,7 +25,8 @@ deleteImage.directive('grDeleteImage', [function () {
     return {
         restrict: 'E',
         template: `
-            <gr-confirm-delete class="gr-delete-image" gr-on-confirm="ctrl.delete()"></gr-confirm-delete>`,
+            <gr-confirm-delete class="gr-delete-image" gr-on-confirm="ctrl.delete()">
+            </gr-confirm-delete>`,
         controller: 'grDeleteImageCtrl',
         controllerAs: 'ctrl',
         bindToController: true,

--- a/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
+++ b/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
@@ -25,9 +25,7 @@ deleteImage.directive('grDeleteImage', [function () {
     return {
         restrict: 'E',
         template: `
-            <gr-confirm-delete class="gr-delete-image" gr-on-confirm="ctrl.delete()">
-                <span class="gr-delete-image__label">Delete</span>
-            </gr-confirm-delete>`,
+            <gr-confirm-delete class="gr-delete-image" gr-on-confirm="ctrl.delete()"></gr-confirm-delete>`,
         controller: 'grDeleteImageCtrl',
         controllerAs: 'ctrl',
         bindToController: true,

--- a/kahuna/public/js/components/gr-icon/gr-icon.css
+++ b/kahuna/public/js/components/gr-icon/gr-icon.css
@@ -28,3 +28,9 @@ gr-icon .gr-icon { /* avoid targeting i element */
 gr-icon .gr-icon--small {
     font-size: 1.2rem;
 }
+
+@media screen and (max-width: 800px) {
+    gr-icon-label .icon-label {
+        display: none;
+    }
+}

--- a/kahuna/public/js/components/gr-icon/gr-icon.js
+++ b/kahuna/public/js/components/gr-icon/gr-icon.js
@@ -15,3 +15,16 @@ icon.directive('grIcon', [function() {
         }
     };
 }]);
+
+icon.directive('grIconLabel', [function () {
+    return {
+        restrict: 'E',
+        scope: {
+            grIcon: '@'
+        },
+        transclude: 'replace',
+        template: `
+            <gr-icon>{{grIcon}}</gr-icon>
+            <span class="icon-label"><ng:transclude></ng:transclude></span>`
+    };
+}]);

--- a/kahuna/public/js/edits/archiver.html
+++ b/kahuna/public/js/edits/archiver.html
@@ -5,16 +5,14 @@
         ng:disabled="archiver.archiving">
     <!-- TODO: Start looking at a new loader to replace our "ing…" loader -->
     <span ng:show="archiver.isArchived" title="unarchive">
-        <gr-icon>star</gr-icon>
-        <span class="archiver__label">
+        <gr-icon-label gr-icon="star">
             <span ng:show="archiver.withText">Unarchiv<span ng:show="!archiver.archiving">e</span><span ng:show="archiver.archiving">ing…</span></span>
-        </span>
+        </gr-icon-label>
     </span>
     <span ng:show="!archiver.isArchived" title="archive">
-        <gr-icon>star_border</gr-icon>
-        <span class="archiver__label">
+        <gr-icon-label gr-icon="star_border">
             <span ng:show="archiver.withText">Archiv<span ng:show="!archiver.archiving">e</span><span ng:show="archiver.archiving">ing…</span></span>
-        </span>
+        </gr-icon-label>
     </span>
 </button>
 

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -1,10 +1,11 @@
 <gr-top-bar>
     <gr-top-bar-nav>
-        <a class="top-bar-item"
-           ui:sref="search"><gr-icon>search</gr-icon><span class="top-bar-item__label">Search</span></a>
-        <a class="top-bar-item"
-           ng:if="ctrl.crop"
-           ui:sref="{ crop: null }"><gr-icon>crop_original</gr-icon><span class="top-bar-item__label">Original</span></a>
+        <a class="top-bar-item" ui:sref="search">
+            <gr-icon-label gr-icon="search">Search</gr-icon-label>
+        </a>
+        <a class="top-bar-item" ng:if="ctrl.crop" ui:sref="{ crop: null }">
+            <gr-icon-label gr-icon="crop_original">Original</gr-icon-label>
+        </a>
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
@@ -15,7 +16,7 @@
         </gr-delete-image>
 
         <a class="top-bar-item" href="{{ ctrl.image.data.source | assetFile }}" download target="_blank">
-            <gr-icon>file_download</gr-icon><span class="top-bar-item__label">Download</span>
+            <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
         </a>
 
         <ui-archiver class="top-bar-item top-bar-item--filled"
@@ -25,7 +26,7 @@
         <a class="top-bar-item"
            ng:if="ctrl.canBeCropped"
            ui:sref="crop({imageId: ctrl.image.data.id})">
-            <gr-icon>crop</gr-icon><span class="top-bar-item__label">Crop</span>
+            <gr-icon-label gr-icon="crop">Crop</gr-icon-label>
         </a>
         <span class="top-bar-item"
               ng:if="! ctrl.canBeCropped">Cannot crop</span>

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -10,8 +10,7 @@
            gr:track-click-data="{'Location': 'Search navigation'}"
            class="top-bar-item"
            title="your recent uploads">
-            <gr-icon>photo_library</gr-icon>
-            <span class="top-bar-item__label">Your recent uploads</span>
+            <gr-icon-label gr-icon="photo_library">Your recent uploads</gr-icon-label>
         </a>
         <file-uploader class="top-bar-item"></file-uploader>
     </gr-top-bar-actions>

--- a/kahuna/public/js/upload/file-uploader.html
+++ b/kahuna/public/js/upload/file-uploader.html
@@ -9,7 +9,6 @@
     <button class="file-uploader__select-files button"
             gr:track-click="Upload action"
             gr:track-click-data="{ 'Action': 'Button click' }">
-        <gr-icon>file_upload</gr-icon>
-        <span class="file-uploader__select-files--label">Upload</span>
+        <gr-icon-label gr-icon="file_upload">Upload</gr-icon-label>
     </button>
 </form>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -377,9 +377,7 @@ textarea.ng-invalid {
 }
 
 @media screen and (max-width: 800px) {
-    .top-bar-item__label,
-    .top-bar-item .gr-delete-image__label,
-    .top-bar-item .gr-confirm-delete__label {
+    .top-bar-item__label {
         display: none;
     }
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -377,10 +377,6 @@ textarea.ng-invalid {
 }
 
 @media screen and (max-width: 800px) {
-    .top-bar-item__label {
-        display: none;
-    }
-
     .top-bar-item .gr-confirm-delete {
         min-width: inherit;
     }
@@ -643,12 +639,6 @@ input.search-query__input {
 .file-uploader__select-files {
     margin-top: 12px;
     padding: 5px 10px;
-}
-
-@media screen and (max-width: 800px) {
-    .file-uploader__select-files--label {
-        display: none;
-    }
 }
 
 /* ==========================================================================
@@ -1781,13 +1771,6 @@ FIXME: what to do with touch devices
 /* ==========================================================================
    Archviver
    ========================================================================== */
-
-@media screen and (max-width: 800px) {
-    .archiver__label {
-        display: none;
-    }
-}
-
 .top-bar-item .archiver {
     padding: 0 10px;
     height: 100%;


### PR DESCRIPTION
We've got a few `media screen and (max-width: 800px)` - this creates a `gr-icon-label` component that should keep it DRY.

I've not updated everywhere...yet! But that'll be another PR as the remaining (the selection based ones) have the icon on the right.