### PR TITLE
Manage concurrent update requests to the same Resource using a pool, last one wins

### DIFF
--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -39,7 +39,6 @@ jobs.controller('RequiredMetadataEditorCtrl',
             then(resource => {
                 ctrl.resource = resource;
             }).
-            catch(() => $window.alert('Failed to save the changes, please try again.')).
             finally(() => ctrl.saving = false);
     };
 


### PR DESCRIPTION
This should fix the "saving failed" errors a lot of people are seeing when saving metadata. These errors are caused by multiple saving requests (+ background polling to detect when the saved changes have been written) being issued in close succession. Intermediate requests end up failing because subsequent requests have been written back to media-api already (eventual consistency of multiple PUTs).

Bit fiddlier than I'd hoped, hopefully we can simplify further in the future.