### PR TITLE
Use CROSS_FIELDS type in multi_match query.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -10,7 +10,7 @@ object Mappings {
   val nonAnalyzedString = Json.obj("type" -> "string", "index" -> "not_analyzed")
   val nonIndexedString  = Json.obj("type" -> "string", "index" -> "no")
 
-  val sStemmerAnalysedString = Json.obj("type" -> "string", "analyzer" -> "english_s_stemmer")
+  val sStemmerAnalysedString = Json.obj("type" -> "string", "analyzer" -> IndexSettings.guAnalyzer)
   val standardAnalysedString = Json.obj("type" -> "string", "analyzer" -> "standard")
 
   val simpleSuggester = Json.obj(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
@@ -3,6 +3,8 @@ package com.gu.mediaservice.lib.elasticsearch
 import play.api.libs.json.Json
 
 object IndexSettings {
+  // TODO rename `english_s_stemmer` as its an analyzer not a stemmer - would require a reindex.
+  val guAnalyzer = "english_s_stemmer"
 
   val englishSStemmer = Json.obj(
     "type" -> "custom",
@@ -32,7 +34,7 @@ object IndexSettings {
   )
 
   val analyzer = Json.obj(
-    "english_s_stemmer" -> englishSStemmer
+    guAnalyzer -> englishSStemmer
   )
 
   val analysis = Json.obj(

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -14,7 +14,7 @@ class QueryBuilder(matchFields: Seq[String]) {
 
   def makeMultiQuery(value: Value, fields: Seq[String]) = value match {
     // Force AND operator else it will only require *any* of the words, not *all*
-    case Words(string) => multiMatchQuery(string, fields: _*).operator(MatchQueryBuilder.Operator.AND)
+    case Words(string) => multiMatchQuery(string, fields: _*).operator(MatchQueryBuilder.Operator.AND).`type`(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
     case Phrase(string) => multiMatchPhraseQuery(string, fields)
     // That's OK, we only do date queries on a single field at a time
     case DateRange(start, end) => throw InvalidQuery("Cannot do multiQuery on date range")

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -1,5 +1,6 @@
 package lib.elasticsearch
 
+import com.gu.mediaservice.lib.elasticsearch.IndexSettings
 import lib.querysyntax._
 import org.elasticsearch.index.query.{MatchQueryBuilder, MultiMatchQueryBuilder}
 import org.elasticsearch.index.query.QueryBuilders._
@@ -14,7 +15,10 @@ class QueryBuilder(matchFields: Seq[String]) {
 
   def makeMultiQuery(value: Value, fields: Seq[String]) = value match {
     // Force AND operator else it will only require *any* of the words, not *all*
-    case Words(string) => multiMatchQuery(string, fields: _*).operator(MatchQueryBuilder.Operator.AND).`type`(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
+    case Words(string) => multiMatchQuery(string, fields: _*)
+                          .operator(MatchQueryBuilder.Operator.AND)
+                          .`type`(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
+                          .analyzer(IndexSettings.guAnalyzer)
     case Phrase(string) => multiMatchPhraseQuery(string, fields)
     // That's OK, we only do date queries on a single field at a time
     case DateRange(start, end) => throw InvalidQuery("Cannot do multiQuery on date range")


### PR DESCRIPTION
The [default](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types) is [`BEST_FIELDS`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-best-fields) which is most useful when searching for multiple words best found in the same field.

[`CROSS_FIELDS`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-cross-fields) treats fields with the same analyzer as though they were one big field. Looks for each word in any field.

If we have the image:

```json
{
  "title": "foo",
  "description": "bar"
}
```

and we search for `foo bar`, `BEST_FIELDS` does not find it because its expecting the whole search term to exist in a single field.

Using `CROSS_FIELDS` means all the fields are (essentially) concatenated together and the search is run on that, and so a match is found.