### PR TITLE
Fix bug where the delete button disappears after editing usage rights on uploads page.

### DIFF
--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -28,7 +28,7 @@ upload.controller('UploadCtrl', [
                 resource.data.forEach(image => {
                     imageService(image).states.canDelete.then(deletable => {
                         if (deletable) {
-                            deletableImages.add(image);
+                            deletableImages.add(image.data.id);
                         }
                     });
                 });
@@ -38,7 +38,7 @@ upload.controller('UploadCtrl', [
         });
 
         ctrl.canBeDeleted = function (image) {
-            return deletableImages.has(image);
+            return deletableImages.has(image.data.id);
         };
 
         const freeImageDeleteListener = $rootScope.$on('images-deleted', (e, images) => {


### PR DESCRIPTION
Steps to reproduce bug:

- Visit `/upload`
- Find an image which you can delete
- Edit the usage rights of that image
- On saving the usage rights, observe the delete button disappear