### PR TITLE
Label styling and recognising labels-with-spaces

### DIFF
--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -20,7 +20,7 @@ queryFilters.filter('queryLabelFilter', function() {
     return (value) => {
         let cleanValue = stripQuotes(value);
         if (containsSpace(cleanValue)) {
-            return `label:"${cleanValue}"`;
+            return `#"${cleanValue}"`;
         } else {
             return `#${cleanValue}`;
         }

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -29,7 +29,7 @@
                         results__related-labels related-labels flex-container text-small"
                         ng:class="{'related-labels--with-labels': ctrl.relatedLabels.length !== 0}">
                 <div class="related-labels__title">
-                    Related to:
+                    Related to
                     <span ng:switch="ctrl.relatedLabels.length === 0">
                         <form class="inline-block" ng:switch-when="true" ng:submit="ctrl.setParentLabel()">
                             <gr-datalist
@@ -44,7 +44,7 @@
                                        gr:datalist-input />
                             </gr-datalist>
                         </form>
-                        <span ng:switch-default>{{ctrl.parentLabel}}</span>
+                        <span ng:switch-default>{{ctrl.parentLabel}}:</span>
                     </span>
                 </div>
                 <ul class="flex-container related-labels__labels">

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -55,6 +55,7 @@ results.controller('SearchResultsCtrl', [
     'panelService',
     'range',
     'isReloadingPreviousSearch',
+    'queryLabelFilterFilter',
     function($rootScope,
              $scope,
              $state,
@@ -73,7 +74,8 @@ results.controller('SearchResultsCtrl', [
              results,
              panelService,
              range,
-             isReloadingPreviousSearch) {
+             isReloadingPreviousSearch,
+             queryLabelFilterFilter) {
 
         const ctrl = this;
 
@@ -197,8 +199,9 @@ results.controller('SearchResultsCtrl', [
         ctrl.toggleLabelToSearch = label => {
             // TODO: Move this to a searchQueryService
             const oldQ = $stateParams.query.trim();
-            const query = (label.selected ? oldQ.replace(`#${label.name}`, '')
-                          : `${oldQ} #${label.name}`).trim();
+            const searchableLabel = queryLabelFilterFilter(label.name);
+            const query = (label.selected ? oldQ.replace(`${searchableLabel}`, '')
+                          : `${oldQ} ${searchableLabel}`).trim();
             const newStateParams = angular.extend({}, $stateParams, { query });
             $state.transitionTo($state.current, newStateParams, {
                 reload: true, inherit: false, notify: true
@@ -207,7 +210,8 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.setParentLabel = () => {
             if (ctrl.parentLabel) {
-                $state.transitionTo($state.current, { query: `#${ctrl.parentLabel}` }, {
+                const parentLabel = queryLabelFilterFilter(ctrl.parentLabel);
+                $state.transitionTo($state.current, { query: `${parentLabel}` }, {
                     reload: true, inherit: false, notify: true
                 });
             }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -957,7 +957,7 @@ input.search-query__input {
 .related-labels--with-labels {
     /* This is to allow scrolling of labels, but show the
     autocomplete dropdown */
-    overflow: auto;
+    overflow-x: auto;
 }
 
 .related-labels__datalist {
@@ -974,7 +974,8 @@ input.related-labels__parent {
 }
 
 .related-labels__labels {
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .related-labels__label {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -239,6 +239,7 @@ object MediaApi extends Controller with ArgoHelpers {
     val labels = searchParams.structuredQuery.flatMap {
       // TODO: Use ImageFields for guard
       case Match(field: SingleField, value:Words) if field.name == "userMetadata.labels" => Some(value.string)
+      case Match(field: SingleField, value:Phrase) if field.name == "userMetadata.labels" => Some(value.string)
       case _ => None
     }
 


### PR DESCRIPTION
**Labels-with-spaces**
Filters labels-with-spaces (e.g. #NEW nauru pics from BD) so they become enclosed in quote marks and therefore searchable
Adds case to match phrases in imageSearch so that labels-with-spaces have .selected assigned to them
- label turns blue when selected
- label cannot be added twice

NOW:
![labels](https://cloud.githubusercontent.com/assets/8484757/10431297/31ddbb86-70fc-11e5-9a64-9ad284745995.gif)


BEFORE:
![labels2](https://cloud.githubusercontent.com/assets/8484757/10431300/377bc5c4-70fc-11e5-9bb2-7273d380801d.gif)

**Styling**
Removes scroll bar under related labels
Moves semicolon to after the parent label

NOW:
![screenshot-media local dev-gutools co uk 2015-10-12 16-24-58](https://cloud.githubusercontent.com/assets/8484757/10431579/bc365b70-70fd-11e5-9f6a-f99aa6f0f521.png)


BEFORE: 
![screenshot-media local dev-gutools co uk 2015-10-12 16-17-18](https://cloud.githubusercontent.com/assets/8484757/10431555/a2622cec-70fd-11e5-959e-5ec22406ca9c.png)
