### PR TITLE
a few bits of styling on the results tolbar

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -15,31 +15,31 @@
         <div class="results-toolbar"
             ng:class="{'results-toolbar--selection-mode': ctrl.metadataPanelAvailable}">
 
-	        <div class="results-toolbar-item image-results-count results-toolbar-item--static results-toolbar-item--left results-toolbar-item--split">
-                <div class="results-count">
-                    {{ctrl.totalResults | toLocaleString}} matches
-                    <button ng:show="ctrl.newImagesCount > 0"
-                            ng:click="ctrl.revealNewImages()"
-                            class="image-results-count__new">
-                        {{ctrl.newImagesCount | toLocaleString}} new
-                    </button>
-                </div>
-
-                <div class="results__related-labels related-labels flex-container text-small"
-                     ng:if="ctrl.relatedLabels.length !== 0">
-                    <div class="related-labels__title">Related to {{ctrl.parentLabel}}:</div>
-                    <ul class="flex-container">
-                        <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
-                            <button ng:click="ctrl.toggleLabelToSearch(relatedLabel)"
-                                    ng:class="{ 'related-labels__label-text--selected': relatedLabel.selected }"
-                                    class="related-labels__label-text">{{relatedLabel.name}}</button>
-
-                        </li>
-                    </ul>
-                </div>
+            <div class="results-toolbar-item results-toolbar-item--static results-toolbar-item--left
+                        image-results-count">
+                {{ctrl.totalResults | toLocaleString}} matches
+                <button ng:show="ctrl.newImagesCount > 0"
+                        ng:click="ctrl.revealNewImages()"
+                        class="image-results-count__new">
+                    {{ctrl.newImagesCount | toLocaleString}} new
+                </button>
             </div>
 
-            <div class="action-bar" ng:if="ctrl.inSelectionMode">
+            <div class="results-toolbar-item results-toolbar-item--static results-toolbar-item--left
+                        results__related-labels related-labels flex-container text-small"
+                 ng:if="ctrl.relatedLabels.length !== 0">
+                <div class="related-labels__title">Related to {{ctrl.parentLabel}}:</div>
+                <ul class="flex-container related-labels__labels">
+                    <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
+                        <button ng:click="ctrl.toggleLabelToSearch(relatedLabel)"
+                                ng:class="{ 'related-labels__label-text--selected': relatedLabel.selected }"
+                                class="related-labels__label-text">{{relatedLabel.name}}</button>
+
+                    </li>
+                </ul>
+            </div>
+
+            <div class="results-toolbar__right flex-container" ng:if="ctrl.inSelectionMode">
                 <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static">
                     {{ctrl.selectionCount}} selected
                 </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -904,10 +904,6 @@ input.search-query__input {
     padding: 0 10px;
 }
 
-.results-toolbar-item--split {
-    margin-right: auto;
-}
-
 .results-toolbar-item--left {
     border-left: 0;
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -879,13 +879,20 @@ input.search-query__input {
     position: fixed;
     z-index: 2;
 }
+
+.results-toolbar__right {
+    margin-left: auto;
+    line-height: 35px;
+}
+
 .results-toolbar-item {
     vertical-align: middle;
-    border-width: 0px 1px;
+    border-width: 0 1px;
     border-color: #565656;
     border-style: solid;
     position: relative;
     height: 35px;
+    white-space: nowrap;
 }
 
 .results-toolbar-item:hover {
@@ -903,7 +910,6 @@ input.search-query__input {
 
 .results-toolbar-item--left {
     border-left: 0;
-    padding-left: 0;
 }
 
 .results-toolbar-item--right {
@@ -942,15 +948,19 @@ input.search-query__input {
     height: 36px;
 }
 
-/* TODO: remove this once eveything is in the action-bar */
-.results-count {
-    float: left;
-    padding: 0 10px;
+.related-labels {
+    line-height: 35px;
+    overflow: auto;
+}
+
+.related-labels__labels {
+    overflow: auto;
 }
 
 .related-labels__label {
     margin-left: 2px;
 }
+
 .related-labels__label-text {
     padding: 2px 5px 4px;
     box-sizing: border-box;
@@ -971,7 +981,7 @@ input.search-query__input {
 }
 
 .image-results-count {
-    border: 0;
+    border-left: 0;
     line-height: 35px;
 }
 
@@ -1998,25 +2008,6 @@ ui-archiver .archiver:hover {
     display: none;
 }
 
-
-/* ==========================================================================
-   Forms
-   ========================================================================== */
-.action-bar {
-    line-height: 35px;
-    display: flex;
-}
-
-.action-bar__item {
-    line-height: inherit;
-    padding: 0 10px;
-    display: block;
-    border-left: 1px solid #565656;
-}
-
-.action-bar__item--last {
-    border-right: 1px solid #565656;
-}
 
 
 /* ==========================================================================


### PR DESCRIPTION
* Got rid of some superfluous css
* used the generic CSS
* Made related labels not break

[Easy to read PR](https://github.com/guardian/grid/pull/1319/files?w=1)

# All bust up
![results-toolbar-boken](https://cloud.githubusercontent.com/assets/31692/10246433/22cd6646-6909-11e5-814b-a9e23fb8cbdf.gif)

# Wow!
![results-toolbar-fix](https://cloud.githubusercontent.com/assets/31692/10246434/22ce6474-6909-11e5-89a3-14c5a0688dbb.gif)
