### PR TITLE
allow uploads after uploading

### DIFF
--- a/kahuna/public/js/upload/prompt/prompt.css
+++ b/kahuna/public/js/upload/prompt/prompt.css
@@ -5,8 +5,12 @@ file-prompt {
 }
 
 file-prompt file-uploader {
-    display: flex;
-    justify-content: center;
+    display: inline-block;
+    padding: 0 5px;
+}
+
+file-prompt file-uploader .file-uploader__select-files {
+    margin-top: 0;
 }
 
 file-prompt .message {

--- a/kahuna/public/js/upload/prompt/prompt.html
+++ b/kahuna/public/js/upload/prompt/prompt.html
@@ -1,9 +1,3 @@
-<file-uploader></file-uploader>
-
-<p class="message">
-    Select files to upload.
-</p>
-
-<p class="message">
-    Either drag 'n drop images onto this screen or click the upload button to get your images on the Grid.
-</p>
+<div class="message">
+    Either drag 'n drop images onto this screen or click <file-uploader></file-uploader> to get your images on the Grid.
+</div>

--- a/kahuna/public/js/upload/prompt/prompt.js
+++ b/kahuna/public/js/upload/prompt/prompt.js
@@ -11,6 +11,7 @@ prompt.directive('filePrompt', [function () {
     return {
         restrict: 'E',
         transclude: 'replace',
+        scope: {}, // ensure isolated scope
         template: template
     };
 }]);

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -8,24 +8,22 @@
 </gr-top-bar>
 
 <div class="page-wrapper">
+    <file-prompt class="section"></file-prompt>
+
     <section class="section"
              ng:if="ctrl.latestJob && ctrl.latestJob.length > 0">
 
-        <div class="flex-container section-heading">
-            <h2>Your current uploads</h2>
-            <span class="flex-spacer"></span>
+        <div class="flex-container section-heading current-uploads">
+            <h2 class="flex-spacer">Your current uploads</h2>
             <a ng:controller="SessionCtrl" class="coloured-link" ui:sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
         </div>
 
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
     </section>
 
-    <file-prompt class="section" ng:if="!ctrl.latestJob || ctrl.latestJob.length === 0"></file-prompt>
-
     <section class="section">
         <div class="flex-container section-heading">
-            <h2>Your past 50 uploads</h2>
-            <span class="flex-spacer"></span>
+            <h2 class="flex-spacer">Your past 50 uploads</h2>
             <a ng:controller="SessionCtrl" class="coloured-link" ui:sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
         </div>
 


### PR DESCRIPTION
Display the file upload button once all uploads have finished. The behaviour is:
1. Upload image
2. Fill in metadata
3. Press Upload button
4. Images from 1. are moved to recent uploads

Note, this is the current behaviour if you replace 3. with drag and drop more images.

![upload-after-upload](https://cloud.githubusercontent.com/assets/836140/9961081/7528089a-5e16-11e5-8b7c-ea9ed7983448.gif)

I view this as a temporary solution until we have "add to upload queue" abilities.