### PR TITLE
Add logging to ELK for all services except ES and ftp-watcher

### DIFF
--- a/cropper/app/Global.scala
+++ b/cropper/app/Global.scala
@@ -5,10 +5,16 @@ import play.filters.gzip.GzipFilter
 
 import controllers.{Application => App}
 
+import lib.{LogConfig, Config}
+
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 
 
 object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
+
+  override def beforeStart(app: Application) {
+    LogConfig.init(Config)
+  }
 
   override def onStart(app: Application) {
     App.keyStore.scheduleUpdates(Akka.system(app).scheduler)

--- a/cropper/app/lib/Config.scala
+++ b/cropper/app/lib/Config.scala
@@ -1,11 +1,11 @@
 package lib
 
-import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppProperties}
+import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppProperties, CommonPlayAppConfig}
 import java.io.File
 import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
 
 
-object Config extends CommonPlayAppProperties {
+object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
 
   val appName = "cropper"
 

--- a/image-loader/app/Global.scala
+++ b/image-loader/app/Global.scala
@@ -3,12 +3,18 @@ import play.api.mvc.WithFilters
 import play.api.{Application, GlobalSettings}
 import play.filters.gzip.GzipFilter
 
+import lib.{LogConfig, Config}
+
 import controllers.{Application => App}
 
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 
 
 object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
+
+  override def beforeStart(app: Application) {
+    LogConfig.init(Config)
+  }
 
   override def onStart(app: Application) {
     App.keyStore.scheduleUpdates(Akka.system(app).scheduler)

--- a/image-loader/app/lib/Config.scala
+++ b/image-loader/app/lib/Config.scala
@@ -1,10 +1,10 @@
 package lib
 
 import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
-import com.gu.mediaservice.lib.config.{CommonPlayAppProperties, Properties}
+import com.gu.mediaservice.lib.config.{CommonPlayAppConfig, CommonPlayAppProperties, Properties}
 
 
-object Config extends CommonPlayAppProperties {
+object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
 
   val appName = "image-loader"
 

--- a/image-loader/conf/logger.xml
+++ b/image-loader/conf/logger.xml
@@ -21,6 +21,9 @@
         </encoder>
     </appender>
 
+    <logger name="play" level="INFO" />
+    <logger name="application" level="DEBUG" />
+
     <root level="ERROR">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="LOGFILE"/>

--- a/kahuna/app/Global.scala
+++ b/kahuna/app/Global.scala
@@ -5,7 +5,7 @@ import play.api.{Logger, Application, GlobalSettings}
 import play.api.mvc.WithFilters
 import play.filters.gzip.GzipFilter
 
-import lib.{Config, ForceHTTPSFilter}
+import lib.{LogConfig, Config, ForceHTTPSFilter}
 
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 
@@ -13,6 +13,7 @@ import com.gu.mediaservice.lib.play.RequestLoggingFilter
 object Global extends WithFilters(ForceHTTPSFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
 
   override def beforeStart(app: Application) {
+    LogConfig.init(Config)
 
     val allAppConfig: Seq[(String, ConfigValue)] =
       Config.appConfig.underlying.entrySet.asScala.toSeq.map(entry => (entry.getKey, entry.getValue))

--- a/media-api/app/Global.scala
+++ b/media-api/app/Global.scala
@@ -6,12 +6,16 @@ import play.api.{Application, GlobalSettings}
 import play.api.mvc.WithFilters
 import play.filters.gzip.GzipFilter
 
+import lib.{LogConfig, Config}
+
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 
 
 object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
 
   override def beforeStart(app: Application) {
+    LogConfig.init(Config)
+
     ElasticSearch.ensureAliasAssigned()
   }
 

--- a/metadata-editor/app/Global.scala
+++ b/metadata-editor/app/Global.scala
@@ -3,12 +3,18 @@ import play.api.{Application, GlobalSettings}
 import play.api.mvc.WithFilters
 import play.filters.gzip.GzipFilter
 
+import lib.{LogConfig, Config}
+
 import controllers.EditsApi
 
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 
 
 object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
+
+  override def beforeStart(app: Application) {
+    LogConfig.init(Config)
+  }
 
   override def onStart(app: Application) {
     EditsApi.keyStore.scheduleUpdates(Akka.system(app).scheduler)

--- a/metadata-editor/app/lib/Config.scala
+++ b/metadata-editor/app/lib/Config.scala
@@ -1,11 +1,11 @@
 package lib
 
 import com.amazonaws.regions.{Regions, Region}
-import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppProperties}
+import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppConfig, CommonPlayAppProperties}
 import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
 
 
-object Config extends CommonPlayAppProperties {
+object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
 
   val appName = "metadata-editor"
 


### PR DESCRIPTION
Adds logging config to log to the shared ELK stack for most apps.

We can't do ES right now because it's not a Play app and it also perhaps doesn't make sense to push it's logs off to another ES instance. ftp-watcher (in our implementation) is not an AWS app so needs further work to have the right permissions to put to a kinesis stream.

- Depends: https://github.com/guardian/grid-infra/pull/119