### PR TITLE
Allow editing copyright field

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -238,6 +238,37 @@
                         </span>
                     </span>
                 </dd>
+
+                <dt ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
+                <dd ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                    <button class="image-info__edit"
+                            ng:if="ctrl.userCanEdit"
+                            ng:click="copyrightEditForm.$show()"
+                            ng:hide="copyrightEditForm.$visible"
+                    >✎</button>
+                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
+                         editable-text="ctrl.metadata.copyright"
+                         onbeforesave="ctrl.updateMetadataField('copyright', $data)"
+                         e:form="copyrightEditForm"
+                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
+
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
+                            Multiple copyrights (click ✎ to edit <strong>all</strong>)
+                        </span>
+
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
+                            Multiple copyrights
+                        </span>
+
+                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
+                            <span ng:if="ctrl.metadata.copyright">
+                                <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                            </span>
+
+                            <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
+                        </span>
+                    </span>
+                </dd>
             </dl>
         </div>
 

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -188,8 +188,28 @@
                     </span>
                 </dd>
 
-                <dt ng:if="ctrl.metadata.copyright" class="image-info__group--dl__key metadata-line__key">Copyright</dt>
-                <dd ng:if="ctrl.metadata.copyright" class="image-info__group--dl__value metadata-line__info"><a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a></dd>
+
+                <dt ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
+                <dd ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
+                    <button class="image-info__edit"
+                                    ng:if="ctrl.userCanEdit"
+                                    ng:click="copyrightEditForm.$show()"
+                                    ng:hide="copyrightEditForm.$visible"
+                    >✎</button>
+                    <span class="image-info__copyright"
+                                  editable-text="ctrl.metadata.copyright"
+                                  onbeforesave="ctrl.updateMetadataField('copyright', $data)"
+                                  e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}"
+                                  e:form="copyrightEditForm">
+
+                        <span ng:if="ctrl.metadata.copyright">
+                            <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                        </span>
+                        <span ng:if="! ctrl.metadata.copyright">
+                            Unknown (click ✎ to add the copyright)
+                        </span>
+                    </span>
+                </dd>
 
 
                 <dt class="image-info__group--dl__key metadata-line__key">Uploaded</dt>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -71,6 +71,27 @@
                 ng:click="ctrl.batchApplyMetadata('credit')"
             >⇔</button>
         </div>
+        <label ng:if="ctrl.metadata.copyright" class="job-info--editor__field">
+            <div class="job-info--editor__label">Copyright</div>
+            <input
+                type="text"
+                name="copyright"
+                placeholder="e.g. …"
+                class="job-info--editor__input job-info--editor__input--copyright"
+                ng:model="ctrl.metadata.copyright"
+                ng:change="ctrl.save()"
+                ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+            />
+
+            <button
+                class="job-editor__apply-to-all"
+                title="Apply this copyright to all"
+                type="button"
+                ng:if="ctrl.withBatch"
+                ng:click="ctrl.batchApplyMetadata('copyright')"
+            >⇔</button>
+        </label>
     </div>
     <!-- Angular doesn't submit a form without a submit element, bonza!
     see: https://docs.angularjs.org/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action -->

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -67,6 +67,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
         return {
             byline: originalMetadata.byline,
             credit: originalMetadata.credit,
+            copyright: originalMetadata.copyright,
             description: originalMetadata.description
         };
     }


### PR DESCRIPTION
We should allow people to edit this field in case it's wrong. (We should allow editing more/all fields but that's just one more easy step.)

I decided not to show the input field on the upload page if there is no initial copyright metadata (i.e. you can edit existing but not add missing). This is because we don't make use of copyright anywhere so not worth confusing people at upload time by prompting for unnecessary information. I also noticed even agencies rarely fill in the copyright field, making it more of a nice-to-have field.

Copyright field can be added from the image view or search meta panel.

![image](https://cloud.githubusercontent.com/assets/36964/9385058/083eeaf4-474c-11e5-9f59-15dcb91b5e5e.png)

![screenshot-2015-08-20t14 55 16](https://cloud.githubusercontent.com/assets/36964/9384961/a1e9d200-474b-11e5-9ce3-16e9b22e81b7.png)
