### PR TITLE
Pass uri as part of image object for Composer to pick up

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -304,8 +304,10 @@ kahuna.filter('asImageDragData', function() {
         var uri = image && image.uri;
         if (uri) {
             const kahunaUri = syncGetLinkUri(image, 'ui:image');
+            // Resources don't serialise well yet..
+            const imageObj = { data: image.data, uri };
             return {
-                'application/vnd.mediaservice.image+json': JSON.stringify({ data: image.data, uri }),
+                'application/vnd.mediaservice.image+json': JSON.stringify(imageObj),
                 'application/vnd.mediaservice.kahuna.uri': kahunaUri,
                 'text/plain':    uri,
                 'text/uri-list': uri

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -301,15 +301,14 @@ kahuna.filter('asImageDragData', function() {
     }
 
     return function(image) {
-        var url = image && image.uri;
-
-        if (url) {
+        var uri = image && image.uri;
+        if (uri) {
             const kahunaUri = syncGetLinkUri(image, 'ui:image');
             return {
-                'application/vnd.mediaservice.image+json': JSON.stringify({ data: image.data }),
+                'application/vnd.mediaservice.image+json': JSON.stringify({ data: image.data, uri }),
                 'application/vnd.mediaservice.kahuna.uri': kahunaUri,
-                'text/plain':    url,
-                'text/uri-list': url
+                'text/plain':    uri,
+                'text/uri-list': uri
             };
         }
     };


### PR DESCRIPTION
I noticed `mediaApiUri` was missing in Composer when drag and dropping an image from the Grid into Composer. This seems to be caused by the `uri` missing on the image object in the drag transfer data. It may have been missing for many months, as I can't see where it'd have changed recently.

I'm curious if this going to reveal a higher usage of Grid images than we thought.

cc @cb372 who inadvertently helped reveal this issue.