### PR TITLE
More aggressively attribute images to Getty based on credit

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -147,7 +147,6 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
 object GettyCreditParser extends ImageProcessor with GettyProcessor {
   val gettyCredits = List("afp")
 
-  //
   val IncludesGetty = ".*Getty Images.*".r
   // Take a leap of faith as the credit may be truncated if too long...
   val ViaGetty = ".+ via Getty(?: .*)?".r

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -127,11 +127,16 @@ object EpaParser extends ImageProcessor {
   }
 }
 
-object GettyXmpParser extends ImageProcessor {
+trait GettyProcessor {
+  def gettyAgencyWithCollection(suppliersCollection: Option[String]) =
+    Agency("Getty Images", suppliersCollection = suppliersCollection)
+}
+
+object GettyXmpParser extends ImageProcessor with GettyProcessor {
   def apply(image: Image): Image = image.fileMetadata.getty.isEmpty match {
     // Only images supplied by Getty have getty fileMetadata
     case false => image.copy(
-      usageRights = Agency("Getty Images", suppliersCollection = image.metadata.source),
+      usageRights = gettyAgencyWithCollection(image.metadata.source),
       // Set a default "credit" for when Getty is too lazy to provide one
       metadata    = image.metadata.copy(credit = Some(image.metadata.credit.getOrElse("Getty Images")))
     )
@@ -139,12 +144,21 @@ object GettyXmpParser extends ImageProcessor {
   }
 }
 
-object GettyCreditParser extends ImageProcessor {
-  val gettyCredits = List("afp", "afp/getty images", "bloomberg via getty images", "getty images")
+object GettyCreditParser extends ImageProcessor with GettyProcessor {
+  val gettyCredits = List("afp")
 
-  def apply(image: Image): Image = image.metadata.credit.map(c => gettyCredits.contains(c.toLowerCase)) match {
-    case Some(true) => image.copy(
-       usageRights = Agency("Getty Images", suppliersCollection = image.metadata.source)
+  //
+  val IncludesGetty = ".*Getty Images.*".r
+  // Take a leap of faith as the credit may be truncated if too long...
+  val ViaGetty = ".+ via Getty(?: .*)?".r
+  val SlashGetty = ".+/Getty(?: .*)?".r
+
+  def apply(image: Image): Image = image.metadata.credit match {
+    case Some(credit) if gettyCredits.contains(credit.toLowerCase) => image.copy(
+       usageRights = gettyAgencyWithCollection(image.metadata.source)
+    )
+    case Some(IncludesGetty()) | Some(ViaGetty()) | Some(SlashGetty()) => image.copy(
+       usageRights = gettyAgencyWithCollection(image.metadata.source)
     )
     case _ => image
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -218,11 +218,40 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.credit should be(Some("AFP/Getty Images"))
     }
 
+    // Truncation FTW!
+    it("should match 'The LIFE Images Collection/Getty' credit") {
+      val image = createImageFromMetadata("credit" -> "The LIFE Images Collection/Getty", "source" -> "The LIFE Images Collection")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Getty Images", Some("The LIFE Images Collection")))
+      processedImage.metadata.credit should be(Some("The LIFE Images Collection/Getty"))
+    }
+
+    it("should match 'Getty Images/Ikon Images' credit") {
+      val image = createImageFromMetadata("credit" -> "Getty Images/Ikon Images", "source" -> "Ikon Images")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Getty Images", Some("Ikon Images")))
+      processedImage.metadata.credit should be(Some("Getty Images/Ikon Images"))
+    }
+
     it("should match 'Bloomberg via Getty Images' credit") {
       val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Getty Images", Some("Bloomberg")))
       processedImage.metadata.credit should be(Some("Bloomberg via Getty Images"))
+    }
+
+    it("should match 'Some Long Provider via Getty Im' credit") {
+      val image = createImageFromMetadata("credit" -> "Some Long Provider via Getty Im", "source" -> "Some Long Provider")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Getty Images", Some("Some Long Provider")))
+      processedImage.metadata.credit should be(Some("Some Long Provider via Getty Im"))
+    }
+
+    it("should match 'Getty Images for Apple' credit") {
+      val image = createImageFromMetadata("credit" -> "Getty Images for Apple", "source" -> "Getty Images Europe")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Getty Images", Some("Getty Images Europe")))
+      processedImage.metadata.credit should be(Some("Getty Images for Apple"))
     }
   }
 


### PR DESCRIPTION
Basically any image that includes "Getty Images" somewhere in the credit line, or that contains "... via Getty" or ".../Getty", will be attribute to Getty.

This is to work around the poor standardisation of metadata in Getty Images, particularly from the archive pre-2014. Particularly helpful to attribute images downloaded from the Getty archive to Getty when manually uploaded.