### PR TITLE
Labels in panel

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -70,3 +70,7 @@
 .batch-archive__unarchive:hover {
     color: white;
 }
+
+.panel__collections {
+    font-size: 1.4rem;
+}

--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -46,13 +46,9 @@
     padding-top: 0;
 }
 
-.panel__bottom .panel__close{
+.panel__bottom .panel__close {
     width: 100%;
     height: 100%;
-}
-
-.panel__empty-message {
-    padding: 10px;
 }
 
 .panel__close-panel {

--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -51,6 +51,16 @@
     height: 100%;
 }
 
+.panel__empty-message {
+    padding: 10px;
+}
+
+.panel__close-panel {
+    position: absolute;
+    top: 15px;
+    right: 10px;
+}
+
 .batch-label .labels {
     white-space: normal;
 }

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -3,14 +3,14 @@
      ng:mouseleave="ctrl.metadataPanelMouseLeave()"
      ng:class="{ 'panel__right--hidden': !ctrl.isVisible }">
 
-    <button class="panel__close-panel"
-            ng:click="ctrl.metadataPanelHide()">
-        <gr-icon>close</gr-icon>
-    </button>
-
     <div class="panel__empty-message"
         ng:if="ctrl.selectedImages.size === 0">
         No images selected
+
+        <button class="panel__close-panel"
+                ng:click="ctrl.metadataPanelHide()">
+            <gr-icon>close</gr-icon>
+        </button>
     </div>
 
     <div ng:if="ctrl.selectedImages.size > 0">

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -33,7 +33,10 @@
         </div>
 
         <div ng:if="!showMetadata">
-            <gr-related-labels></gr-related-labels>
+            <div class="panel__top">
+                <gr-related-labels class="panel__collections">
+                </gr-related-labels>
+            </div>
         </div>
 
         <div ng:if="showMetadata">

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -1,343 +1,354 @@
-<div ng:if="ctrl.selectedImages.size > 0"
-    class="panel panel--side panel__right image-details"
-    ng:mouseover="ctrl.metadataPanelMouseOver()"
-    ng:mouseleave="ctrl.metadataPanelMouseLeave()"
-    ng:class="{ 'panel__right--hidden': !ctrl.isVisible }">
+<div class="panel panel--side panel__right image-details"
+     ng:mouseover="ctrl.metadataPanelMouseOver()"
+     ng:mouseleave="ctrl.metadataPanelMouseLeave()"
+     ng:class="{ 'panel__right--hidden': !ctrl.isVisible }">
 
-    <div class="panel__top">
-        <ul class="costs">
-            <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
-                <div ng:switch="cost.data">
-                    <div ng:switch-when="free"
-                         class="image-notice image-info__group status cost cost--free">
-                        {{cost.count}} free
-                    </div>
+    <button class="panel__close-panel"
+            ng:click="ctrl.metadataPanelHide()">
+        <gr-icon>close</gr-icon>
+    </button>
 
-                    <div ng:switch-when="pay"
-                         class="image-notice image-info__group status cost cost--pay">
-                        {{cost.count}} pay
-                    </div>
-
-                    <div ng:switch-when="conditional"
-                         class="image-notice image-info__group cost cost--conditional">
-                        {{cost.count}} restricted
-                    </div>
-                </div>
-            </li>
-        </ul>
+    <div class="panel__empty-message"
+        ng:if="ctrl.selectedImages.size === 0">
+        No images selected
     </div>
 
-    <div class="panel__content">
-        <div class="image-info__group">
-            <dl class="image-info__wrap metadata-line image-info__usage-rights">
-                <dt class="metadata-line__key">Usage rights category</dt>
-                <gr-usage-rights-editor
-                    ng:if="ctrl.showUsageRights"
-                    gr:usage-rights="ctrl.usageRights"
-                    gr:on-save="ctrl.showUsageRights = false"
-                    gr:on-cancel="ctrl.showUsageRights = false">
-                </gr-usage-rights-editor>
-                <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
-                    {{ctrl.usageCategory || 'None'}}
-                </dd>
-
-                <button
-                    ng:click="ctrl.showUsageRights = true"
-                    ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
-                    class="image-info__edit">✎</button>
-            </dl>
-        </div>
-
-        <div class="image-info__group">
-            <dl>
-                <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
-                    <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="titleEditForm.$show()"
-                            ng:hide="titleEditForm.$visible">✎</button>
-                    <dt class="metadata-line metadata-line__key">Title</dt>
-                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
-                         editable-text="ctrl.metadata.title"
-                         onbeforesave="ctrl.updateMetadataField('title', $data)"
-                         e:form="titleEditForm"
-                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}">
-
-                        <div ng:if="ctrl.userCanEdit">
-                            <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                Multiple titles (click ✎ to edit <strong>all</strong>)
-                            </dd>
-
-                            <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
-                            </dd>
+    <div ng:if="ctrl.selectedImages.size > 0">
+        <div class="panel__top">
+            <ul class="costs">
+                <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
+                    <div ng:switch="cost.data">
+                        <div ng:switch-when="free"
+                             class="image-notice image-info__group status cost cost--free">
+                            {{cost.count}} free
                         </div>
 
-                        <div ng:if="!ctrl.userCanEdit">
-                            <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                Multiple titles
-                            </dd>
-
-                            <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                {{ctrl.metadata.title || "unknown"}}
-                            </dd>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="image-info__wrap">
-                    <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="descriptionEditForm.$show()"
-                            ng:hide="descriptionEditForm.$visible">✎</button>
-                    <dt class="metadata-line metadata-line__key">Description</dt>
-                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
-                         editable-textarea="ctrl.metadata.description"
-                         onbeforesave="ctrl.updateMetadataField('description', $data)"
-                         e:msd-elastic
-                         e:form="descriptionEditForm"
-                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
-
-                        <div ng:if="ctrl.userCanEdit">
-                            <dd class="image-info__description"
-                                  ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                >Multiple descriptions (click ✎ to edit <strong>all</strong>)
-                            </dd>
-
-                            <dd class="image-info__description"
-                                  ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
-                            </dd>
+                        <div ng:switch-when="pay"
+                             class="image-notice image-info__group status cost cost--pay">
+                            {{cost.count}} pay
                         </div>
 
-                        <div ng:if="!ctrl.userCanEdit">
-                            <dd class="image-info__description"
-                                  ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                >Multiple descriptions
-                            </dd>
-
-                            <dd class="image-info__description"
-                                  ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                >{{ctrl.metadata.description || "unknown"}}
-                            </dd>
+                        <div ng:switch-when="conditional"
+                             class="image-notice image-info__group cost cost--conditional">
+                            {{cost.count}} restricted
                         </div>
                     </div>
-                </div>
-
-            </dl>
-        </div>
-
-        <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
-            <dl class="image-info__wrap">
-                <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="specialInstructionsEditForm.$show()"
-                        ng:hide="specialInstructionsEditForm.$visible">✎</button>
-                <dt class="metadata-line metadata-line__key">Special instructions</dt>
-
-
-                <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
-                     editable-textarea="ctrl.metadata.specialInstructions"
-                     onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
-                     e:msd-elastic
-                     e:form="specialInstructionsEditForm"
-                     e:ng-class="{'image-info__editor--error': $error,
-                                  'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
-
-                    <div ng:if="ctrl.userCanEdit">
-                        <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                              class="image-info__special-instructions"
-                            >Multiple special instructions (click ✎ to edit <strong>all</strong>)
-                        </dd>
-
-                        <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                              class="image-info__special-instructions"
-                            >{{ctrl.metadata.specialInstructions}}
-                        </dd>
-                    </div>
-
-                    <div ng:if="!ctrl.userCanEdit">
-                        <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                              class="image-info__special-instructions"
-                            >Multiple special instructions
-                        </dd>
-
-                        <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                              class="image-info__special-instructions"
-                            >{{ctrl.metadata.specialInstructions}}
-                        </dd>
-                    </div>
-                </div>
-            </dl>
-        </div>
-
-        <div class="image-info__group">
-            <dl class="image-info__group--dl metadata-line">
-                <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
-                <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
-                    <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="bylineEditForm.$show()"
-                            ng:hide="bylineEditForm.$visible"
-                    >✎</button>
-                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
-                         editable-text="ctrl.metadata.byline"
-                         onbeforesave="ctrl.updateMetadataField('byline', $data)"
-                         e:form="bylineEditForm"
-                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': bylineEditForm.$waiting}">
-
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
-                            Multiple bylines (click ✎ to edit <strong>all</strong>)
-                        </span>
-
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
-                            Multiple bylines
-                        </span>
-
-                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
-                            <span ng:if="ctrl.metadata.byline">
-                                <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
-                            </span>
-
-                            <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
-                        </span>
-                    </span>
-                </dd>
-
-                <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
-                <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
-                    <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="creditEditForm.$show()"
-                        ng:hide="creditEditForm.$visible"
-                    >✎</button>
-
-                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
-                          editable-text="ctrl.metadata.credit"
-                          e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
-                          onbeforesave="ctrl.updateMetadataField('credit', $data)"
-                          e:form="creditEditForm"
-                          e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': creditEditForm.$waiting}">
-
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
-                            Multiple credits (click ✎ to edit <strong>all</strong>)
-                        </span>
-
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
-                            Multiple credits
-                        </span>
-
-                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
-                            <span ng:if="ctrl.metadata.credit">
-                                <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
-                            </span>
-
-                            <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
-                        </span>
-                    </span>
-                </dd>
-
-                <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
-                <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                    <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="copyrightEditForm.$show()"
-                            ng:hide="copyrightEditForm.$visible"
-                    >✎</button>
-                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
-                         editable-text="ctrl.metadata.copyright"
-                         onbeforesave="ctrl.updateMetadataField('copyright', $data)"
-                         e:form="copyrightEditForm"
-                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
-
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
-                            Multiple copyrights (click ✎ to edit <strong>all</strong>)
-                        </span>
-
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
-                            Multiple copyrights
-                        </span>
-
-                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
-                            <span ng:if="ctrl.metadata.copyright">
-                                <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
-                            </span>
-
-                            <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
-                        </span>
-                    </span>
-                </dd>
-            </dl>
-        </div>
-
-        <div class="image-info__group">
-            <div class="image-info__heading">
-                <span>Labels</span>
-                <gr-add-label ng:blur="ctrl.cancel"
-                              gr-small="true"
-                              images="ctrl.selectedImages">
-                </gr-add-label>
-            </div>
-            <ul class="labels">
-                <li class="label"
-                    ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
-                    ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
-                    <button ng:if="label.count < ctrl.selectedImages.size"
-                            class="label__add"
-                            title="Apply label to all"
-                            ng:click="ctrl.addLabel(label.data)">
-                        <gr-icon>library_add</gr-icon>
-                    </button>
-                    <span class="label__value">{{label.data}}</span>
-                    <button class="label__remove"
-                            title="Remove label from all"
-                            ng:click="ctrl.removeLabel(label.data)">
-                        <gr-icon>close</gr-icon>
-                    </button>
                 </li>
             </ul>
         </div>
 
-        <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
-            <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
-                <div class="metadata-line flex-spacer">
-                    <gr-icon>star_half</gr-icon>
-                    <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} archived</span>
-                    <span ng:if="ctrl.archiving">Saving…</span>
-                </div>
-                <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                    <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>star</gr-icon> all
-                    </button>
-                    <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>star_border</gr-icon> none
-                    </button>
-                </span>
+        <div class="panel__content">
+            <div class="image-info__group">
+                <dl class="image-info__wrap metadata-line image-info__usage-rights">
+                    <dt class="metadata-line__key">Usage rights category</dt>
+                    <gr-usage-rights-editor
+                        ng:if="ctrl.showUsageRights"
+                        gr:usage-rights="ctrl.usageRights"
+                        gr:on-save="ctrl.showUsageRights = false"
+                        gr:on-cancel="ctrl.showUsageRights = false">
+                    </gr-usage-rights-editor>
+                    <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
+                        {{ctrl.usageCategory || 'None'}}
+                    </dd>
+
+                    <button
+                        ng:click="ctrl.showUsageRights = true"
+                        ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
+                        class="image-info__edit">✎</button>
+                </dl>
             </div>
 
-            <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
-                <div class="metadata-line flex-spacer">
-                    <gr-icon>star</gr-icon>
-                    <span ng:if="!ctrl.archiving">All archived</span>
-                    <span ng:if="ctrl.archiving">Saving…</span>
-                </div>
-                <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                    <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>star_border</gr-icon> Unarchive all
-                    </button>
-                </span>
+            <div class="image-info__group">
+                <dl>
+                    <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
+                        <button class="image-info__edit"
+                                ng:if="ctrl.userCanEdit"
+                                ng:click="titleEditForm.$show()"
+                                ng:hide="titleEditForm.$visible">✎</button>
+                        <dt class="metadata-line metadata-line__key">Title</dt>
+                        <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
+                             editable-text="ctrl.metadata.title"
+                             onbeforesave="ctrl.updateMetadataField('title', $data)"
+                             e:form="titleEditForm"
+                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}">
+
+                            <div ng:if="ctrl.userCanEdit">
+                                <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                    Multiple titles (click ✎ to edit <strong>all</strong>)
+                                </dd>
+
+                                <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                    {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
+                                </dd>
+                            </div>
+
+                            <div ng:if="!ctrl.userCanEdit">
+                                <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                    Multiple titles
+                                </dd>
+
+                                <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                    {{ctrl.metadata.title || "unknown"}}
+                                </dd>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="image-info__wrap">
+                        <button class="image-info__edit"
+                                ng:if="ctrl.userCanEdit"
+                                ng:click="descriptionEditForm.$show()"
+                                ng:hide="descriptionEditForm.$visible">✎</button>
+                        <dt class="metadata-line metadata-line__key">Description</dt>
+                        <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
+                             editable-textarea="ctrl.metadata.description"
+                             onbeforesave="ctrl.updateMetadataField('description', $data)"
+                             e:msd-elastic
+                             e:form="descriptionEditForm"
+                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
+
+                            <div ng:if="ctrl.userCanEdit">
+                                <dd class="image-info__description"
+                                      ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                    >Multiple descriptions (click ✎ to edit <strong>all</strong>)
+                                </dd>
+
+                                <dd class="image-info__description"
+                                      ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                    >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
+                                </dd>
+                            </div>
+
+                            <div ng:if="!ctrl.userCanEdit">
+                                <dd class="image-info__description"
+                                      ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                    >Multiple descriptions
+                                </dd>
+
+                                <dd class="image-info__description"
+                                      ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                    >{{ctrl.metadata.description || "unknown"}}
+                                </dd>
+                            </div>
+                        </div>
+                    </div>
+
+                </dl>
             </div>
 
-            <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
-                <div class="metadata-line flex-spacer">
-                    <gr-icon>star_border</gr-icon>
-                    <span ng:if="!ctrl.archiving">All unarchived</span>
-                    <span ng:if="ctrl.archiving">Saving…</span>
+            <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
+                <dl class="image-info__wrap">
+                    <button class="image-info__edit"
+                            ng:if="ctrl.userCanEdit"
+                            ng:click="specialInstructionsEditForm.$show()"
+                            ng:hide="specialInstructionsEditForm.$visible">✎</button>
+                    <dt class="metadata-line metadata-line__key">Special instructions</dt>
+
+
+                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
+                         editable-textarea="ctrl.metadata.specialInstructions"
+                         onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
+                         e:msd-elastic
+                         e:form="specialInstructionsEditForm"
+                         e:ng-class="{'image-info__editor--error': $error,
+                                      'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
+
+                        <div ng:if="ctrl.userCanEdit">
+                            <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                  class="image-info__special-instructions"
+                                >Multiple special instructions (click ✎ to edit <strong>all</strong>)
+                            </dd>
+
+                            <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                  class="image-info__special-instructions"
+                                >{{ctrl.metadata.specialInstructions}}
+                            </dd>
+                        </div>
+
+                        <div ng:if="!ctrl.userCanEdit">
+                            <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                  class="image-info__special-instructions"
+                                >Multiple special instructions
+                            </dd>
+
+                            <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                  class="image-info__special-instructions"
+                                >{{ctrl.metadata.specialInstructions}}
+                            </dd>
+                        </div>
+                    </div>
+                </dl>
+            </div>
+
+            <div class="image-info__group">
+                <dl class="image-info__group--dl metadata-line">
+                    <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
+                    <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
+                        <button class="image-info__edit"
+                                ng:if="ctrl.userCanEdit"
+                                ng:click="bylineEditForm.$show()"
+                                ng:hide="bylineEditForm.$visible"
+                        >✎</button>
+                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
+                             editable-text="ctrl.metadata.byline"
+                             onbeforesave="ctrl.updateMetadataField('byline', $data)"
+                             e:form="bylineEditForm"
+                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': bylineEditForm.$waiting}">
+
+                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
+                                Multiple bylines (click ✎ to edit <strong>all</strong>)
+                            </span>
+
+                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
+                                Multiple bylines
+                            </span>
+
+                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
+                                <span ng:if="ctrl.metadata.byline">
+                                    <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                                </span>
+
+                                <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
+                            </span>
+                        </span>
+                    </dd>
+
+                    <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
+                    <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
+                        <button class="image-info__edit"
+                            ng:if="ctrl.userCanEdit"
+                            ng:click="creditEditForm.$show()"
+                            ng:hide="creditEditForm.$visible"
+                        >✎</button>
+
+                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
+                              editable-text="ctrl.metadata.credit"
+                              e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
+                              onbeforesave="ctrl.updateMetadataField('credit', $data)"
+                              e:form="creditEditForm"
+                              e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': creditEditForm.$waiting}">
+
+                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
+                                Multiple credits (click ✎ to edit <strong>all</strong>)
+                            </span>
+
+                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
+                                Multiple credits
+                            </span>
+
+                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
+                                <span ng:if="ctrl.metadata.credit">
+                                    <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                                </span>
+
+                                <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
+                            </span>
+                        </span>
+                    </dd>
+
+                    <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
+                    <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                        <button class="image-info__edit"
+                                ng:if="ctrl.userCanEdit"
+                                ng:click="copyrightEditForm.$show()"
+                                ng:hide="copyrightEditForm.$visible"
+                        >✎</button>
+                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
+                             editable-text="ctrl.metadata.copyright"
+                             onbeforesave="ctrl.updateMetadataField('copyright', $data)"
+                             e:form="copyrightEditForm"
+                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
+
+                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
+                                Multiple copyrights (click ✎ to edit <strong>all</strong>)
+                            </span>
+
+                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
+                                Multiple copyrights
+                            </span>
+
+                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
+                                <span ng:if="ctrl.metadata.copyright">
+                                    <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                                </span>
+
+                                <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
+                            </span>
+                        </span>
+                    </dd>
+                </dl>
+            </div>
+
+            <div class="image-info__group">
+                <div class="image-info__heading">
+                    <span>Labels</span>
+                    <gr-add-label ng:blur="ctrl.cancel"
+                                  gr-small="true"
+                                  images="ctrl.selectedImages">
+                    </gr-add-label>
                 </div>
-                <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                    <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>star</gr-icon> Archive all
-                    </button>
-                </span>
+                <ul class="labels">
+                    <li class="label"
+                        ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
+                        ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
+                        <button ng:if="label.count < ctrl.selectedImages.size"
+                                class="label__add"
+                                title="Apply label to all"
+                                ng:click="ctrl.addLabel(label.data)">
+                            <gr-icon>library_add</gr-icon>
+                        </button>
+                        <span class="label__value">{{label.data}}</span>
+                        <button class="label__remove"
+                                title="Remove label from all"
+                                ng:click="ctrl.removeLabel(label.data)">
+                            <gr-icon>close</gr-icon>
+                        </button>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
+                <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
+                    <div class="metadata-line flex-spacer">
+                        <gr-icon>star_half</gr-icon>
+                        <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} archived</span>
+                        <span ng:if="ctrl.archiving">Saving…</span>
+                    </div>
+                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                        <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
+                            <gr-icon>star</gr-icon> all
+                        </button>
+                        <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
+                            <gr-icon>star_border</gr-icon> none
+                        </button>
+                    </span>
+                </div>
+
+                <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
+                    <div class="metadata-line flex-spacer">
+                        <gr-icon>star</gr-icon>
+                        <span ng:if="!ctrl.archiving">All archived</span>
+                        <span ng:if="ctrl.archiving">Saving…</span>
+                    </div>
+                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                        <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
+                            <gr-icon>star_border</gr-icon> Unarchive all
+                        </button>
+                    </span>
+                </div>
+
+                <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
+                    <div class="metadata-line flex-spacer">
+                        <gr-icon>star_border</gr-icon>
+                        <span ng:if="!ctrl.archiving">All unarchived</span>
+                        <span ng:if="ctrl.archiving">Saving…</span>
+                    </div>
+                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                        <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
+                            <gr-icon>star</gr-icon> Archive all
+                        </button>
+                    </span>
+                </div>
             </div>
         </div>
     </div>

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -3,351 +3,382 @@
      ng:mouseleave="ctrl.metadataPanelMouseLeave()"
      ng:class="{ 'panel__right--hidden': !ctrl.isVisible }">
 
-    <div class="panel__empty-message"
-        ng:if="ctrl.selectedImages.size === 0">
-        No images selected
+    <div ng:init="showMetadata = true">
+        <div class="radio-list">
+            <input type="radio"
+                   id="metadata-tab"
+                   class="radio-list__circle"
+                   name="metadata-tab"/>
 
-        <button class="panel__close-panel"
-                ng:click="ctrl.metadataPanelHide()">
-            <gr-icon>close</gr-icon>
-        </button>
-    </div>
+            <label for="metadata-tab"
+                   class="radio-list__label"
+                   ng:class="{'radio-list--selected': showMetadata}"
+                   ng:click="showMetadata = true">
+                <div class="radio-list__selection-state"></div>
+                <div class="radio-list__label-value">Metadata</div>
+            </label>
 
-    <div ng:if="ctrl.selectedImages.size > 0">
-        <div class="panel__top">
-            <ul class="costs">
-                <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
-                    <div ng:switch="cost.data">
-                        <div ng:switch-when="free"
-                             class="image-notice image-info__group status cost cost--free">
-                            {{cost.count}} free
-                        </div>
+            <input type="radio"
+                   id="labels-tab"
+                   class="radio-list__circle"
+                   name="labels-tab"/>
 
-                        <div ng:switch-when="pay"
-                             class="image-notice image-info__group status cost cost--pay">
-                            {{cost.count}} pay
-                        </div>
-
-                        <div ng:switch-when="conditional"
-                             class="image-notice image-info__group cost cost--conditional">
-                            {{cost.count}} restricted
-                        </div>
-                    </div>
-                </li>
-            </ul>
+            <label for="labels-tab"
+                   class="radio-list__label"
+                   ng:class="{'radio-list--selected': ! showMetadata}"
+                   ng:click="showMetadata = false">
+                <div class="radio-list__selection-state"></div>
+                <div class="radio-list__label-value">Labels</div>
+            </label>
         </div>
 
-        <div class="panel__content">
-            <div class="image-info__group">
-                <dl class="image-info__wrap metadata-line image-info__usage-rights">
-                    <dt class="metadata-line__key">Usage rights category</dt>
-                    <gr-usage-rights-editor
-                        ng:if="ctrl.showUsageRights"
-                        gr:usage-rights="ctrl.usageRights"
-                        gr:on-save="ctrl.showUsageRights = false"
-                        gr:on-cancel="ctrl.showUsageRights = false">
-                    </gr-usage-rights-editor>
-                    <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
-                        {{ctrl.usageCategory || 'None'}}
-                    </dd>
+        <div ng:if="!showMetadata">
+            <gr-related-labels></gr-related-labels>
+        </div>
 
-                    <button
-                        ng:click="ctrl.showUsageRights = true"
-                        ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
-                        class="image-info__edit">✎</button>
-                </dl>
+        <div ng:if="showMetadata">
+            <div class="panel__top"
+                ng:if="ctrl.selectedImages.size === 0">
+                No images selected
             </div>
 
-            <div class="image-info__group">
-                <dl>
-                    <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="titleEditForm.$show()"
-                                ng:hide="titleEditForm.$visible">✎</button>
-                        <dt class="metadata-line metadata-line__key">Title</dt>
-                        <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
-                             editable-text="ctrl.metadata.title"
-                             onbeforesave="ctrl.updateMetadataField('title', $data)"
-                             e:form="titleEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}">
+            <div ng:if="ctrl.selectedImages.size > 0">
+                <div class="panel__top">
+                    <ul class="costs">
+                        <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
+                            <div ng:switch="cost.data">
+                                <div ng:switch-when="free"
+                                     class="image-notice image-info__group status cost cost--free">
+                                    {{cost.count}} free
+                                </div>
 
-                            <div ng:if="ctrl.userCanEdit">
-                                <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    Multiple titles (click ✎ to edit <strong>all</strong>)
-                                </dd>
+                                <div ng:switch-when="pay"
+                                     class="image-notice image-info__group status cost cost--pay">
+                                    {{cost.count}} pay
+                                </div>
 
-                                <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
-                                </dd>
+                                <div ng:switch-when="conditional"
+                                     class="image-notice image-info__group cost cost--conditional">
+                                    {{cost.count}} restricted
+                                </div>
                             </div>
-
-                            <div ng:if="!ctrl.userCanEdit">
-                                <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    Multiple titles
-                                </dd>
-
-                                <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    {{ctrl.metadata.title || "unknown"}}
-                                </dd>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="image-info__wrap">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="descriptionEditForm.$show()"
-                                ng:hide="descriptionEditForm.$visible">✎</button>
-                        <dt class="metadata-line metadata-line__key">Description</dt>
-                        <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
-                             editable-textarea="ctrl.metadata.description"
-                             onbeforesave="ctrl.updateMetadataField('description', $data)"
-                             e:msd-elastic
-                             e:form="descriptionEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
-
-                            <div ng:if="ctrl.userCanEdit">
-                                <dd class="image-info__description"
-                                      ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >Multiple descriptions (click ✎ to edit <strong>all</strong>)
-                                </dd>
-
-                                <dd class="image-info__description"
-                                      ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
-                                </dd>
-                            </div>
-
-                            <div ng:if="!ctrl.userCanEdit">
-                                <dd class="image-info__description"
-                                      ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >Multiple descriptions
-                                </dd>
-
-                                <dd class="image-info__description"
-                                      ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >{{ctrl.metadata.description || "unknown"}}
-                                </dd>
-                            </div>
-                        </div>
-                    </div>
-
-                </dl>
-            </div>
-
-            <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
-                <dl class="image-info__wrap">
-                    <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="specialInstructionsEditForm.$show()"
-                            ng:hide="specialInstructionsEditForm.$visible">✎</button>
-                    <dt class="metadata-line metadata-line__key">Special instructions</dt>
-
-
-                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
-                         editable-textarea="ctrl.metadata.specialInstructions"
-                         onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
-                         e:msd-elastic
-                         e:form="specialInstructionsEditForm"
-                         e:ng-class="{'image-info__editor--error': $error,
-                                      'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
-
-                        <div ng:if="ctrl.userCanEdit">
-                            <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >Multiple special instructions (click ✎ to edit <strong>all</strong>)
-                            </dd>
-
-                            <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >{{ctrl.metadata.specialInstructions}}
-                            </dd>
-                        </div>
-
-                        <div ng:if="!ctrl.userCanEdit">
-                            <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >Multiple special instructions
-                            </dd>
-
-                            <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >{{ctrl.metadata.specialInstructions}}
-                            </dd>
-                        </div>
-                    </div>
-                </dl>
-            </div>
-
-            <div class="image-info__group">
-                <dl class="image-info__group--dl metadata-line">
-                    <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
-                    <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="bylineEditForm.$show()"
-                                ng:hide="bylineEditForm.$visible"
-                        >✎</button>
-                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
-                             editable-text="ctrl.metadata.byline"
-                             onbeforesave="ctrl.updateMetadataField('byline', $data)"
-                             e:form="bylineEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': bylineEditForm.$waiting}">
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
-                                Multiple bylines (click ✎ to edit <strong>all</strong>)
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
-                                Multiple bylines
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
-                                <span ng:if="ctrl.metadata.byline">
-                                    <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
-                                </span>
-
-                                <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
-                            </span>
-                        </span>
-                    </dd>
-
-                    <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
-                    <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
-                        <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="creditEditForm.$show()"
-                            ng:hide="creditEditForm.$visible"
-                        >✎</button>
-
-                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
-                              editable-text="ctrl.metadata.credit"
-                              e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
-                              onbeforesave="ctrl.updateMetadataField('credit', $data)"
-                              e:form="creditEditForm"
-                              e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': creditEditForm.$waiting}">
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
-                                Multiple credits (click ✎ to edit <strong>all</strong>)
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
-                                Multiple credits
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
-                                <span ng:if="ctrl.metadata.credit">
-                                    <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
-                                </span>
-
-                                <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
-                            </span>
-                        </span>
-                    </dd>
-
-                    <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
-                    <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="copyrightEditForm.$show()"
-                                ng:hide="copyrightEditForm.$visible"
-                        >✎</button>
-                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
-                             editable-text="ctrl.metadata.copyright"
-                             onbeforesave="ctrl.updateMetadataField('copyright', $data)"
-                             e:form="copyrightEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
-                                Multiple copyrights (click ✎ to edit <strong>all</strong>)
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
-                                Multiple copyrights
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
-                                <span ng:if="ctrl.metadata.copyright">
-                                    <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
-                                </span>
-
-                                <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
-                            </span>
-                        </span>
-                    </dd>
-                </dl>
-            </div>
-
-            <div class="image-info__group">
-                <div class="image-info__heading">
-                    <span>Labels</span>
-                    <gr-add-label ng:blur="ctrl.cancel"
-                                  gr-small="true"
-                                  images="ctrl.selectedImages">
-                    </gr-add-label>
-                </div>
-                <ul class="labels">
-                    <li class="label"
-                        ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
-                        ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
-                        <button ng:if="label.count < ctrl.selectedImages.size"
-                                class="label__add"
-                                title="Apply label to all"
-                                ng:click="ctrl.addLabel(label.data)">
-                            <gr-icon>library_add</gr-icon>
-                        </button>
-                        <span class="label__value">{{label.data}}</span>
-                        <button class="label__remove"
-                                title="Remove label from all"
-                                ng:click="ctrl.removeLabel(label.data)">
-                            <gr-icon>close</gr-icon>
-                        </button>
-                    </li>
-                </ul>
-            </div>
-
-            <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
-                <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
-                    <div class="metadata-line flex-spacer">
-                        <gr-icon>star_half</gr-icon>
-                        <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} archived</span>
-                        <span ng:if="ctrl.archiving">Saving…</span>
-                    </div>
-                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                        <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                            <gr-icon>star</gr-icon> all
-                        </button>
-                        <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                            <gr-icon>star_border</gr-icon> none
-                        </button>
-                    </span>
+                        </li>
+                    </ul>
                 </div>
 
-                <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
-                    <div class="metadata-line flex-spacer">
-                        <gr-icon>star</gr-icon>
-                        <span ng:if="!ctrl.archiving">All archived</span>
-                        <span ng:if="ctrl.archiving">Saving…</span>
-                    </div>
-                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                        <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                            <gr-icon>star_border</gr-icon> Unarchive all
-                        </button>
-                    </span>
-                </div>
+                <div class="panel__content">
+                    <div class="image-info__group">
+                        <dl class="image-info__wrap metadata-line image-info__usage-rights">
+                            <dt class="metadata-line__key">Usage rights category</dt>
+                            <gr-usage-rights-editor
+                                ng:if="ctrl.showUsageRights"
+                                gr:usage-rights="ctrl.usageRights"
+                                gr:on-save="ctrl.showUsageRights = false"
+                                gr:on-cancel="ctrl.showUsageRights = false">
+                            </gr-usage-rights-editor>
+                            <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
+                                {{ctrl.usageCategory || 'None'}}
+                            </dd>
 
-                <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
-                    <div class="metadata-line flex-spacer">
-                        <gr-icon>star_border</gr-icon>
-                        <span ng:if="!ctrl.archiving">All unarchived</span>
-                        <span ng:if="ctrl.archiving">Saving…</span>
+                            <button
+                                ng:click="ctrl.showUsageRights = true"
+                                ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
+                                class="image-info__edit">✎</button>
+                        </dl>
                     </div>
-                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                        <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                            <gr-icon>star</gr-icon> Archive all
-                        </button>
-                    </span>
+
+                    <div class="image-info__group">
+                        <dl>
+                            <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
+                                <button class="image-info__edit"
+                                        ng:if="ctrl.userCanEdit"
+                                        ng:click="titleEditForm.$show()"
+                                        ng:hide="titleEditForm.$visible">✎</button>
+                                <dt class="metadata-line metadata-line__key">Title</dt>
+                                <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
+                                     editable-text="ctrl.metadata.title"
+                                     onbeforesave="ctrl.updateMetadataField('title', $data)"
+                                     e:form="titleEditForm"
+                                     e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}">
+
+                                    <div ng:if="ctrl.userCanEdit">
+                                        <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                            Multiple titles (click ✎ to edit <strong>all</strong>)
+                                        </dd>
+
+                                        <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                            {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
+                                        </dd>
+                                    </div>
+
+                                    <div ng:if="!ctrl.userCanEdit">
+                                        <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                            Multiple titles
+                                        </dd>
+
+                                        <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                            {{ctrl.metadata.title || "unknown"}}
+                                        </dd>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="image-info__wrap">
+                                <button class="image-info__edit"
+                                        ng:if="ctrl.userCanEdit"
+                                        ng:click="descriptionEditForm.$show()"
+                                        ng:hide="descriptionEditForm.$visible">✎</button>
+                                <dt class="metadata-line metadata-line__key">Description</dt>
+                                <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
+                                     editable-textarea="ctrl.metadata.description"
+                                     onbeforesave="ctrl.updateMetadataField('description', $data)"
+                                     e:msd-elastic
+                                     e:form="descriptionEditForm"
+                                     e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
+
+                                    <div ng:if="ctrl.userCanEdit">
+                                        <dd class="image-info__description"
+                                              ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                            >Multiple descriptions (click ✎ to edit <strong>all</strong>)
+                                        </dd>
+
+                                        <dd class="image-info__description"
+                                              ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                            >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
+                                        </dd>
+                                    </div>
+
+                                    <div ng:if="!ctrl.userCanEdit">
+                                        <dd class="image-info__description"
+                                              ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                            >Multiple descriptions
+                                        </dd>
+
+                                        <dd class="image-info__description"
+                                              ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                            >{{ctrl.metadata.description || "unknown"}}
+                                        </dd>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </dl>
+                    </div>
+
+                    <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
+                        <dl class="image-info__wrap">
+                            <button class="image-info__edit"
+                                    ng:if="ctrl.userCanEdit"
+                                    ng:click="specialInstructionsEditForm.$show()"
+                                    ng:hide="specialInstructionsEditForm.$visible">✎</button>
+                            <dt class="metadata-line metadata-line__key">Special instructions</dt>
+
+
+                            <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
+                                 editable-textarea="ctrl.metadata.specialInstructions"
+                                 onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
+                                 e:msd-elastic
+                                 e:form="specialInstructionsEditForm"
+                                 e:ng-class="{'image-info__editor--error': $error,
+                                              'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
+
+                                <div ng:if="ctrl.userCanEdit">
+                                    <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                          class="image-info__special-instructions"
+                                        >Multiple special instructions (click ✎ to edit <strong>all</strong>)
+                                    </dd>
+
+                                    <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                          class="image-info__special-instructions"
+                                        >{{ctrl.metadata.specialInstructions}}
+                                    </dd>
+                                </div>
+
+                                <div ng:if="!ctrl.userCanEdit">
+                                    <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                          class="image-info__special-instructions"
+                                        >Multiple special instructions
+                                    </dd>
+
+                                    <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                                          class="image-info__special-instructions"
+                                        >{{ctrl.metadata.specialInstructions}}
+                                    </dd>
+                                </div>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="image-info__group">
+                        <dl class="image-info__group--dl metadata-line">
+                            <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
+                            <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
+                                <button class="image-info__edit"
+                                        ng:if="ctrl.userCanEdit"
+                                        ng:click="bylineEditForm.$show()"
+                                        ng:hide="bylineEditForm.$visible"
+                                >✎</button>
+                                <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
+                                     editable-text="ctrl.metadata.byline"
+                                     onbeforesave="ctrl.updateMetadataField('byline', $data)"
+                                     e:form="bylineEditForm"
+                                     e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': bylineEditForm.$waiting}">
+
+                                    <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
+                                        Multiple bylines (click ✎ to edit <strong>all</strong>)
+                                    </span>
+
+                                    <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
+                                        Multiple bylines
+                                    </span>
+
+                                    <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
+                                        <span ng:if="ctrl.metadata.byline">
+                                            <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                                        </span>
+
+                                        <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
+                                    </span>
+                                </span>
+                            </dd>
+
+                            <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
+                            <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
+                                <button class="image-info__edit"
+                                    ng:if="ctrl.userCanEdit"
+                                    ng:click="creditEditForm.$show()"
+                                    ng:hide="creditEditForm.$visible"
+                                >✎</button>
+
+                                <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
+                                      editable-text="ctrl.metadata.credit"
+                                      e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
+                                      onbeforesave="ctrl.updateMetadataField('credit', $data)"
+                                      e:form="creditEditForm"
+                                      e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': creditEditForm.$waiting}">
+
+                                    <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
+                                        Multiple credits (click ✎ to edit <strong>all</strong>)
+                                    </span>
+
+                                    <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
+                                        Multiple credits
+                                    </span>
+
+                                    <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
+                                        <span ng:if="ctrl.metadata.credit">
+                                            <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                                        </span>
+
+                                        <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
+                                    </span>
+                                </span>
+                            </dd>
+
+                            <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
+                            <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                                <button class="image-info__edit"
+                                        ng:if="ctrl.userCanEdit"
+                                        ng:click="copyrightEditForm.$show()"
+                                        ng:hide="copyrightEditForm.$visible"
+                                >✎</button>
+                                <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
+                                     editable-text="ctrl.metadata.copyright"
+                                     onbeforesave="ctrl.updateMetadataField('copyright', $data)"
+                                     e:form="copyrightEditForm"
+                                     e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
+
+                                    <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
+                                        Multiple copyrights (click ✎ to edit <strong>all</strong>)
+                                    </span>
+
+                                    <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
+                                        Multiple copyrights
+                                    </span>
+
+                                    <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
+                                        <span ng:if="ctrl.metadata.copyright">
+                                            <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                                        </span>
+
+                                        <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
+                                    </span>
+                                </span>
+                            </dd>
+                        </dl>
+                    </div>
+
+                    <div class="image-info__group">
+                        <div class="image-info__heading">
+                            <span>Labels</span>
+                            <gr-add-label ng:blur="ctrl.cancel"
+                                          gr-small="true"
+                                          images="ctrl.selectedImages">
+                            </gr-add-label>
+                        </div>
+                        <ul class="labels">
+                            <li class="label"
+                                ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
+                                ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
+                                <button ng:if="label.count < ctrl.selectedImages.size"
+                                        class="label__add"
+                                        title="Apply label to all"
+                                        ng:click="ctrl.addLabel(label.data)">
+                                    <gr-icon>library_add</gr-icon>
+                                </button>
+                                <span class="label__value">{{label.data}}</span>
+                                <button class="label__remove"
+                                        title="Remove label from all"
+                                        ng:click="ctrl.removeLabel(label.data)">
+                                    <gr-icon>close</gr-icon>
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
+                        <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
+                            <div class="metadata-line flex-spacer">
+                                <gr-icon>star_half</gr-icon>
+                                <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} archived</span>
+                                <span ng:if="ctrl.archiving">Saving…</span>
+                            </div>
+                            <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                                <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
+                                    <gr-icon>star</gr-icon> all
+                                </button>
+                                <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
+                                    <gr-icon>star_border</gr-icon> none
+                                </button>
+                            </span>
+                        </div>
+
+                        <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
+                            <div class="metadata-line flex-spacer">
+                                <gr-icon>star</gr-icon>
+                                <span ng:if="!ctrl.archiving">All archived</span>
+                                <span ng:if="ctrl.archiving">Saving…</span>
+                            </div>
+                            <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                                <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
+                                    <gr-icon>star_border</gr-icon> Unarchive all
+                                </button>
+                            </span>
+                        </div>
+
+                        <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
+                            <div class="metadata-line flex-spacer">
+                                <gr-icon>star_border</gr-icon>
+                                <span ng:if="!ctrl.archiving">All unarchived</span>
+                                <span ng:if="ctrl.archiving">Saving…</span>
+                            </div>
+                            <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                                <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
+                                    <gr-icon>star</gr-icon> Archive all
+                                </button>
+                            </span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -9,6 +9,7 @@ import '../../services/image-list';
 import '../../services/label';
 import '../../services/panel';
 import '../../edits/service';
+import '../../related-labels/related-labels';
 import '../../forms/gr-xeditable/gr-xeditable';
 import '../../util/rx';
 
@@ -19,6 +20,7 @@ export var grPanel = angular.module('grPanel', [
     'kahuna.services.label',
     'kahuna.services.panel',
     'kahuna.edits.service',
+    'gr.relatedLabels',
     'grXeditable',
     'ui.bootstrap',
     'util.rx'

--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -59,22 +59,25 @@ grPanel.controller('GrPanel', [
         editsService,
         editsApi) {
 
-        var ctrl = this;
+        const ctrl = this;
+        const panelName = 'gr-panel';
 
         ctrl.showUsageRights = false;
 
-        const panelName = 'gr-panel';
-
         panelService.addPanel(panelName, false);
+        panelService.available(panelName, false);
         ctrl.isVisible = panelService.isVisible(panelName);
 
         $rootScope.$on(
-            'ui:panels:gr-panel:updated',
+            `ui:panels:${panelName}:updated`,
             () => ctrl.isVisible = panelService.isVisible(panelName)
         );
         ctrl.metadataPanelMouseOver = () => panelService.show(panelName);
         ctrl.metadataPanelMouseLeave = () => panelService.hide(panelName);
-
+        ctrl.metadataPanelHide = () => {
+            panelService.unlock(panelName);
+            panelService.hide(panelName);
+        };
 
         inject$($scope, selectedImagesList$, ctrl, 'selectedImages');
 
@@ -169,16 +172,6 @@ grPanel.controller('GrPanel', [
               flatMap(Rx.Observable.fromPromise).
               map(allEditable => allEditable.every(v => v === true));
         inject$($scope, selectionIsEditable$, ctrl, 'userCanEdit');
-
-
-        subscribe$($scope, selection.isEmpty$, isEmpty => {
-            if (isEmpty) {
-                panelService.unavailable(panelName, false);
-            } else {
-                panelService.available(panelName, false);
-            }
-        });
-
 
         ctrl.hasMultipleValues = (val) => Array.isArray(val) && val.length > 1;
 

--- a/kahuna/public/js/related-labels/related-labels.css
+++ b/kahuna/public/js/related-labels/related-labels.css
@@ -1,0 +1,29 @@
+.related-labels__form-label {
+    margin-right: 10px;
+}
+
+.related-labels__form-input {
+    width: 100%;
+    box-sizing: border-box;
+    border: 0;
+    border-bottom: 1px solid #999;
+}
+
+.related-labels__labels {
+    margin-top: 10px;
+    list-style: square inside;
+}
+
+.related-labels__label {
+    margin-left: 2px;
+}
+
+.related-labels__label-text {
+    padding: 2px 5px 4px;
+    box-sizing: border-box;
+}
+
+.related-labels__label-text--selected {
+    border-top: 2px solid #00adee;
+    background-color: #444;
+}

--- a/kahuna/public/js/related-labels/related-labels.html
+++ b/kahuna/public/js/related-labels/related-labels.html
@@ -18,6 +18,7 @@
                 <ul class="related-labels__labels">
                     <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
                         <button class="related-labels__label-text"
+                                ng:click="ctrl.switchCollection(relatedLabel)"
                                 gr:track-click="Related label remove"
                                 gr:track-click-data="{'Label': relatedLabel}">
                                 {{relatedLabel}}

--- a/kahuna/public/js/related-labels/related-labels.html
+++ b/kahuna/public/js/related-labels/related-labels.html
@@ -1,38 +1,30 @@
 <div class="related-labels">
     <div class="related-labels__title">
-        <form ng:submit="ctrl.setCollection()">
-            <label for="collection-name">Collection:</label>
-            <gr-datalist class="related-labels__datalist inline-block"
-                         gr:search="ctrl.suggestedLabelSearch(q)">
-                <!-- TODO: autogrow this element -->
-                <input class="related-labels__parent" type="text"
-                       placeholder="e.g. g2features"
-                       id="collection-name"
-                       ng:model="ctrl.collection"
-                       ng:model-options="{ updateOn: 'gr:datalist:update' }"
-                       ng:change="ctrl.setCollection()"
-                       gr:datalist-input />
-            </gr-datalist>
+        <form ng:submit="ctrl.setCollection()" class="flex-container">
+            <label class="related-labels__form-label" for="collection-name">Collection:</label>
+            <div class="flex-spacer">
+                <gr-datalist class="related-labels__datalist flex-spacer datalist--dark"
+                             gr:search="ctrl.suggestedLabelSearch(q)">
+                    <!-- TODO: autogrow this element -->
+                    <input class="related-labels__form-input" type="text"
+                           placeholder="e.g. g2features"
+                           id="collection-name"
+                           ng:model="ctrl.collection"
+                           ng:model-options="{ updateOn: 'gr:datalist:update' }"
+                           ng:change="ctrl.suggestedLabelSearch(ctrl.collection)"
+                           gr:datalist-input />
+                </gr-datalist>
+
+                <ul class="related-labels__labels">
+                    <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
+                        <button class="related-labels__label-text"
+                                gr:track-click="Related label remove"
+                                gr:track-click-data="{'Label': relatedLabel}">
+                                {{relatedLabel}}
+                        </button>
+                    </li>
+                </ul>
+            </div>
         </form>
     </div>
-    <ul class="flex-container related-labels__labels">
-        <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
-            <div ng:switch="relatedLabel.selected">
-                <button class="related-labels__label-text related-labels__label-text--selected"
-                        ng:switch-when="true"
-                        ng:click="ctrl.removeSuggestedLabel(relatedLabel)"
-                        gr:track-click="Related label remove"
-                        gr:track-click-data="{'Label': relatedLabel.name}">
-                        {{relatedLabel.name}}
-                </button>
-                <button class="related-labels__label-text"
-                        ng:switch-when="false"
-                        ng:click="ctrl.switchSuggestedLabelTo(relatedLabel)"
-                        gr:track-click="Related label select"
-                        gr:track-click-data="{'Label': relatedLabel.name}">
-                        {{relatedLabel.name}}
-                </button>
-            </div>
-        </li>
-    </ul>
 </div>

--- a/kahuna/public/js/related-labels/related-labels.html
+++ b/kahuna/public/js/related-labels/related-labels.html
@@ -1,0 +1,38 @@
+<div class="related-labels">
+    <div class="related-labels__title">
+        <form ng:submit="ctrl.setCollection()">
+            <label for="collection-name">Collection:</label>
+            <gr-datalist class="related-labels__datalist inline-block"
+                         gr:search="ctrl.suggestedLabelSearch(q)">
+                <!-- TODO: autogrow this element -->
+                <input class="related-labels__parent" type="text"
+                       placeholder="e.g. g2features"
+                       id="collection-name"
+                       ng:model="ctrl.collection"
+                       ng:model-options="{ updateOn: 'gr:datalist:update' }"
+                       ng:change="ctrl.setCollection()"
+                       gr:datalist-input />
+            </gr-datalist>
+        </form>
+    </div>
+    <ul class="flex-container related-labels__labels">
+        <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
+            <div ng:switch="relatedLabel.selected">
+                <button class="related-labels__label-text related-labels__label-text--selected"
+                        ng:switch-when="true"
+                        ng:click="ctrl.removeSuggestedLabel(relatedLabel)"
+                        gr:track-click="Related label remove"
+                        gr:track-click-data="{'Label': relatedLabel.name}">
+                        {{relatedLabel.name}}
+                </button>
+                <button class="related-labels__label-text"
+                        ng:switch-when="false"
+                        ng:click="ctrl.switchSuggestedLabelTo(relatedLabel)"
+                        gr:track-click="Related label select"
+                        gr:track-click-data="{'Label': relatedLabel.name}">
+                        {{relatedLabel.name}}
+                </button>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/kahuna/public/js/related-labels/related-labels.js
+++ b/kahuna/public/js/related-labels/related-labels.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import '../services/api/media-api';
+
+import template from './related-labels.html!text';
+
+export const relatedLabels = angular.module('gr.relatedLabels', []);
+
+relatedLabels.controller('GrRelatedLabelsCtrl', ['mediaApi', function(mediaApi) {
+    let ctrl = this;
+
+    ctrl.suggestedLabelSearch = q =>
+        mediaApi.labelsSuggest({q}).then(labels => labels.data);
+
+    
+}]);
+
+relatedLabels.directive('grRelatedLabels', [function() {
+    return {
+        restrict: 'E',
+        controller: 'GrRelatedLabelsCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true,
+        template: template
+    }
+}]);

--- a/kahuna/public/js/related-labels/related-labels.js
+++ b/kahuna/public/js/related-labels/related-labels.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import Rx from 'rx';
 
 import template from './related-labels.html!text';
 import './related-labels.css!';
@@ -34,5 +33,5 @@ relatedLabels.directive('grRelatedLabels', [function() {
         controllerAs: 'ctrl',
         bindToController: true,
         template: template
-    }
+    };
 }]);

--- a/kahuna/public/js/related-labels/related-labels.js
+++ b/kahuna/public/js/related-labels/related-labels.js
@@ -1,12 +1,20 @@
 import angular from 'angular';
+import * as querySyntax from '../search-query/query-syntax';
 
 import template from './related-labels.html!text';
 import './related-labels.css!';
+
 import '../services/api/media-api';
 
 export const relatedLabels = angular.module('gr.relatedLabels', []);
 
-relatedLabels.controller('GrRelatedLabelsCtrl', ['mediaApi', function(mediaApi) {
+relatedLabels.controller('GrRelatedLabelsCtrl', [
+    '$state',
+    '$stateParams',
+    'mediaApi',
+
+function($state, $stateParams, mediaApi) {
+
     let ctrl = this;
     ctrl.relatedLabels = [];
 
@@ -16,6 +24,7 @@ relatedLabels.controller('GrRelatedLabelsCtrl', ['mediaApi', function(mediaApi) 
             then(labels => {
                 labels.follow('related-labels').get().then(related => {
                     ctrl.relatedLabels = related.data.map(label => {
+                        // TODO: return a model that does this for us from the API
                         return label.key.replace(`${ctrl.collection}/`, '');
                     });
                 });
@@ -23,7 +32,29 @@ relatedLabels.controller('GrRelatedLabelsCtrl', ['mediaApi', function(mediaApi) 
                 return labels.data;
             });
 
+    // TODO: Move to query service.
+    ctrl.switchCollection = labelPostfix => {
+        // TODO: return a model that does this for us from the API
+        const label = `${ctrl.collection}/${labelPostfix}`;
+        const q = $stateParams.query || '';
+        const removedLabelsQ = querySyntax.removeLabels(q, ctrl.relatedLabels);
+        const query = querySyntax.addLabel(removedLabelsQ, label);
+        setQuery(query);
+    };
 
+    ctrl.removeCollection = labelPostfix => {
+        // TODO: return a model that does this for us from the API
+        const label = `${ctrl.collection}/${labelPostfix}`;
+        const query = querySyntax.removeLabel($stateParams.query || '', label);
+        setQuery(query);
+    };
+
+    function setQuery(query) {
+        const newStateParams = angular.extend({}, $stateParams, { query });
+        $state.transitionTo($state.current, newStateParams, {
+            reload: true, inherit: false, notify: true
+        });
+    }
 }]);
 
 relatedLabels.directive('grRelatedLabels', [function() {

--- a/kahuna/public/js/related-labels/related-labels.js
+++ b/kahuna/public/js/related-labels/related-labels.js
@@ -1,17 +1,30 @@
 import angular from 'angular';
-import '../services/api/media-api';
+import Rx from 'rx';
 
 import template from './related-labels.html!text';
+import './related-labels.css!';
+import '../services/api/media-api';
 
 export const relatedLabels = angular.module('gr.relatedLabels', []);
 
 relatedLabels.controller('GrRelatedLabelsCtrl', ['mediaApi', function(mediaApi) {
     let ctrl = this;
+    ctrl.relatedLabels = [];
 
     ctrl.suggestedLabelSearch = q =>
-        mediaApi.labelsSuggest({q}).then(labels => labels.data);
+        mediaApi.
+            labelsSuggest({q}).
+            then(labels => {
+                labels.follow('related-labels').get().then(related => {
+                    ctrl.relatedLabels = related.data.map(label => {
+                        return label.key.replace(`${ctrl.collection}/`, '');
+                    });
+                });
+                return labels;
+            }).
+            then(labels => labels.data);
 
-    
+
 }]);
 
 relatedLabels.directive('grRelatedLabels', [function() {

--- a/kahuna/public/js/related-labels/related-labels.js
+++ b/kahuna/public/js/related-labels/related-labels.js
@@ -19,9 +19,9 @@ relatedLabels.controller('GrRelatedLabelsCtrl', ['mediaApi', function(mediaApi) 
                         return label.key.replace(`${ctrl.collection}/`, '');
                     });
                 });
-                return labels;
-            }).
-            then(labels => labels.data);
+                // return this to the search query
+                return labels.data;
+            });
 
 
 }]);

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -25,50 +25,6 @@
                 </button>
             </div>
 
-            <div class="results-toolbar-item results-toolbar-item--static results-toolbar-item--left
-                        results__related-labels related-labels flex-container text-small"
-                        ng:class="{'related-labels--with-labels': ctrl.relatedLabels.length !== 0}">
-                <div class="related-labels__title">
-                    Related to
-                    <span ng:switch="ctrl.relatedLabels.length === 0">
-                        <form class="inline-block" ng:switch-when="true" ng:submit="ctrl.setParentLabel()">
-                            <gr-datalist
-                                    class="related-labels__datalist"
-                                gr:search="ctrl.suggestedLabelSearch(q)">
-                                <!-- TODO: autogrow this element -->
-                                <input class="related-labels__parent" type="text"
-                                       placeholder="e.g. observer"
-                                       ng:model="ctrl.parentLabel"
-                                       ng:model-options="{ updateOn: 'gr:datalist:update' }"
-                                       ng:change="ctrl.setParentLabel()"
-                                       gr:datalist-input />
-                            </gr-datalist>
-                        </form>
-                        <span ng:switch-default>{{ctrl.parentLabel}}:</span>
-                    </span>
-                </div>
-                <ul class="flex-container related-labels__labels">
-                    <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
-                        <div ng:switch="relatedLabel.selected">
-                            <button class="related-labels__label-text related-labels__label-text--selected"
-                                    ng:switch-when="true"
-                                    ng:click="ctrl.removeSuggestedLabel(relatedLabel)"
-                                    gr:track-click="Related label remove"
-                                    gr:track-click-data="{'Label': relatedLabel.name}">
-                                    {{relatedLabel.name}}
-                            </button>
-                            <button class="related-labels__label-text"
-                                    ng:switch-when="false"
-                                    ng:click="ctrl.switchSuggestedLabelTo(relatedLabel)"
-                                    gr:track-click="Related label select"
-                                    gr:track-click-data="{'Label': relatedLabel.name}">
-                                    {{relatedLabel.name}}
-                            </button>
-                        </div>
-                    </li>
-                </ul>
-            </div>
-
             <div class="results-toolbar__right flex-container">
                 <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static"
                      ng:if="ctrl.selectionCount > 0">

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -69,22 +69,25 @@
                 </ul>
             </div>
 
-            <div class="results-toolbar__right flex-container" ng:if="ctrl.inSelectionMode">
-                <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static">
+            <div class="results-toolbar__right flex-container">
+                <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static"
+                     ng:if="ctrl.selectionCount > 0">
                     {{ctrl.selectionCount}} selected
                 </div>
 
                 <a class="results-toolbar-item results-toolbar-item--right"
-			        ng:click="ctrl.clearSelection()">
+			       ng:click="ctrl.clearSelection()"
+			       ng:if="ctrl.selectionCount > 0">
                     <gr-icon-label gr-icon="clear">Clear selection</gr-icon-label>
                 </a>
 
                 <gr-downloader class="results-toolbar-item results-toolbar-item--right"
-                    gr:images="ctrl.selectedImages"></gr-downloader>
+                    gr:images="ctrl.selectedImages"
+                    ng:if="ctrl.selectionCount > 0"></gr-downloader>
 
                 <gr-delete-image class="results-toolbar-item results-toolbar-item--right"
                                  images="ctrl.selectedImages"
-                                 ng:if="ctrl.selectionIsDeletable">
+                                 ng:if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0">
                 </gr-delete-image>
 
                 <a class="results-toolbar-item results-toolbar-item--right results-toolbar-item__metadata-panel-controls"
@@ -92,15 +95,14 @@
                     ng:mouseover="ctrl.showMetadataPanelMouseOver()"
                     ng:mouseleave="ctrl.showMetadataPanelMouseLeave()"
                     ng:click="ctrl.toggleLockMetadataPanel()">
-
                     <span ng:if="ctrl.metadataPanelVisible && !ctrl.metadataPanelLocked">
-                        <gr-icon-label gr-icon="lock_open">Lock meta panel</gr-icon-label>
+                        <gr-icon-label gr-icon="lock_open">Lock info panel</gr-icon-label>
                     </span>
                     <span ng:if="ctrl.metadataPanelVisible && ctrl.metadataPanelLocked">
-                        <gr-icon-label gr-icon="lock">Unlock meta panel</gr-icon-label>
+                        <gr-icon-label gr-icon="lock">Unlock info panel</gr-icon-label>
                     </span>
                     <span ng:if="!ctrl.metadataPanelVisible">
-                        <gr-icon-label gr-icon="chrome_reader_mode">Show meta panel</gr-icon-label>
+                        <gr-icon-label gr-icon="chrome_reader_mode">Show info panel</gr-icon-label>
                     </span>
                 </a>
             </div>

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -78,7 +78,7 @@ results.controller('SearchResultsCtrl', [
 
         const ctrl = this;
 
-        var metadataPanelName = 'gr-panel';
+        const metadataPanelName = 'gr-panel';
 
         ctrl.metadataPanelAvailable = panelService.isAvailable(metadataPanelName);
         ctrl.metadataPanelVisible = panelService.isVisible(metadataPanelName);
@@ -97,7 +97,7 @@ results.controller('SearchResultsCtrl', [
         ctrl.showMetadataPanelMouseLeave = () => panelService.hide(metadataPanelName);
 
         $rootScope.$on(
-            'ui:panels:' + metadataPanelName + ':updated',
+            `ui:panels:${metadataPanelName}:updated`,
             () => {
                 ctrl.metadataPanelAvailable = panelService.isAvailable(metadataPanelName);
                 ctrl.metadataPanelVisible = panelService.isVisible(metadataPanelName);
@@ -376,9 +376,6 @@ results.controller('SearchResultsCtrl', [
         }
 
         ctrl.clearSelection = () => {
-            panelService.hide(metadataPanelName, false);
-            panelService.unavailable(metadataPanelName, false);
-
             selection.clear();
         };
 

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import Rx from 'rx';
-import * as querySyntax from '../search-query/query-syntax';
 
 import '../services/scroll-position';
 import '../services/panel';
@@ -177,54 +176,6 @@ results.controller('SearchResultsCtrl', [
         }).finally(() => {
             ctrl.loading = false;
         });
-
-        // related labels
-        const relatedLabelsPromise$ = Rx.Observable.fromPromise(ctrl.searched).flatMap(images =>
-            Rx.Observable
-                .fromPromise(images.follow('related-labels').get())
-                .catch(err => err.message === 'No link found for rel: related-labels' ?
-                    Rx.Observable.empty() : Rx.Observable.throw(err)
-                )
-        );
-
-        const relatedLabels$ = relatedLabelsPromise$.map(labels =>
-            labels.data.siblings).startWith([]);
-
-        const parentLabel$ = relatedLabelsPromise$.map(labels => labels.data.label);
-
-        inject$($scope, relatedLabels$, ctrl, 'relatedLabels');
-        inject$($scope, parentLabel$, ctrl, 'parentLabel');
-
-        ctrl.switchSuggestedLabelTo = label => {
-            const q = $stateParams.query;
-            const removedLabelsQ = querySyntax.removeLabels(q, ctrl.relatedLabels);
-            const query = querySyntax.addLabel(removedLabelsQ, label.name);
-            setQuery(query);
-        };
-
-        ctrl.removeSuggestedLabel = label => {
-            const query = querySyntax.removeLabel($stateParams.query, label.name);
-            setQuery(query);
-        };
-
-        ctrl.setParentLabel = () => {
-            if (ctrl.parentLabel) {
-                const query = querySyntax.addLabel($stateParams.query || '', ctrl.parentLabel);
-                setQuery(query);
-            }
-        };
-
-        function setQuery(query) {
-            const newStateParams = angular.extend({}, $stateParams, { query });
-            $state.transitionTo($state.current, newStateParams, {
-                reload: true, inherit: false, notify: true
-            });
-        }
-
-        ctrl.suggestedLabelSearch = q =>
-            ctrl.searched.then(images =>
-                images.follow('suggested-labels').get({q}).then(labels => labels.data)
-            ).catch(() => []);
 
         ctrl.loadRange = function(start, end) {
             const length = end - start + 1;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -951,46 +951,6 @@ input.search-query__input {
     height: 36px;
 }
 
-.related-labels {
-    line-height: 35px;
-}
-.related-labels--with-labels {
-    /* This is to allow scrolling of labels, but show the
-    autocomplete dropdown */
-    overflow-x: auto;
-}
-
-.related-labels__datalist {
-    line-height: 1;
-}
-
-input.related-labels__parent {
-    border: 0;
-    background: transparent;
-    border-bottom: 1px solid #999;
-    box-sizing: border-box;
-    padding: 2px 5px;
-    width: 150px;
-}
-
-.related-labels__labels {
-    overflow-x: auto;
-    overflow-y: hidden;
-}
-
-.related-labels__label {
-    margin-left: 2px;
-}
-
-.related-labels__label-text {
-    padding: 2px 5px 4px;
-    box-sizing: border-box;
-}
-.related-labels__label-text--selected {
-    border-top: 2px solid #00adee;
-    background-color: #444;
-}
-
 .image-results-count__new {
     font-family: inherit;
     background-color: #00adee;
@@ -1998,6 +1958,10 @@ ui-archiver .archiver--unarchived:hover {
 .datalist {
     position: relative;
     width: 100%;
+}
+
+.datalist--dark .datalist__options {
+    background: #333;
 }
 
 .datalist__options {


### PR DESCRIPTION
A second suggestion / POC for how to organise labels.

I have done a bit of research, especially around the way Google / Gmail has never moved away from their original labels for multiple reasons, and they do something similar.

The related labels work I think still has value, but due to pollution described by the Observer desk* meant it needed some working out, after the investigation - these seems like an even simpler potential solution.

There will have to be some migration work too if this makes sense.

__TODO:__
- [ ] Ordering
- [ ] Better state handling
- [ ] No UI has been done on this, it's more about the model

* When you have a sub looking knowing that there is something about James Bond going on, and there is the "related labels" of "spies, film, bond" -> how would they know which one it is.

__To demonstrate the model only__
[![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/293iJUPWCIk/0.jpg)](http://www.youtube.com/watch?v=293iJUPWCIk)
