### PR TITLE
extending creative commons model

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -149,4 +149,8 @@ object MetadataConfig {
   val contractPhotographersMap = PhotographersList.creditBylineMap(staffPhotographers)
   val allPhotographersMap = PhotographersList.creditBylineMap(allPhotographers)
 
+  val creativeCommonsLicense = List(
+    "CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0"
+  )
+
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -79,7 +79,8 @@ object Mappings {
     "publication" -> nonAnalyzedString,
     "creator" -> nonAnalyzedString,
     "licence" -> nonAnalyzedString,
-    "source" -> nonAnalyzedString
+    "source" -> nonAnalyzedString,
+    "contentLink" -> nonAnalyzedString
   )
 
   val exportsMapping =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -77,7 +77,9 @@ object Mappings {
     "suppliersCollection" -> nonAnalyzedString,
     "photographer" -> standardAnalysedString,
     "publication" -> nonAnalyzedString,
-    "creator" -> nonAnalyzedString
+    "creator" -> nonAnalyzedString,
+    "licence" -> nonAnalyzedString,
+    "source" -> nonAnalyzedString
   )
 
   val exportsMapping =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -383,7 +383,8 @@ object CommissionedIllustrator {
  )(i => (i.category, i.creator, i.restrictions))
 }
 
-case class CreativeCommons(licence: String, source: String, creator: String, restrictions: Option[String] = None)
+case class CreativeCommons(licence: String, source: String, creator: String, contentLink: String,
+                           restrictions: Option[String] = None)
   extends UsageRights {
     val category = "creative-commons"
     val defaultCost = Some(Free)
@@ -401,6 +402,7 @@ object CreativeCommons {
    (__ \ "licence").write[String] ~
    (__ \ "source").write[String] ~
    (__ \ "creator").write[String] ~
+   (__ \ "contentLink").write[String] ~
    (__ \ "restrictions").writeNullable[String]
- )(i => (i.category, i.licence, i.source, i.creator, i.restrictions))
+ )(i => (i.category, i.licence, i.source, i.creator, i.contentLink, i.restrictions))
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -383,7 +383,7 @@ object CommissionedIllustrator {
  )(i => (i.category, i.creator, i.restrictions))
 }
 
-case class CreativeCommons(restrictions: Option[String] = None)
+case class CreativeCommons(licence: String, source: String, creator: String, restrictions: Option[String] = None)
   extends UsageRights {
     val category = "creative-commons"
     val defaultCost = Some(Free)
@@ -396,5 +396,11 @@ case class CreativeCommons(restrictions: Option[String] = None)
   }
 object CreativeCommons {
  implicit val jsonReads: Reads[CreativeCommons] = Json.reads[CreativeCommons]
- implicit val jsonWrites: Writes[CreativeCommons] = UsageRights.defaultWrites
+ implicit val jsonWrites: Writes[CreativeCommons] = (
+   (__ \ "category").write[String] ~
+   (__ \ "licence").write[String] ~
+   (__ \ "source").write[String] ~
+   (__ \ "creator").write[String] ~
+   (__ \ "restrictions").writeNullable[String]
+ )(i => (i.category, i.licence, i.source, i.creator, i.restrictions))
 }

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -43,7 +43,7 @@ object EditsApi extends Controller with ArgoHelpers {
         NoRights, Handout(), PrImage(), Screengrab(), SocialMedia(),
         Agency("?"), CommissionedAgency("?"), Chargeable(),
         StaffPhotographer("?", "?"), ContractPhotographer("?"), CommissionedPhotographer("?"),
-        CreativeCommons("?", "?", "?"), GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
+        CreativeCommons("?", "?", "?", "?"), GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
         ContractIllustrator("?"), CommissionedIllustrator("?")
       ).map(CategoryResponse.fromUsageRights)
 

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -43,7 +43,7 @@ object EditsApi extends Controller with ArgoHelpers {
         NoRights, Handout(), PrImage(), Screengrab(), SocialMedia(),
         Agency("?"), CommissionedAgency("?"), Chargeable(),
         StaffPhotographer("?", "?"), ContractPhotographer("?"), CommissionedPhotographer("?"),
-        CreativeCommons(), GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
+        CreativeCommons("?", "?", "?"), GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
         ContractIllustrator("?"), CommissionedIllustrator("?")
       ).map(CategoryResponse.fromUsageRights)
 

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -92,7 +92,8 @@ object UsageRightsProperty {
     case _:CreativeCommons => List(
       UsageRightsProperty("licence", "Licence", "string", true, Some(creativeCommonsLicense)),
       UsageRightsProperty("source", "Source", "string", true),
-      UsageRightsProperty("creator", "Owner", "string", true)
+      UsageRightsProperty("creator", "Owner", "string", true),
+      UsageRightsProperty("contentLink", "Link to content", "string", true)
     )
 
     case _ => List()

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -23,7 +23,7 @@ object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import MetadataConfig.{externalPhotographersMap, contractIllustrators}
+  import MetadataConfig.{externalPhotographersMap, contractIllustrators, creativeCommonsLicense}
   import UsageRightsConfig.freeSuppliers
 
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
@@ -31,7 +31,7 @@ object UsageRightsProperty {
   def sortList(l: List[String]) = l.sortWith(_.toLowerCase < _.toLowerCase)
 
   val props: List[(UsageRights) => List[UsageRightsProperty]] =
-    List(agencyProperties, photographerProperties, illustrationProperties, restrictionProperties)
+    List(agencyProperties, creativeCommonsProperties, photographerProperties, illustrationProperties, restrictionProperties)
 
   def getPropertiesForCat(u: UsageRights): List[UsageRightsProperty] = props.flatMap(f => f(u))
 
@@ -85,6 +85,16 @@ object UsageRightsProperty {
       UsageRightsProperty("creator", "Illustrator", "string", true, Some(sortList(contractIllustrators))))
     case _:CommissionedIllustrator => List(
       UsageRightsProperty("creator", "Illustrator", "string", true))
+    case _ => List()
+  }
+
+  private def creativeCommonsProperties(u: UsageRights) = u match {
+    case _:CreativeCommons => List(
+      UsageRightsProperty("licence", "Licence", "string", true, Some(creativeCommonsLicense)),
+      UsageRightsProperty("source", "Source", "string", true),
+      UsageRightsProperty("creator", "Owner", "string", true)
+    )
+
     case _ => List()
   }
 }


### PR DESCRIPTION
The current model of creative commons is not extensive enough - this adds:
* `licence`
* `source`
* `creator`
* `contentLink`

And Maps to:
* `credit => licence / source`
* `creator => byline`
* `contentLink => creditLink`

- [ ] Get actual list from RH for licenses (I've included the current commercial licences)
- [ ] Do mappings to metadata