### PR TITLE
remove 'Guardian' from free credits

### DIFF
--- a/media-api/app/lib/usagerights/Config.scala
+++ b/media-api/app/lib/usagerights/Config.scala
@@ -47,11 +47,7 @@ object DeprecatedConfig {
     "AFP/Getty Images",
     "Bloomberg via Getty Images",
     "Fairfax Media via Getty Images",
-    // FIXME: we've actually settled on "The Guardian" as canonical source.
-    // There's now a MetadataCleaner to transform all to The Guardian canonical name.
-    // We need to migrate all indexed content with "Guardian" to "The Guardian" before we can
-    // retire Guardian from whitelist here.
-    "Guardian", "The Guardian", "The Observer")
+    "The Guardian", "The Observer")
 
   val freeSourceList = List(
     "Corbis",


### PR DESCRIPTION
After using batcher there are no more `credit:Guardian`s.
Removing it now will stop it being used in the future.