### PR TITLE
Make S3 Watcher logging more verbose

### DIFF
--- a/s3watcher/S3Watcher.js
+++ b/s3watcher/S3Watcher.js
@@ -20,7 +20,7 @@ exports.handler = function(event, context) {
             });
         }).flatMap(t.success);
     }).subscribe(
-        lambda.done,
+        lambda.success,
         lambda.fail
     );
 

--- a/s3watcher/lib/Lambda.js
+++ b/s3watcher/lib/Lambda.js
@@ -58,16 +58,16 @@ module.exports = {
             context.fail(err);
         };
 
-        const succeed = function() {
-            console.log("Operation successful.");
-            context.succeed();
+        const success = function() {
+            console.log("Finished successfully.", s3Event);
+            context.succeed(s3Event);
         };
 
         return {
             s3Event: s3Event,
             config: config,
             fail: fail,
-            succeed: succeed
+            success: success
         };
     }
 }

--- a/s3watcher/lib/Lambda.js
+++ b/s3watcher/lib/Lambda.js
@@ -58,16 +58,16 @@ module.exports = {
             context.fail(err);
         };
 
-        const done = function() {
+        const succeed = function() {
             console.log("Operation successful.");
-            context.done();
+            context.succeed();
         };
 
         return {
             s3Event: s3Event,
             config: config,
             fail: fail,
-            done: done
+            succeed: succeed
         };
     }
 }

--- a/s3watcher/lib/Transfer.js
+++ b/s3watcher/lib/Transfer.js
@@ -4,54 +4,71 @@ const Upload       = require('./Upload');
 
 module.exports = {
     init: function(s3Event, config){
+
         const objectKey = s3Event.bucket + "/" +  s3Event.key;
+
         const s3Object = {
             Bucket: s3Event.bucket,
             Key: s3Event.key
         };
+
         const s3CopyObject = {
             CopySource: s3Event.bucket + "/" + s3Event.key,
             Bucket: config.failBucket,
             Key: s3Event.key
         };
+
         const upload = Upload.buildUpload(config, s3Event);
 
-        const logDownload = function(){
-            console.log("Downloading from ingest bucket.", s3Object);
-        };
-        const logUpload = function(){
-            console.log("Uploading to image-loader.", upload);
-        };
-        const logDelete = function(){
-            console.log("Deleting from ingest bucket.", s3Object);
-        };
-        const logCopy = function(){
-            console.log("Copying to fail bucket.", s3CopyObject);
-        };
+        function log(state) {
+            const states = {
+                "download": {
+                    message: "Downloading from ingest bucket.",
+                    state: s3Object
+                },
+                "upload": {
+                    message: "Uploading to image-loader.",
+                    state: upload
+                },
+                "delete": {
+                    message: "Deleting from ingest bucket.",
+                    state: s3Object
+                },
+                "copy": {
+                    message: "Copying to fail bucket.",
+                    state: s3CopyObject
+                }
+            };
 
-        // TODO: Pipe download stream into upload stream
-        // Currently the whole file is loaded into memory before
-        // being uploaded to the image loader.
+            const stateMessage = states[state].message;
+            const stateObject  = states[state].state;
+
+            console.log(stateMessage, stateObject);
+        }
+
+        // TODO: Use stream API
         const operation = function() {
-            logDownload();
+            log("download");
 
             return S3Helper.getS3Object(s3Object).flatMap(function(data){
-                logUpload();
+                log("upload");
 
                 return Upload.postData(upload, data.Body)
             }).retry(3);
         };
 
         const success = function(result) {
-            logDelete();
+            log("delete");
 
             return S3Helper.deleteS3Object(s3Object);
         };
 
         const fail = function() {
-            logCopy();
+            log("copy");
+
             return S3Helper.copyS3Object(s3CopyObject).flatMap(function(){
-                logDelete();
+                log("delete");
+
                 return S3Helper.deleteS3Object(s3Object);
             });
         };

--- a/s3watcher/lib/Transfer.js
+++ b/s3watcher/lib/Transfer.js
@@ -4,45 +4,55 @@ const Upload       = require('./Upload');
 
 module.exports = {
     init: function(s3Event, config){
+        const objectKey = s3Event.bucket + "/" +  s3Event.key;
+        const s3Object = {
+            Bucket: s3Event.bucket,
+            Key: s3Event.key
+        };
+        const s3CopyObject = {
+            CopySource: s3Event.bucket + "/" + s3Event.key,
+            Bucket: config.failBucket,
+            Key: s3Event.key
+        };
+        const upload = Upload.buildUpload(config, s3Event);
+
+        const logDownload = function(){
+            console.log("Downloading from ingest bucket.", s3Object);
+        };
+        const logUpload = function(){
+            console.log("Uploading to image-loader.", upload);
+        };
+        const logDelete = function(){
+            console.log("Deleting from ingest bucket.", s3Object);
+        };
+        const logCopy = function(){
+            console.log("Copying to fail bucket.", s3CopyObject);
+        };
+
         // TODO: Pipe download stream into upload stream
         // Currently the whole file is loaded into memory before
         // being uploaded to the image loader.
-        //
         const operation = function() {
-            console.log("Downloading from ingest bucket.");
+            logDownload();
 
-            const upload = Upload.buildUpload(config, s3Event);
-
-            return S3Helper.getS3Object({
-                Bucket: s3Event.bucket,
-                Key: s3Event.key
-            }).flatMap(function(data){
-                console.log("Uploading to image-loader.");
+            return S3Helper.getS3Object(s3Object).flatMap(function(data){
+                logUpload();
 
                 return Upload.postData(upload, data.Body)
             }).retry(3);
         };
 
         const success = function(result) {
-            console.log("Deleting from ingest bucket.");
-            return S3Helper.deleteS3Object({
-                Bucket: s3Event.bucket,
-                Key: s3Event.key
-            });
+            logDelete();
+
+            return S3Helper.deleteS3Object(s3Object);
         };
 
         const fail = function() {
-            console.log("Copying to fail bucket.");
-            return S3Helper.copyS3Object({
-                CopySource: s3Event.bucket + "/" + s3Event.key,
-                Bucket: config.failBucket,
-                Key: s3Event.key
-            }).flatMap(function(){
-                console.log("Deleting from ingest bucket.");
-                return S3Helper.deleteS3Object({
-                    Bucket: s3Event.bucket,
-                    Key: s3Event.key
-                });
+            logCopy();
+            return S3Helper.copyS3Object(s3CopyObject).flatMap(function(){
+                logDelete();
+                return S3Helper.deleteS3Object(s3Object);
             });
         };
 

--- a/s3watcher/lib/Upload.js
+++ b/s3watcher/lib/Upload.js
@@ -48,7 +48,9 @@ module.exports = {
                 if(response.statusCode == 202){
                     observer.onNext(response);
                 } else {
-                    observer.onError("Failed to upload.");
+                    const failMessage =
+                        "Failed upload with code: " + response.statusCode;
+                    observer.onError(failMessage);
                 }
            });
            uploadRequest.on("error", observer.onError.bind(observer));


### PR DESCRIPTION
Adds current state to logs to make debugging simpler.

**Note:** This will log the API key when making an upload request.