### PR TITLE
more contrast between persisted and non-persisted.

### DIFF
--- a/kahuna/public/js/edits/archiver.html
+++ b/kahuna/public/js/edits/archiver.html
@@ -18,7 +18,7 @@
             </span>
         </gr-icon-label>
     </span>
-    <span ng:show="!archiver.isArchived" title="Add to library">
+    <span ng:show="!archiver.isArchived" title="Add to library" class="archiver--unarchived">
         <gr-icon-label gr-icon="lock_open">
             <span ng:show="archiver.withText">
                 <span ng:show="!archiver.archiving">Add to library</span>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1243,7 +1243,7 @@ FIXME: what to do with touch devices
 }
 
 .result-editor__archiver {
-    background: black;
+    background: #393939;
     padding: 0 5px;
 }
 
@@ -1918,7 +1918,12 @@ ui-archiver {
     color: #ccc;
 }
 
-ui-archiver .archiver:hover {
+ui-archiver .archiver--unarchived {
+    color: #737373;
+}
+
+ui-archiver .archiver:hover,
+ui-archiver .archiver--unarchived:hover {
     color: white;
 }
 


### PR DESCRIPTION
From the upload page, it isn't obvious when a non-system persisted image has been persisted or not. Now the behaviour is:

- non-persisted is dark grey with hover white
- persisted is light grey with hover white (as before)
- system persisted is filled lock (as before)

![lock](https://cloud.githubusercontent.com/assets/836140/10520142/ade4dd3e-7360-11e5-9c57-0c8a39055277.gif)
