### PR TITLE
show other photographer if it is set

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -112,7 +112,8 @@
 
                         <div class="flex-container"
                              ng:if="property.optionsMap"
-                             ng:init="otherValue = false">
+                             ng:init="otherValue = ctrl.isOther(property)">
+
                             <select
                                 class="full-width"
                                 name="{{ property.name }}"
@@ -122,6 +123,7 @@
                                 ng:if="!otherValue">
                                 <option value="">None</option>
                             </select>
+
                             <input type="text"
                                 class="full-width"
                                 ng:model="ctrl.model[property.name]"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -112,7 +112,7 @@
 
                         <div class="flex-container"
                              ng:if="property.optionsMap"
-                             ng:init="otherValue = ctrl.isOther(property)">
+                             ng:init="otherValue = ctrl.isOtherValue(property)">
 
                             <select
                                 class="full-width"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -134,6 +134,14 @@ usageRightsEditor.controller(
         return property.optionsMap[val];
     };
 
+    ctrl.isOther = property => {
+        const missingVal =
+            !ctrl.getOptionsFor(property)
+                .find(option => option === ctrl.model[property.name]);
+
+        return missingVal;
+    };
+
     ctrl.isRestricted = prop => ctrl.showRestrictions || prop.required;
 
     $scope.$watch(() => ctrl.showRestrictions, onValChange(isRestricted => {

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -134,7 +134,7 @@ usageRightsEditor.controller(
         return property.optionsMap[val];
     };
 
-    ctrl.isOther = property => {
+    ctrl.isOtherValue = property => {
         const missingVal =
             !ctrl.getOptionsFor(property)
                 .find(option => option === ctrl.model[property.name]);


### PR DESCRIPTION
We do not set `isOther` on load so if it was set, we just show and empty dropdown.
This makes sure we do.

![other-photo](https://cloud.githubusercontent.com/assets/31692/9767438/24c36dba-5716-11e5-85c2-b4eff048d722.gif)
