### PR TITLE
Performance improvement to recover previous optim from .first()

### DIFF
--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -187,7 +187,9 @@ lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
                                      preloadedRows$, viewportTop$, viewportBottom$}) {
         return (item) => {
             // share() because it's an expensive operation
-            const index$  = items$.map(items => items.indexOf(item)).share();
+            const index$  = items$.map(items => items.indexOf(item)).
+                distinctUntilChanged().
+                share();
             const getPos$ = createGetCellPosition$({
                 cellWidth$, cellHeight$, columns$,
                 preloadedRows$, viewportTop$, viewportBottom$


### PR DESCRIPTION
We've identified that the performance issue seems to be related to removing the `.first()` optimisation.

This change seems to recover much of the lost performance by avoiding firing when the index doesn't actually change, which is 99% of the time.

Tried locally vs the PROD API and can definitely see the improvement in terms of memory use.