### PR TITLE
Fix bug where ure wouldn't close.

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -29,22 +29,21 @@
 
     <div class="panel__content">
         <div class="image-info__group">
-            <dl class="image-info__wrap metadata-line image-info__usage-rights"
-                 ng:init="showUsageRights = false">
+            <dl class="image-info__wrap metadata-line image-info__usage-rights">
                 <dt class="metadata-line__key">Usage rights category</dt>
                 <gr-usage-rights-editor
-                    ng:if="showUsageRights"
+                    ng:if="ctrl.showUsageRights"
                     gr:usage-rights="ctrl.usageRights"
-                    gr:on-save="showUsageRights = false"
-                    gr:on-cancel="showUsageRights = false">
+                    gr:on-save="ctrl.showUsageRights = false"
+                    gr:on-cancel="ctrl.showUsageRights = false">
                 </gr-usage-rights-editor>
-                <dd class="image-info__title" ng:hide="showUsageRights">
+                <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
                     {{ctrl.usageCategory || 'None'}}
                 </dd>
 
                 <button
-                    ng:click="showUsageRights = !showUsageRights"
-                    ng:hide="!ctrl.userCanEdit || showUsageRights"
+                    ng:click="ctrl.showUsageRights = true"
+                    ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
                     class="image-info__edit">✎</button>
             </dl>
         </div>

--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -46,6 +46,8 @@ grPanel.controller('GrPanel', [
 
         var ctrl = this;
 
+        ctrl.showUsageRights = false;
+
         const panelName = 'gr-panel';
 
         panelService.addPanel(panelName, false);

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -53,6 +53,8 @@ image.controller('ImageCtrl', [
 
         var ctrl = this;
 
+        ctrl.showUsageRights = false;
+
         ctrl.credits = function(searchText) {
             return ctrl.metadataSearch('credit', searchText);
         };

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -118,24 +118,23 @@
         </div>
 
         <div class="image-info__group">
-            <dl class="image-info__wrap metadata-line image-info__usage-rights"
-                 ng:init="showUsageRights = false">
+            <dl class="image-info__wrap metadata-line image-info__usage-rights">
                 <dt class="metadata-line__key">Usage rights category</dt>
 
                 <gr-usage-rights-editor
-                    ng:if="showUsageRights"
+                    ng:if="ctrl.showUsageRights"
                     gr:usage-rights="[ctrl.usageRights]"
-                    gr:on-save="showUsageRights = false"
-                    gr:on-cancel="showUsageRights = false">
+                    gr:on-save="ctrl.showUsageRights = false"
+                    gr:on-cancel="ctrl.showUsageRights = false">
                 </gr-usage-rights-editor>
 
-                <dd class="image-info__title" ng:hide="showUsageRights">
+                <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
                     {{ctrl.usageCategory || 'None'}}
                 </dd>
 
                 <button
-                    ng:click="showUsageRights = !showUsageRights"
-                    ng:hide="!ctrl.userCanEdit || showUsageRights"
+                    ng:click="ctrl.showUsageRights = true"
+                    ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
                     class="image-info__edit">✎</button>
             </dl>
         </div>


### PR DESCRIPTION
ng:if creates a new scope when the element is restored, use controller property instead.

related - https://github.com/guardian/grid/pull/1184