### PR TITLE
use bloomberg via getty as indication of coming from getty

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -141,8 +141,10 @@ object GettyXmpParser extends ImageProcessor {
 }
 
 object GettyCreditParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit.map(_.toLowerCase) match {
-    case Some("getty images") | Some("afp/getty images") => image.copy(
+  val gettyCredits = List("getty images", "afp/getty images", "bloomberg via getty images")
+
+  def apply(image: Image): Image = image.metadata.credit.map(c => gettyCredits.contains(c.toLowerCase)) match {
+    case Some(true) => image.copy(
        usageRights = Agency("Getty Images", suppliersCollection = image.metadata.source)
     )
     case _ => image

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -201,6 +201,13 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.usageRights should be(Agency("Getty Images"))
       processedImage.metadata.credit should be(Some("AFP/Getty Images"))
     }
+
+    it("should match 'Bloomberg via Getty Images' credit") {
+      val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Getty Images", Some("Bloomberg")))
+      processedImage.metadata.credit should be(Some("Bloomberg via Getty Images"))
+    }
   }
 
 


### PR DESCRIPTION
There seems to be quite a few uploaded by users - I think once they're downloaded from Getty or Bloomberg which don't contain Getty XMP metadata.