### PR TITLE
Fix method name when deleting selected images

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -438,7 +438,7 @@ results.controller('SearchResultsCtrl', [
                 ctrl.deselect(image);
 
                 const indexAll = ctrl.imagesAll.findIndex(i => image.data.id === i.data.id);
-                results.remove(indexAll);
+                results.removeAt(indexAll);
 
                 updateImageArray(ctrl.images, image);
                 updateImageArray(ctrl.imagesAll, image);


### PR DESCRIPTION
Minor typo.

Note that when deleting one selected image, it disappears and then some weird logic kicks in and reveals the image again. That's a bug, but it seems to be already happening on PROD...