### PR TITLE
order by uploadTime rather than uploadedBy.

### DIFF
--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -67,7 +67,7 @@ object Reindex extends EsScript {
           .setScroll(scrollTime)
           .setQuery(matchAllQuery)
           .setSize(scrollSize)
-          .addSort("uploadedBy", SortOrder.ASC)
+          .addSort("uploadTime", SortOrder.ASC)
 
         def reindexScroll(scroll: SearchResponse, done: Long = 0) {
           val total = scroll.getHits.totalHits


### PR DESCRIPTION
This is a change to the query used during a reindex - ordering by `uploadTime` means we process images chronologically.