### PR TITLE
First pass at DRYing the logger xml.

### DIFF
--- a/cropper/conf/logger-include.xml
+++ b/cropper/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/cropper/conf/logger.xml
+++ b/cropper/conf/logger.xml
@@ -2,17 +2,6 @@
 
     <contextName>cropper</contextName>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>

--- a/image-loader/conf/logger-include.xml
+++ b/image-loader/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/image-loader/conf/logger.xml
+++ b/image-loader/conf/logger.xml
@@ -15,21 +15,6 @@
         </encoder>
     </appender>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-    <logger name="com.amazonaws">
-        <level value="ERROR" />
-    </logger>
-
-    <root level="ERROR">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="LOGFILE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>

--- a/image-loader/conf/logger.xml
+++ b/image-loader/conf/logger.xml
@@ -23,6 +23,9 @@
 
     <logger name="play" level="INFO" />
     <logger name="application" level="DEBUG" />
+    <logger name="com.amazonaws">
+        <level value="ERROR" />
+    </logger>
 
     <root level="ERROR">
         <appender-ref ref="CONSOLE"/>

--- a/kahuna/conf/logger-include.xml
+++ b/kahuna/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/kahuna/conf/logger.xml
+++ b/kahuna/conf/logger.xml
@@ -2,17 +2,6 @@
 
     <contextName>kahuna</contextName>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>

--- a/logger-include.xml
+++ b/logger-include.xml
@@ -1,0 +1,20 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="play" level="INFO" />
+
+    <logger name="application" level="DEBUG" />
+
+    <logger name="com.amazonaws">
+        <level value="ERROR" />
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</included>
+

--- a/media-api/conf/logger-include.xml
+++ b/media-api/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/media-api/conf/logger.xml
+++ b/media-api/conf/logger.xml
@@ -2,17 +2,6 @@
 
     <contextName>media-api</contextName>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>

--- a/metadata-editor/conf/logger-include.xml
+++ b/metadata-editor/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/metadata-editor/conf/logger.xml
+++ b/metadata-editor/conf/logger.xml
@@ -2,17 +2,6 @@
 
     <contextName>metadata-editor</contextName>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>

--- a/thrall/conf/logger-include.xml
+++ b/thrall/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/thrall/conf/logger.xml
+++ b/thrall/conf/logger.xml
@@ -2,17 +2,6 @@
 
     <contextName>thrall</contextName>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>

--- a/usage/conf/logger-include.xml
+++ b/usage/conf/logger-include.xml
@@ -1,0 +1,1 @@
+../../logger-include.xml

--- a/usage/conf/logger.xml
+++ b/usage/conf/logger.xml
@@ -2,17 +2,6 @@
 
     <contextName>usance</contextName>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%thread] %-5level GUUID=%X{GUUID} %logger{36}:%L - %msg%n%xException{15}</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
-
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <include resource="logger-include.xml" />
 
 </configuration>


### PR DESCRIPTION
Using an `include` directive DRY out logger configuration commonality.

Not all apps are created equal, however, so `include` isn't used everywhere. For example, `image-loader` has a root level of `ERROR` whereas other apps are `DEBUG`.

This also only logs AWS ERRORs:

```xml
<logger name="com.amazonaws">
  <level value="ERROR" />
</logger>
```