### PR TITLE
don't decode empty string.

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -36,7 +36,7 @@ query.controller('SearchQueryCtrl',
     // Boring - stops slashes being encoded in input - might be fixed with:
     // https://github.com/angular-ui/ui-router/issues/1759
     $scope.$watch(() => ctrl.filter.query, onValChange(newVal => {
-        ctrl.filter.query = decodeURIComponent(newVal);
+        ctrl.filter.query = angular.isDefined(newVal) ? decodeURIComponent(newVal) : '';
     }));
 
     ctrl.filter = {


### PR DESCRIPTION
Otherwise the url becomes `query?=undefined` :cry: 

related - https://github.com/guardian/grid/pull/1235