### PR TITLE
use same font size in all fields on uploads page.

### DIFF
--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -93,7 +93,7 @@
             </span>
 
             <div class="result-editor__usage-rights-container">
-                <div ng:hide="ctrl.showUsageRights">
+                <div ng:hide="ctrl.showUsageRights" class="result-editor__field-value">
                     <span>{{ctrl.usageRightsCategory || 'None'}}</span>
                     <button class="image-info__edit" ng:click="ctrl.showUsageRights = !ctrl.showUsageRights">
                         <gr-icon>edit</gr-icon>
@@ -132,7 +132,7 @@
         </div>
         <div class="result-editor__field-container" ng:if="ctrl.image.data.uploadInfo.filename">
             <div class="result-editor__field-label">File name</div>
-            <div>{{ctrl.image.data.uploadInfo.filename}}</div>
+            <div class="result-editor__field-value">{{ctrl.image.data.uploadInfo.filename}}</div>
         </div>
 
     </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1221,6 +1221,11 @@ FIXME: what to do with touch devices
     width: 100px;
 }
 
+.result-editor__field-value {
+    font-size: 1.4rem;
+    line-height: 24px;
+}
+
 .result-editor__usage-rights-container {
     flex-grow: 1;
 }


### PR DESCRIPTION
Pointed out by @paperboyo 

# Before
![screen shot 2015-09-16 at 13 35 20](https://cloud.githubusercontent.com/assets/836140/9904699/b5a90ac2-5c77-11e5-99de-336489ed5c0b.png)

# After
![screen shot 2015-09-16 at 13 34 44](https://cloud.githubusercontent.com/assets/836140/9904700/b9a4aa28-5c77-11e5-89ba-f8349e2b7902.png)

Hint: look at `Usage rights` and `File name`.