### PR TITLE
Upload metadata bug

### DIFF
--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -71,7 +71,7 @@
                 ng:click="ctrl.batchApplyMetadata('credit')"
             >⇔</button>
         </div>
-        <label ng:if="ctrl.metadata.copyright" class="job-info--editor__field">
+        <label ng:if="ctrl.copyrightWasInitiallyThere" class="job-info--editor__field">
             <div class="job-info--editor__label">Copyright</div>
             <input
                 type="text"

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -30,7 +30,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
         var cleanMetadata = {};
         Object.keys(ctrl.metadata).forEach(key => {
             if (ctrl.metadata[key] !== ctrl.saveWhenChangedFrom[key]) {
-                cleanMetadata[key] = ctrl.metadata[key];
+                cleanMetadata[key] = ctrl.metadata[key] || '';
             }
         });
 

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -22,6 +22,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
     ctrl.disabled = () => Boolean(ctrl.saving || ctrl.externallyDisabled);
     ctrl.metadata = metadataFromOriginal(ctrl.originalMetadata);
     ctrl.saveOnTime = 750; // ms
+    ctrl.copyrightWasInitiallyThere = !!ctrl.metadata.copyright;
 
     ctrl.save = function() {
         ctrl.saving = true;

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -36,7 +36,7 @@
             You haven’t uploaded anything yet.
         </p>
         <ul ng:if="ctrl.myUploads.data.length > 0">
-            <li ng:repeat="result in ctrl.myUploads.data" class="upload-result">
+            <li ng:repeat="result in ctrl.myUploads.data track by result.data.id" class="upload-result">
                 <ui-image-editor image="result"></ui-image-editor>
                 <gr-delete-image class="flex-right"
                                  ng:if="ctrl.canBeDeleted(result)"


### PR DESCRIPTION
Allows users to delete required metadata on uploads page (which they might do in the process of editing data). 
Stops input-blur kicking in halfway through editing. 
Ensures copyright is visible and therefore editable even if it has been deleted by a user. 