### PR TITLE
reset ure form to original values when cancelled

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -33,7 +33,7 @@
                  ng:init="showUsageRights = false">
                 <dt class="metadata-line__key">Usage rights category</dt>
                 <gr-usage-rights-editor
-                    ng:show="showUsageRights"
+                    ng:if="showUsageRights"
                     gr:usage-rights="ctrl.usageRights"
                     gr:on-save="showUsageRights = false"
                     gr:on-cancel="showUsageRights = false">

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -124,7 +124,7 @@
                 </div>
 
                 <gr-usage-rights-editor
-                    ng:show="ctrl.showUsageRights"
+                    ng:if="ctrl.showUsageRights"
                     class="result-editor__usage-rights"
                     gr:usage-rights="[ctrl.usageRights]"
                     gr:on-save="ctrl.showUsageRights = false"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -123,7 +123,7 @@
                 <dt class="metadata-line__key">Usage rights category</dt>
 
                 <gr-usage-rights-editor
-                    ng:show="showUsageRights"
+                    ng:if="showUsageRights"
                     gr:usage-rights="[ctrl.usageRights]"
                     gr:on-save="showUsageRights = false"
                     gr:on-cancel="showUsageRights = false">

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -12,6 +12,7 @@
         <!-- We reset the model here else properties remain attached to the\
         model, even though they don't exist in the form -->
         <select
+            class="full-width"
             ng:model="ctrl.category"
             ng:disabled="ctrl.saving"
             ng:options="category as category.name for category in ctrl.categories track by category.value"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -20,7 +20,7 @@
     </label>
 
     <div class="ure__description">
-        {{ctrl.category.description || ctrl.descriptionPlaceholder}}
+        {{ctrl.category.description}}
     </div>
 
     <div class="ure__properties" ng:if="ctrl.category">

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -18,6 +18,12 @@ usageRightsEditor.controller(
 
     var ctrl = this;
 
+    ctrl.saving = false;
+    ctrl.saved = false;
+    ctrl.categories = [];
+    ctrl.originalCats = [];
+    ctrl.model = angular.extend({}, ctrl.usageRights.data);
+
     const multiRights = { name: 'Multiple categories', value: '' };
     const noRights = { name: 'None', value: '' };
     const catsWithNoRights = () => [noRights].concat(ctrl.originalCats);
@@ -80,12 +86,6 @@ usageRightsEditor.controller(
         ctrl.update();
     }));
 
-    ctrl.saving = false;
-    ctrl.saved = false;
-    ctrl.categories = [];
-    ctrl.model = angular.extend({}, ctrl.usageRights.data);
-
-
     // TODO: What error would we like to show here?
     // TODO: How do we make this more synchronous? You can only resolve on the
     // routeProvider, which is actually bound to the UploadCtrl in this instance
@@ -100,22 +100,13 @@ usageRightsEditor.controller(
         }
     };
 
-    ctrl.remove = remove;
-
     ctrl.cancel = () => ctrl.onCancel();
-
-    ctrl.isDisabled = () => ctrl.saving;
-
-    ctrl.isNotEmpty = () => !angular.equals(ctrl.model, {});
 
     // stop saving on no/multi rights
     ctrl.savingDisabled = () => {
         return ctrl.saving ||
             angular.equals(ctrl.category, noRights) || angular.equals(ctrl.category, multiRights);
     };
-
-    ctrl.pluraliseCategory = () => ctrl.category.name +
-        (ctrl.category.name.toLowerCase().endsWith('image') ? 's' : ' images');
 
     ctrl.getOptionsFor = property => {
         const key = ctrl.category


### PR DESCRIPTION
GIFs may not illustrate the bug. Steps to reproduce:
- Open the usage rights form for any image
- Make a change but don't save, instead press cancel to close the form
- Open the usage rights form again, and the value of the form is that of the change from above rather than the original.

# Before
![ure-reset-on-cancel](https://cloud.githubusercontent.com/assets/836140/9657788/ff136c02-523b-11e5-9133-5e671d34b3cb.gif)

# After
![ure-reset-on-cancel-after](https://cloud.githubusercontent.com/assets/836140/9657790/038c15c2-523c-11e5-978b-732dd583bc1a.gif)

I've also refactored to remove a few unused functions and move instantiation of controller properties higher.