### PR TITLE
split photographers between internal and external

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -78,6 +78,7 @@ object MetadataConfig {
   // them correctly.
   // TODO: Think about removin these once Picdar is dead.
   val internalStaffPhotographers = List(
+    "E Hamilton West"       -> "The Guardian",
     "Emma Baddeley"         -> "The Guardian",
     "Harriet St Johnston"   -> "The Guardian",
     "James Michelson"       -> "The Guardian",
@@ -85,8 +86,7 @@ object MetadataConfig {
     "Marcus Mays"           -> "The Guardian",
     "Millie Burton"         -> "The Guardian",
     "Rachel Vere"           -> "The Guardian",
-    "Richard Blake"         -> "The Guardian",
-    "Ted West"              -> "The Guardian"
+    "Richard Blake"         -> "The Guardian"
   )
 
   val staffPhotographers = externalStaffPhotographers ++ internalStaffPhotographers

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -39,7 +39,7 @@ object PhotographersList {
 
 object MetadataConfig {
 
-  val staffPhotographers: Map[String, String] = Map(
+  val externalStaffPhotographers: Map[String, String] = Map(
     // Current
     "Alicia Canter"  -> "The Guardian",
     "Bill Code"      -> "The Guardian",
@@ -56,32 +56,40 @@ object MetadataConfig {
     "Denis Thorpe"          -> "The Guardian",
     "Don McPhee"            -> "The Guardian",
     "E Hamilton West"       -> "The Guardian",
-    "Emma Baddeley"         -> "The Guardian",
     "Frank Baron"           -> "The Guardian",
     "Frank Martin"          -> "The Guardian",
     "Garry Weaser"          -> "The Guardian",
     "Graham Finlayson"      -> "The Guardian",
-    "Harriet St Johnston"   -> "The Guardian",
-    "James Michelson"       -> "The Guardian",
-    "Lorna Roach"           -> "The Guardian",
-    "Marcus Mays"           -> "The Guardian",
     "Martin Argles"         -> "The Guardian",
-    "Millie Burton"         -> "The Guardian",
     "Peter Johns"           -> "The Guardian",
-    "Rachel Vere"           -> "The Guardian",
-    "Richard Blake"         -> "The Guardian",
     "Robert Smithies"       -> "The Guardian",
-    "Ted West"              -> "The Guardian",
     "Tom Stuttard"          -> "The Guardian",
     "Tricia De Courcy Ling" -> "The Guardian",
     "Walter Doughty"        -> "The Guardian",
-
     "David Newell Smith"    -> "The Observer",
     "Tony McGrath"          -> "The Observer",
     "Catherine Shaw"        -> "The Observer",
     "John Reardon"          -> "The Observer",
     "Sean Gibson"           -> "The Observer"
   )
+
+  // these are people who aren't photographers by trade, but have taken photographs for us.
+  // This is mainly used so when we ingest photos from Picdar, we make sure we categorise
+  // them correctly.
+  // TODO: Think about removin these once Picdar is dead.
+  val internalStaffPhotographers = List(
+    "Emma Baddeley"         -> "The Guardian",
+    "Harriet St Johnston"   -> "The Guardian",
+    "James Michelson"       -> "The Guardian",
+    "Lorna Roach"           -> "The Guardian",
+    "Marcus Mays"           -> "The Guardian",
+    "Millie Burton"         -> "The Guardian",
+    "Rachel Vere"           -> "The Guardian",
+    "Richard Blake"         -> "The Guardian",
+    "Ted West"              -> "The Guardian"
+  )
+
+  val staffPhotographers = externalStaffPhotographers ++ internalStaffPhotographers
 
   val contractedPhotographers: Map[String, String] = Map(
     "Antonio Zazueta"     -> "The Guardian",
@@ -130,6 +138,7 @@ object MetadataConfig {
 
   val allPhotographers = staffPhotographers ++ contractedPhotographers
 
+  val externalPhotographersMap = PhotographersList.creditBylineMap(externalStaffPhotographers)
   val staffPhotographersMap = PhotographersList.creditBylineMap(staffPhotographers)
   val contractPhotographersMap = PhotographersList.creditBylineMap(staffPhotographers)
   val allPhotographersMap = PhotographersList.creditBylineMap(allPhotographers)

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -23,7 +23,7 @@ object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import MetadataConfig.{staffPhotographersMap, contractIllustrators}
+  import MetadataConfig.{externalPhotographersMap, contractIllustrators}
   import UsageRightsConfig.freeSuppliers
 
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
@@ -37,7 +37,7 @@ object UsageRightsProperty {
 
   private def publicationField(required: Boolean)  =
     UsageRightsProperty("publication", "Publication", "string", required,
-      Some(sortList(staffPhotographersMap.keys.toList)))
+      Some(sortList(externalPhotographersMap.keys.toList)))
 
   private def photographerField =
     UsageRightsProperty("photographer", "Photographer", "string", true)
@@ -64,7 +64,7 @@ object UsageRightsProperty {
   private def photographerProperties(u: UsageRights) = u match {
     case _:StaffPhotographer => List(
       publicationField(true),
-      photographerField(staffPhotographersMap, "publication")
+      photographerField(externalPhotographersMap, "publication")
     )
 
     case _:CommissionedPhotographer => List(


### PR DESCRIPTION
Further discussions with Jo B raises that these are people who have worked the picture desk and taken photos for us, but aren't photographers.

Understandably this clutters the list, but we need to make sure that we ingest these people correctly from Picdar or reindex them.

I've removed them from the UI, whilst still ensuring we categorise them correctly.

cc: @akash1810 with #1250 