### PR TITLE
Replaces panel add label button with gr-add-label

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -13,12 +13,8 @@ export var addLabel = angular.module('gr.addLabel', [
 ]);
 
 addLabel.controller('GrAddLabelCtrl', [
-    '$scope',
-    '$window',
-    'labelService',
-    function ($scope,
-              $window,
-              labelService) {
+    '$scope', '$window', 'labelService',
+    function ($scope, $window, labelService) {
 
         let ctrl = this;
 
@@ -38,12 +34,13 @@ addLabel.controller('GrAddLabelCtrl', [
         function save(label, imageArray) {
             ctrl.adding = true;
 
-            labelService.batchAdd(imageArray, label).then(image => {
-                        ctrl.image = image;
-                        reset();
-                    })
-                    .catch(saveFailed)
-                    .finally(() => ctrl.adding = false);
+            labelService.batchAdd(imageArray, label)
+                .then(image => {
+                    ctrl.image = image;
+                    reset();
+                })
+                .catch(saveFailed)
+                .finally(() => ctrl.adding = false);
 
         }
 

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -13,8 +13,8 @@ export var addLabel = angular.module('gr.addLabel', [
 ]);
 
 addLabel.controller('GrAddLabelCtrl', [
-    '$scope', '$window', 'labelService',
-    function ($scope, $window, labelService) {
+    '$window', 'labelService',
+    function ($window, labelService) {
 
         let ctrl = this;
 

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -34,9 +34,10 @@ addLabel.controller('GrAddLabelCtrl', [
         function save(label, imageArray) {
             ctrl.adding = true;
 
+
             labelService.batchAdd(imageArray, label)
-                .then(image => {
-                    ctrl.images = image;
+                .then(images => {
+                    ctrl.images = images;
                     reset();
                 })
                 .catch(saveFailed)

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -12,8 +12,13 @@ export var addLabel = angular.module('gr.addLabel', [
     'gr.autoFocus'
 ]);
 
-addLabel.controller('GrAddLabelCtrl', ['$window', 'labelService',
-    function ($window, labelService) {
+addLabel.controller('GrAddLabelCtrl', [
+    '$scope',
+    '$window',
+    'labelService',
+    function ($scope,
+              $window,
+              labelService) {
 
         let ctrl = this;
 
@@ -21,24 +26,25 @@ addLabel.controller('GrAddLabelCtrl', ['$window', 'labelService',
 
         ctrl.save = () => {
             let labelList = ctrl.newLabel.split(',').map(e => e.trim());
+            let imageArray = ctrl.selected ? Array.from(ctrl.selected) : [ctrl.image];
 
             if (labelList) {
-                save(labelList);
+                save(labelList, imageArray);
             }
         };
 
         ctrl.cancel = reset;
 
-        function save(labels) {
+        function save(label, imageArray) {
             ctrl.adding = true;
 
-            labelService.add(ctrl.image, labels)
-                .then(image => {
-                    ctrl.image = image;
-                    reset();
-                })
-                .catch(saveFailed)
-                .finally(() => ctrl.adding = false);
+            labelService.batchAdd(imageArray, label).then(image => {
+                        ctrl.image = image;
+                        reset();
+                    })
+                    .catch(saveFailed)
+                    .finally(() => ctrl.adding = false);
+
         }
 
         function saveFailed() {
@@ -58,7 +64,8 @@ addLabel.directive('grAddLabel', [function () {
         scope: {
             image: '=',
             grSmall: '=?',
-            active: '='
+            active: '=',
+            selected: '='
         },
         controller: 'GrAddLabelCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -22,7 +22,7 @@ addLabel.controller('GrAddLabelCtrl', [
 
         ctrl.save = () => {
             let labelList = ctrl.newLabel.split(',').map(e => e.trim());
-            let imageArray = ctrl.selected ? Array.from(ctrl.selected) : [ctrl.image];
+            let imageArray = Array.from(ctrl.images);
 
             if (labelList) {
                 save(labelList, imageArray);
@@ -36,7 +36,7 @@ addLabel.controller('GrAddLabelCtrl', [
 
             labelService.batchAdd(imageArray, label)
                 .then(image => {
-                    ctrl.image = image;
+                    ctrl.images = image;
                     reset();
                 })
                 .catch(saveFailed)
@@ -59,10 +59,9 @@ addLabel.directive('grAddLabel', [function () {
     return {
         restrict: 'E',
         scope: {
-            image: '=',
             grSmall: '=?',
             active: '=',
-            selected: '='
+            images: '='
         },
         controller: 'GrAddLabelCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -56,7 +56,7 @@
 }
 
 .batch-label .labels .label,
-.batch-label .labels .label__add {
+.batch-label .labels {
     display: inline-block;
 }
 

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -273,7 +273,6 @@
             <div class="image-info__heading">
                 <span>Labels</span>
                 <gr-add-label ng:blur="ctrl.cancel"
-                              image="ctrl.image"
                               gr-small="true"
                               images="ctrl.selectedImages">
                 </gr-add-label>

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -269,8 +269,15 @@
             </dl>
         </div>
 
-        <div class="image-info__group batch-label">
-            <div class="metadata-line">Labels</div>
+        <div class="image-info__group">
+            <div class="image-info__heading">
+                <span>Labels</span>
+                <gr-add-label ng:blur="ctrl.cancel"
+                              image="ctrl.image"
+                              gr-small="true"
+                              selected="ctrl.selectedImages">
+                </gr-add-label>
+            </div>
             <ul class="labels">
                 <li class="label"
                     ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
@@ -285,11 +292,6 @@
                             title="Remove label from all"
                             ng:click="ctrl.removeLabel(label.data)">
                         <gr-icon>close</gr-icon>
-                    </button>
-                </li>
-                <li class="label__add">
-                    <button class="button-shy" title="Add Label" ng:click="ctrl.newLabel()">
-                        Add
                     </button>
                 </li>
             </ul>

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -275,7 +275,7 @@
                 <gr-add-label ng:blur="ctrl.cancel"
                               image="ctrl.image"
                               gr-small="true"
-                              selected="ctrl.selectedImages">
+                              images="ctrl.selectedImages">
                 </gr-add-label>
             </div>
             <ul class="labels">

--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -208,14 +208,6 @@ grPanel.controller('GrPanel', [
             labelService.batchRemove(imageArray, label);
         };
 
-        ctrl.newLabel = function () {
-            var label = ($window.prompt('Enter a label:') || '').trim();
-
-            if (label) {
-                ctrl.addLabel(label);
-            }
-        };
-
         ctrl.archive = () => {
             ctrl.archiving = true;
             var imageArray = Array.from(ctrl.selectedImages);

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -123,7 +123,7 @@
                 Labels
             </span>
             <div class="result-editor__field-container__labels" ng:class="{'result-editor__field-container__labels--hidden' : ctrl.inputtingLabel}">
-                <gr-add-label image="ctrl.image" active="ctrl.inputtingLabel"></gr-add-label>
+                <gr-add-label images="[ctrl.image]" active="ctrl.inputtingLabel"></gr-add-label>
                 <ui-labeller
                     image="ctrl.image"
                     with-batch="ctrl.withBatch"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -320,7 +320,7 @@
         <dl class="image-info__group">
             <dt class="image-info__heading image-info__heading--first flex-container">
                 <span class="flex-spacer">Labels</span>
-                <gr-add-label gr-small="true" image="ctrl.image" ng:blur="ctrl.cancel"></gr-add-label>
+                <gr-add-label gr-small="true" images="[ctrl.image]" ng:blur="ctrl.cancel"></gr-add-label>
             </dt>
             <dd class="image-info__group--fixed-panel">
                 <ui-labeller image="ctrl.image"></ui-labeller>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -50,7 +50,7 @@
             <span class="flex-spacer"></span>
             <gr-add-label class="gr-add-label"
                           ng:if="!ctrl.selectionMode"
-                          image="ctrl.image"
+                          images="[ctrl.image]"
                           gr-small="true"
                           active="ctrl.inputtingLabel"
                           ng:class="{'gr-add-label--inactive': !ctrl.inputtingLabel}">


### PR DESCRIPTION
Makes label input in metadata-panel consistent with everywhere else. Hurray. 

![labels4](https://cloud.githubusercontent.com/assets/8484757/9819809/0feb43ac-58a8-11e5-9b0e-95b7b055f858.gif)
