### PR TITLE
adds url imports to recent uploads and adds labels

### DIFF
--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -57,11 +57,8 @@ dndUploader.controller('DndUploaderCtrl',
     }
 
    function loadUriImage(fileUri) {
-        return loaderApi.import(fileUri).then(mediaResp =>
-            // Wait until image indexed
-            apiPoll(() => mediaResp.get()).
-                then(() => $state.go('upload', {}, { reload: true }))
-        );
+        uploadManager.uploadUri(fileUri);
+        $state.go('upload', {}, { reload: true });
     }
 
     function importWitnessImage(uri) {
@@ -180,17 +177,7 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track',
                     });
                     track.action(trackEvent, dropAction('Witness'));
                 } else if (uri) {
-                    ctrl.importing = true;
-                    ctrl.loadUriImage(uri)
-                        .catch(error => {
-                            if (error.body && error.body.errorMessage) {
-                                $window.alert(error.body.errorMessage);
-                            } else {
-                                $window.alert('An error occurred while importing the ' +
-                                'image, please try again');
-                            }
-                        })
-                        .finally(() => ctrl.importing = false);
+                    ctrl.loadUriImage(uri);
                 }
                 else {
                     $window.alert('You must drop valid files or ' +

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -10,7 +10,7 @@
 
                     <div class="preview__bottom-bar bottom-bar">
                         <div class="bottom-bar__meta">
-                            {{job.name}}, {{job.size | asFileSize}}
+                            {{job.name}}<span ng:if="job.size">, {{job.size | asFileSize}}</span>
                         </div>
 
                         <div class="bottom-bar__actions"></div>

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -21,6 +21,15 @@ upload.factory('uploadManager',
             resourcePromise: request
         };
     }
+    function createUriJobItem(fileUri) {
+        var request = fileUploader.loadUriImage(fileUri);
+
+        return {
+            name: fileUri,
+            dataUrl: fileUri,
+            resourcePromise: request
+        };
+    }
 
     function upload(files) {
         var job = files.map(createJobItem);
@@ -33,12 +42,25 @@ upload.factory('uploadManager',
         $q.all(promises).finally(() => jobs.delete(job));
     }
 
+    function uploadUri(uri) {
+        var jobItem = createUriJobItem(uri);
+        var promise = jobItem.resourcePromise;
+        var job = [jobItem];
+
+        jobs.add(job);
+
+        // once all `jobItems` in a job are complete, remove it
+        // TODO: potentially move these to a `completeJobs` `Set`
+        promise.finally(() => jobs.delete(job));
+    }
+
     function getLatestRunningJob() {
         return jobs.values().next().value;
     }
 
     return {
         upload,
+        uploadUri,
         getLatestRunningJob
     };
 }]);
@@ -69,7 +91,12 @@ upload.factory('fileUploader',
         return loaderApi.load(new Uint8Array(fileData), uploadInfo);
     }
 
+    function loadUriImage(fileUri) {
+        return loaderApi.import(fileUri);
+    }
+
     return {
-        upload
+        upload,
+        loadUriImage
     };
 }]);


### PR DESCRIPTION
Url images added now passed to upload manager
- preview of image is displayed while uploading
- image to 'Your current uploads' not 'Your past 50 uploads'
- labels are added :laughing: 

NOW
![labels3](https://cloud.githubusercontent.com/assets/8484757/10481020/ea999f54-7265-11e5-9b05-c0bafe8568c0.gif)

BEFORE
![labels4](https://cloud.githubusercontent.com/assets/8484757/10481111/7a40b142-7266-11e5-8284-50addfd3ff15.gif)
