### PR TITLE
delete crops from ES record from thrall

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -120,7 +120,8 @@ object ElasticSearch extends ElasticSearchClient {
         "lastModified" -> asGroovy(JsString(currentIsoDateString))
       ).asJava)
       .setScript(
-          deleteExportsScript,
+          deleteExportsScript +
+          updateLastModifiedScript,
         scriptType)
       .executeAndLog(s"removing exports from image $id")
       .incrementOnFailure(failedExportsUpdates) { case e: VersionConflictEngineException => true }

--- a/thrall/app/lib/MessageConsumer.scala
+++ b/thrall/app/lib/MessageConsumer.scala
@@ -75,6 +75,7 @@ object MessageConsumer {
       case "delete-image"               => deleteImage
       case "update-image"               => indexImage
       case "update-image-exports"       => updateImageExports
+      case "delete-image-exports"       => deleteImageExports
       case "update-image-user-metadata" => updateImageUserMetadata
       case "heartbeat"                  => heartbeat
     }
@@ -101,6 +102,9 @@ object MessageConsumer {
 
   def updateImageExports(exports: JsValue): Future[UpdateResponse] =
     withImageId(exports)(id => ElasticSearch.updateImageExports(id, exports \ "data"))
+
+  def deleteImageExports(exports: JsValue): Future[UpdateResponse] =
+    withImageId(exports)(id => ElasticSearch.deleteImageExports(id))
 
   def updateImageUserMetadata(metadata: JsValue): Future[UpdateResponse] =
     withImageId(metadata)(id => ElasticSearch.applyImageMetadataOverride(id, metadata \ "data"))


### PR DESCRIPTION
Towards the greater goal of deleting crops.
The ability to publish this message will be behind an [authed, permission-checked endpoint in cropper](/guardian/grid/pull/1154).