### PR TITLE
hey thrall, use this alias!

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -85,7 +85,7 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
     // this is because the delete query does not respond with anything useful
     // TODO: is there a more efficient way to do this?
     client
-      .prepareCount()
+      .prepareCount(imagesAlias)
       .setQuery(q)
       .executeAndLog(s"Searching for image to delete: $id")
       .flatMap { countQuery =>


### PR DESCRIPTION
Tell thrall what alias to use when performing the "does the image appear exactly once in elastic" check.

This fixes the problem of no images being deleted when there is more than one open index in the elastic cluster.

I've tested this locally by running two indexes and observing the logs saying `Could not delete image 0fb78b5efdbf034261c3ceea226ef3c2f229dfdf` before the change and succeeding when the alias is set.


NB - https://github.com/taskrabbit/elasticsearch-dump is an excellent tool to clone indexes!!