### PR TITLE
Allow deleting of images without an export.

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -148,9 +148,9 @@ object MediaApi extends Controller with ArgoHelpers {
       case Some(source) =>
         val image = source.as[Image]
 
-        val isPersisted = ImageResponse.imagePersistenceReasons(image).nonEmpty
+        val hasExports = ImageResponse.imagePersistenceReasons(image).contains("exports")
 
-        if (isPersisted) {
+        if (hasExports) {
           Future.successful(ImageCannotBeDeleted)
         } else {
           canUserDeleteImage(request, source) map { canDelete =>

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -96,9 +96,7 @@ object ImageResponse extends EditsResponse {
 
     val links = imageLinks(id, secureUrl, withWritePermission, valid)
 
-    val noExports = persistenceReasons.isEmpty || !persistenceReasons.contains("exports")
-
-    val isDeletable = noExports && withDeletePermission
+    val isDeletable = !persistenceReasons.contains("exports") && withDeletePermission
 
     val actions = imageActions(id, isDeletable, withWritePermission)
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -96,7 +96,12 @@ object ImageResponse extends EditsResponse {
 
     val links = imageLinks(id, secureUrl, withWritePermission, valid)
 
-    val actions = imageActions(id, isPersisted, withWritePermission, withDeletePermission)
+    val isDeletableOnPersistence = persistenceReasons.isEmpty ||
+      persistenceReasons.length == 1 && persistenceReasons.contains("photographer-category")
+
+    val isDeletable = isDeletableOnPersistence && withDeletePermission
+
+    val actions = imageActions(id, isDeletable, withWritePermission)
 
     (data, links, actions)
   }
@@ -116,18 +121,16 @@ object ImageResponse extends EditsResponse {
     if (valid) (cropLink :: baseLinks) else baseLinks
   }
 
-  def imageActions(id: String, isPersisted: Boolean, withWritePermission: Boolean,
-                   withDeletePermission: Boolean) = {
+  def imageActions(id: String, isDeletable: Boolean, withWritePermission: Boolean) = {
 
     val imageUri = URI.create(s"${Config.rootUri}/images/$id")
     val reindexUri = URI.create(s"${Config.rootUri}/images/$id/reindex")
-    val canDelete = ! isPersisted && withDeletePermission
 
     val deleteAction = Action("delete", imageUri, "DELETE")
     val reindexAction = Action("reindex", reindexUri, "POST")
 
     List(
-      deleteAction       -> canDelete,
+      deleteAction       -> isDeletable,
       reindexAction      -> withWritePermission
     )
     .filter{ case (action, active) => active }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -96,10 +96,9 @@ object ImageResponse extends EditsResponse {
 
     val links = imageLinks(id, secureUrl, withWritePermission, valid)
 
-    val isDeletableOnPersistence = persistenceReasons.isEmpty ||
-      persistenceReasons.length == 1 && persistenceReasons.contains("photographer-category")
+    val noExports = persistenceReasons.isEmpty || !persistenceReasons.contains("exports")
 
-    val isDeletable = isDeletableOnPersistence && withDeletePermission
+    val isDeletable = noExports && withDeletePermission
 
     val actions = imageActions(id, isDeletable, withWritePermission)
 

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -10,7 +10,7 @@ import org.elasticsearch.action.update.{UpdateRequestBuilder, UpdateResponse}
 import org.elasticsearch.action.updatebyquery.UpdateByQueryResponse
 import org.elasticsearch.client.UpdateByQueryClientWrapper
 import org.elasticsearch.index.engine.VersionConflictEngineException
-import org.elasticsearch.index.query.FilterBuilders.{andFilter, boolFilter, missingFilter, termFilter}
+import org.elasticsearch.index.query.FilterBuilders.{andFilter, missingFilter}
 import org.elasticsearch.index.query.QueryBuilders.{boolQuery, filteredQuery, matchAllQuery, matchQuery}
 import org.elasticsearch.script.ScriptService
 import org.joda.time.DateTime
@@ -66,11 +66,7 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
 
     val q = filteredQuery(
       boolQuery.must(matchQuery("_id", id)),
-      andFilter(
-        missingOrEmptyFilter("exports"),
-        missingOrEmptyFilter(identifierField(Config.persistenceIdentifier)),
-        boolFilter.mustNot(termFilter(editsField("archived"), true))
-      )
+      andFilter(missingOrEmptyFilter("exports"))
     )
 
     val deleteQuery = client

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -2,7 +2,6 @@ package lib
 
 import _root_.play.api.libs.json._
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, ImageFields}
-import com.gu.mediaservice.model.{CommissionedPhotographer, ContractPhotographer, StaffPhotographer}
 import com.gu.mediaservice.syntax._
 import groovy.json.JsonSlurper
 import lib.ThrallMetrics._
@@ -70,10 +69,7 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
       andFilter(
         missingOrEmptyFilter("exports"),
         missingOrEmptyFilter(identifierField(Config.persistenceIdentifier)),
-        boolFilter.mustNot(termFilter(editsField("archived"), true)),
-        boolFilter.mustNot(termFilter(usageRightsField("category"), StaffPhotographer.category)),
-        boolFilter.mustNot(termFilter(usageRightsField("category"), ContractPhotographer.category)),
-        boolFilter.mustNot(termFilter(usageRightsField("category"), CommissionedPhotographer.category))
+        boolFilter.mustNot(termFilter(editsField("archived"), true))
       )
     )
 


### PR DESCRIPTION
These changes will allow any image that doesn't have an export to be manually deleted via a DELETE request to the media-api.

This change adds the DELETE action to an image response in the media-api iff there are no exports.

Reaper is not affected as `persisted=false` will still [omit `archived`, `staff-photographer` and `picdarUrn` images](https://github.com/guardian/grid/blob/aa-api-allow-delete-from-photographer/media-api/app/lib/elasticsearch/SearchFilters.scala#L100-L107).