### PR TITLE
Disable mangling of var names when minifying for better debug

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "test": "npm run lint",
     "lint": "jscs public/js/ && jshint public/js --exclude public/js/dist/build.js",
-    "dist": "jspm bundle js/main public/js/dist/build.js -m --inject",
+    "dist": "jspm bundle js/main public/js/dist/build.js -m --inject --no-mangle",
     "undist": "jspm unbundle && rm -f public/js/dist/build.js*",
     "postinstall": "jspm install"
   },


### PR DESCRIPTION
Bit of a cop out, but I have spent a fair amount of time digging into why `names` mappings are not correct in our source maps and I could not find a solution. I was able to reproduce with a very simple test case, and it is the minification that gets in the way. I tried both Traceur and Babel, and a variety of code changes, to no avail.

See https://github.com/jspm/jspm-cli/issues/1104 for details.

This change disables the mangling of variable names in the minification stage (to make them shorter and reduce payload size). While it sounds a little dramatic, the bundle file size only goes up from 307KB to 380KB gzipped (1.1MB to 1.5MB not gzipped), which isn't that bad considering it should hopefully get Sentry working again and let us use the debugger tools in TEST/PROD with proper variable names.