### PR TITLE
Map "crop" that covers the whole image to a "full" export

### DIFF
--- a/cropper/app/model/ExportRequest.scala
+++ b/cropper/app/model/ExportRequest.scala
@@ -39,6 +39,9 @@ object ExportRequest {
 
   def toCropSpec(cropRequest: ExportRequest, dimensions: Dimensions): CropSpec = cropRequest match {
     case FullExportRequest(uri)          => CropSpec(uri, boundsFill(dimensions), None, FullExport)
+    // Map "crop" that covers the whole image to a "full" export
+    case CropRequest(uri, bounds, ratio) if bounds == boundsFill(dimensions)
+                                         => CropSpec(uri, boundsFill(dimensions), ratio, FullExport)
     case CropRequest(uri, bounds, ratio) => CropSpec(uri, bounds, ratio, CropExport)
   }
 


### PR DESCRIPTION
That way we avoid confusion between the two, as a crop that contains the whole image is always a "full" export, regardless of how the user generated it (e.g. freeform selection of the entire image, or "full export" shortcut).

Note that the day we make "full" exports smarter e.g. to exclude silly agency banners, this logic will also need to be adapted.