### PR TITLE
sleep for a second before scrolling.

### DIFF
--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -91,6 +91,8 @@ object Reindex extends EsScript {
           }
         }
 
+        Thread.sleep(1000)
+
         reindexScroll(query.execute.actionGet)
 
         // TODO: deleteIndex when we are confident


### PR DESCRIPTION
should hopefully reduce the impact a reindex has on overall performance.