### PR TITLE
add possessive_english stemmer.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
@@ -9,6 +9,7 @@ object IndexSettings {
     "tokenizer" -> "standard",
     "filter" -> Json.arr(
       "lowercase",
+      "asciifolding",
       "english_possessive_stemmer",
       "gu_stopwords",
       "s_stemmer"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
@@ -8,9 +8,9 @@ object IndexSettings {
     "type" -> "custom",
     "tokenizer" -> "standard",
     "filter" -> Json.arr(
+      "lowercase",
       "english_possessive_stemmer",
       "gu_stopwords",
-      "lowercase",
       "s_stemmer"
     )
   )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
@@ -1,6 +1,5 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.Json
 
 object IndexSettings {
@@ -9,6 +8,7 @@ object IndexSettings {
     "type" -> "custom",
     "tokenizer" -> "standard",
     "filter" -> Json.arr(
+      "english_possessive_stemmer",
       "gu_stopwords",
       "lowercase",
       "s_stemmer"
@@ -23,6 +23,10 @@ object IndexSettings {
     "gu_stopwords" -> Json.obj(
       "type" -> "stop",
       "stopwords" -> "_english_"
+    ),
+    "english_possessive_stemmer" -> Json.obj(
+      "type" -> "stemmer",
+      "language" -> "possessive_english"
     )
   )
 


### PR DESCRIPTION
Solves the problem of a search for `Corbyn` and `Corbyn's` yielding different results.

Need to talk to @kenoir about release process as involves a re-index :cry:.