### PR TITLE
Give more memory to cropper and image-loader

### DIFF
--- a/cropper/conf/cropper.conf
+++ b/cropper/conf/cropper.conf
@@ -2,7 +2,7 @@ env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
+env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
 env APP_OPTIONS=""
 
 env LOGFILE=/home/media-service/logs/stdout.log

--- a/image-loader/conf/image-loader.conf
+++ b/image-loader/conf/image-loader.conf
@@ -3,7 +3,7 @@ env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
 # Workaround for https://github.com/aws/aws-sdk-java/issues/123
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log  -Djdk.xml.entityExpansionLimit=0"
+env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log  -Djdk.xml.entityExpansionLimit=0"
 env APP_OPTIONS=""
 
 env LOGFILE=/home/media-service/logs/stdout.log


### PR DESCRIPTION
Don't see why not, and we're seeing OutOfMemory errors on cropper (and rarely on loader too).

Could be a leak, but unlikely because it happened shortly after a release.

Bit of a finger in the air update to be honest, but there's 3GB of RAM on these boxes so let's try this first.