### PR TITLE
(singular) image cost message as a component.

### DIFF
--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.css
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.css
@@ -1,0 +1,3 @@
+gr-image-cost-message {
+    display: block;
+}

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
@@ -1,0 +1,12 @@
+<div ng:switch="image.data.cost">
+    <div ng:switch-when="pay"
+         class="image-notice image-info__group status cost cost--pay">
+        Pay to use
+    </div>
+
+    <div ng:switch-when="conditional"
+         class="image-notice image-info__group cost cost--conditional"
+         title="This image can be used but only within certain restrictions">
+        <b>Restricted use:</b> {{image.data.usageRights.restrictions}}
+    </div>
+</div>

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
@@ -1,0 +1,17 @@
+import angular from 'angular';
+
+import template from './gr-image-cost-message.html!text';
+import './gr-image-cost-message.css!';
+
+export const module = angular.module('gr.imageCostMessage', []);
+
+module.directive('grImageCostMessage', [function () {
+    return {
+        restrict: 'E',
+        template: template,
+        transclude: true,
+        scope: {
+            image: '=grImage'
+        }
+    };
+}]);

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -10,6 +10,7 @@ import '../components/gr-crop-image/gr-crop-image';
 import '../components/gr-delete-crops/gr-delete-crops';
 import '../components/gr-image-persist-status/gr-image-persist-status';
 import '../components/gr-metadata-validity/gr-metadata-validity';
+import '../components/gr-image-cost-message/gr-image-cost-message';
 
 var image = angular.module('kahuna.image.controller', [
     'kahuna.edits.service',
@@ -21,7 +22,8 @@ var image = angular.module('kahuna.image.controller', [
     'gr.cropImage',
     'gr.deleteCrops',
     'gr.imagePersistStatus',
-    'gr.metadataValidity'
+    'gr.metadataValidity',
+    'gr.imageCostMessage'
 ]);
 
 image.controller('ImageCtrl', [

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -94,18 +94,7 @@
     <div class="image-info">
         <gr-metadata-validity gr-image="ctrl.image"></gr-metadata-validity>
 
-        <div ng:switch="ctrl.image.data.cost">
-            <div ng:switch-when="pay"
-                 class="image-notice image-info__group status cost cost--pay">
-                Pay to use
-            </div>
-
-            <div ng:switch-when="conditional"
-                 class="image-notice image-info__group cost cost--conditional"
-                 title="This image can be used but only within certain restrictions">
-                <b>Restricted use:</b> {{ctrl.image.data.usageRights.restrictions}}
-            </div>
-        </div>
+        <gr-image-cost-message gr-image="ctrl.image"></gr-image-cost-message>
 
         <div class="image-info__group">
             <dl class="image-info__wrap metadata-line image-info__usage-rights">


### PR DESCRIPTION
Similar to https://github.com/guardian/grid/pull/1354.