### PR TITLE
fix failed upload navigation

### DIFF
--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -4,28 +4,31 @@
         <div ng:if="!job.image"
              class="job-uploading">
 
-            <div class="job-preview preview">
-                <img ng:src="{{job.dataUrl}}" class="preview__image" />
+            <div class="result-editor__result">
+                <div>
+                    <img ng:src="{{job.dataUrl}}" class="preview__image" />
 
-                <div class="preview__bottom-bar bottom-bar">
-                    <div class="bottom-bar__meta">
-                        {{job.name}}, {{job.size | asFileSize}}
+                    <div class="preview__bottom-bar bottom-bar">
+                        <div class="bottom-bar__meta">
+                            {{job.name}}, {{job.size | asFileSize}}
+                        </div>
+
+                        <div class="bottom-bar__actions"></div>
                     </div>
+                </div>
+                <div class="job-status status"
+                     ng:class="{
+                         'status--invalid': job.status === 'upload error',
+                         'status--valid':   job.status === 'uploaded'
+                     }">
 
-                    <div class="bottom-bar__actions"></div>
+                     {{job.status}}
+                     <span ng:if="job.status === 'upload error'">({{job.error}})</span>
                 </div>
             </div>
-            <div class="job-status status"
-                 ng:class="{
-                     'status--invalid': job.status === 'upload error',
-                     'status--valid':   job.status === 'uploaded'
-                 }">
 
-                 {{job.status}}
-                 <span ng:if="job.status === 'upload error'">({{job.error}})</span>
-            </div>
-
-            <gr-confirm-delete ng:if="job.status === 'upload error'"
+            <gr-confirm-delete class="flex-right"
+                               ng:if="job.status === 'upload error'"
                                gr:on-confirm="ctrl.removeJob(job)">
             </gr-confirm-delete>
         </div>

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -24,6 +24,10 @@
                  {{job.status}}
                  <span ng:if="job.status === 'upload error'">({{job.error}})</span>
             </div>
+
+            <gr-confirm-delete ng:if="job.status === 'upload error'"
+                               gr:on-confirm="ctrl.removeJob(job)">
+            </gr-confirm-delete>
         </div>
 
         <ui-image-editor ng:if="job.image"

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -80,6 +80,14 @@ jobs.controller('UploadJobsCtrl', [
     // this needs to be a function due to the stateful `jobItem`
     ctrl.jobImages = () => ctrl.jobs.map(jobItem => jobItem.image);
 
+    ctrl.removeJob = (job) => {
+        const index = ctrl.jobs.findIndex(j => j.name === job.name);
+
+        if (index > -1) {
+            ctrl.jobs.splice(index, 1);
+        }
+    };
+
     const freeImageDeleteListener = $rootScope.$on('images-deleted', (e, images) => {
         images.forEach(image => {
             var index = ctrl.jobs.findIndex(i => i.image.data.id === image.data.id);

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -30,7 +30,7 @@ upload.factory('uploadManager',
 
         // once all `jobItems` in a job are complete, remove it
         // TODO: potentially move these to a `completeJobs` `Set`
-        $q.all(promises).then(() => jobs.delete(job));
+        $q.all(promises).finally(() => jobs.delete(job));
     }
 
     function getLatestRunningJob() {

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -9,7 +9,7 @@
 
 <div class="page-wrapper">
     <section class="section"
-             ng:if="ctrl.latestJob">
+             ng:if="ctrl.latestJob && ctrl.latestJob.length > 0">
 
         <div class="flex-container section-heading">
             <h2>Your current uploads</h2>
@@ -20,7 +20,7 @@
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
     </section>
 
-    <file-prompt class="section" ng:if="!ctrl.latestJob"></file-prompt>
+    <file-prompt class="section" ng:if="!ctrl.latestJob || ctrl.latestJob.length === 0"></file-prompt>
 
     <section class="section">
         <div class="flex-container section-heading">

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1752,7 +1752,6 @@ FIXME: what to do with touch devices
 }
 
 .job-uploading {
-    width: 200px;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
To reproduce bug:
- Upload a bad image (e.g. a png)
- Navigate to search
- Navigate back to uploads
- Witness:
  - the bad upload is still there
  - the upload prompt isn't shown
  - drag and drop uploading doesn't work

Now the flow is:
- Upload a bad image
- Navigate to search
- Navigate back to uploads
- Witness:
  - You're able to upload in the usual ways.

You can also delete a failed upload from the upload job.

Before
![current](https://cloud.githubusercontent.com/assets/836140/9851118/ffded32c-5aee-11e5-89a1-38c885409742.gif)

After
![after](https://cloud.githubusercontent.com/assets/836140/9851124/04c8f250-5aef-11e5-9c8c-d529782e6838.gif)

