### PR TITLE
Use the correct name for the Life picture collection

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -32,7 +32,7 @@ object UsageRightsConfig {
     "Terry O'Neill",
     "The Asahi Shimbun Premium Archive",
     "The LIFE Images Collection",
-    "The LIFE Picture Collection Editorial",
+    "The LIFE Picture Collection",
     "The LIFE Premium Collection"
   )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -32,6 +32,8 @@ object UsageRightsConfig {
     "Terry O'Neill",
     "The Asahi Shimbun Premium Archive",
     "The LIFE Images Collection",
+    // On the Getty list this is called "The LIFE picture collection Editorial"
+    // whereas in their metadata they use the below
     "The LIFE Picture Collection",
     "The LIFE Premium Collection"
   )


### PR DESCRIPTION
Search for `source:"The LIFE Picture Collection Editorial"` and `source:"The LIFE Picture Collection"`. We have none in the former.

These are not included in out contract,