### PR TITLE
Removing the upload button from the top bar on the uploads page.

### DIFF
--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -2,10 +2,12 @@ import angular from 'angular';
 import '../edits/image-editor';
 import '../components/gr-delete-image/gr-delete-image';
 import '../image/service';
+import './prompt/prompt';
 
 var upload = angular.module('kahuna.upload.controller', [
     'kahuna.edits.imageEditor',
-    'gr.image.service'
+    'gr.image.service',
+    'kahuna.upload.prompt'
 ]);
 
 upload.controller('UploadCtrl', [

--- a/kahuna/public/js/upload/prompt/prompt.css
+++ b/kahuna/public/js/upload/prompt/prompt.css
@@ -1,0 +1,14 @@
+file-prompt {
+    display: block;
+    background: #444;
+    padding: 10px;
+}
+
+file-prompt file-uploader {
+    display: flex;
+    justify-content: center;
+}
+
+file-prompt .message {
+    text-align: center;
+}

--- a/kahuna/public/js/upload/prompt/prompt.html
+++ b/kahuna/public/js/upload/prompt/prompt.html
@@ -5,5 +5,5 @@
 </p>
 
 <p class="message">
-    Either drag 'n drop an image onto this screen or click the upload button to get your images on the Grid.
+    Either drag 'n drop images onto this screen or click the upload button to get your images on the Grid.
 </p>

--- a/kahuna/public/js/upload/prompt/prompt.html
+++ b/kahuna/public/js/upload/prompt/prompt.html
@@ -1,0 +1,9 @@
+<file-uploader></file-uploader>
+
+<p class="message">
+    Select files to upload.
+</p>
+
+<p class="message">
+    Either drag 'n drop an image onto this screen or click the upload button to get your images on the Grid.
+</p>

--- a/kahuna/public/js/upload/prompt/prompt.js
+++ b/kahuna/public/js/upload/prompt/prompt.js
@@ -1,0 +1,16 @@
+import angular from 'angular';
+
+import './prompt.css!';
+import template from './prompt.html!text';
+
+export let prompt = angular.module('kahuna.upload.prompt', [
+
+]);
+
+prompt.directive('filePrompt', [function () {
+    return {
+        restrict: 'E',
+        transclude: 'replace',
+        template: template
+    }
+}]);

--- a/kahuna/public/js/upload/prompt/prompt.js
+++ b/kahuna/public/js/upload/prompt/prompt.js
@@ -12,5 +12,5 @@ prompt.directive('filePrompt', [function () {
         restrict: 'E',
         transclude: 'replace',
         template: template
-    }
+    };
 }]);

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -4,9 +4,7 @@
            ui:sref="search"><gr-icon>search</gr-icon>
            <span class="top-bar-item__label">Search</span></a>
     </gr-top-bar-nav>
-    <gr-top-bar-actions>
-        <file-uploader class="top-bar-item"></file-uploader>
-    </gr-top-bar-actions>
+    <gr-top-bar-actions></gr-top-bar-actions>
 </gr-top-bar>
 
 <div class="page-wrapper">
@@ -18,6 +16,7 @@
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
     </section>
 
+    <file-prompt ng:if="!ctrl.latestJob"></file-prompt>
 
     <section class="section" ng:if="ctrl.myUploads.data.length > 0">
         <h2 class="section-heading">Your past 50 uploads</h2>
@@ -37,14 +36,6 @@
             <a class="coloured-link" ui:sref="search.results({uploadedBy: user.email})">View all your uploads.</a>
         </p>
     </section>
-
-    <div class="upload-yours"
-       ng:if="ctrl.myUploads.data.length === 0">
-        <p>You haven't uploaded anything yet.</p>
-        <p>Either drag 'n drop an image onto this screen or click the blue
-        upload button in the top right hand corner to get your images on
-        the Grid.</p>
-    </div>
 </div>
 
 <dnd-uploader></dnd-uploader>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -394,6 +394,7 @@ textarea.ng-invalid {
 .page-wrapper {
     margin: 0 auto;
     max-width: 900px;
+    padding-top: 10px;
 }
 
 


### PR DESCRIPTION
In an effort to reduce the confusion on the uploads process, move the upload button to the body of the page - which is not shown when a job is in progress.

![screen shot 2015-08-19 at 15 42 26](https://cloud.githubusercontent.com/assets/836140/9359466/2cba6ba6-4689-11e5-8c91-344592186844.png)

cc @alastairjardine 