### PR TITLE
Prepare for reindex

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -14,9 +14,9 @@ trait ElasticSearchClient {
   def host: String
   def port: Int
   def cluster: String
+  def imagesAlias: String
 
   protected val imagesIndexPrefix = "images"
-  protected val imagesAlias = "imagesAlias"
   protected val imageType = "image"
 
   val initialImagesIndex = "images"

--- a/elasticsearch/reindex/add_alias.sh
+++ b/elasticsearch/reindex/add_alias.sh
@@ -1,0 +1,16 @@
+#/bin/bash
+
+# Usage: ./swap_alias.sh newIndexName localhost
+
+NEW_INDEX_NAME=$1
+ES_URL=$2
+
+cat << EOF > add_alias.json
+{
+    "actions" : [
+        { "add" : { "index" : "$NEW_INDEX_NAME", "alias" : "newImagesAlias" } }
+    ]
+}
+EOF
+
+curl -XPOST $ES_URL:9200/_aliases -d @add_alias.json

--- a/elasticsearch/reindex/asg_instances.sh
+++ b/elasticsearch/reindex/asg_instances.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+
+ASG=$1
+
+aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $ASG --region eu-west-1 | jq ".AutoScalingGroups[].Instances | length"

--- a/elasticsearch/reindex/queue_length.sh
+++ b/elasticsearch/reindex/queue_length.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+
+QUEUE_URL=$1
+
+aws sqs get-queue-attributes --queue-url $QUEUE_URL --attribute-names ApproximateNumberOfMessages --region eu-west-1 | jq -r ".Attributes.ApproximateNumberOfMessages"

--- a/elasticsearch/reindex/swap_alias.sh
+++ b/elasticsearch/reindex/swap_alias.sh
@@ -1,0 +1,20 @@
+#/bin/bash
+
+# Usage: ./swap_alias.sh oldIndexName newIndexName localhost
+
+OLD_INDEX_NAME=$1
+NEW_INDEX_NAME=$2
+ES_URL=$3
+
+cat << EOF > swap_alias.json
+{
+    "actions" : [
+        { "remove" : { "index" : "$NEW_INDEX_NAME", "alias" : "newImagesAlias" } },
+        { "remove" : { "index" : "$OLD_INDEX_NAME", "alias" : "imagesAlias" } },
+        { "add" : { "index" : "$NEW_INDEX_NAME", "alias" : "imagesAlias" } },
+        { "add" : { "index" : "$OLD_INDEX_NAME", "alias" : "newImagesAlias" } }
+    ]
+}
+EOF
+
+curl -XPOST $ES_URL:9200/_aliases -d @swap_alias.json

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -51,6 +51,7 @@ case class BucketResult(key: String, count: Long)
 object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFields {
 
   import MediaApiMetrics._
+  val imagesAlias = "imagesAlias"
 
   lazy val host = Config.elasticsearchHost
   lazy val port = Config.int("es.port")

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -6,6 +6,7 @@ object Main extends App {
   args.toList match {
     case "LoadFromS3Bucket" :: as => LoadFromS3Bucket(as)
     case "Reindex"          :: as => Reindex(as)
+    case "MoveIndex"        :: as => MoveIndex(as)
     case "UpdateMapping"    :: as => UpdateMapping(as)
     case a :: _ => sys.error(s"Unrecognised command: $a")
     case Nil    => sys.error("Usage: <Command> <args ...>")

--- a/thrall/app/lib/Config.scala
+++ b/thrall/app/lib/Config.scala
@@ -23,6 +23,8 @@ object Config extends CommonPlayAppConfig {
 
   val imageBucket: String = properties("s3.image.bucket")
 
+  val imagesAlias = properties("es.index.alias")
+
   val thumbnailBucket: String = properties("s3.thumb.bucket")
 
   val elasticsearchHost: String =

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -28,6 +28,7 @@ object ElasticSearch extends ElasticSearchClient {
   import Config.persistenceIdentifier
   import com.gu.mediaservice.lib.formatting._
 
+  val imagesAlias = Config.imagesAlias
   val host = Config.elasticsearchHost
   val port = Config.int("es.port")
   val cluster = Config("es.cluster")


### PR DESCRIPTION
These changes allow Thrall to be configured with the alias to use in ES. This allows us to have multiple indexes being written to by different instances of Thrall fed by different queues (one of which will act as a message buffer during a reindex operation).

**Ultimately this will allow us to perform a reindex operation with 0 downtime and no loss of availability of documents.**

Depends: https://github.com/guardian/grid-infra/pull/120

A reindex operation has 4 phases:

- **None:** No reindex is taking place. 
  - The reindex phase param is set to "none" resulting in:
    - The ThrallReindex ASG is scaled to 0.
    - Messages are not sent to the ReindexQueue (and its' retention period is 1 minute).
- **Reindexing:** A reindex has begun, `scripts/run Reindex [env]` can be run. 
  - The reindex phase param is set to "reindexing", this results in:
    - Messages being sent to the Reindex SQS queue and these are retained for up to 4 days. 
    - The ThrallReindex ASG is scaled to 0.
- **Syncing:** The reindex operation is complete. 
  - The reindex phase param is set to "syncing", this results in:
    - Messages continuing to be sent to the Reindex SQS queue and they continue to be retained for up to 4 days. 
    - The ThrallReindex ASG is scaled to 1, messages are consumed from the Reindex SQS queue and the new index is synced with changes that occured during the reindex operation.
- **Finalised:** The sync has complete indicated by a 0 length reindex queue.
  - The reindex phase param remains "syncing"
  - It is now safe to run  `scripts/run MoveIndex [env]`.
  - When we are comfortable the operation was successful:
    - The old index can be deleted manually: `curl -XDELETE localhost:9200/images_n`.
    - The reindex phase param can be set to "none".
