### PR TITLE
Restrict image with the Guardian credit

### DIFF
--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -11,8 +11,11 @@ object CostCalculator {
   val defaultCost = Pay
 
   // HACK: This is until we decide what to do with Guardian credits
-  def getCost(credit: Option[String]): Option[Cost] =
-    if (credit.exists(guardianCredits.contains)) Some(Free) else None
+  // We've also added the restrictions here as that needs to override `Free`
+  // but I didn't want to pollute the "pure" cost calculations
+  def getCost(credit: Option[String], restrictions: Option[String]): Option[Cost] =
+    if (restrictions.nonEmpty) Some(Conditional)
+    else if (credit.exists(guardianCredits.contains)) Some(Free) else None
 
   def getCost(supplier: String, collection: Option[String]): Option[Cost] = {
       val free = isFreeSupplier(supplier) && ! collection.exists(isExcludedColl(supplier, _))
@@ -33,7 +36,7 @@ object CostCalculator {
   }
 
   def getCost(usageRights: UsageRights, credit: Option[String]): Cost = {
-    getCost(credit)
+    getCost(credit, usageRights.restrictions)
       .orElse(getCost(usageRights))
       .getOrElse(defaultCost)
   }

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -46,12 +46,20 @@ class CostCalculatorTest extends FunSpec with Matchers {
       cost should be (Free)
     }
 
+    it ("should be Conditional if it is 'The Guardian' credit with restrictions") {
+      val usageRights = SocialMedia(Some("This here be restricted"))
+      val credit = Some("The Guardian")
+      val cost = CostCalculator.getCost(usageRights, credit)
+
+      cost should be (Conditional)
+    }
+
     it("should work out 'The Guardian' credit to be free, but not other suppliers") {
       val theGuardian = Some("The Guardian")
       val getty = Some("Getty Image")
 
-      val theGuardianCost = CostCalculator.getCost(theGuardian)
-      val gettyCost = CostCalculator.getCost(getty)
+      val theGuardianCost = CostCalculator.getCost(theGuardian, None)
+      val gettyCost = CostCalculator.getCost(getty, None)
 
       theGuardianCost should be (Some(Free))
       gettyCost should be (None)


### PR DESCRIPTION
I've added this into the hack method to keep it all self contained although there might have been a way to change the ordering of the whole thing to look at restrictions only once - but that felt like pollution.