### PR TITLE
`q` in related labels

### DIFF
--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -81,7 +81,7 @@ class ImageLoader extends Controller with ArgoHelpers {
     val DigestedFile(tempFile_, id_) = digestedFile
 
     // only allow AuthenticatedService to set with query string
-    val uploadedBy_ = (user, uploadedBy) match {
+    val uploadawedBy_ = (user, uploadedBy) match {
       case (user: AuthenticatedService, Some(by)) => by
       case (user: PandaUser, _) => user.email
       case (user, _) => user.name

--- a/image-loader/app/controllers/Application.scala
+++ b/image-loader/app/controllers/Application.scala
@@ -81,7 +81,7 @@ class ImageLoader extends Controller with ArgoHelpers {
     val DigestedFile(tempFile_, id_) = digestedFile
 
     // only allow AuthenticatedService to set with query string
-    val uploadawedBy_ = (user, uploadedBy) match {
+    val uploadedBy_ = (user, uploadedBy) match {
       case (user: AuthenticatedService, Some(by)) => by
       case (user: PandaUser, _) => user.email
       case (user, _) => user.name

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -18,15 +18,11 @@ searchQueryService.factory('searchQueryService', ['observe$', function(observe$)
     }
 
     function addLabel(label) {
-        query$.onNext(state => {
-            return `${state.trim()} #${label}`;
-        });
+        query$.onNext(q => hasLabel(q, label) ? q : `${q} #${label}`);
     }
 
     function removeLabel(label) {
-        query$.onNext(state => {
-            return state.replace(`#${label}`, '').trim();
-        });
+        query$.onNext(q => q.replace(`#${label}`, ''));
     }
 
     function set(q) {

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -6,8 +6,8 @@ export const searchQueryService = angular.module('gr.searchQuery.service', ['uti
 
 searchQueryService.factory('searchQueryService', [function() {
     // TODO: When we update rx, we need to swap the seed / acc around
-    const q$ = (query$, startWith) => query$.
-        scan(startWith || '', (state, fn) => fn(state).trim()).
+    const q$ = (query$, startWith = '') => query$.
+        scan(startWith, (state, fn) => fn(state).trim()).
         distinctUntilChanged().
         shareReplay(1);
 

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -1,0 +1,37 @@
+import angular from 'angular';
+import Rx from 'rx';
+import '../util/rx';
+
+export const searchQueryService = angular.module('gr.searchQuery.service', ['util.rx']);
+
+searchQueryService.factory('searchQueryService', ['observe$', function(observe$) {
+    const query$ = new Rx.Subject();
+
+    // TODO: When we update rx, we need to swap the seed / acc around
+
+    const q$ = query$.scan('', (state, fn) => fn(state).trim());
+
+    function hasLabel(q, label) {
+        // TODO: It'd be nice to build this up from an API
+        const r = new RegExp(`[#|label\:]${label}\\b`);
+        return r.test(q);
+    }
+
+    function addLabel(label) {
+        query$.onNext(state => {
+            return `${state.trim()} #${label}`;
+        });
+    }
+
+    function removeLabel(label) {
+        query$.onNext(state => {
+            return state.replace(`#${label}`, '').trim();
+        });
+    }
+
+    function set(q) {
+        query$.onNext(() => q || '');
+    }
+
+    return { addLabel, removeLabel, set, q$ };
+}]);

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -4,7 +4,7 @@ import '../util/rx';
 
 export const searchQueryService = angular.module('gr.searchQuery.service', ['util.rx']);
 
-searchQueryService.factory('searchQueryService', ['observe$', function(observe$) {
+searchQueryService.factory('searchQueryService', [function() {
     const query$ = new Rx.Subject();
 
     // TODO: When we update rx, we need to swap the seed / acc around
@@ -28,5 +28,5 @@ searchQueryService.factory('searchQueryService', ['observe$', function(observe$)
         query$.onNext(() => q || '');
     }
 
-    return { addLabel, removeLabel, set, q$ };
+    return { q$, addLabel, removeLabel, 'set': set };
 }]);

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -12,7 +12,7 @@ searchQueryService.factory('searchQueryService', [function() {
 
     function hasLabel(q, label) {
         // TODO: It'd be nice to build this up from an API
-        const r = new RegExp(`[#|label\:]${label}\\b`);
+        const r = new RegExp(`(#|label\:)${label}\\b`);
         return r.test(q);
     }
 

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -8,7 +8,6 @@ searchQueryService.factory('searchQueryService', ['observe$', function(observe$)
     const query$ = new Rx.Subject();
 
     // TODO: When we update rx, we need to swap the seed / acc around
-
     const q$ = query$.scan('', (state, fn) => fn(state).trim());
 
     function hasLabel(q, label) {

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -6,10 +6,14 @@ export const searchQueryService = angular.module('gr.searchQuery.service', ['uti
 
 searchQueryService.factory('searchQueryService', [function() {
     // TODO: When we update rx, we need to swap the seed / acc around
-    const q$ = (query$, startWith = '') => query$.
-        scan(startWith, (state, fn) => fn(state).trim()).
-        distinctUntilChanged().
-        shareReplay(1);
+    // FIXME: We use startWith and set the start value as we want to emit
+    // the first value, but strangely that doesn't get saved into the state
+    const q$ = (query$, startWith = '') =>
+        query$.
+            scan(startWith, (state, fn) => fn(state).trim()).
+            distinctUntilChanged().
+            shareReplay(1).
+            startWith(startWith);
 
     // TODO: It'd be nice to build this up from an API
     const hasSpace    = s     => /\s/g.test(s);

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -13,18 +13,21 @@ searchQueryService.factory('searchQueryService', [function() {
         distinctUntilChanged().
         shareReplay(1);
 
+    // TODO: It'd be nice to build this up from an API
+    const hasSpace    = s     => /\s/g.test(s);
+    const labelMatch  = label => new RegExp(`(label:|#)("|')?${label}(("|')|\\b)`, 'g');
+    const createLabel = label => hasSpace(label) ? `#"${label}"` : `#${label}`;
+
     function hasLabel(q, label) {
-        // TODO: It'd be nice to build this up from an API
-        const r = new RegExp(`(#|label\:)${label}\\b`);
-        return r.test(q);
+        return labelMatch(label).test(q);
     }
 
     function addLabel(label) {
-        query$.onNext(q => hasLabel(q, label) ? q : `${q} #${label}`);
+        query$.onNext(q => hasLabel(q, label) ? q : `${q} ${createLabel(label)}`);
     }
 
     function removeLabel(label) {
-        query$.onNext(q => q.replace(`#${label}`, ''));
+        query$.onNext(q => q.replace(labelMatch(label), ''));
     }
 
     function set(q) {

--- a/kahuna/public/js/search-query/service.js
+++ b/kahuna/public/js/search-query/service.js
@@ -8,7 +8,10 @@ searchQueryService.factory('searchQueryService', [function() {
     const query$ = new Rx.Subject();
 
     // TODO: When we update rx, we need to swap the seed / acc around
-    const q$ = query$.scan('', (state, fn) => fn(state).trim());
+    const q$ = query$.
+        scan('', (state, fn) => fn(state).trim()).
+        distinctUntilChanged().
+        shareReplay(1);
 
     function hasLabel(q, label) {
         // TODO: It'd be nice to build this up from an API

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -54,7 +54,7 @@ search.config(['$stateProvider',
             }]
         },
         resolve: {
-            searchQueryService: ['$stateParams', 'searchQueryService', function($stateParams, searchQueryService) {
+            searchQuery: ['$stateParams', 'searchQueryService', function($stateParams, searchQueryService) {
                 return searchQueryService($stateParams.query);
             }]
         }

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -10,10 +10,12 @@ import '../lib/data-structure/list-factory';
 import '../lib/data-structure/ordered-set-factory';
 import '../components/gr-top-bar/gr-top-bar';
 import '../components/gr-panel/gr-panel';
+import '../search-query/service';
 
+import searchQueryTemplate   from './query.html!text';
 import searchTemplate        from './view.html!text';
 import searchResultsTemplate from './results.html!text';
-import panelTemplate        from '../components/gr-panel/gr-panel.html!text';
+import panelTemplate         from '../components/gr-panel/gr-panel.html!text';
 
 
 export var search = angular.module('kahuna.search', [
@@ -23,6 +25,7 @@ export var search = angular.module('kahuna.search', [
     'kahuna.preview.image',
     'data-structure.list-factory',
     'data-structure.ordered-set-factory',
+    'gr.searchQuery.service',
     'gr.topBar',
     'grPanel'
 ]);
@@ -36,7 +39,9 @@ search.config(['$stateProvider',
     $stateProvider.state('search', {
         // FIXME [1]: This state should be abstract, but then we can't navigate to
         // it, which we need to do to access it's deeper / remembered chile state
-        url: '/',
+        // FIXME: We now share the `query` param between the `query` and results view.
+        // I'm not sure if this is exactly what we want.
+        url: '/?query',
         template: searchTemplate,
         deepStateRedirect: {
             // Inject a transient $stateParams for the results state
@@ -47,11 +52,16 @@ search.config(['$stateProvider',
                 });
                 return {state: $dsr$.redirect.state, params};
             }]
+        },
+        resolve: {
+            searchQueryService: ['$stateParams', 'searchQueryService', function($stateParams, searchQueryService) {
+                return searchQueryService($stateParams.query);
+            }]
         }
     });
 
     $stateProvider.state('search.results', {
-        url: 'search?query&ids&since&nonFree&uploadedBy&until&orderBy',
+        url: 'search?ids&since&nonFree&uploadedBy&until&orderBy',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has
@@ -104,6 +114,11 @@ search.config(['$stateProvider',
             }]
         },
         views: {
+            query: {
+                template: searchQueryTemplate,
+                controller: 'SearchQueryCtrl',
+                controllerAs: 'searchQuery'
+            },
             results: {
                 template: searchResultsTemplate,
                 controller: 'SearchResultsCtrl',

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -7,6 +7,7 @@
                autofocus="autofocus"
                ng:model="searchQuery.filter.query"
                ng:model-options="{ debounce: 400 }"
+               ng:change="searchQuery.changeQuery()"
                grid:focus-on="search:focus-query"
         />
         <button class="search-query__icon search-query__clear clear-button"

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -72,10 +72,11 @@ query.controller('SearchQueryCtrl',
 
     // FIXME: This is here to stop circular injection of the model.
     // Avoiding: queryChange => set() => emit() => queryChange()
-    searchQueryService.q$.subscribe(q => {
-        if (q !== ctrl.filter.query) {
-            ctrl.filter.query = q;
-        }
+    searchQueryService.q$.filter(q =>
+        q !== ctrl.filter.query
+    ).subscribe(q => {
+        ctrl.filter.query = q;
+        console.log(q);
     });
     searchQueryService.set(ctrl.filter.query);
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -25,8 +25,10 @@ export var query = angular.module('kahuna.search.query', [
 ]);
 
 query.controller('SearchQueryCtrl',
-                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track', 'searchQueryService', 'observe$',
-                 function($scope, $state, $stateParams, onValChange , mediaApi, track, searchQueryService, observe$) {
+                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track',
+                  'searchQueryService',
+                 function($scope, $state, $stateParams, onValChange , mediaApi, track,
+                          searchQueryService) {
 
     var ctrl = this;
 
@@ -74,10 +76,7 @@ query.controller('SearchQueryCtrl',
     // Avoiding: queryChange => set() => emit() => queryChange()
     searchQueryService.q$.filter(q =>
         q !== ctrl.filter.query
-    ).subscribe(q => {
-        ctrl.filter.query = q;
-        console.log(q);
-    });
+    ).subscribe(q => ctrl.filter.query = q);
     searchQueryService.set(ctrl.filter.query);
 
     // pass undefined to the state on empty to remove the QueryString

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -76,6 +76,7 @@ query.controller('SearchQueryCtrl',
 
     function setAndWatchParam(key) {
         // query is handled by Rx
+        // we also don't track changes to `query` as it would trigger on every keypress
         if (key !== 'query') {
             ctrl.filter[key] = $stateParams[key];
 
@@ -84,10 +85,7 @@ query.controller('SearchQueryCtrl',
                 // FIXME: + they triggers filter $watch and $state.go (breaks history)
                 ctrl.filter[key] = valOrUndefined(newVal);
 
-                // don't track changes to `query` as it would trigger on every keypress
-                if (key !== 'query') {
-                    track.success('Query change', { field: key, value: newVal });
-                }
+                track.success('Query change', { field: key, value: newVal });
             }));
         }
     }

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -75,18 +75,21 @@ query.controller('SearchQueryCtrl',
     function valOrUndefined(str) { return str || undefined; }
 
     function setAndWatchParam(key) {
-        ctrl.filter[key] = $stateParams[key];
+        // query is handled by Rx
+        if (key !== 'query') {
+            ctrl.filter[key] = $stateParams[key];
 
-        $scope.$watch(() => $stateParams[key], onValChange(newVal => {
-            // FIXME: broken for 'your uploads'
-            // FIXME: + they triggers filter $watch and $state.go (breaks history)
-            ctrl.filter[key] = valOrUndefined(newVal);
+            $scope.$watch(() => $stateParams[key], onValChange(newVal => {
+                // FIXME: broken for 'your uploads'
+                // FIXME: + they triggers filter $watch and $state.go (breaks history)
+                ctrl.filter[key] = valOrUndefined(newVal);
 
-            // don't track changes to `query` as it would trigger on every keypress
-            if (key !== 'query') {
-                track.success('Query change', { field: key, value: newVal });
-            }
-        }));
+                // don't track changes to `query` as it would trigger on every keypress
+                if (key !== 'query') {
+                    track.success('Query change', { field: key, value: newVal });
+                }
+            }));
+        }
     }
 
     $scope.$watchCollection(() => ctrl.filter, onValChange(filter => {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -11,7 +11,6 @@ import template from './query.html!text';
 
 import '../analytics/track';
 
-import '../search-query/service';
 import '../util/rx';
 
 export var query = angular.module('kahuna.search.query', [
@@ -20,15 +19,14 @@ export var query = angular.module('kahuna.search.query', [
     'util.eq',
     'gu-dateRange',
     'analytics.track',
-    'gr.searchQuery.service',
     'util.rx'
 ]);
 
 query.controller('SearchQueryCtrl',
-                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track',
-                  'searchQueryService', 'inject$',
-                 function($scope, $state, $stateParams, onValChange , mediaApi, track,
-                          searchQueryService, inject$) {
+                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track', 'inject$',
+                  'searchQueryService',
+                 function($scope, $state, $stateParams, onValChange , mediaApi, track, inject$,
+                          searchQueryService) {
 
     var ctrl = this;
 
@@ -69,14 +67,10 @@ query.controller('SearchQueryCtrl',
     Object.keys($stateParams)
           .forEach(setAndWatchParam);
 
-    ctrl.changeQuery = () =>
-        searchQueryService.set(ctrl.filter.query);
-
     // FIXME: This is here to stop circular injection of the model.
     // Avoiding: queryChange => set() => emit() => queryChange()
     const changedQuery$ = searchQueryService.q$.filter(q => q !== ctrl.filter.query);
     inject$($scope, changedQuery$, ctrl.filter, 'query');
-    searchQueryService.set(ctrl.filter.query);
 
     // pass undefined to the state on empty to remove the QueryString
     function valOrUndefined(str) { return str || undefined; }
@@ -112,14 +106,6 @@ query.controller('SearchQueryCtrl',
         ctrl.filter.query = '';
         $scope.$broadcast('search:focus-query');
     }
-}]);
-
-query.directive('searchQuery', [function() {
-    return {
-        restrict: 'E',
-        controller: 'SearchQueryCtrl as searchQuery',
-        template: template
-    };
 }]);
 
 query.directive('gridFocusOn', function() {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -11,17 +11,22 @@ import template from './query.html!text';
 
 import '../analytics/track';
 
+import '../search-query/service';
+import '../util/rx';
+
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
     // 'ngAnimate',
     'util.eq',
     'gu-dateRange',
-    'analytics.track'
+    'analytics.track',
+    'gr.searchQuery.service',
+    'util.rx'
 ]);
 
 query.controller('SearchQueryCtrl',
-                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track',
-                 function($scope, $state, $stateParams, onValChange , mediaApi, track) {
+                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track', 'searchQueryService', 'observe$',
+                 function($scope, $state, $stateParams, onValChange , mediaApi, track, searchQueryService, observe$) {
 
     var ctrl = this;
 
@@ -61,6 +66,18 @@ query.controller('SearchQueryCtrl',
 
     Object.keys($stateParams)
           .forEach(setAndWatchParam);
+
+    ctrl.changeQuery = () =>
+        searchQueryService.set(ctrl.filter.query);
+
+    // FIXME: This is here to stop circular injection of the model.
+    // Avoiding: queryChange => set() => emit() => queryChange()
+    searchQueryService.q$.subscribe(q => {
+        if (q !== ctrl.filter.query) {
+            ctrl.filter.query = q;
+        }
+    });
+    searchQueryService.set(ctrl.filter.query);
 
     // pass undefined to the state on empty to remove the QueryString
     function valOrUndefined(str) { return str || undefined; }

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -24,9 +24,9 @@ export var query = angular.module('kahuna.search.query', [
 
 query.controller('SearchQueryCtrl',
                  ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track', 'inject$',
-                  'searchQueryService',
+                  'searchQuery',
                  function($scope, $state, $stateParams, onValChange , mediaApi, track, inject$,
-                          searchQueryService) {
+                          searchQuery) {
 
     var ctrl = this;
 
@@ -69,8 +69,7 @@ query.controller('SearchQueryCtrl',
 
     // FIXME: This is here to stop circular injection of the model.
     // Avoiding: queryChange => set() => emit() => queryChange()
-    const changedQuery$ = searchQueryService.q$.filter(q => q !== ctrl.filter.query);
-    inject$($scope, changedQuery$, ctrl.filter, 'query');
+    inject$($scope, searchQuery.q$, ctrl.filter, 'query');
 
     // pass undefined to the state on empty to remove the QueryString
     function valOrUndefined(str) { return str || undefined; }

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -26,9 +26,9 @@ export var query = angular.module('kahuna.search.query', [
 
 query.controller('SearchQueryCtrl',
                  ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track',
-                  'searchQueryService',
+                  'searchQueryService', 'inject$',
                  function($scope, $state, $stateParams, onValChange , mediaApi, track,
-                          searchQueryService) {
+                          searchQueryService, inject$) {
 
     var ctrl = this;
 
@@ -74,9 +74,8 @@ query.controller('SearchQueryCtrl',
 
     // FIXME: This is here to stop circular injection of the model.
     // Avoiding: queryChange => set() => emit() => queryChange()
-    searchQueryService.q$.filter(q =>
-        q !== ctrl.filter.query
-    ).subscribe(q => ctrl.filter.query = q);
+    const changedQuery$ = searchQueryService.q$.filter(q => q !== ctrl.filter.query);
+    inject$($scope, changedQuery$, ctrl.filter, 'query');
     searchQueryService.set(ctrl.filter.query);
 
     // pass undefined to the state on empty to remove the QueryString

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -29,7 +29,7 @@
                         results__related-labels related-labels flex-container text-small"
                         ng:class="{'related-labels--with-labels': ctrl.relatedLabels.length !== 0}">
                 <div class="related-labels__title">
-                    Related to:
+                    Related to
                     <span ng:switch="ctrl.relatedLabels.length === 0">
                         <form class="inline-block" ng:switch-when="true" ng:submit="ctrl.setParentLabel()">
                             <gr-datalist
@@ -44,7 +44,7 @@
                                        gr:datalist-input />
                             </gr-datalist>
                         </form>
-                        <span ng:switch-default>{{ctrl.parentLabel}}</span>
+                        <span ng:switch-default>{{ctrl.parentLabel}}</span>:
                     </span>
                 </div>
                 <ul class="flex-container related-labels__labels">

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -9,7 +9,6 @@ import '../util/seq';
 import '../components/gu-lazy-table/gu-lazy-table';
 import '../downloader/downloader';
 import '../components/gr-delete-image/gr-delete-image';
-import '../search-query/service';
 
 export var results = angular.module('kahuna.search.results', [
     'kahuna.services.scroll-position',
@@ -19,8 +18,7 @@ export var results = angular.module('kahuna.search.results', [
     'util.seq',
     'gu.lazyTable',
     'gr.downloader',
-    'gr.deleteImage',
-    'gr.searchQuery.service'
+    'gr.deleteImage'
 ]);
 
 

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -55,7 +55,7 @@ results.controller('SearchResultsCtrl', [
     'panelService',
     'range',
     'isReloadingPreviousSearch',
-    'searchQueryService',
+    'searchQuery',
     function($rootScope,
              $scope,
              $state,
@@ -75,7 +75,7 @@ results.controller('SearchResultsCtrl', [
              panelService,
              range,
              isReloadingPreviousSearch,
-             searchQueryService) {
+             searchQuery) {
 
         const ctrl = this;
 
@@ -198,15 +198,15 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.toggleLabelToSearch = label => {
             if (label.selected) {
-                searchQueryService.removeLabel(label.name);
+                searchQuery.removeLabel(label.name);
             } else {
-                searchQueryService.addLabel(label.name);
+                searchQuery.addLabel(label.name);
             }
         };
 
         ctrl.setParentLabel = () => {
             if (ctrl.parentLabel) {
-                searchQueryService.addLabel(ctrl.parentLabel);
+                searchQuery.addLabel(ctrl.parentLabel);
             }
         };
         ctrl.suggestedLabelSearch = q =>

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -208,9 +208,7 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.setParentLabel = () => {
             if (ctrl.parentLabel) {
-                $state.transitionTo($state.current, { query: `#${ctrl.parentLabel}` }, {
-                    reload: true, inherit: false, notify: true
-                });
+                searchQueryService.addLabel(ctrl.parentLabel);
             }
         };
         ctrl.suggestedLabelSearch = q =>

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -9,6 +9,7 @@ import '../util/seq';
 import '../components/gu-lazy-table/gu-lazy-table';
 import '../downloader/downloader';
 import '../components/gr-delete-image/gr-delete-image';
+import '../search-query/service';
 
 export var results = angular.module('kahuna.search.results', [
     'kahuna.services.scroll-position',
@@ -18,7 +19,8 @@ export var results = angular.module('kahuna.search.results', [
     'util.seq',
     'gu.lazyTable',
     'gr.downloader',
-    'gr.deleteImage'
+    'gr.deleteImage',
+    'gr.searchQuery.service'
 ]);
 
 
@@ -55,6 +57,7 @@ results.controller('SearchResultsCtrl', [
     'panelService',
     'range',
     'isReloadingPreviousSearch',
+    'searchQueryService',
     function($rootScope,
              $scope,
              $state,
@@ -73,7 +76,8 @@ results.controller('SearchResultsCtrl', [
              results,
              panelService,
              range,
-             isReloadingPreviousSearch) {
+             isReloadingPreviousSearch,
+             searchQueryService) {
 
         const ctrl = this;
 
@@ -195,14 +199,11 @@ results.controller('SearchResultsCtrl', [
         inject$($scope, parentLabel$, ctrl, 'parentLabel');
 
         ctrl.toggleLabelToSearch = label => {
-            // TODO: Move this to a searchQueryService
-            const oldQ = $stateParams.query.trim();
-            const query = (label.selected ? oldQ.replace(`#${label.name}`, '')
-                          : `${oldQ} #${label.name}`).trim();
-            const newStateParams = angular.extend({}, $stateParams, { query });
-            $state.transitionTo($state.current, newStateParams, {
-                reload: true, inherit: false, notify: true
-            });
+            if (label.selected) {
+                searchQueryService.removeLabel(label.name);
+            } else {
+                searchQueryService.addLabel(label.name);
+            }
         };
 
         ctrl.setParentLabel = () => {

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -1,7 +1,7 @@
 <!-- TODO: rename this file and split it into it's components -->
 <gr-top-bar fixed="true">
     <gr-top-bar-nav>
-        <search-query></search-query>
+        <ui-view name="query"></ui-view>
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -300,7 +300,7 @@ object MediaApi extends Controller with ArgoHelpers {
     }
 
     mainLabel.map { label =>
-      val uriTemplate = URITemplate(s"$rootUri/suggest/edits/labels/$label/related{?selectedLabels,q}")
+      val uriTemplate = URITemplate(s"$rootUri/suggest/edits/labels/$label/sibling-labels{?selectedLabels,q}")
       val paramMap = Map(
         "selectedLabels" -> Some(selectedLabels.mkString(",")).filter(_.trim.nonEmpty),
         "q" -> searchParams.query

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -240,7 +240,7 @@ object MediaApi extends Controller with ArgoHelpers {
       prevLink = getPrevLink(searchParams)
       nextLink = getNextLink(searchParams, totalCount)
       relatedLabelsLink = getRelatedLabelsLink(searchParams)
-      links = suggestedLabelsLink :: relatedLabelsLink :: List(prevLink, nextLink).flatten
+      links = suggestedLabelsLink :: List(prevLink, nextLink, relatedLabelsLink).flatten
     } yield respondCollection(imageEntities, Some(searchParams.offset), Some(totalCount), links)
   }
 
@@ -299,16 +299,16 @@ object MediaApi extends Controller with ArgoHelpers {
       case label :: extraLabels => (Some(label), extraLabels)
     }
 
-    val uriTemplate = URITemplate(s"$rootUri/suggest/edits/labels/related{?mainLabel,selectedLabels,q}")
-    val paramMap = Map(
-      "mainLabel" -> mainLabel,
-      "selectedLabels" -> Some(selectedLabels.mkString(",")).filter(_.trim.nonEmpty),
-      "q" -> searchParams.query
-    )
-    val paramVars = paramMap.map { case (key, value) => key := value }.toSeq
-    val uri = uriTemplate expand (paramVars: _*)
-
-    Link("related-labels", uri)
+    mainLabel.map { label =>
+      val uriTemplate = URITemplate(s"$rootUri/suggest/edits/labels/$label/related{?selectedLabels,q}")
+      val paramMap = Map(
+        "selectedLabels" -> Some(selectedLabels.mkString(",")).filter(_.trim.nonEmpty),
+        "q" -> searchParams.query
+      )
+      val paramVars = paramMap.map { case (key, value) => key := value }.toSeq
+      val uri = uriTemplate expand (paramVars: _*)
+      Link("related-labels", uri)
+    }
   }
 
   def suggestMetadataCredit(q: Option[String], size: Option[Int]) = Authenticated.async { request =>

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -286,7 +286,7 @@ object MediaApi extends Controller with ArgoHelpers {
 
   private def getRelatedLabelsLink(searchParams: SearchParams) = {
     // We search if we have a label in the search, take the first one and then look up it's
-    // siblings s that we can return them as "related labels"
+    // siblings so that we can return them as "related labels"
     val labels = searchParams.structuredQuery.flatMap {
       // TODO: Use ImageFields for guard
       case Match(field: SingleField, value:Words) if field.name == "userMetadata.labels" => Some(value.string)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -290,6 +290,7 @@ object MediaApi extends Controller with ArgoHelpers {
     val labels = searchParams.structuredQuery.flatMap {
       // TODO: Use ImageFields for guard
       case Match(field: SingleField, value:Words) if field.name == "userMetadata.labels" => Some(value.string)
+      case Match(field: SingleField, value:Phrase) if field.name == "userMetadata.labels" => Some(value.string)
       case _ => None
     }
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -19,7 +19,7 @@ GET     /images                                       controllers.MediaApi.image
 
 # completion
 GET     /suggest/metadata/credit                      controllers.MediaApi.suggestMetadataCredit(q: Option[String], size: Option[Int])
-GET     /suggest/edits/labels/:label/sibling-labels   controllers.MediaApi.suggestLabelSiblings(label: String, selectedLabels: Option[String])
+GET     /suggest/edits/labels/related                 controllers.MediaApi.suggestLabelSiblings(mainLabel: String, q: Option[String], selectedLabels: Option[String])
 GET     /suggest/edits/labels                         controllers.MediaApi.suggestLabels(q: Option[String])
 
 # Management

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -19,7 +19,7 @@ GET     /images                                       controllers.MediaApi.image
 
 # completion
 GET     /suggest/metadata/credit                      controllers.MediaApi.suggestMetadataCredit(q: Option[String], size: Option[Int])
-GET     /suggest/edits/labels/related                 controllers.MediaApi.suggestLabelSiblings(mainLabel: String, q: Option[String], selectedLabels: Option[String])
+GET     /suggest/edits/labels/:mainLabel/related      controllers.MediaApi.suggestLabelSiblings(mainLabel: String, q: Option[String], selectedLabels: Option[String])
 GET     /suggest/edits/labels                         controllers.MediaApi.suggestLabels(q: Option[String])
 
 # Management

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -10,25 +10,25 @@ GET     /images/metadata/:field                       controllers.MediaApi.metad
 GET     /images/edits/:field                          controllers.MediaApi.editsSearch(field: String, q: Option[String])
 
 # Images
-GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
-GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
-POST    /images/:id/reindex                           controllers.MediaApi.reindexImage(id: String)
-DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
+GET     /images/:id                                      controllers.MediaApi.getImage(id: String)
+GET     /images/:id/fileMetadata                         controllers.MediaApi.getImageFileMetadata(id: String)
+POST    /images/:id/reindex                              controllers.MediaApi.reindexImage(id: String)
+DELETE  /images/:id                                      controllers.MediaApi.deleteImage(id: String)
 
-GET     /images                                       controllers.MediaApi.imageSearch
+GET     /images                                          controllers.MediaApi.imageSearch
 
 # completion
-GET     /suggest/metadata/credit                      controllers.MediaApi.suggestMetadataCredit(q: Option[String], size: Option[Int])
-GET     /suggest/edits/labels/:mainLabel/related      controllers.MediaApi.suggestLabelSiblings(mainLabel: String, q: Option[String], selectedLabels: Option[String])
-GET     /suggest/edits/labels                         controllers.MediaApi.suggestLabels(q: Option[String])
+GET     /suggest/metadata/credit                         controllers.MediaApi.suggestMetadataCredit(q: Option[String], size: Option[Int])
+GET     /suggest/edits/labels/:mainLabel/sibling-labels  controllers.MediaApi.suggestLabelSiblings(mainLabel: String, q: Option[String], selectedLabels: Option[String])
+GET     /suggest/edits/labels                            controllers.MediaApi.suggestLabels(q: Option[String])
 
 # Management
-GET     /management/healthcheck                       controllers.HealthCheck.healthCheck
-GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                          controllers.HealthCheck.healthCheck
+GET     /management/manifest                             com.gu.mediaservice.lib.management.Management.manifest
 
 # Enable CORS
-OPTIONS /                                             controllers.CorsPreflight.options(ignoredUrl = "")
-OPTIONS /*ignoredUrl                                  controllers.CorsPreflight.options(ignoredUrl)
+OPTIONS /                                                controllers.CorsPreflight.options(ignoredUrl = "")
+OPTIONS /*ignoredUrl                                     controllers.CorsPreflight.options(ignoredUrl)
 
 # Shoo robots away
-GET     /robots.txt                                   controllers.Robots.disallowAll
+GET     /robots.txt                                      controllers.Robots.disallowAll


### PR DESCRIPTION
* retain previous search when adding a mainLabel
* take `q` into consideration when searching for related labels (previously we were returning labels that wouldn't have any results as we weren't including q)

![related-labels-filter](https://cloud.githubusercontent.com/assets/31692/10428663/f6781124-70ea-11e5-9476-43e98f003c4c.gif)
