### PR TITLE
Stop propagation to allow popout in selection mode

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -1,17 +1,18 @@
 <div class="preview image-actions-container">
 
-    <ul class="image-actions" ng:if="! ctrl.selectionMode">
+    <ul class="image-actions">
         <li>
             <a class="image-action image-action--first"
                target="_blank"
                title="Pop out"
                ng:href="/images/{{::ctrl.image.data.id}}"
+               gr:stop-propagation="click"
                gr:track-click="Popout button">
                 <gr-icon>open_in_new</gr-icon>
             </a>
         </li>
 
-        <li>
+        <li ng:if="! ctrl.selectionMode">
             <a class="image-action"
                title="crop"
                ng:if="ctrl.states.isValid"
@@ -19,7 +20,7 @@
                 <gr-icon>crop</gr-icon>
             </a>
         </li>
-        <li>
+        <li ng:if="! ctrl.selectionMode">
             <ng:transclude></ng:transclude>
         </li>
     </ul>
@@ -33,7 +34,7 @@
             gr:image-fade-on-load />
     </a>
 
-    <span  ng:if="ctrl.selectionMode" class="preview__no-link">
+    <span ng:if="ctrl.selectionMode" class="preview__no-link">
         <div class="preview__fade"></div>
         <img class="preview__image"
              ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -55,3 +55,12 @@ image.directive('uiPreviewImage', function() {
         bindToController: true
     };
 });
+
+image.directive('grStopPropagation', function() {
+    return {
+        restrict: 'A',
+        link: function(scope, element, attrs) {
+            element.on(attrs.grStopPropagation, e => e.stopPropagation());
+        }
+    }
+});


### PR DESCRIPTION
Seemed to be a sensible suggestion by picture editors as they often go through selecting loads of image, but want a closer look at one mid-way.

![popout-on-selection](https://cloud.githubusercontent.com/assets/31692/10514607/a9c61f66-7346-11e5-94c7-30224c8b115f.gif)
