### PR TITLE
Add a few category mappings of picdar rights

### DIFF
--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/cleanup/UsageRightsOverride.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/cleanup/UsageRightsOverride.scala
@@ -65,10 +65,14 @@ object UsageRightsOverride {
          "PA Archive/Press Association Ima" | "Press Association Images"
                                     => agency("PA")
     case "AFP" | "AFP/Getty Images" => agency("Getty Images", Some("AFP"))
+    case "Allsport"                 => agency("Getty Images", Some("Allsport"))
     case "FilmMagic"                => agency("Getty Images", Some("FilmMagic"))
     case "BFI"                      => agency("Getty Images", Some("BFI"))
     case "WireImage"                => agency("Getty Images", Some("WireImage"))
     case "Hulton Getty"             => agency("Getty Images", Some("Hulton"))
+    case "Allstar"                  => agency("Allstar Picture Library")
+    case "Sportsphoto Ltd." | "Sportsphoto Ltd./Allstar"
+                                    => agency("Allstar Picture Library", Some("Sportsphoto Ltd."))
     // TODO: Allsport (only in 2000?)? ANSA?
     case _                          => None
   }


### PR DESCRIPTION
As provided by Jo.

There are a few others (Keystone, ANSA) but it's less clearcut and low numbers so going to leave them out.