### PR TITLE
Use stream to keep up with changes to a cell's `item`.

### DIFF
--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table-cell.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table-cell.js
@@ -7,8 +7,8 @@ export var lazyTableCell = angular.module('gu.lazyTableCell', [
 ]);
 
 lazyTableCell.directive('guLazyTableCell',
-                        ['subscribe$',
-                         function(subscribe$) {
+                        ['subscribe$', 'observe$',
+                         function(subscribe$, observe$) {
     return {
         restrict: 'A',
         require: '^guLazyTable',
@@ -17,8 +17,8 @@ lazyTableCell.directive('guLazyTableCell',
         transclude: true,
         template: '<ng-transclude ng:if="guLazyTableCellVisible"></ng-transclude>',
         link: function(scope, element, attrs, ctrl) {
-            const item = scope.$eval(attrs.guLazyTableCell);
-            const position$ = ctrl.getItemPosition$(item);
+            const item$ = observe$(scope, attrs.guLazyTableCell);
+            const position$ = item$.flatMapLatest((item) => ctrl.getItemPosition$(item));
             subscribe$(scope, position$,
                        ({top, left, width, height, display}) => {
                 // use applyAsync rather than rx.safeApply to batch

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table-cell.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table-cell.js
@@ -18,7 +18,7 @@ lazyTableCell.directive('guLazyTableCell',
         template: '<ng-transclude ng:if="guLazyTableCellVisible"></ng-transclude>',
         link: function(scope, element, attrs, ctrl) {
             const item$ = observe$(scope, attrs.guLazyTableCell);
-            const position$ = item$.flatMapLatest((item) => ctrl.getItemPosition$(item));
+            const position$ = item$.flatMapLatest(ctrl.getItemPosition$);
             subscribe$(scope, position$,
                        ({top, left, width, height, display}) => {
                 // use applyAsync rather than rx.safeApply to batch


### PR DESCRIPTION
The emission of the `image-updated` event means the image has changed and so the cell's `item` is stale.

Converting to stream means we keep up to date with changes.