### PR TITLE
use updated image when sending over metadata edit

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -168,7 +168,7 @@ image.controller('ImageCtrl', [
         });
 
         ctrl.updateMetadataField = function (field, value) {
-            return editsService.updateMetadataField(image, field, value)
+            return editsService.updateMetadataField(ctrl.image, field, value)
                 .then((updatedImage) => {
                     if (updatedImage) {
                         ctrl.image = updatedImage;


### PR DESCRIPTION
If we keep using the non-updated one, the metadata diff doesn't work correctly.
To reproduce: 
* get image with no description / credit
* update description
* update credit

Then the credit disappears as the image is the image we loaded the page with, which wouldn't have a description.

Surprised this hasn't come up earlier.