### PR TITLE
Creative commons

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.css
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.css
@@ -18,6 +18,10 @@
     margin: 10px 0;
 }
 
+.ure__caution {
+    margin: 10px 0;
+}
+
 .ure__restrictions {
     display: block;
 }

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -20,6 +20,10 @@
         </select>
     </label>
 
+    <div class="ure__caution warning warning--small" ng:if="ctrl.category.caution">
+        {{ctrl.category.caution}}
+    </div>
+
     <div class="ure__description">
         {{ctrl.category.description}}
     </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -459,6 +459,9 @@ textarea.ng-invalid {
     padding: 20px 40px;
     text-align: center;
 }
+.warning--small {
+    padding: 5px 10px;
+}
 
 .full-error {
     margin-top: 3rem;

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -82,7 +82,8 @@ trait SearchFilters extends ImageFields {
     "contract-photographer",
     "commissioned-photographer",
     "commissioned-agency",
-    "pool"
+    "pool",
+    "creative-commons"
   )
 
   val persistedFilter = filters.or(

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -36,8 +36,6 @@ object EditsApi extends Controller with ArgoHelpers {
   def index = Authenticated { indexResponse }
 
   val usageRightsResponse = {
-    // FIXME: GuardianWitness should be there but isn't for simplicity;
-    // their images can be imported by drag and drop instead
     // FIXME: Creating new instances? Rubbish ಠ_ಠ. I can't think of a way
     // to access the `val`s of the classes though without instantiating them.
     val usageRightsData =
@@ -45,7 +43,7 @@ object EditsApi extends Controller with ArgoHelpers {
         Handout(), PrImage(), Screengrab(), SocialMedia(),
         Agency("?"), CommissionedAgency("?"),
         StaffPhotographer("?", "?"), ContractPhotographer("?"), CommissionedPhotographer("?"),
-        GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
+        CreativeCommons(), GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
         ContractIllustrator("?"), CommissionedIllustrator("?")
       ).map(CategoryResponse.fromUsageRights)
 
@@ -61,6 +59,7 @@ case class CategoryResponse(
   cost: String,
   description: String,
   defaultRestrictions: Option[String],
+  caution: Option[String],
   properties: List[UsageRightsProperty] = List()
 )
 object CategoryResponse {
@@ -73,6 +72,7 @@ object CategoryResponse {
       cost                = u.defaultCost.getOrElse(Pay).toString,
       description         = u.description,
       defaultRestrictions = u.defaultRestrictions,
+      caution             = u.caution,
       properties          = UsageRightsProperty.getPropertiesForCat(u)
     )
 


### PR DESCRIPTION
Adding creative commons with a caution.
I've used the word caution as I think we will need to allow users to add warnings later, and didn't want to use `defaultWarning` as that implies it can be overrides as is the case with restrictions.

![creative-commons](https://cloud.githubusercontent.com/assets/31692/9932541/a64fed96-5d3c-11e5-9af0-d0adf9297105.png)

Release strategy - Kahuna then Metadata-editor - we can stagger this if we think it is completely nesseary. It will not break anything, but only show the caution when you have the new version of the js app.
