### PR TITLE
stops byline and copyright disappearing in side panel when multiple images selected

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -173,7 +173,7 @@
         <div class="image-info__group">
             <dl class="image-info__group--dl metadata-line">
                 <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
-                <dd class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
+                <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="bylineEditForm.$show()"

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -172,8 +172,8 @@
 
         <div class="image-info__group">
             <dl class="image-info__group--dl metadata-line">
-                <dt ng:if="ctrl.metadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
-                <dd ng:if="ctrl.metadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
+                <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
+                <dd class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="bylineEditForm.$show()"
@@ -236,8 +236,8 @@
                     </span>
                 </dd>
 
-                <dt ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
-                <dd ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
+                <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="copyrightEditForm.$show()"


### PR DESCRIPTION
ng-if for 'byline' and 'copyright' tags checks if they exist in ctrl.rawMetadata.x (which returns an array of the different values) rather than ctrl.metadata.x (which returns 'undefined' if there is more than one image selected and their values are different).  

FIXES: #1377