### PR TITLE
Expose reindex action in API, check edit rights

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -68,7 +68,7 @@ object ImageResponse {
 
     val links = imageLinks(id, secureUrl, withWritePermission, valid)
 
-    val actions = imageActions(id, isPersisted, withDeletePermission)
+    val actions = imageActions(id, isPersisted, withWritePermission, withDeletePermission)
 
     (data, links, actions)
   }
@@ -88,11 +88,16 @@ object ImageResponse {
     if (valid) (cropLink :: baseLinks) else baseLinks
   }
 
-  def imageActions(id: String, isPersisted: Boolean, withDeletePermission: Boolean) = {
+  def imageActions(id: String, isPersisted: Boolean, withWritePermission: Boolean, withDeletePermission: Boolean) = {
     val imageUri = URI.create(s"${Config.rootUri}/images/$id")
+    val reindexUri = URI.create(s"${Config.rootUri}/images/$id/reindex")
     val deleteAction = Action("delete", imageUri, "DELETE")
+    val reindexAction = Action("reindex", reindexUri, "POST")
 
-    if (! isPersisted && withDeletePermission) List(deleteAction) else Nil
+    List(
+      if (! isPersisted && withDeletePermission) List(deleteAction) else Nil,
+      if (withWritePermission) List(reindexAction) else Nil
+    ).flatten
   }
 
   def addUsageCost(source: JsValue): Reads[JsObject] = {

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -12,7 +12,7 @@ GET     /images/edits/:field        controllers.MediaApi.editsSearch(field: Stri
 # Images
 GET     /images/:id                 controllers.MediaApi.getImage(id: String)
 GET     /images/:id/fileMetadata    controllers.MediaApi.getImageFileMetadata(id: String)
-POST    /images/:id/reindex         controllers.MediaApi.cleanImage(id: String)
+POST    /images/:id/reindex         controllers.MediaApi.reindexImage(id: String)
 DELETE  /images/:id                 controllers.MediaApi.deleteImage(id: String)
 
 GET     /images                     controllers.MediaApi.imageSearch


### PR DESCRIPTION
This will help the batch action script I'm writing.

Example link:

``` json
{
  "data": {
    "id": "932f5e8f3906efdc46598b9d770da5cfcc649b86",
    "uploadTime": "2015-08-21T16:46:08Z",
    ...,
  },
  "actions": [{
    "name": "delete",
    "href": "https://api.media.gu.com/images/932f5e8f3906efdc46598b9d770da5cfcc649b86",
    "method": "DELETE"
  }, {
    "name": "reindex",
    "href": "https://api.media.gu.com/images/932f5e8f3906efdc46598b9d770da5cfcc649b86/reindex",
    "method": "POST"
  }]
}
```