### PR TITLE
use autocomplete to update staff photographers

### DIFF
--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -50,7 +50,7 @@
         <div class="job-info--editor__field">
             <div class="job-info--editor__label">Credit</div>
 
-            <gr:datalist
+            <gr-datalist
                 class="job-info--editor__input"
                 gr:search="ctrl.metadataSearch('credit', q)">
 
@@ -61,7 +61,7 @@
                     ng:model="ctrl.metadata.credit"
                     ng:change="ctrl.save()"
                     ng:model-options="{ updateOn: 'gr:datalist:update blur' }" />
-            </gr:datalist>
+            </gr-datalist>
 
             <button
                 class="job-editor__apply-to-all"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -110,15 +110,21 @@
                                 </select>
                         </div>
 
-                        <select
-                            class="full-width"
-                            name="{{ property.name }}"
-                            ng:if="property.optionsMap"
-                            ng:model="ctrl.model[property.name]"
-                            ng:required="property.required"
-                            ng:options="o for o in ctrl.getOptionsFor(property)">
-                            <option value="">None</option>
-                        </select>
+                        <div ng:if="property.optionsMap && ctrl.getOptionsFor(property)">
+                            <gr-datalist
+                                class="full-width"
+                                gr:list-data="ctrl.getOptionsFor(property)">
+
+                                <input
+                                    type="text"
+                                    name="{{ property.name }}"
+                                    class="full-width"
+                                    gr:datalist-input
+                                    ng:model="ctrl.model[property.name]"
+                                    ng:required="property.required">
+                                </input>
+                            </gr-datalist>
+                        </div>
                     </div>
 
                     <textarea

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -23,29 +23,48 @@ object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
+  import MetadataConfig.staffPhotographersMap
+  import UsageRightsConfig.freeSuppliers
+
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
+
+  def sortList(list: List[String]) = list.sortWith(_.toLowerCase < _.toLowerCase)
 
   def getPropertiesForCat(u: UsageRights): List[UsageRightsProperty] =
     agencyProperties(u) ++ photographerProperties(u) ++ restrictionProperties(u)
 
   private def publicationField(required: Boolean)  =
-    UsageRightsProperty("publication", "Publication", "string", required,
-      Some(MetadataConfig.staffPhotographersMap.keys.toList.sortWith(_.toLowerCase < _.toLowerCase)))
+    UsageRightsProperty(
+      "publication",
+      "Publication",
+      "string",
+      required,
+      Some(sortList(staffPhotographersMap.keys.toList)))
 
   private def photographerField =
     UsageRightsProperty("photographer", "Photographer", "string", true)
 
   private def photographerField(photographers: OptionsMap, key: String) =
-    UsageRightsProperty("photographer", "Photographer", "string", true, optionsMap = Some(photographers), optionsMapKey = Some(key))
+    UsageRightsProperty(
+      "photographer",
+      "Photographer",
+      "string",
+      true,
+      optionsMap = Some(photographers),
+      optionsMapKey = Some(key))
 
   private def restrictionProperties(u: UsageRights): List[UsageRightsProperty] = u match {
     case _:NoRights.type => List()
-    case _ => List(UsageRightsProperty("restrictions", "Restrictions", "text", u.defaultCost.contains(Conditional)))
+    case _ => List(UsageRightsProperty(
+      "restrictions",
+      "Restrictions",
+      "text",
+      u.defaultCost.contains(Conditional)))
   }
 
   private def agencyProperties(u: UsageRights): List[UsageRightsProperty] = u match {
     case _:Agency => List(
-      UsageRightsProperty("supplier", "Supplier", "string", true, Some(UsageRightsConfig.freeSuppliers.sortWith(_.toLowerCase < _.toLowerCase))),
+      UsageRightsProperty("supplier", "Supplier", "string", true, Some(sortList(freeSuppliers))),
       UsageRightsProperty("suppliersCollection", "Collection", "string", false)
     )
 
@@ -57,7 +76,7 @@ object UsageRightsProperty {
   private def photographerProperties(u: UsageRights): List[UsageRightsProperty] = u match {
     case _:StaffPhotographer => List(
       publicationField(true),
-      photographerField(MetadataConfig.staffPhotographersMap, "publication")
+      photographerField(staffPhotographersMap, "publication")
     )
 
     case _:CommissionedPhotographer => List(


### PR DESCRIPTION
We've been told that people who are staff, but are not official photographers still submit photography, especially editors in the field.

As far as I can tell and have been told this photography belongs to use and should be flagged as such.

To this end, we can make the photographer field in the usage rights box an autocomplete input.

__TODO__
- [ ] Swap data list dependant on publication
- [ ] Stop enter submitting the form