### PR TITLE
search with q in related labels

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -211,7 +211,8 @@ results.controller('SearchResultsCtrl', [
         ctrl.setParentLabel = () => {
             if (ctrl.parentLabel) {
                 const parentLabel = queryLabelFilterFilter(ctrl.parentLabel);
-                $state.transitionTo($state.current, { query: `${parentLabel}` }, {
+                const newQ = `${$stateParams.query.trim()} ${parentLabel}`;
+                $state.transitionTo($state.current, { query: newQ }, {
                     reload: true, inherit: false, notify: true
                 });
             }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -19,7 +19,7 @@ GET     /images                                       controllers.MediaApi.image
 
 # completion
 GET     /suggest/metadata/credit                      controllers.MediaApi.suggestMetadataCredit(q: Option[String], size: Option[Int])
-GET     /suggest/edits/labels/:label/sibling-labels   controllers.MediaApi.suggestLabelSiblings(label: String, selectedLabels: Option[String])
+GET     /suggest/edits/labels/:label/sibling-labels   controllers.MediaApi.suggestLabelSiblings(label: String, q: Option[String], selectedLabels: Option[String])
 GET     /suggest/edits/labels                         controllers.MediaApi.suggestLabels(q: Option[String])
 
 # Management


### PR DESCRIPTION
Decoupling from #1345 
We now consider the query in the search for related labels.
We also don't clear the search when adding the main label.
![](https://cloud.githubusercontent.com/assets/31692/10428663/f6781124-70ea-11e5-9476-43e98f003c4c.gif)