### PR TITLE
exclude newpiz images even though they have getty data

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -172,7 +172,7 @@ trait GettyProcessor {
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   val excludeFrom = List("newspix international")
 
-  // Some people send over Getty XMP data
+  // Some people send over Getty XMP data, but are not affiliated with Getty
   def excludedCredit(credit: Option[String]) = credit.map(_.toLowerCase).exists(excludeFrom.contains)
 
   def apply(image: Image): Image = (excludedCredit(image.metadata.credit), image.fileMetadata.getty.isEmpty) match {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -225,6 +225,13 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.source should be(Some("AFP"))
     }
 
+    it("should exclude images that have Getty metadata that aren't from Getty") {
+      val image = createImageFromMetadata("credit" -> "NEWSPIX INTERNATIONAL")
+      val notGettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Composition" -> "Headshot")))
+      val processedImage = applyProcessors(notGettyImage)
+      processedImage.usageRights should be(NoRights)
+    }
+
     it("should use 'Getty Images' as credit if missing from the file metadata") {
       val image = createImageFromMetadata()
       val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "lol.jpg")))


### PR DESCRIPTION
As per #1391 - it seems Newspix Int are not affiliated with Newspix Aus (who are affiliated with Getty), but they do attach Getty metadata. I can only theorise why, but not 100% sure.

