### PR TITLE
use elastic's count search type

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -150,7 +150,6 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
       .map{ response =>
         val buckets = response.getAggregations.getAsMap.get(name).asInstanceOf[InternalTerms].getBuckets
         val results = buckets.toList map (s => BucketResult(s.getKey, s.getDocCount))
-        println(response)
 
         AggregateSearchResults(results, buckets.size)
       }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -3,14 +3,14 @@ package lib.elasticsearch
 import java.util.regex.Pattern
 
 import org.elasticsearch.index.query.{FilterBuilder, FilteredQueryBuilder}
-import org.elasticsearch.search.aggregations.bucket.terms.{InternalTerms, StringTerms}
+import org.elasticsearch.search.aggregations.bucket.terms.InternalTerms
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConversions._
 
 import play.api.libs.json._
 import org.elasticsearch.action.get.GetRequestBuilder
-import org.elasticsearch.action.search.SearchRequestBuilder
+import org.elasticsearch.action.search.{SearchType, SearchRequestBuilder}
 import org.elasticsearch.search.aggregations.AggregationBuilders
 import org.elasticsearch.search.suggest.completion.{CompletionSuggestion, CompletionSuggestionBuilder}
 
@@ -144,13 +144,13 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
     val search = prepareImagesSearch.addAggregation(aggregate)
 
     search
-      .setFrom(0)
-      .setSize(0)
+      .setSearchType(SearchType.COUNT)
       .executeAndLog("metadata aggregate search")
       .toMetric(searchQueries, List(searchTypeDimension("aggregate")))(_.getTookInMillis)
       .map{ response =>
         val buckets = response.getAggregations.getAsMap.get(name).asInstanceOf[InternalTerms].getBuckets
         val results = buckets.toList map (s => BucketResult(s.getKey, s.getDocCount))
+        println(response)
 
         AggregateSearchResults(results, buckets.size)
       }


### PR DESCRIPTION
[As suggested by the ES docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html#_returning_only_aggregation_results).

I'd like to monitor performance on this, if it's bad, it's an easy rollback.