### PR TITLE
scripts to semi-automate starting all services in dev.

### DIFF
--- a/dev/00-run-elastic-search.sh
+++ b/dev/00-run-elastic-search.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../elasticsearch
+source dev-start.sh

--- a/dev/01-run-media-api.sh
+++ b/dev/01-run-media-api.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../
+sbt -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9011 "project media-api" "run 9001"

--- a/dev/02-run-thrall.sh
+++ b/dev/02-run-thrall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../
+sbt -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9012 "project thrall" "run 9002"

--- a/dev/03-run-image-loader.sh
+++ b/dev/03-run-image-loader.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../
+sbt -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9013 "project image-loader" "run 9003"

--- a/dev/05-run-kahuna.sh
+++ b/dev/05-run-kahuna.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../
+sbt -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9015 "project kahuna" "run 9005"

--- a/dev/06-run-cropper.sh
+++ b/dev/06-run-cropper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../
+sbt -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9016 "project cropper" "run 9006"

--- a/dev/07-run-metadata-editor.sh
+++ b/dev/07-run-metadata-editor.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../
+sbt -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9017 "project metadata-editor" "run 9007"

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,12 @@
+# Developing on the Grid
+
+This directory contains a shell script to launch each service individually, for example `./00-run-elastic-search.sh` will start your elasticsearch cluster.
+
+## Interactive Debugging
+The scripts that run sbt will also add debug flags to the jvm so that you can interactively debug using [IntelliJ](https://www.jetbrains.com/idea/help/run-debug-configuration-remote.html).
+Their debug ports are correspond to their application port +10. For example, `media-api` runs on port `9001` and its debug port is set to `9011`.
+
+To start interactively debugging, [add a remote debug configuration to Intellij](https://www.jetbrains.com/idea/help/run-debug-configuration-remote.html) (one per service) and set their ports accordingly.
+
+## iTerm2
+Using iTerm2? Why not [setup a profile](http://chris-schmitz.com/develop-faster-with-iterm-profiles-and-window-arrangements/) for each script, then save it as a window arangement.


### PR DESCRIPTION
Set of scripts to launch each service with debug ports attached for interactive debugging in IntelliJ.

I've been using these scripts locally and they work fairly well. After sharing them with @tsop14 I thought I'd check them in.

I hadn't been using iTerm profiles before (I was running them one by one), but I've just set them up (plus window arrangements) and starting a dev environment is a lot simpler now - launch iTerm, `CMD + Shift + R` and away you go. :smile: 

Could definitely do the same in tmux, but I'm still a novice when it comes to that...