### PR TITLE
Shift selecting in preview

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -125,8 +125,7 @@
                     <!-- We don't want to add a property on `image` to determine the state of the checkbox, so render two individual inputs. -->
                     <!-- </HACK> -->
                     <div class="result__select result__select--selected"
-                         ng:if="ctrl.imageHasBeenSelected(image)"
-                         ng:class="{ 'result__select--allow-shift-click': ctrl.inSelectionMode}">
+                         ng:if="ctrl.imageHasBeenSelected(image)">
                         <input type="checkbox"
                                class="result__select__checkbox"
                                id="id-{{::image.data.id}}-result__select__checkbox--select"

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -125,7 +125,8 @@
                     <!-- We don't want to add a property on `image` to determine the state of the checkbox, so render two individual inputs. -->
                     <!-- </HACK> -->
                     <div class="result__select result__select--selected"
-                         ng:if="ctrl.imageHasBeenSelected(image)">
+                         ng:if="ctrl.imageHasBeenSelected(image)"
+                         ng:class="{ 'result__select--allow-shift-click': ctrl.inSelectionMode}">
                         <input type="checkbox"
                                class="result__select__checkbox"
                                id="id-{{::image.data.id}}-result__select__checkbox--select"
@@ -136,7 +137,9 @@
                             <gr-icon>check_box</gr-icon>
                         </label>
                     </div>
-                    <div class="result__select" ng:if="!ctrl.imageHasBeenSelected(image)">
+                    <div class="result__select"
+                         ng:if="!ctrl.imageHasBeenSelected(image)"
+                         ng:class="{ 'result__select--allow-shift-click': ctrl.inSelectionMode}">
                         <input type="checkbox"
                                class="result__select__checkbox"
                                id="id-{{::image.data.id}}-result__select__checkbox--deselect"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -407,7 +407,7 @@ results.controller('SearchResultsCtrl', [
         ctrl.imageHasBeenSelected = (image) => ctrl.selectedItems.has(image.uri);
 
         const toggleSelection = (image) => selection.toggle(image.uri);
-        ctrl.select           = (image) => selection.add(image.uri);
+        ctrl.select           = (image) => { selection.add(image.uri), $window.getSelection().empty(); }
         ctrl.deselect         = (image) => selection.remove(image.uri);
 
         ctrl.onImageClick = function (image, $event) {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -408,7 +408,7 @@ results.controller('SearchResultsCtrl', [
 
         const toggleSelection = (image) => selection.toggle(image.uri);
         ctrl.select           = (image) => { selection.add(image.uri), $window.getSelection().empty(); }
-        ctrl.deselect         = (image) => selection.remove(image.uri);
+        ctrl.deselect         = (image) => { selection.remove(image.uri), $window.getSelection().empty(); }
 
         ctrl.onImageClick = function (image, $event) {
             if (ctrl.inSelectionMode) {
@@ -437,6 +437,7 @@ results.controller('SearchResultsCtrl', [
                     }
                 }
                 else {
+                    $window.getSelection().empty();
                     toggleSelection(image);
                 }
             }

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -407,8 +407,16 @@ results.controller('SearchResultsCtrl', [
         ctrl.imageHasBeenSelected = (image) => ctrl.selectedItems.has(image.uri);
 
         const toggleSelection = (image) => selection.toggle(image.uri);
-        ctrl.select           = (image) => { selection.add(image.uri), $window.getSelection().empty(); }
-        ctrl.deselect         = (image) => { selection.remove(image.uri), $window.getSelection().empty(); }
+
+        ctrl.select = (image) => {
+            selection.add(image.uri);
+            $window.getSelection().empty();
+        };
+
+        ctrl.deselect = (image) => {
+            selection.remove(image.uri);
+            $window.getSelection().empty();
+        };
 
         ctrl.onImageClick = function (image, $event) {
             if (ctrl.inSelectionMode) {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -779,6 +779,10 @@ input.search-query__input {
     z-index: 1;
 }
 
+.result__select--allow-shift-click {
+    pointer-events: none;
+}
+
 .result__select__checkbox__label {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Allows click on check box to go through to image and so select it. 
Stops selection process when you click on a checkbox to prevent text highlighting. 

![selecting](https://cloud.githubusercontent.com/assets/8484757/10606414/9012a57a-772a-11e5-8cc4-e65b0b68df19.gif)
