### PR TITLE
Clean null unicode

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -16,7 +16,8 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
     CleanRubbishLocation,
     StripCopyrightPrefix,
     UseCanonicalGuardianCredit,
-    ExtractGuardianCreditFromByline
+    ExtractGuardianCreditFromByline,
+    StripFromNullUnicodeChar
   ) ++ attrCreditFromBylineCleaners ++ List(
     StripBylineFromCredit,
     CountryCode,

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/StripFromNullUnicodeChar.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/StripFromNullUnicodeChar.scala
@@ -1,0 +1,17 @@
+package com.gu.mediaservice.lib.cleanup
+
+import com.gu.mediaservice.model.ImageMetadata
+
+object StripFromNullUnicodeChar extends MetadataCleaner {
+  val unicodeChar = "\u0000"
+
+  def stripFromNullUnicodeChar(s: String): Option[String] = {
+    s.split(unicodeChar).headOption
+  }
+
+  override def clean(metadata: ImageMetadata): ImageMetadata =
+    metadata.copy(
+      source = metadata.source.flatMap(stripFromNullUnicodeChar),
+      byline = metadata.byline.flatMap(stripFromNullUnicodeChar)
+    )
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/StripFromNullUnicodeCharTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/StripFromNullUnicodeCharTest.scala
@@ -1,0 +1,27 @@
+package com.gu.mediaservice.lib.cleanup
+
+import org.scalatest.{FunSpec, Matchers}
+
+class StripFromNullUnicodeCharTest extends FunSpec with Matchers with MetadataHelper {
+  val invalidByline = "Ian Waldie\u0000\u0000"
+  val invalidSource = "Getty Images\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0003\u0000\u0000\u0000\u0005\u0000\u0000\u0000\nï¿½ï¿½ï¿½ï¿½"
+
+  it("should not change a valid name") {
+    StripFromNullUnicodeChar.stripFromNullUnicodeChar("Getty Images") should be (Some("Getty Images"))
+  }
+
+  it ("should strip everything beyond a null unicode character") {
+    StripFromNullUnicodeChar.stripFromNullUnicodeChar(invalidSource) should be (Some("Getty Images"))
+  }
+
+  it("should clean byline and source") {
+    val metadata = createImageMetadata(
+      "byline" -> invalidByline,
+      "source" -> invalidSource
+    )
+    val cleanedMetadata = StripFromNullUnicodeChar.clean(metadata)
+    cleanedMetadata.byline should be (Some("Ian Waldie"))
+    cleanedMetadata.source should be (Some("Getty Images"))
+  }
+
+}


### PR DESCRIPTION
Realised while going through some data Getty, lo and behold, adds some pretty strange info to the byline and source.

e.g.
* `Ian Waldie\u0000\u0000`
* `Getty Images\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0003\u0000\u0000\u0000\u0005\u0000\u0000\u0000\nï¿½ï¿½ï¿½ï¿½`

Superb, I'll try and find a way of searching for this and reindex on change.
