### PR TITLE
Fix meta-panel button styling.

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -923,7 +923,6 @@ input.search-query__input {
 
 .results-toolbar-item__metadata-panel-controls {
     line-height: 35px;
-    width: 129.5px;
     height: 36px;
 }
 


### PR DESCRIPTION
[Let the meta-panel button grow](http://i.giphy.com/85dCPlhUW5bYk.gif) by itself.

Fixes issue where the "Unlock meta panel" text is positioned incorrectly. Also fixes the responsive view.

Before
![screen shot 2015-09-07 at 15 23 59](https://cloud.githubusercontent.com/assets/836140/9718599/389d2364-5575-11e5-9d03-d0fcf65291d5.png)

After
![screen shot 2015-09-07 at 15 24 54](https://cloud.githubusercontent.com/assets/836140/9718604/40b3ff8c-5575-11e5-8397-92c041744596.png)

Before
![screen shot 2015-09-07 at 15 24 15](https://cloud.githubusercontent.com/assets/836140/9718615/49d33330-5575-11e5-90ec-7f9099220194.png)

After
![screen shot 2015-09-07 at 15 24 42](https://cloud.githubusercontent.com/assets/836140/9718619/530226d2-5575-11e5-9a0c-7a273bbb71fe.png)

