### PR TITLE
raise exception if no stack is defined in settings.ini.

### DIFF
--- a/scripts/dot-properties/main.py
+++ b/scripts/dot-properties/main.py
@@ -3,6 +3,8 @@
 from ConfigParser import ConfigParser
 from generate import generate_files
 
+CONFIG_FILE = 'settings/settings.ini'
+
 def _default_option(config, section, option, default=None):
     return config.get(section, option) \
         if config.has_option(section, option) else default
@@ -10,11 +12,14 @@ def _default_option(config, section, option, default=None):
 
 def main():
     config = ConfigParser()
-    config.read('settings/settings.ini')
+    config.read(CONFIG_FILE)
 
     aws_profile_name = _default_option(config, 'aws', 'profile-name', 'media-service')
     aws_region = _default_option(config, 'aws', 'region', 'eu-west-1')
-    cf_stack = _default_option(config, 'aws', 'stack-name')
+    cf_stack = _default_option(config, 'aws', 'stack-name', None)
+
+    if not cf_stack:
+        raise Exception('No stack found in {}'.format(CONFIG_FILE))
 
     output_dir = _default_option(config, 'output', 'directory', 'output')
 


### PR DESCRIPTION
the properties generator script appears to select an arbitrary stack otherwise - better to fail early.