### PR TITLE
Upgrade to ES 1.7.1

### DIFF
--- a/elasticsearch/build.sh
+++ b/elasticsearch/build.sh
@@ -18,7 +18,7 @@ then
 
     ./downloads/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.7.1
     ./downloads/elasticsearch/bin/plugin -install mobz/elasticsearch-head
-    ./downloads/elasticsearch/bin/plugin -install com.gu/elasticsearch-cloudwatch/1.0
+    ./downloads/elasticsearch/bin/plugin -install com.gu/elasticsearch-cloudwatch/1.1
     ./downloads/elasticsearch/bin/plugin -install karmi/elasticsearch-paramedic
 
     cp ../elasticsearch.yml downloads/elasticsearch/config

--- a/elasticsearch/build.sh
+++ b/elasticsearch/build.sh
@@ -18,7 +18,7 @@ then
 
     ./downloads/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.7.1
     ./downloads/elasticsearch/bin/plugin -install mobz/elasticsearch-head
-    ./downloads/elasticsearch/bin/plugin -url https://github.com/guardian/elasticsearch-cloudwatch/releases/download/1.0-redux/elasticsearch-CloudwatchPlugin-1.7.1.zip -install CloudwatchPlugin
+    ./downloads/elasticsearch/bin/plugin -install com.gu/elasticsearch-cloudwatch/1.0
     ./downloads/elasticsearch/bin/plugin -install karmi/elasticsearch-paramedic
 
     cp ../elasticsearch.yml downloads/elasticsearch/config

--- a/elasticsearch/build.sh
+++ b/elasticsearch/build.sh
@@ -20,7 +20,6 @@ then
     ./downloads/elasticsearch/bin/plugin -install mobz/elasticsearch-head
     ./downloads/elasticsearch/bin/plugin -url https://github.com/guardian/elasticsearch-cloudwatch/releases/download/1.2/elasticsearch-CloudwatchPlugin-1.2.zip -install CloudwatchPlugin
     ./downloads/elasticsearch/bin/plugin -install karmi/elasticsearch-paramedic
-    ./downloads/elasticsearch/bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-action-updatebyquery/2.6.0
 
     cp ../elasticsearch.yml downloads/elasticsearch/config
     cp ../logging.yml downloads/elasticsearch/config

--- a/elasticsearch/build.sh
+++ b/elasticsearch/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ELASTICSEARCH_VERSION=1.3.4
+ELASTICSEARCH_VERSION=1.7.1
 ELASTICSEARCH_DIR=$(dirname $0)
 TARGET=$ELASTICSEARCH_DIR/target
 
@@ -16,12 +16,11 @@ then
     tar xfv downloads/elasticsearch.tar.gz -C downloads
     mv downloads/elasticsearch-* downloads/elasticsearch
 
-    ./downloads/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.3.0
+    ./downloads/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.7.1
     ./downloads/elasticsearch/bin/plugin -install mobz/elasticsearch-head
-    ./downloads/elasticsearch/bin/plugin -install lukas-vlcek/bigdesk
     ./downloads/elasticsearch/bin/plugin -url https://github.com/guardian/elasticsearch-cloudwatch/releases/download/1.2/elasticsearch-CloudwatchPlugin-1.2.zip -install CloudwatchPlugin
     ./downloads/elasticsearch/bin/plugin -install karmi/elasticsearch-paramedic
-    ./downloads/elasticsearch/bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-action-updatebyquery/2.2.0
+    ./downloads/elasticsearch/bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-action-updatebyquery/2.6.0
 
     cp ../elasticsearch.yml downloads/elasticsearch/config
     cp ../logging.yml downloads/elasticsearch/config

--- a/elasticsearch/build.sh
+++ b/elasticsearch/build.sh
@@ -18,7 +18,7 @@ then
 
     ./downloads/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.7.1
     ./downloads/elasticsearch/bin/plugin -install mobz/elasticsearch-head
-    ./downloads/elasticsearch/bin/plugin -url https://github.com/guardian/elasticsearch-cloudwatch/releases/download/1.2/elasticsearch-CloudwatchPlugin-1.2.zip -install CloudwatchPlugin
+    ./downloads/elasticsearch/bin/plugin -url https://github.com/guardian/elasticsearch-cloudwatch/releases/download/1.0-redux/elasticsearch-CloudwatchPlugin-1.7.1.zip -install CloudwatchPlugin
     ./downloads/elasticsearch/bin/plugin -install karmi/elasticsearch-paramedic
 
     cp ../elasticsearch.yml downloads/elasticsearch/config

--- a/elasticsearch/dev-install.sh
+++ b/elasticsearch/dev-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ELASTICSEARCH_VERSION=1.3.4
+ELASTICSEARCH_VERSION=1.7.1
 ELASTICSEARCH_DIR=$(dirname $0)
 
 if [ -d "$ELASTICSEARCH_DIR/elasticsearch" ]; then
@@ -27,9 +27,8 @@ then
     cd elasticsearch
     ./bin/plugin -install mobz/elasticsearch-head
     ./bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.3.0
-    ./bin/plugin -install lukas-vlcek/bigdesk
     ./bin/plugin -install karmi/elasticsearch-paramedic
-    ./bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-action-updatebyquery/2.2.0
+    ./bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-action-updatebyquery/2.6.0
     echo "Done"
     echo "Start it with $ELASTICSEARCH_DIR/dev-start.sh"
 else

--- a/elasticsearch/dev-install.sh
+++ b/elasticsearch/dev-install.sh
@@ -28,7 +28,6 @@ then
     ./bin/plugin -install mobz/elasticsearch-head
     ./bin/plugin -install elasticsearch/elasticsearch-cloud-aws/2.3.0
     ./bin/plugin -install karmi/elasticsearch-paramedic
-    ./bin/plugin -install com.yakaz.elasticsearch.plugins/elasticsearch-action-updatebyquery/2.6.0
     echo "Done"
     echo "Start it with $ELASTICSEARCH_DIR/dev-start.sh"
 else

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -360,3 +360,7 @@ action.disable_delete_all_indices: true
 
 ################## ES Cloudwatch config ##################
 metrics.cloudwatch.namespace: "@@STAGE/Elasticsearch"
+
+################## Dynamic scripting ##################
+script.inline: on
+script.indexed: on

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -11,7 +11,7 @@ cluster.name: media-service
 # Node names are generated dynamically on startup, so you're relieved
 # from configuring them manually. You can tie this node to a specific name:
 #
-# node.name: "Franz Kafka"
+node.name: ${HOSTNAME}
 
 # Every node can be configured to allow or deny being eligible as the master,
 # and to allow or deny to store the data.

--- a/elasticsearch/logging.yml
+++ b/elasticsearch/logging.yml
@@ -5,7 +5,7 @@ logger:
   action: DEBUG
 
   # aws
-  com.amazonaws: DEBUG
+  com.amazonaws: WARN
 
   # gateway
   gateway: DEBUG


### PR DESCRIPTION
This PR:
- Upgrades to ES 1.7.1
- Changes log level for aws plugin to be less noisy
- Upgrades plugins where necessary
- Remove BigDesk plugin as it is incompatible (and not used)

**TODO:**
- Update Cloudwatch logs plugin to be compatible.