### PR TITLE
quote query for elastic regexp query

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -139,7 +139,7 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
     val aggregate = AggregationBuilders
       .terms(name)
       .field(field)
-      .include(q.getOrElse("") + ".*", Pattern.CASE_INSENSITIVE)
+      .include(Pattern.quote(q.getOrElse("")) + ".*", Pattern.CASE_INSENSITIVE)
 
     val search = prepareImagesSearch.addAggregation(aggregate)
 


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html#_standard_operators

Annoyingly, I spent far too long trying to build a regex parser for this, then found `Pattern.quote` :unamused: 

> [`Pattern.quote`](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html#quote(java.lang.String)) produces a String that can be used to create a Pattern that would match the string s as if it were a literal pattern.

ATM, there are several `ERROR` logs from media-api on the label search end-point. These are caused by searching for `%5B` (`[`), which is a reserved regex character. We currently pass this directly to elastic, which interprets it as an invalid regex - that is, elastic performs a regex search for `[.*`, which is invalid.

Why are people searching for `[`? Typos would be my guess.