### PR TITLE
surface 500 and 503 errors to ng:messages.

### DIFF
--- a/kahuna/public/js/errors/global.html
+++ b/kahuna/public/js/errors/global.html
@@ -22,4 +22,14 @@
             to reauthenticate.
         </div>
     </div>
+
+    <div class="global-error warning" ng:message="unknown">
+        An unknown error has occurred.
+        If the problem persists please <a href="mailto:thegrid.dev@theguardian.com" class="coloured-link">email the Grid team</a>.
+    </div>
+
+    <div class="global-error error" ng:message="server">
+        A server error has occurred; the Grid may not be fully functional at this time.
+        If the problem persists please <a href="mailto:thegrid.dev@theguardian.com" class="coloured-link">email the Grid team</a>.
+    </div>
 </ng:messages>

--- a/kahuna/public/js/errors/http.js
+++ b/kahuna/public/js/errors/http.js
@@ -14,5 +14,13 @@ httpErrors.constant('httpErrors', {
     authFailed: {
         errorCode: 419,
         errorMessage: 'Authentication re-establishment failed'
+    },
+    internalServerError: {
+        errorCode: 500,
+        errorMessage: 'Server error'
+    },
+    serviceUnavailableError: {
+        errorCode: 503,
+        errorMessage: 'Server error'
     }
 });

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -161,6 +161,11 @@ kahuna.factory('httpErrorInterceptor',
         responseError: function(response) {
             switch (response.status) {
                 case 0: {
+                    /*
+                    Status is 0 when the headers of the response does not
+                    include the correct cors. This happens when the request
+                    fails and we don't explicitly return an error code.
+                     */
                     $rootScope.$emit('events:error:unknown');
                     break;
                 }


### PR DESCRIPTION
Further to this, we should be using `ng:messages` more, rather than [`$window.alert`](https://github.com/guardian/grid/blob/master/kahuna/public/js/components/gr-add-label/gr-add-label.js#L15) so that it doesn't block the UI. Though we'd most likely need to give the `ng:message` context so that the message is more meaningful/helpful.