### PR TITLE
blocks drag'n'drop uploading of grid thumbnails

### DIFF
--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -21,6 +21,8 @@ dndUploader.controller('DndUploaderCtrl',
                             apiPoll, witnessApi) {
 
     var ctrl = this;
+    //hack to prevent grid thumbnails being re-added to the grid for now
+    //TODO make generic - have API tell kahuna S3 buckets' domain
     const gridThumbnailPattern = /https:\/\/media-service([0-9-a-z]+)thumbbucket([0-9-a-z]+)/;
 
     ctrl.uploadFiles = uploadFiles;

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -21,9 +21,12 @@ dndUploader.controller('DndUploaderCtrl',
                             apiPoll, witnessApi) {
 
     var ctrl = this;
+    const gridThumbnailPattern = /https:\/\/media-service([0-9-a-z]+)thumbbucket([0-9-a-z]+)/;
+
     ctrl.uploadFiles = uploadFiles;
     ctrl.importWitnessImage = importWitnessImage;
     ctrl.isWitnessUri = witnessApi.isWitnessUri;
+    ctrl.isNotGridThumbnail = (uri)  => !gridThumbnailPattern.test(uri);
     ctrl.loadUriImage = loadUriImage;
 
     function uploadFiles(files) {
@@ -176,7 +179,7 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track',
                         ctrl.importing = false;
                     });
                     track.action(trackEvent, dropAction('Witness'));
-                } else if (uri) {
+                } else if (ctrl.isNotGridThumbnail(uri)) {
                     ctrl.loadUriImage(uri);
                 }
                 else {


### PR DESCRIPTION
Checks if URIs match pattern of Grid thumbnail images' URIs, only uploads images that do not match. 

NOW :v: 
![uploads1](https://cloud.githubusercontent.com/assets/8484757/10539437/745cbc34-73f7-11e5-93b3-ee0de6bc9bee.gif)

BEFORE 
![uploads2](https://cloud.githubusercontent.com/assets/8484757/10539463/a4a382f6-73f7-11e5-8a8a-96d75ba603c6.gif)
