### PR TITLE
Composite

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -80,7 +80,8 @@ object Mappings {
     "creator" -> nonAnalyzedString,
     "licence" -> nonAnalyzedString,
     "source" -> nonAnalyzedString,
-    "contentLink" -> nonAnalyzedString
+    "contentLink" -> nonAnalyzedString,
+    "suppliers" -> standardAnalysedString
   )
 
   val exportsMapping =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -452,7 +452,7 @@ object CreativeCommons {
 
 case class Composite(suppliers: String, restrictions: Option[String] = None)
   extends UsageRights {
-  val category = CreativeCommons.category
+  val category = Composite.category
   val defaultCost = Some(Free)
   val name = "Composite"
   val description =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -48,6 +48,7 @@ object UsageRights {
     case o: ContractIllustrator      => ContractIllustrator.jsonWrites.writes(o)
     case o: CommissionedIllustrator  => CommissionedIllustrator.jsonWrites.writes(o)
     case o: CreativeCommons          => CreativeCommons.jsonWrites.writes(o)
+    case o: Composite                => Composite.jsonWrites.writes(o)
     case o: NoRights.type            => NoRights.jsonWrites.writes(o)
   }
 
@@ -78,6 +79,7 @@ object UsageRights {
         case ContractIllustrator.category       => json.asOpt[ContractIllustrator]
         case CommissionedIllustrator.category   => json.asOpt[CommissionedIllustrator]
         case CreativeCommons.category           => json.asOpt[CreativeCommons]
+        case Composite.category                 => json.asOpt[Composite]
         case _                                  => None
       })
         .orElse(supplier.flatMap(_ => json.asOpt[Agency]))
@@ -380,6 +382,7 @@ object CrownCopyright {
   implicit val jsonWrites: Writes[CrownCopyright] = UsageRights.defaultWrites
 }
 
+
 case class ContractIllustrator(creator: String, restrictions: Option[String] = None)
   extends UsageRights {
   val category = ContractIllustrator.category
@@ -399,6 +402,7 @@ object ContractIllustrator {
     )(i => (i.category, i.creator, i.restrictions))
 }
 
+
 case class CommissionedIllustrator(creator: String, restrictions: Option[String] = None)
   extends UsageRights {
   val category = CommissionedIllustrator.category
@@ -417,6 +421,7 @@ object CommissionedIllustrator {
       (__ \ "restrictions").writeNullable[String]
     )(i => (i.category, i.creator, i.restrictions))
 }
+
 
 case class CreativeCommons(licence: String, source: String, creator: String, contentLink: String,
                            restrictions: Option[String] = None)
@@ -442,4 +447,28 @@ object CreativeCommons {
       (__ \ "contentLink").write[String] ~
       (__ \ "restrictions").writeNullable[String]
     )(i => (i.category, i.licence, i.source, i.creator, i.contentLink, i.restrictions))
+}
+
+
+case class Composite(suppliers: String, restrictions: Option[String] = None)
+  extends UsageRights {
+  val category = CreativeCommons.category
+  val defaultCost = Some(Free)
+  val name = "Composite"
+  val description =
+    "An image created from multiple images within our usage rights."
+
+  override val caution = Some("All images should be free to use, or restrictions applied")
+}
+
+object Composite {
+  val category = "composite"
+  val name = "Composite"
+
+  implicit val jsonReads: Reads[Composite] = Json.reads[Composite]
+  implicit val jsonWrites: Writes[Composite] = (
+    (__ \ "category").write[String] ~
+      (__ \ "suppliers").write[String] ~
+      (__ \ "restrictions").writeNullable[String]
+    )(i => (i.category, i.suppliers, i.restrictions))
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -456,7 +456,7 @@ case class Composite(suppliers: String, restrictions: Option[String] = None)
   val defaultCost = Some(Free)
   val name = "Composite"
   val description =
-    "An image created from multiple images within our usage rights."
+    "Any restricted images within the composite must be identified."
 
   override val caution = Some("All images should be free to use, or restrictions applied")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -463,8 +463,6 @@ case class Composite(suppliers: String, restrictions: Option[String] = None)
 
 object Composite {
   val category = "composite"
-  val name = "Composite"
-
   implicit val jsonReads: Reads[Composite] = Json.reads[Composite]
   implicit val jsonWrites: Writes[Composite] = (
     (__ \ "category").write[String] ~

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -81,6 +81,7 @@
                             class="form-input-text"
                             type="text"
                             name="{{ property.name }}"
+                            placeholder="e.g. {{ property.examples }}"
                             ng:if="!property.options && !property.optionsMap"
                             ng:model="ctrl.model[property.name]"
                             ng:required="property.required" />
@@ -93,10 +94,11 @@
                                          ng:repeat="o in options">
 
                                         <input type="radio"
-                                            ng:value="o.value"
                                             id="id-{{::$id}}-{{o.key}}-{{property.name}}-radio-list__item"
                                             class="radio-list__circle"
                                             name="{{property.name}}-radio-list"
+                                            placeholder="e.g. {{ property.examples }}"
+                                            ng:value="o.value"
                                             ng:required="property.required"
                                             ng:model="ctrl.model[property.name]" />
                                         <label
@@ -136,6 +138,7 @@
 
                             <input type="text"
                                 class="full-width"
+                                placeholder="e.g. {{ property.examples }}"
                                 ng:model="ctrl.model[property.name]"
                                 ng:required="property.required"
                                 ng:if="otherValue" />
@@ -150,6 +153,7 @@
                     <textarea
                         class="form-input-text"
                         name="{{ property.name }}"
+                        placeholder="e.g. {{ property.examples }}"
                         ng:model="ctrl.model[property.name]"
                         ng:switch-when="text"
                         ng:required="property.required">

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -44,7 +44,7 @@ object EditsApi extends Controller with ArgoHelpers {
         Agency("?"), CommissionedAgency("?"), Chargeable(),
         StaffPhotographer("?", "?"), ContractPhotographer("?"), CommissionedPhotographer("?"),
         CreativeCommons("?", "?", "?", "?"), GuardianWitness(), Pool(), CrownCopyright(), Obituary(),
-        ContractIllustrator("?"), CommissionedIllustrator("?")
+        ContractIllustrator("?"), CommissionedIllustrator("?"), Composite("?")
       ).map(CategoryResponse.fromUsageRights)
 
     respond(usageRightsData)

--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -11,7 +11,7 @@ object UsageRightsMetadataMapper {
       case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: ContractIllustrator      => ImageMetadata(credit = Some(u.creator))
       case u: CommissionedIllustrator  => ImageMetadata(credit = Some(u.creator))
-      case u: Composite                => ImageMetadata(byline = Some(u..suppliers), credit = Some(u.suppliers))
+      case u: Composite                => ImageMetadata(byline = Some(u.suppliers), credit = Some(u.suppliers))
     }
 
     // if we don't match, return None

--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -11,6 +11,7 @@ object UsageRightsMetadataMapper {
       case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: ContractIllustrator      => ImageMetadata(credit = Some(u.creator))
       case u: CommissionedIllustrator  => ImageMetadata(credit = Some(u.creator))
+      case u: Composite                => ImageMetadata(byline = Some(u..suppliers), credit = Some(u.suppliers))
     }
 
     // if we don't match, return None

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -15,7 +15,8 @@ case class UsageRightsProperty(
   required: Boolean,
   options: Option[List[String]] = None,
   optionsMap: Option[Map[String, List[String]]] = None,
-  optionsMapKey: Option[String] = None
+  optionsMapKey: Option[String] = None,
+  examples: Option[String] = None
 )
 
 
@@ -31,7 +32,8 @@ object UsageRightsProperty {
   def sortList(l: List[String]) = l.sortWith(_.toLowerCase < _.toLowerCase)
 
   val props: List[(UsageRights) => List[UsageRightsProperty]] =
-    List(agencyProperties, creativeCommonsProperties, photographerProperties, illustrationProperties, restrictionProperties)
+    List(agencyProperties, creativeCommonsProperties, photographerProperties,
+         illustrationProperties, compositeProperties, restrictionProperties)
 
   def getPropertiesForCat(u: UsageRights): List[UsageRightsProperty] = props.flatMap(f => f(u))
 
@@ -96,6 +98,11 @@ object UsageRightsProperty {
       UsageRightsProperty("contentLink", "Link to content", "string", true)
     )
 
+    case _ => List()
+  }
+
+  private def compositeProperties(u: UsageRights) = u match {
+    case _:Composite => List(UsageRightsProperty("suppliers", "Suppliers", "string", true, examples = Some("REX/Getty Images/Corbis, Corbis/Reuters")))
     case _ => List()
   }
 }


### PR DESCRIPTION
We need something for composites so we can retire the old cost model.
This will hopefully leave us in a situation where we can just split the string later. It would be great to have references to the images used too, but that's going to need quite a lot of off platform integration, perhaps with the mighty skills of @blishen.

* Added composite
* Added examples to placeholder
* Small code tidy

- [x] Get approval & wording from Robert H and Jo B

![composite](https://cloud.githubusercontent.com/assets/31692/10305930/447553fc-6c1b-11e5-81a2-145ca6bd1630.png)
