### PR TITLE
Caret bug fix

### DIFF
--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -95,7 +95,7 @@ datalist.directive('grDatalistInput',
                     scope.$apply(parentCtrl.setValueFromSelectedIndex);
                 }
                 //to prevent the caret moving to the start/end of the input box
-                if (keys[event.which] === 'up' || keys[event.which] === 'down') {
+                if (parentCtrl.active && ( keys[event.which] === 'up' || keys[event.which] === 'down' ) ) {
                     event.preventDefault();
                 }
             });

--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -95,7 +95,8 @@ datalist.directive('grDatalistInput',
                     scope.$apply(parentCtrl.setValueFromSelectedIndex);
                 }
                 //to prevent the caret moving to the start/end of the input box
-                if (parentCtrl.active && ( keys[event.which] === 'up' || keys[event.which] === 'down' ) ) {
+                if (parentCtrl.active &&
+                    ( keys[event.which] === 'up' || keys[event.which] === 'down' ) ) {
                     event.preventDefault();
                 }
             });

--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -94,6 +94,10 @@ datalist.directive('grDatalistInput',
                     event.preventDefault();
                     scope.$apply(parentCtrl.setValueFromSelectedIndex);
                 }
+                //to prevent the caret moving to the start/end of the input box
+                if (keys[event.which] === 'up' || keys[event.which] === 'down') {
+                    event.preventDefault();
+                }
             });
 
             input.on('keyup', event => {


### PR DESCRIPTION
Caret no longer jumping to the start/end of the input text when scrolling through suggestion list using nav keys. 

Default behaviour: down-arrow keydown moves the caret to the end of input text; up-arrow keydown moves the caret to the start of input text. This default behaviour is prevented when suggestion list is active.   

Now
![labels21](https://cloud.githubusercontent.com/assets/8484757/10076717/c5eb5ac6-62d4-11e5-8d14-a6a9f1ea3fea.gif)


Before
![labels20](https://cloud.githubusercontent.com/assets/8484757/10076498/c57cbbc6-62d3-11e5-86e4-eeba65d06e2a.gif)