### PR TITLE
fix linting by removing unused function.

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -144,15 +144,6 @@ usageRightsEditor.controller(
         }, {});
     }
 
-    function remove() {
-        ctrl.error = null;
-        ctrl.saving = true;
-        $q.all(ctrl.usageRights.map((usageRights) => {
-            return usageRights.remove();
-        })).catch(uiError).
-            finally(() => ctrl.saving = false);
-    }
-
     function save(data) {
         ctrl.error = null;
         ctrl.saving = true;


### PR DESCRIPTION
Linter is complaining that `remove` is declared but never used.

I missed this function in refactorings from https://github.com/guardian/grid/pull/1184.