### PR TITLE
adding reasons for image persistence.

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -151,7 +151,7 @@ object MediaApi extends Controller with ArgoHelpers {
       case Some(source) =>
         val image = source.as[Image]
 
-        val isPersisted = ImageResponse.imageIsPersisted(image)
+        val (isPersisted, _) = ImageResponse.imagePersistenceState(image)
         if (isPersisted) {
           Future.successful(ImageCannotBeDeleted)
         } else {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -151,7 +151,8 @@ object MediaApi extends Controller with ArgoHelpers {
       case Some(source) =>
         val image = source.as[Image]
 
-        val (isPersisted, _) = ImageResponse.imagePersistenceState(image)
+        val isPersisted = ImageResponse.imagePersistenceReasons(image).nonEmpty
+
         if (isPersisted) {
           Future.successful(ImageCannotBeDeleted)
         } else {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -3,6 +3,7 @@ package lib
 import lib.usagerights.CostCalculator
 
 import java.net.URI
+import scala.collection.mutable.ListBuffer
 import scala.util.{Try, Failure}
 import org.joda.time.{DateTime, Duration}
 
@@ -24,18 +25,37 @@ object ImageResponse {
 
   def fileMetaDataUri(id: String) = URI.create(s"${Config.rootUri}/images/$id/fileMetadata")
 
+  def hasPersistenceIdentifier(image: Image) =
+    image.identifiers.contains(Config.persistenceIdentifier)
+
+  def hasExports(image: Image) =
+    image.exports.nonEmpty
+
+  def isArchived(image: Image) =
+    image.userMetadata.exists(_.archived)
+
   def isPhotographerCategory[T <: UsageRights](usageRights: T) =
     usageRights match {
       case _:Photographer => true
       case _ => false
     }
 
-  // TODO: move this as a method of Image (fiddly due to dep on Config)
-  def imageIsPersisted(image: Image) = {
-    image.identifiers.contains(Config.persistenceIdentifier) ||
-      image.exports.nonEmpty ||
-      image.userMetadata.exists(_.archived) ||
-      isPhotographerCategory(image.usageRights)
+  def imagePersistenceState(image: Image): (Boolean, List[String]) = {
+    val reasons: ListBuffer[String] = ListBuffer[String]()
+
+    if (hasPersistenceIdentifier(image))
+      reasons += "persistence-identifier"
+
+    if (hasExports(image))
+      reasons += "exports"
+
+    if (isArchived(image))
+      reasons += "archived"
+
+    if (isPhotographerCategory(image.usageRights))
+      reasons += "photographer-category"
+
+    (reasons.nonEmpty, reasons.toList)
   }
 
   def create(id: String, esSource: JsValue, withWritePermission: Boolean,
@@ -64,14 +84,14 @@ object ImageResponse {
 
     val valid = ImageExtras.isValid(source \ "metadata")
 
-    val isPersisted = imageIsPersisted(image)
+    val (isPersisted, persistenceReasons) = imagePersistenceState(image)
 
     val data = source.transform(addSecureSourceUrl(secureUrl))
       .flatMap(_.transform(wrapUserMetadata(id)))
       .flatMap(_.transform(addSecureThumbUrl(secureThumbUrl)))
       .flatMap(_.transform(addValidity(valid)))
       .flatMap(_.transform(addUsageCost(source)))
-      .flatMap(_.transform(addPersistedState(isPersisted))).get
+      .flatMap(_.transform(addPersistedState(isPersisted, persistenceReasons))).get
 
     val links = imageLinks(id, secureUrl, withWritePermission, valid)
 
@@ -132,8 +152,11 @@ object ImageResponse {
     __.json.update(__.read[JsObject].map(_ ++ Json.obj("cost" -> cost.toString)))
   }
 
-  def addPersistedState(isPersisted: Boolean): Reads[JsObject] =
-    __.json.update(__.read[JsObject]).map(_ ++ Json.obj("persisted" -> isPersisted))
+  def addPersistedState(isPersisted: Boolean, persistenceReasons: List[String]): Reads[JsObject] =
+    __.json.update(__.read[JsObject]).map(_ ++ Json.obj(
+      "persisted" -> Json.obj(
+        "data" -> isPersisted,
+        "reasons" -> persistenceReasons)))
 
   // FIXME: tidier way to replace a key in a JsObject?
   def wrapUserMetadata(id: String): Reads[JsObject] =


### PR DESCRIPTION
Return a list of reasons for image persistence. This will allow the UI to intelligently display `ui-archiver`, that is, ~~don't display if `reasons` contains `persistence-identifier`, `exports` or `photographer-category`~~ display if `reasons` contains only `exports`, as manually archiving an image in these cases has no effect (other than possibly user reassurance). In these cases, we'll show a library icon (or something similar).

Response looks like:

```json
"persisted": {
  "data": true,
  "reasons": [
    "exports",
    "archived"
  ]
}
```

or

```json
"persisted": {
  "data": false,
  "reasons": []
}
```