### PR TITLE
update persisted formula.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -1,5 +1,4 @@
-package lib.elasticsearch
-
+package com.gu.mediaservice.lib.elasticsearch
 
 trait ImageFields {
   // TODO: share with mappings

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -50,7 +50,7 @@ object MediaApi extends Controller with ArgoHelpers {
     "since", "until", "modifiedSince", "modifiedUntil", "takenSince", "takenUntil",
     "uploadedBy", "archived", "valid", "free",
     "hasExports", "hasIdentifier", "missingIdentifier", "hasMetadata",
-    "costModelDiff").mkString(",")
+    "costModelDiff", "persisted").mkString(",")
 
   val searchLinkHref = s"$rootUri/images{?$searchParamList}"
 
@@ -324,7 +324,8 @@ case class SearchParams(
   uploadedBy: Option[String],
   labels: List[String],
   hasMetadata: List[String],
-  costModelDiff: Boolean
+  costModelDiff: Boolean,
+  persisted: Option[Boolean]
 )
 
 object SearchParams {
@@ -365,7 +366,8 @@ object SearchParams {
       request.getQueryString("uploadedBy"),
       commaSep("labels"),
       commaSep("hasMetadata"),
-      request.getQueryString("costModelDiff") flatMap parseBooleanFromQuery getOrElse false
+      request.getQueryString("costModelDiff") flatMap parseBooleanFromQuery getOrElse false,
+      request.getQueryString("persisted") flatMap parseBooleanFromQuery
     )
   }
 
@@ -391,7 +393,8 @@ object SearchParams {
       "uploadedBy"        -> searchParams.uploadedBy,
       "labels"            -> listToCommas(searchParams.labels),
       "hasMetadata"       -> listToCommas(searchParams.hasMetadata),
-      "costModelDiff"     -> Some(searchParams.costModelDiff.toString)
+      "costModelDiff"     -> Some(searchParams.costModelDiff.toString),
+      "persisted"         -> searchParams.persisted.map(_.toString)
     ).foldLeft(Map[String, String]()) {
       case (acc, (key, Some(value))) => acc + (key -> value)
       case (acc, (_,   None))        => acc

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -26,7 +26,7 @@ object ImageResponse {
 
   def isPhotographerCategory[T <: UsageRights](usageRights: T) =
     usageRights match {
-      case _:StaffPhotographer | _:ContractPhotographer | _:CommissionedPhotographer => true
+      case _:Photographer => true
       case _ => false
     }
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -24,11 +24,18 @@ object ImageResponse {
 
   def fileMetaDataUri(id: String) = URI.create(s"${Config.rootUri}/images/$id/fileMetadata")
 
+  def isPhotographerCategory[T <: UsageRights](usageRights: T) =
+    usageRights match {
+      case _:StaffPhotographer | _:ContractPhotographer | _:CommissionedPhotographer => true
+      case _ => false
+    }
+
   // TODO: move this as a method of Image (fiddly due to dep on Config)
   def imageIsPersisted(image: Image) = {
     image.identifiers.contains(Config.persistenceIdentifier) ||
       image.exports.nonEmpty ||
-      image.userMetadata.exists(_.archived)
+      image.userMetadata.exists(_.archived) ||
+      isPhotographerCategory(image.usageRights)
   }
 
   def create(id: String, esSource: JsValue, withWritePermission: Boolean,

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -20,7 +20,7 @@ import scalaz.NonEmptyList
 
 
 import com.gu.mediaservice.syntax._
-import com.gu.mediaservice.lib.elasticsearch.ElasticSearchClient
+import com.gu.mediaservice.lib.elasticsearch.{ImageFields, ElasticSearchClient}
 import controllers.{AggregateSearchParams, SearchParams}
 import lib.{MediaApiMetrics, Config}
 

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -87,7 +87,7 @@ trait SearchFilters extends ImageFields {
   val persistedFilter = filters or (
     filters.bool.must(filters.existsOrMissing("exports", true)),
     filters.exists(NonEmptyList(identifierField(Config.persistenceIdentifier))),
-    filters.bool.must(filters.term(editsField("archived"), true)),
+    filters.bool.must(filters.boolTerm(editsField("archived"), true)),
     filters.bool.must(filters.term(usageRightsField("category"), "staff-photographer")),
     filters.bool.must(filters.term(usageRightsField("category"), "contract-photographer")),
     filters.bool.must(filters.term(usageRightsField("category"), "commissioned-photographer"))

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -96,7 +96,10 @@ trait SearchFilters extends ImageFields {
   val nonPersistedFilter = filters and (
     filters.bool.must(filters.existsOrMissing("exports", false)),
     filters.missing(NonEmptyList(identifierField(Config.persistenceIdentifier))),
-    filters.existsOrMissing(editsField("archived"), false),
+    filters or (
+      filters.missing(NonEmptyList(editsField("archived"))),
+      filters.bool.must(filters.boolTerm(editsField("archived"), false))
+    ),
     filters.bool.mustNot(filters.term(usageRightsField("category"), "staff-photographer")),
     filters.bool.mustNot(filters.term(usageRightsField("category"), "contract-photographer")),
     filters.bool.mustNot(filters.term(usageRightsField("category"), "commissioned-photographer"))

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -1,5 +1,6 @@
 package lib.elasticsearch
 
+import com.gu.mediaservice.lib.elasticsearch.ImageFields
 import lib.usagerights.{DeprecatedConfig => UsageRightsDepConfig}
 import com.gu.mediaservice.lib.config.UsageRightsConfig
 import org.elasticsearch.index.query.FilterBuilder

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -84,7 +84,7 @@ trait SearchFilters extends ImageFields {
     "pool"
   )
 
-  val persistedFilter = filters or (
+  val persistedFilter = filters.or(
     filters.bool.must(filters.existsOrMissing("exports", true)),
     filters.exists(NonEmptyList(identifierField(Config.persistenceIdentifier))),
     filters.bool.must(filters.boolTerm(editsField("archived"), true)),
@@ -93,17 +93,7 @@ trait SearchFilters extends ImageFields {
     filters.bool.must(filters.term(usageRightsField("category"), "commissioned-photographer"))
   )
 
-  val nonPersistedFilter = filters and (
-    filters.bool.must(filters.existsOrMissing("exports", false)),
-    filters.missing(NonEmptyList(identifierField(Config.persistenceIdentifier))),
-    filters or (
-      filters.missing(NonEmptyList(editsField("archived"))),
-      filters.bool.must(filters.boolTerm(editsField("archived"), false))
-    ),
-    filters.bool.mustNot(filters.term(usageRightsField("category"), "staff-photographer")),
-    filters.bool.mustNot(filters.term(usageRightsField("category"), "contract-photographer")),
-    filters.bool.mustNot(filters.term(usageRightsField("category"), "commissioned-photographer"))
-  )
+  val nonPersistedFilter = filters.not(persistedFilter)
 
   def filterOrFilter(filter: Option[FilterBuilder], orFilter: Option[FilterBuilder]): Option[FilterBuilder] = (filter, orFilter) match {
     case (Some(someFilter), Some(orSomeFilter)) => Some(filters.or(someFilter, orSomeFilter))

--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -36,6 +36,9 @@ object filters {
   def term(field: String, term: String): FilterBuilder =
     termFilter(field, term)
 
+  def term(field: String, value: Boolean): FilterBuilder =
+    termFilter(field, value)
+
   def terms(field: String, terms: NonEmptyList[String]): FilterBuilder =
     termsFilter(field, terms.list: _*)
 

--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -36,7 +36,7 @@ object filters {
   def term(field: String, term: String): FilterBuilder =
     termFilter(field, term)
 
-  def term(field: String, value: Boolean): FilterBuilder =
+  def boolTerm(field: String, value: Boolean): FilterBuilder =
     termFilter(field, value)
 
   def terms(field: String, terms: NonEmptyList[String]): FilterBuilder =

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -3,7 +3,7 @@ package lib.querysyntax
 import org.joda.time.DateTime
 import org.parboiled2._
 
-import lib.elasticsearch.ImageFields
+import com.gu.mediaservice.lib.elasticsearch.ImageFields
 
 class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   def Query = rule { Expression ~ EOI }

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -1,6 +1,6 @@
 package lib.querysyntax
 
-import lib.elasticsearch.ImageFields
+import com.gu.mediaservice.lib.elasticsearch.ImageFields
 import org.scalatest.{FunSpec, Matchers, BeforeAndAfter}
 import org.joda.time.DateTime
 import org.joda.time.DateTimeUtils

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -74,7 +74,10 @@ object ElasticSearch extends ElasticSearchClient {
           missingOrEmptyFilter(s"identifiers.$persistenceIdentifier"),
           boolFilter.should(
             missingOrEmptyFilter("userMetadata.archived"),
-            boolFilter.must(termFilter("userMetadata.archived", false))
+            boolFilter.must(termFilter("userMetadata.archived", false)),
+            boolFilter.mustNot(termFilter("usageRights.category", "staff-photographer")),
+            boolFilter.mustNot(termFilter("usageRights.category", "contract-photographer")),
+            boolFilter.mustNot(termFilter("usageRights.category", "commissioned-photographer"))
           )
         )
       )


### PR DESCRIPTION
include photographer usage rights categories.

Related to https://github.com/guardian/grid/pull/1027. https://github.com/guardian/grid/pull/1027 won't need to send messages to a new queue now...

TODO:
- [x] add a `persisted` query to the media-api to simplify reaper.