### PR TITLE
Avoid exposing mixpanel token in auth-free index page, return in media-api config instead

### DIFF
--- a/kahuna/app/controllers/Application.scala
+++ b/kahuna/app/controllers/Application.scala
@@ -9,7 +9,6 @@ object Application extends Controller {
     Ok(views.html.main(
       Config.mediaApiUri,
       Config.watUri,
-      Config.mixpanelToken,
       Config.sentryDsn))
   }
 

--- a/kahuna/app/lib/Config.scala
+++ b/kahuna/app/lib/Config.scala
@@ -13,7 +13,6 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
   val loginUriTemplate = services.loginUriTemplate
 
   val keyStoreBucket: String = properties("auth.keystore.bucket")
-  val mixpanelToken: Option[String] = properties.get("mixpanel.token").filterNot(_.isEmpty)
   val sentryDsn: Option[String] = properties.get("sentry.dsn").filterNot(_.isEmpty)
   val watUri: Option[String] = properties.get("wat.uri").filterNot(_.isEmpty)
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -1,6 +1,5 @@
 @(mediaApiUri: String,
   watUri: Option[String],
-  mixpanelToken: Option[String],
   sentryDsn: Option[String])
 <!DOCTYPE html>
 <html>
@@ -20,9 +19,6 @@
     <link rel="sentry-dsn" href="@dsn" />
 }
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/main.css")" />
-@mixpanelToken.map { token =>
-    <meta name="mixpanel-token" content="@token" />
-}
 
     <style>
         .ng-cloak { display: none }

--- a/kahuna/public/js/mixpanel/mixpanel.js
+++ b/kahuna/public/js/mixpanel/mixpanel.js
@@ -6,17 +6,14 @@ import UAParser from 'ua-parser-js';
 
 export var mp = angular.module('mixpanel', []);
 
-mp.constant('mixpanelEnabled', ['mixpanelToken', function(mixpanelToken) {
-    return angular.isString(mixpanelToken);
-}]);
-
 /**
  * This module is to allow the rest of the app to include mixpanel as a dependency
  * and not have to deal with the global `var`.
  */
-mp.factory('mixpanel', ['$window', 'mixpanelEnabled', function($window, mixpanelEnabled) {
+mp.factory('mixpanel', ['$window', function($window) {
     var ua      = new UAParser($window.navigator.userAgent);
     var browser = ua.getBrowser();
+    var initialised = false;
 
     function init(mixpanelToken, id, { firstName, lastName, email }, registerProps = {}) {
         mixpanel.init(mixpanelToken);
@@ -34,6 +31,8 @@ mp.factory('mixpanel', ['$window', 'mixpanelEnabled', function($window, mixpanel
         mixpanel.register_once(angular.extend({
             'Browser version': browser.major
         }, registerProps));
+
+        initialised = true;
     }
 
     function track(event, opts) {
@@ -47,6 +46,6 @@ mp.factory('mixpanel', ['$window', 'mixpanelEnabled', function($window, mixpanel
     return {
         init: init,
         track: track,
-        isEnabled: () => mixpanelEnabled
+        isEnabled: () => initialised
     };
 }]);

--- a/kahuna/public/js/mixpanel/mixpanel.js
+++ b/kahuna/public/js/mixpanel/mixpanel.js
@@ -13,7 +13,6 @@ export var mp = angular.module('mixpanel', []);
 mp.factory('mixpanel', ['$window', function($window) {
     var ua      = new UAParser($window.navigator.userAgent);
     var browser = ua.getBrowser();
-    var initialised = false;
 
     function init(mixpanelToken, id, { firstName, lastName, email }, registerProps = {}) {
         mixpanel.init(mixpanelToken);
@@ -31,8 +30,6 @@ mp.factory('mixpanel', ['$window', function($window) {
         mixpanel.register_once(angular.extend({
             'Browser version': browser.major
         }, registerProps));
-
-        initialised = true;
     }
 
     function track(event, opts) {
@@ -45,7 +42,6 @@ mp.factory('mixpanel', ['$window', function($window) {
 
     return {
         init: init,
-        track: track,
-        isEnabled: () => initialised
+        track: track
     };
 }]);

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -91,7 +91,7 @@ async.factory('onNextEvent', ['$q', function($q) {
 
     function onNextEvent(scope, event) {
         const defer = $q.defer();
-        const unregister = scope.$on(event, defer.resolve);
+        const unregister = scope.$on(event, (_, arg) => defer.resolve(arg));
         return defer.promise.finally(unregister);
     }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -54,7 +54,13 @@ object MediaApi extends Controller with ArgoHelpers {
   val searchLinkHref = s"$rootUri/images{?$searchParamList}"
 
   val indexResponse = {
-    val indexData = Map("description" -> "This is the Media API")
+    val indexData = Json.obj(
+      "description" -> "This is the Media API",
+      "configuration" -> Map(
+        "mixpanelToken" -> Config.mixpanelToken
+      ).collect { case (key, Some(value)) => key -> value }
+      // ^ Flatten None away
+    )
     val indexLinks = List(
       Link("search",          searchLinkHref),
       Link("image",           s"$rootUri/images/{id}"),

--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -37,6 +37,8 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val configBucket: String = properties("s3.config.bucket")
 
+  val mixpanelToken: Option[String] = properties.get("mixpanel.token").filterNot(_.isEmpty)
+
   // Note: had to make these lazy to avoid init order problems ;_;
 
   lazy val rootUri: String = services.apiBaseUri

--- a/scripts/dot-properties/templates/kahuna.properties.template
+++ b/scripts/dot-properties/templates/kahuna.properties.template
@@ -2,4 +2,3 @@ domain.root={{domain_root}}
 aws.id={{AwsId}}
 aws.secret={{AwsSecret}}
 auth.keystore.bucket={{KeyBucket}}
-mixpanel.token={{mixpanel_token}}

--- a/scripts/dot-properties/templates/media-api.properties.template
+++ b/scripts/dot-properties/templates/media-api.properties.template
@@ -8,3 +8,4 @@ sns.topic.arn={{SnsTopicArn}}
 cors.allowed.origins={{cors}}
 s3.config.bucket={{ConfigBucket}}
 persistence.identifier=picdarUrn
+mixpanel.token={{mixpanel_token}}


### PR DESCRIPTION
Had to change some of the client code to handle the fact that the token now comes asynchronously.

See related CF change https://github.com/guardian/grid-infra/pull/116