### PR TITLE
add close icon to generic error message.

### DIFF
--- a/kahuna/public/js/errors/global.html
+++ b/kahuna/public/js/errors/global.html
@@ -26,6 +26,10 @@
     <div class="global-error warning" ng:message="unknown">
         An unknown error has occurred.
         If the problem persists please <a href="mailto:thegrid.dev@theguardian.com" class="coloured-link">email the Grid team</a>.
+
+        <gr-icon class="global-error__close"
+                 title="Close"
+                 ng:click="ctrl.dismiss('unknown')">close</gr-icon>
     </div>
 
     <div class="global-error error" ng:message="server">

--- a/kahuna/public/js/errors/global.js
+++ b/kahuna/public/js/errors/global.js
@@ -44,6 +44,7 @@ global.controller('GlobalErrorsCtrl',
     // handy as these can happen anywhere
     ctrl.getCurrentLocation = () => $location.url();
 
+    ctrl.dismiss = (error) => globalErrors.destroy(error);
 }]);
 
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -438,6 +438,15 @@ textarea.ng-invalid {
     border-radius: 5px;
 }
 
+.global-error__close {
+    padding-left: 10px;
+    cursor: pointer;
+}
+
+.global-error__close:hover {
+    color: white;
+}
+
 .error {
     background: darkred;
     color: white;


### PR DESCRIPTION
At the moment, the message blocks the UI - in the gif, you can't archive the image, for example.

This PR adds the ability to close the generic error message.

![dismiss](https://cloud.githubusercontent.com/assets/836140/9881596/9a66f314-5bc8-11e5-8cc6-55cca4bd3081.gif)
