### PR TITLE
switch between suggested labels

### DIFF
--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -1,0 +1,19 @@
+const hasSpace    = s     => /\s/g.test(s);
+const labelMatch  = label => new RegExp(`(label:|#)("|')?${label}(("|')|\\b)`, 'g');
+const createLabel = label => hasSpace(label) ? `#"${label}"` : `#${label}`;
+
+function hasLabel(q, label) {
+    return labelMatch(label).test(q);
+}
+
+export function addLabel(q, label) {
+    return hasLabel(q, label) ? q : `${(q || '').trim()} ${createLabel(label)}`;
+}
+
+export function removeLabel(q, label) {
+    return q.replace(labelMatch(label), '');
+}
+
+export function removeLabels(q, labels) {
+    return labels.reduce((q, curr) => removeLabel(q, curr.name), q);
+}

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -49,12 +49,22 @@
                 </div>
                 <ul class="flex-container related-labels__labels">
                     <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
-                        <button ng:click="ctrl.toggleLabelToSearch(relatedLabel)"
-                                ng:class="{ 'related-labels__label-text--selected': relatedLabel.selected }"
-                                gr:track-click="Related label select"
-                                gr:track-click-data="{'Label': relatedLabel.name}"
-                                class="related-labels__label-text">{{relatedLabel.name}}</button>
-
+                        <div ng:switch="relatedLabel.selected">
+                            <button class="related-labels__label-text related-labels__label-text--selected"
+                                    ng:switch-when="true"
+                                    ng:click="ctrl.removeSuggestedLabel(relatedLabel)"
+                                    gr:track-click="Related label remove"
+                                    gr:track-click-data="{'Label': relatedLabel.name}">
+                                    {{relatedLabel.name}}
+                            </button>
+                            <button class="related-labels__label-text"
+                                    ng:switch-when="false"
+                                    ng:click="ctrl.switchSuggestedLabelTo(relatedLabel)"
+                                    gr:track-click="Related label select"
+                                    gr:track-click-data="{'Label': relatedLabel.name}">
+                                    {{relatedLabel.name}}
+                            </button>
+                        </div>
                     </li>
                 </ul>
             </div>

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import Rx from 'rx';
+import * as querySyntax from '../search-query/query-syntax';
 
 import '../services/scroll-position';
 import '../services/panel';
@@ -196,29 +197,32 @@ results.controller('SearchResultsCtrl', [
         inject$($scope, relatedLabels$, ctrl, 'relatedLabels');
         inject$($scope, parentLabel$, ctrl, 'parentLabel');
 
-        ctrl.toggleLabelToSearch = label => {
-            // TODO: Move this to a searchQueryService
-            const oldQ = $stateParams.query.trim();
-            const searchableLabel = queryLabelFilterFilter(label.name);
-            const query = (label.selected ? oldQ.replace(`${searchableLabel}`, '')
-                          : `${oldQ} ${searchableLabel}`).trim();
-            const newStateParams = angular.extend({}, $stateParams, { query });
-            $state.transitionTo($state.current, newStateParams, {
-                reload: true, inherit: false, notify: true
-            });
+        ctrl.switchSuggestedLabelTo = label => {
+            const q = $stateParams.query;
+            const removedLabelsQ = querySyntax.removeLabels(q, ctrl.relatedLabels);
+            const query = querySyntax.addLabel(removedLabelsQ, label.name);
+            setQuery(query);
+        };
+
+        ctrl.removeSuggestedLabel = label => {
+            const query = querySyntax.removeLabel($stateParams.query, label.name);
+            setQuery(query);
         };
 
         ctrl.setParentLabel = () => {
             if (ctrl.parentLabel) {
-                const parentLabel = queryLabelFilterFilter(ctrl.parentLabel);
-                // this can be undefined...
-                const q = ($stateParams.query || '').trim();
-                const newQ = `${q} ${parentLabel}`;
-                $state.transitionTo($state.current, { query: newQ }, {
-                    reload: true, inherit: false, notify: true
-                });
+                const query = querySyntax.addLabel($stateParams.query || '', ctrl.parentLabel);
+                setQuery(query);
             }
         };
+
+        function setQuery(query) {
+            const newStateParams = angular.extend({}, $stateParams, { query });
+            $state.transitionTo($state.current, newStateParams, {
+                reload: true, inherit: false, notify: true
+            });
+        }
+
         ctrl.suggestedLabelSearch = q =>
             ctrl.searched.then(images =>
                 images.follow('suggested-labels').get({q}).then(labels => labels.data)

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -56,7 +56,6 @@ results.controller('SearchResultsCtrl', [
     'panelService',
     'range',
     'isReloadingPreviousSearch',
-    'queryLabelFilterFilter',
     function($rootScope,
              $scope,
              $state,
@@ -75,8 +74,7 @@ results.controller('SearchResultsCtrl', [
              results,
              panelService,
              range,
-             isReloadingPreviousSearch,
-             queryLabelFilterFilter) {
+             isReloadingPreviousSearch) {
 
         const ctrl = this;
 


### PR DESCRIPTION
As per feedback and also not having completed the `searchQueryService`(#1345), the suggested labels now switch as opposed to toggle.

I image the toggle would be more useful in a slightly less hierarchical world, but for now we have two levels and this is how users are using it.

![switch-related-tags](https://cloud.githubusercontent.com/assets/31692/10479767/25c1d9c8-725e-11e5-88f8-a91424dc553d.gif)
