### PR TITLE
Hides suggestion list when an option has been picked with enter key

### DIFF
--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -101,7 +101,7 @@ datalist.directive('grDatalistInput',
                 if (func && parentCtrl.active) {
                     event.preventDefault();
                     scope.$apply(func);
-                } else {
+                } else if (keys[event.which] !== 'enter') {
                     searchAndActivate();
                 }
             });


### PR DESCRIPTION
Makes pressing enter key consistent with clicking on a result using the mouse. 

This was a problem when the input generated more than one suggestion result e.g. various case combinations appear for the same input ('the guardian' and 'The Guardian') or the input was a substring ('sun' and 'sunday').

Now
![labels15](https://cloud.githubusercontent.com/assets/8484757/9962304/e426c6ae-5e1c-11e5-8a54-e45c1cf0b7bb.gif)

Before
![labels13](https://cloud.githubusercontent.com/assets/8484757/9962374/5e59f590-5e1d-11e5-92bc-68e80b0f59bf.gif)