### PR TITLE
add guardian witness to the categories list

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -49,13 +49,24 @@
                            ng:disabled="property.required" />
                     Restricted
                 </label>
-                <div ng:if="ctrl.isRestricted(property)">
+
+                <div ng:if="ctrl.isRestricted(property)"
+                     ng:switch="ctrl.category.defaultRestrictions === undefined">
+                    <!-- We don't allow you to set the restrictions if there are defaults.
+                    This might not be the behaviour we want in the future, but works for now. -->
                     <textarea
                         class="form-input-text"
                         name="{{ property.name }}"
                         placeholder="What restrictions apply to this image? e.g. 'Use in relation to the Windsor Triathlon only'"
+                        ng:switch-when="true"
                         ng:model="ctrl.model[property.name]"
                         ng:required="ctrl.isRestricted(property)"></textarea>
+
+                    <textarea
+                        class="form-input-text"
+                        disabled="disabled"
+                        ng:switch-default>{{ctrl.category.defaultRestrictions}}</textarea>
+
                 </div>
             </div>
 

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -148,7 +148,8 @@ usageRightsEditor.controller(
         }
     };
 
-    ctrl.isRestricted = prop => ctrl.showRestrictions || prop.required;
+    ctrl.isRestricted = prop =>
+        ctrl.showRestrictions || ctrl.category.defaultRestrictions || prop.required;
 
     $scope.$watch(() => ctrl.showRestrictions, onValChange(isRestricted => {
         if (!isRestricted) {

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -44,7 +44,7 @@ object EditsApi extends Controller with ArgoHelpers {
       List(PrImage(), Handout(), Screengrab(), SocialMedia(), Obituary(), Pool(),
            StaffPhotographer("?", "?"), ContractPhotographer("?"), CommissionedPhotographer("?"),
            Agency("?"), CommissionedAgency("?"), CrownCopyright(),
-           ContractIllustrator("?"), CommissionedIllustrator("?"))
+           ContractIllustrator("?"), CommissionedIllustrator("?"), GuardianWitness())
            .sortWith(_.name.toLowerCase < _.name.toLowerCase)
         .map(CategoryResponse.fromUsageRights)
 
@@ -59,6 +59,7 @@ case class CategoryResponse(
   name: String,
   cost: String,
   description: String,
+  defaultRestrictions: Option[String],
   properties: List[UsageRightsProperty] = List()
 )
 object CategoryResponse {
@@ -66,11 +67,12 @@ object CategoryResponse {
   // with the JSON parsing stuff
   def fromUsageRights(u: UsageRights): CategoryResponse =
     CategoryResponse(
-      value        = u.category,
-      name         = u.name,
-      cost         = u.defaultCost.getOrElse(Pay).toString,
-      description  = u.description,
-      properties   = UsageRightsProperty.getPropertiesForCat(u)
+      value               = u.category,
+      name                = u.name,
+      cost                = u.defaultCost.getOrElse(Pay).toString,
+      description         = u.description,
+      defaultRestrictions = u.defaultRestrictions,
+      properties          = UsageRightsProperty.getPropertiesForCat(u)
     )
 
   implicit val categoryResponseWrites: Writes[CategoryResponse] = Json.writes[CategoryResponse]


### PR DESCRIPTION
Adding the GuardianWitness category to the usage rights.

We don't allow you to edit the restrictions if there are defaults. This might not be completely desired, but is the simplest for now in terms of what we surface to the user.

![guardian-witness-category](https://cloud.githubusercontent.com/assets/31692/9852335/b5d0b028-5af5-11e5-892a-8a3641abdc08.gif)
