### PR TITLE
Auto update md from ur

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/api/Transformers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/api/Transformers.scala
@@ -1,8 +1,10 @@
 package com.gu.mediaservice.api
 
-import java.net.URLEncoder
+import java.net.{URI, URLEncoder}
 
+import com.gu.mediaservice.lib.argo.model.{EmbeddedEntity, Action}
 import com.gu.mediaservice.lib.config.Services
+import com.gu.mediaservice.model.{Edits, ImageMetadata}
 import play.api.libs.json._
 
 class Transformers(services: Services) {
@@ -46,6 +48,18 @@ class Transformers(services: Services) {
       )
     }
 
+  def entityUri(id: String, endpoint: String = ""): URI =
+    URI.create(s"$metadataBaseUri/metadata/$id$endpoint")
+
+  type MetadataEntity = EmbeddedEntity[ImageMetadata]
+
+  def metadataEntity(id: String, m: ImageMetadata): Option[MetadataEntity] =
+    Edits.noneIfEmptyMetadata(m).map(i =>
+      EmbeddedEntity(entityUri(id, "/metadata"), Some(i), actions = List(
+        Action("set-metadata-from-usage-rights", entityUri(id, "/metadata/set-from-usage-rights"), "POST")
+      ))
+    )
+
   def wrapMetadata(id: String): Reads[JsObject] =
     __.read[JsObject].map { metadata =>
       Json.obj(
@@ -55,7 +69,9 @@ class Transformers(services: Services) {
         // always returns Array(). This is just making sure that bug is replicated
         // so we can do equalities to see if the services are synced. This will
         // be rectified when we use Argo here.
-        "data" -> (metadata ++ Json.obj("keywords" -> Json.arr()))
+        "data" -> (metadata ++ Json.obj("keywords" -> Json.arr())),
+        "actions" -> List(Action("set-from-usage-rights",
+          URI.create(s"$metadataBaseUri/metadata/$id/metadata/set-from-usage-rights"), "POST"))
       )
     }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -12,9 +12,10 @@ trait ArgoHelpers extends Results {
   val ArgoMediaType = "application/vnd.argo+json"
 
   // FIXME: DSL to append links and actions?
-  def respond[T](data: T, links: List[Link] = Nil, actions: List[Action] = Nil)
+  def respond[T](data: T, links: List[Link] = Nil, actions: List[Action] = Nil, uri: Option[URI] = None)
                 (implicit writes: Writes[T]): Result = {
     val response = EntityReponse(
+      uri     = uri,
       data    = data,
       links   = links,
       actions = actions
@@ -23,7 +24,8 @@ trait ArgoHelpers extends Results {
     serializeAndWrap(response, Ok)
   }
 
-  def respondCollection[T](data: Seq[T], offset: Option[Long] = None, total: Option[Long] = None, links: List[Link] = Nil, uri: Option[URI] = None)
+  def respondCollection[T](data: Seq[T], offset: Option[Long] = None, total: Option[Long] = None,
+                           links: List[Link] = Nil, uri: Option[URI] = None)
                           (implicit writes: Writes[T]): Result = {
     val response = CollectionReponse(
       uri    = uri,

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -149,8 +149,10 @@ service.factory('editsService',
         return existingRequestPool.promise;
     }
 
-    function perform(resource, action, originalImage) {
-        const newRequest = resource.perform(action).
+    // HACK: This is a very specific action that we use the `updateRequestPool` ast this action
+    // actually updates the metadata as a sideeffect.
+    function updateMetadataFromUsageRights(resource, originalImage) {
+        const newRequest = resource.perform('set-from-usage-rights').
               then(edit => getSynced(originalImage, newImage => matches(edit, newImage)));
 
         const existingRequestPool = updateRequestPools.get(resource) ||
@@ -283,7 +285,7 @@ service.factory('editsService',
     }
 
     return {
-        update, add, on, canUserEdit, perform,
+        update, add, on, canUserEdit, updateMetadataFromUsageRights,
         updateMetadataField, batchUpdateMetadataField
     };
 

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -151,7 +151,7 @@ service.factory('editsService',
 
     function perform(resource, action, originalImage) {
         const newRequest = resource.perform(action).
-              then(action => resource.get().then(edit => getSynced(originalImage, newImage => matches(edit, newImage))));
+              then(edit => getSynced(originalImage, newImage => matches(edit, newImage)));
 
         const existingRequestPool = updateRequestPools.get(resource) ||
             registerUpdateRequest(resource, originalImage);

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -159,20 +159,6 @@ service.factory('editsService',
         existingRequestPool.registerPromise(newRequest);
 
         return existingRequestPool.promise;
-
-        const lastmodified = new Date(image.data.lastModified);
-        return image.data.userMetadata.data.metadata.perform('set-from-usage-rights').then(() => {
-            apiPoll(() => {
-                return image.get().then(newImage => {
-                    const newLastMod = new Date(newImage.data.lastModified);
-                    if (newLastMod > lastmodified) {
-                        return Promise.resolve(newImage);
-                    } else {
-                        return Promise.reject('no modified yet');
-                    }
-                });
-            });
-        });
     }
 
     // Event handling

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -20,9 +20,12 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     ctrl.saving = false;
     ctrl.disabled = () => Boolean(ctrl.saving || ctrl.externallyDisabled);
-    ctrl.metadata = metadataFromOriginal(ctrl.originalMetadata);
     ctrl.saveOnTime = 750; // ms
-    ctrl.copyrightWasInitiallyThere = !!ctrl.metadata.copyright;
+    ctrl.copyrightWasInitiallyThere = !!ctrl.originalMetadata.copyright;
+
+    $scope.$watch(() => ctrl.originalMetadata, newMetadata => {
+        ctrl.metadata = metadataFromOriginal(newMetadata);
+    });
 
     ctrl.save = function() {
         ctrl.saving = true;

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -23,6 +23,8 @@ jobs.controller('RequiredMetadataEditorCtrl',
     ctrl.saveOnTime = 750; // ms
     ctrl.copyrightWasInitiallyThere = !!ctrl.originalMetadata.copyright;
 
+    // HACK: We watch the `originalMetadata` and re-set the `ctrl.metadata` as it can be mutated
+    // in other parts of the system and we need to reflect that (◞‸◟；)
     $scope.$watch(() => ctrl.originalMetadata, newMetadata => {
         ctrl.metadata = metadataFromOriginal(newMetadata);
     });

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -182,9 +182,15 @@ usageRightsEditor.controller(
             const image = usageRights.image;
             const resource = image.data.userMetadata.data.usageRights;
             return editsService.update(resource, data, image).
-                then(resource => resource.data);
+                then(resource => resource.data).
+                then(() => updateMetadataFromUsageRights(image));
+
         })).catch(uiError).
             finally(() => updateSuccess(data));
+    }
+
+    function updateMetadataFromUsageRights(image) {
+        return editsService.perform(image.data.userMetadata.data.metadata, 'set-from-usage-rights', image);
     }
 
     function updateSuccess(data) {

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -193,7 +193,8 @@ usageRightsEditor.controller(
     }
 
     function updateMetadataFromUsageRights(image) {
-        return editsService.perform(image.data.userMetadata.data.metadata, 'set-from-usage-rights', image);
+        return editsService.
+               updateMetadataFromUsageRights(image.data.userMetadata.data.metadata, image);
     }
 
     function updateSuccess(data) {

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -183,6 +183,9 @@ usageRightsEditor.controller(
             const resource = image.data.userMetadata.data.usageRights;
             return editsService.update(resource, data, image).
                 then(resource => resource.data).
+                // HACK: This should probably live somewhere else, but it's the least intrusive
+                // here. This updates the metadata based on the usage rights to stop users having
+                // to enter content twice.
                 then(() => updateMetadataFromUsageRights(image));
 
         })).catch(uiError).

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -106,8 +106,8 @@ object ImageResponse {
     val reindexAction = Action("reindex", reindexUri, "POST")
 
     List(
-      deleteAction       -> canDelete,
-      reindexAction      -> withWritePermission
+      deleteAction                     -> canDelete,
+      reindexAction                    -> withWritePermission
     )
     .filter{ case (action, active) => active }
     .map   { case (action, active) => action }

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -150,7 +150,6 @@ object EditsController extends Controller with ArgoHelpers with DynamoEdits {
 
       val usageRights = (dynamoEntry \ "usageRights").asOpt[UsageRights]
       val metadataOpt = usageRights.flatMap(metadataFromUsageRights)
-      println(metadataOpt)
       metadataOpt.map { metadata =>
         dynamo.jsonPatch(id, "metadata", metadataAsMap(metadata))
           .map(publish(id))

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -150,6 +150,7 @@ object EditsController extends Controller with ArgoHelpers with DynamoEdits {
 
       val usageRights = (dynamoEntry \ "usageRights").asOpt[UsageRights]
       val metadataOpt = usageRights.flatMap(metadataFromUsageRights)
+      println(metadataOpt)
       metadataOpt.map { metadata =>
         dynamo.jsonPatch(id, "metadata", metadataAsMap(metadata))
           .map(publish(id))
@@ -158,7 +159,7 @@ object EditsController extends Controller with ArgoHelpers with DynamoEdits {
       .getOrElse(Future.failed(EditsValidationError("no-matching-metadata-found", "Couldn't find any matching metadata")))
     } recover {
       case NoItemFound => respondError(NotFound, "item-not-found", "Could not find image")
-      case e: EditsValidationError => respondError(BadRequest, e.key, e.message)
+      case e: EditsValidationError => respondError(NotFound, e.key, e.message)
     }
   }
 

--- a/metadata-editor/app/lib/EditsResponse.scala
+++ b/metadata-editor/app/lib/EditsResponse.scala
@@ -5,18 +5,17 @@ import java.net.{URLEncoder, URI}
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-import com.gu.mediaservice.lib.argo.model.EmbeddedEntity
+import com.gu.mediaservice.lib.argo.model.{Action, EmbeddedEntity}
 import com.gu.mediaservice.model._
 
 
 object EditsResponse {
+  import Config.services.metadataBaseUri
 
   type ArchivedEntity = EmbeddedEntity[Boolean]
   type SetEntity = EmbeddedEntity[Seq[EmbeddedEntity[String]]]
   type MetadataEntity = EmbeddedEntity[ImageMetadata]
   type UsageRightsEntity = EmbeddedEntity[UsageRights]
-
-  val metadataBaseUri = Config.services.metadataBaseUri
 
   // the types are in the arguments because of a whining scala compiler
   def editsResponseWrites(id: String): Writes[Edits] = (
@@ -30,7 +29,11 @@ object EditsResponse {
     EmbeddedEntity(entityUri(id, "/archived"), Some(a))
 
   def metadataEntity(id: String, m: ImageMetadata): Option[MetadataEntity] =
-    Edits.noneIfEmptyMetadata(m).map(i => EmbeddedEntity(entityUri(id, "/metadata"), Some(i)))
+    Edits.noneIfEmptyMetadata(m).map(i =>
+      EmbeddedEntity(entityUri(id, "/metadata"), Some(i), actions = List(
+        Action("set-from-usage-rights", entityUri(id, "/metadata/set-from-usage-rights"), "POST")
+      ))
+    )
 
   def usageRightsEntity(id: String, u: Option[UsageRights]): Option[UsageRightsEntity] =
     u.map(i => EmbeddedEntity(entityUri(id, "/usage-rights"), Some(i)))


### PR DESCRIPTION
When a user sets the usage rights on an image, they will need to re-set the metadata with information that can be inferred from the usage rights i.e. Staff photographer => credit & byline.

This adds a call to the server to set that automatically where we can after setting the usage rights.

__TODO__
- [x] Write PR description
- [x] Comment all the hacks
- [x] What to do if no metadata can be found
