### PR TITLE
add watch to metadata to update

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -164,7 +164,6 @@ image.controller('ImageCtrl', [
             ctrl.image = updatedImage;
             ctrl.usageRights = imageService(ctrl.image).usageRights;
             ctrl.metadata = updatedImage.data.metadata;
-            console.log(ctrl.metadata)
             ctrl.setUsageCategory(ctrl.usageCategories, ctrl.usageRights.data.category);
         });
 

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -163,6 +163,8 @@ image.controller('ImageCtrl', [
         const freeUpdateListener = $rootScope.$on('image-updated', (e, updatedImage) => {
             ctrl.image = updatedImage;
             ctrl.usageRights = imageService(ctrl.image).usageRights;
+            ctrl.metadata = updatedImage.data.metadata;
+            console.log(ctrl.metadata)
             ctrl.setUsageCategory(ctrl.usageCategories, ctrl.usageRights.data.category);
         });
 

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -50,10 +50,8 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     // As we make a copy of this, we need to watch it
     // in case the metadata changes from above.
-    $scope.$watch(() => ctrl.originalMetadata, metadata => {
-        console.log(metadata)
-        ctrl.metadata = metadataFromOriginal(metadata)
-    });
+    $scope.$watch(() => ctrl.originalMetadata, metadata =>
+        ctrl.metadata = metadataFromOriginal(metadata));
 
     // TODO: Find a way to broadcast more selectively
     const batchApplyMetadataEvent = 'events:batch-apply:metadata';

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -14,15 +14,12 @@ export var jobs = angular.module('kahuna.upload.jobs.requiredMetadataEditor', [
 
 jobs.controller('RequiredMetadataEditorCtrl',
                 ['$rootScope', '$scope', '$window', 'mediaApi', 'editsService',
-                 'onValChange',
-                 function($rootScope, $scope, $window, mediaApi, editsService,
-                          onValChange) {
+                 function($rootScope, $scope, $window, mediaApi, editsService) {
 
     var ctrl = this;
 
     ctrl.saving = false;
     ctrl.disabled = () => Boolean(ctrl.saving || ctrl.externallyDisabled);
-    ctrl.metadata = metadataFromOriginal(ctrl.originalMetadata);
     ctrl.saveOnTime = 750; // ms
     ctrl.copyrightWasInitiallyThere = !!ctrl.metadata.copyright;
 
@@ -53,9 +50,10 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     // As we make a copy of this, we need to watch it
     // in case the metadata changes from above.
-    $scope.$watch(() => ctrl.originalMetadata, onValChange(metadata => {
-        ctrl.metadata = metadataFromOriginal(metadata);
-    }));
+    $scope.$watch(() => ctrl.originalMetadata, metadata => {
+        console.log(metadata)
+        ctrl.metadata = metadataFromOriginal(metadata)
+    });
 
     // TODO: Find a way to broadcast more selectively
     const batchApplyMetadataEvent = 'events:batch-apply:metadata';

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -14,7 +14,9 @@ export var jobs = angular.module('kahuna.upload.jobs.requiredMetadataEditor', [
 
 jobs.controller('RequiredMetadataEditorCtrl',
                 ['$rootScope', '$scope', '$window', 'mediaApi', 'editsService',
-                 function($rootScope, $scope, $window, mediaApi, editsService) {
+                 'onValChange',
+                 function($rootScope, $scope, $window, mediaApi, editsService,
+                          onValChange) {
 
     var ctrl = this;
 
@@ -44,11 +46,16 @@ jobs.controller('RequiredMetadataEditorCtrl',
     };
 
     ctrl.metadataSearch = (field, q) => {
-
         return mediaApi.metadataSearch(field,  { q }).then(resource => {
             return resource.data.map(d => d.key);
         });
     };
+
+    // As we make a copy of this, we need to watch it
+    // in case the metadata changes from above.
+    $scope.$watch(() => ctrl.originalMetadata, onValChange(metadata => {
+        ctrl.metadata = metadataFromOriginal(metadata);
+    }));
 
     // TODO: Find a way to broadcast more selectively
     const batchApplyMetadataEvent = 'events:batch-apply:metadata';


### PR DESCRIPTION
On the image and uploads page, the metadata isn't updating when changed from the `usage-rights-editor`'s `setMetadataFromUsageRights`.

It's updated in the [`image-editor`](https://github.com/guardian/grid/blob/master/kahuna/public/js/edits/image-editor.js#L71), but, as we [make a copy in the `required-metadata-editor`](https://github.com/guardian/grid/blob/master/kahuna/public/js/upload/jobs/required-metadata-editor.js#L23), it's not "listened" to.