### PR TITLE
centre crop thumbnail.

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -33,21 +33,17 @@
             <dl>
                 <dt class="image-info__heading">Original <span class="image-info__file-size"> {{ctrl.image.data.source.size | asFileSize}}</span></dt>
                     <dd class="image-info__heading--crops">
-                        <ul class="image-crops">
-                            <li class="image-crop"
-                                ng:class="{'image-crop--selected': !ctrl.crop}">
-                                <a draggable="true"
-                                    ui:sref="{ crop: null }">
-                                    <img class="image-crop__image" ng:src="{{ ctrl.image.data.thumbnail | assetFile }}" />
-                                    <div class="image-crop__aspect-ratio"
-                                        ng:class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
-                                        <ul>
-                                            <li>{{ctrl.image.data.source.dimensions.width}} &times; {{ctrl.image.data.source.dimensions.height}}</li>
-                                        </ul>
-                                    </div>
-                                </a>
-                            </li>
-                        </ul>
+                        <div class="image-crop"
+                             ng:class="{'image-crop--selected': !ctrl.crop}">
+                            <a draggable="true"
+                                ui:sref="{ crop: null }">
+                                <img class="image-crop__image" ng:src="{{ ctrl.image.data.thumbnail | assetFile }}" />
+                                <div class="image-crop__aspect-ratio"
+                                    ng:class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
+                                    {{ctrl.image.data.source.dimensions.width}} &times; {{ctrl.image.data.source.dimensions.height}}
+                                </div>
+                            </a>
+                        </div>
                     </dd>
                 </dt>
             </dl>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1607,6 +1607,7 @@ FIXME: what to do with touch devices
     display: block;
     max-width: 100%;
     max-height: 64px;
+    margin: 0 auto;
 }
 
 .image-crop__aspect-ratio {


### PR DESCRIPTION
Also removing a `ul` with a single `li` to keep the DOM (slightly) lighter.

before
![screen shot 2015-09-29 at 16 54 24](https://cloud.githubusercontent.com/assets/836140/10169774/905f3888-66ca-11e5-9199-1cf66a2b688b.png)

after
![screen shot 2015-09-29 at 16 54 03](https://cloud.githubusercontent.com/assets/836140/10169779/94cd4f5e-66ca-11e5-9662-370ed9f67da5.png)
