### PR TITLE
allow empty publication in usage when contract or commissioned

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -46,7 +46,7 @@ object PhotographerParser extends ImageProcessor {
 
         // contracted photographer
         case (byline, credit, None, Some(publication)) => image.copy(
-          usageRights = ContractPhotographer(byline, publication),
+          usageRights = ContractPhotographer(byline, Some(publication)),
           metadata    = image.metadata.copy(credit = Some(publication))
         )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -256,7 +256,7 @@ object StaffPhotographer {
 }
 
 
-case class ContractPhotographer(photographer: String, publication: String, restrictions: Option[String] = None)
+case class ContractPhotographer(photographer: String, publication: Option[String] = None, restrictions: Option[String] = None)
   extends UsageRights {
     val category = "contract-photographer"
     val defaultCost = Some(Free)
@@ -269,13 +269,13 @@ object ContractPhotographer {
  implicit val jsonWrites: Writes[ContractPhotographer] = (
    (__ \ "category").write[String] ~
    (__ \ "photographer").write[String] ~
-   (__ \ "publication").write[String] ~
+   (__ \ "publication").writeNullable[String] ~
    (__ \ "restrictions").writeNullable[String]
  )(s => (s.category, s.photographer, s.publication, s.restrictions))
 }
 
 
-case class CommissionedPhotographer(photographer: String, publication: String, restrictions: Option[String] = None)
+case class CommissionedPhotographer(photographer: String, publication: Option[String] = None, restrictions: Option[String] = None)
   extends UsageRights {
     val category = "commissioned-photographer"
     val defaultCost = Some(Free)
@@ -288,7 +288,7 @@ object CommissionedPhotographer {
  implicit val jsonWrites: Writes[CommissionedPhotographer] = (
    (__ \ "category").write[String] ~
    (__ \ "photographer").write[String] ~
-   (__ \ "publication").write[String] ~
+   (__ \ "publication").writeNullable[String] ~
    (__ \ "restrictions").writeNullable[String]
  )(s => (s.category, s.photographer, s.publication, s.restrictions))
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -31,7 +31,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     it("should match ContractPhotographer byline") {
       val image = createImageFromMetadata("byline" -> "Linda Nylind")
       val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(ContractPhotographer("Linda Nylind", "The Guardian"))
+      processedImage.usageRights should be(ContractPhotographer("Linda Nylind", Option("The Guardian")))
       processedImage.metadata.credit should be(Some("The Guardian"))
     }
   }

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -42,7 +42,7 @@ object EditsApi extends Controller with ArgoHelpers {
     // to access the `val`s of the classes though without instantiating them.
     val usageRightsData =
       List(PrImage(), Handout(), Screengrab(), SocialMedia(), Obituary(), Pool(),
-           StaffPhotographer("?", "?"), ContractPhotographer("?", "?"), CommissionedPhotographer("?", "?"),
+           StaffPhotographer("?", "?"), ContractPhotographer("?"), CommissionedPhotographer("?"),
            Agency("?"), CommissionedAgency("?"), CrownCopyright()).sortWith(_.name.toLowerCase < _.name.toLowerCase)
         .map(CategoryResponse.fromUsageRights)
 


### PR DESCRIPTION
Allow omission of publication in PUT body for usage rights when contract or commissioned photographer.

Allows the body of the PUT request to be:

```json
{"data":{"category":"contract-photographer","photographer":"foo"}}
```

Meaning we won't be storing empty string for the `None` publication.