### PR TITLE
New cost model option

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -313,7 +313,7 @@ case class SearchParams(
   uploadedBy: Option[String],
   labels: List[String],
   hasMetadata: List[String],
-  newCostModel: Boolean
+  costModelDiff: Boolean
 )
 
 object SearchParams {
@@ -350,7 +350,7 @@ object SearchParams {
       request.getQueryString("uploadedBy"),
       commaSep("labels"),
       commaSep("hasMetadata"),
-      request.getQueryString("newCostModel").nonEmpty
+      request.getQueryString("costModelDiff").nonEmpty
     )
   }
 
@@ -375,7 +375,8 @@ object SearchParams {
       "free"              -> searchParams.free.map(_.toString),
       "uploadedBy"        -> searchParams.uploadedBy,
       "labels"            -> listToCommas(searchParams.labels),
-      "hasMetadata"       -> listToCommas(searchParams.hasMetadata)
+      "hasMetadata"       -> listToCommas(searchParams.hasMetadata),
+      "costModelDiff"     -> Some(searchParams.costModelDiff.toString())
     ).foldLeft(Map[String, String]()) {
       case (acc, (key, Some(value))) => acc + (key -> value)
       case (acc, (_,   None))        => acc

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -313,7 +313,7 @@ case class SearchParams(
   uploadedBy: Option[String],
   labels: List[String],
   hasMetadata: List[String],
-  newCostModel: Option[Boolean]
+  newCostModel: Boolean
 )
 
 object SearchParams {
@@ -350,7 +350,7 @@ object SearchParams {
       request.getQueryString("uploadedBy"),
       commaSep("labels"),
       commaSep("hasMetadata"),
-      request.getQueryString("newCostModel").map(_.toBoolean)
+      request.getQueryString("newCostModel").nonEmpty
     )
   }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -312,7 +312,8 @@ case class SearchParams(
   free: Option[Boolean],
   uploadedBy: Option[String],
   labels: List[String],
-  hasMetadata: List[String]
+  hasMetadata: List[String],
+  newCostModel: Option[Boolean]
 )
 
 object SearchParams {
@@ -348,7 +349,8 @@ object SearchParams {
       request.getQueryString("free").map(_.toBoolean),
       request.getQueryString("uploadedBy"),
       commaSep("labels"),
-      commaSep("hasMetadata")
+      commaSep("hasMetadata"),
+      request.getQueryString("newCostModel").map(_.toBoolean)
     )
   }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -91,8 +91,10 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
     val uploadedByFilter = params.uploadedBy.map(uploadedBy => filters.terms("uploadedBy", NonEmptyList(uploadedBy)))
 
     val validityFilter   = params.valid.flatMap(valid => if(valid) validFilter else invalidFilter)
-
-    val costFilter       = params.free.flatMap(free => if (free) freeFilter else nonFreeFilter)
+    
+    val costFilter       =
+      if (params.newCostModel) params.free.flatMap(free => if (free) newFreeFilter else newNonFreeFilter)
+      else                     params.free.flatMap(free => if (free) freeFilter else nonFreeFilter)
 
     val filterOpt = (
       metadataFilter.toList ++ labelFilter ++ archivedFilter ++

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -91,10 +91,10 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
     val uploadedByFilter = params.uploadedBy.map(uploadedBy => filters.terms("uploadedBy", NonEmptyList(uploadedBy)))
 
     val validityFilter   = params.valid.flatMap(valid => if(valid) validFilter else invalidFilter)
-    
+
     val costFilter       =
-      if (params.newCostModel) params.free.flatMap(free => if (free) newFreeFilter else newNonFreeFilter)
-      else                     params.free.flatMap(free => if (free) freeFilter else nonFreeFilter)
+      if (params.costModelDiff) params.free.flatMap(free => if (free) freeDiffFilter else nonFreeDiffFilter)
+      else                      params.free.flatMap(free => if (free) freeFilter else nonFreeFilter)
 
     val filterOpt = (
       metadataFilter.toList ++ labelFilter ++ archivedFilter ++

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -61,8 +61,11 @@ trait SearchFilters extends ImageFields {
   val freeFilter = filterOrFilter(freeMetadataFilter, freeUsageRightsFilter)
   val nonFreeFilter = freeFilter.map(filters.not)
 
-  val newFreeFilter = filterOrFilter(freeMetadataFilter, freeUsageRightsFilter)
+  val newFreeFilter = filterOrFilter(freeSupplierFilter, freeUsageRightsFilter)
   val newNonFreeFilter = newFreeFilter.map(filters.not)
+
+  val freeDiffFilter = filterAndFilter(freeFilter, newNonFreeFilter)
+  val nonFreeDiffFilter = filterAndFilter(newNonFreeFilter, newFreeFilter)
 
   // FIXME: There must be a better way (._.). Potentially making cost a lookup
   // again?
@@ -82,6 +85,11 @@ trait SearchFilters extends ImageFields {
   def filterOrFilter(filter: Option[FilterBuilder], orFilter: Option[FilterBuilder]): Option[FilterBuilder] = (filter, orFilter) match {
     case (Some(someFilter), Some(orSomeFilter)) => Some(filters.or(someFilter, orSomeFilter))
     case (filterOpt,    orFilterOpt)    => filterOpt orElse orFilterOpt
+  }
+
+  def filterAndFilter(filter: Option[FilterBuilder], andFilter: Option[FilterBuilder]): Option[FilterBuilder] = (filter, andFilter) match {
+    case (Some(someFilter), Some(andSomeFilter)) => Some(filters.and(someFilter, andSomeFilter))
+    case (filterOpt,    andFilterOpt)    => filterOpt orElse andFilterOpt
   }
 
 }

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch
 
 import lib.usagerights.{DeprecatedConfig => UsageRightsDepConfig}
 import com.gu.mediaservice.lib.config.UsageRightsConfig
+import org.elasticsearch.index.query.FilterBuilder
 
 import scalaz.syntax.std.list._
 
@@ -22,10 +23,8 @@ trait SearchFilters extends ImageFields {
   // to a canonical representation in the future
   val creditFilter  = freeCreditList.toNel.map(cs => filters.terms(metadataField("credit"), cs))
   val sourceFilter  = freeSourceList.toNel.map(cs => filters.terms(metadataField("source"), cs))
-  val freeWhitelist = (creditFilter, sourceFilter) match {
-    case (Some(credit), Some(source)) => Some(filters.or(credit, source))
-    case (creditOpt,    sourceOpt)    => creditOpt orElse sourceOpt
-  }
+  val freeWhitelist = filterOrFilter(creditFilter, sourceFilter)
+  
   val sourceExclFilter = payGettySourceList.toNel.map(cs => filters.terms(metadataField("source"), cs))
   val freeCreditFilter = (freeWhitelist, sourceExclFilter) match {
     case (Some(whitelist), Some(sourceExcl)) => Some(filters.bool.must(whitelist).mustNot(sourceExcl))
@@ -49,31 +48,21 @@ trait SearchFilters extends ImageFields {
   val suppliersWithExclusionsFilter = suppliersWithExclusionsFilters.toList.toNel.map(filters.or)
 
   val suppliersNoExclusionsFilter = suppliersNoExclusions.toNel.map(filters.terms(usageRightsField("supplier"), _))
-  val freeSupplierFilter = (suppliersWithExclusionsFilter, suppliersNoExclusionsFilter) match {
-    case (Some(withExclusions), Some(noExclusions)) => Some(filters.or(withExclusions, noExclusions))
-    case (withExclusionsOpt,    noExclusionsOpt)    => withExclusionsOpt orElse noExclusionsOpt
-  }
-
+  val freeSupplierFilter = filterOrFilter(suppliersWithExclusionsFilter, suppliersNoExclusionsFilter)
 
   // Merge legacy and new way of matching free images (matching either is enough)
-  val freeMetadataFilter = (freeCreditFilter, freeSupplierFilter) match {
-    case (Some(freeCredit), Some(freeSupplier)) => Some(filters.or(freeCredit, freeSupplier))
-    case (freeCreditOpt,    freeSupplierOpt)    => freeCreditOpt orElse freeSupplierOpt
-  }
-
+  val freeMetadataFilter = filterOrFilter(freeCreditFilter, freeSupplierFilter)
 
   // We're showing `Conditional` here too as we're considering them potentially
   // free. We could look into sending over the search query as a cost filter
   // that could take a comma separated list e.g. `cost=free,conditional`.
   val freeUsageRightsFilter = freeToUseCategories.toNel.map(filters.terms(usageRightsField("category"), _))
 
-  val freeFilter = (freeMetadataFilter, freeUsageRightsFilter) match {
-    case (Some(freeMetadata), Some(freeUsageRights)) => Some(filters.or(freeMetadata, freeUsageRights))
-    case (freeMetadataOpt,    freeUsageRightsOpt)    => freeMetadataOpt orElse freeUsageRightsOpt
-  }
-
-
+  val freeFilter = filterOrFilter(freeMetadataFilter, freeUsageRightsFilter)
   val nonFreeFilter = freeFilter.map(filters.not)
+
+  val newFreeFilter = filterOrFilter(freeMetadataFilter, freeUsageRightsFilter)
+  val newNonFreeFilter = newFreeFilter.map(filters.not)
 
   // FIXME: There must be a better way (._.). Potentially making cost a lookup
   // again?
@@ -89,5 +78,10 @@ trait SearchFilters extends ImageFields {
     "commissioned-photographer",
     "pool"
   )
+
+  def filterOrFilter(filter: Option[FilterBuilder], orFilter: Option[FilterBuilder]): Option[FilterBuilder] = (filter, orFilter) match {
+    case (Some(someFilter), Some(orSomeFilter)) => Some(filters.or(someFilter, orSomeFilter))
+    case (filterOpt,    orFilterOpt)    => filterOpt orElse orFilterOpt
+  }
 
 }

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -24,7 +24,7 @@ trait SearchFilters extends ImageFields {
   val creditFilter  = freeCreditList.toNel.map(cs => filters.terms(metadataField("credit"), cs))
   val sourceFilter  = freeSourceList.toNel.map(cs => filters.terms(metadataField("source"), cs))
   val freeWhitelist = filterOrFilter(creditFilter, sourceFilter)
-  
+
   val sourceExclFilter = payGettySourceList.toNel.map(cs => filters.terms(metadataField("source"), cs))
   val freeCreditFilter = (freeWhitelist, sourceExclFilter) match {
     case (Some(whitelist), Some(sourceExcl)) => Some(filters.bool.must(whitelist).mustNot(sourceExcl))


### PR DESCRIPTION
An `newCostModel` flag so we can test the numbers, specifically with the rights-inspector.