### PR TITLE
safer typecasting to fix endpoint

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -3,7 +3,7 @@ package lib.elasticsearch
 import java.util.regex.Pattern
 
 import org.elasticsearch.index.query.{FilterBuilder, FilteredQueryBuilder}
-import org.elasticsearch.search.aggregations.bucket.terms.StringTerms
+import org.elasticsearch.search.aggregations.bucket.terms.{InternalTerms, StringTerms}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConversions._
@@ -149,7 +149,7 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
       .executeAndLog("metadata aggregate search")
       .toMetric(searchQueries, List(searchTypeDimension("aggregate")))(_.getTookInMillis)
       .map{ response =>
-        val buckets = response.getAggregations.getAsMap.get(name).asInstanceOf[StringTerms].getBuckets
+        val buckets = response.getAggregations.getAsMap.get(name).asInstanceOf[InternalTerms].getBuckets
         val results = buckets.toList map (s => BucketResult(s.getKey, s.getDocCount))
 
         AggregateSearchResults(results, buckets.size)


### PR DESCRIPTION
When visiting `https://api.media....co.uk/images/edits/label{?q}` the following is thrown:

```
ClassCastException: org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms cannot be cast to org.elasticsearch.search.aggregations.bucket.terms.StringTerms
```

Cast as the more abstract `InternalTerms` which both `UnmappedTerms` and `StringTerms` extend.