### PR TITLE
make reindex log more verbose by displaying percentage completion.

### DIFF
--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -72,11 +72,15 @@ object Reindex extends EsScript {
         def reindexScroll(scroll: SearchResponse, done: Long = 0) {
           val total = scroll.getHits.totalHits
           val doing = done + scrollSize
+
+          // roughly accurate as we're using done, which is relative to scrollSize, rather than the actual number of docs in the new index
+          val percentage = (done.toFloat / total) * 100
+
           val hits = scroll.getHits.hits
 
-          if (hits.length > 0) {
+          if (hits.nonEmpty) {
             // TODO: Abstract out logging
-            System.out.println(s"Reindexing $doing of $total")
+            System.out.println(s"Reindexing $doing of $total ($percentage%)")
 
             val bulk = client.prepareBulk
 


### PR DESCRIPTION
Alternate (but less precise) version of https://github.com/guardian/grid/pull/1297. However, this PR means one less script to run when running a re-index.