### PR TITLE
Also sync originalMetadata to store the cleaned version

### DIFF
--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -52,8 +52,11 @@ case object ImageUpload {
         baseImage      = createImage(uploadRequest, sourceAsset, thumbAsset, fileMetadata, cleanMetadata)
         processedImage = SupplierProcessors.process(baseImage)
 
-        // FIXME: dirty hack to sync the originalUsageRights as well
-        finalImage     = processedImage.copy(originalUsageRights = processedImage.usageRights)
+        // FIXME: dirty hack to sync the originalUsageRights and originalMetadata as well
+        finalImage     = processedImage.copy(
+          originalMetadata    = processedImage.metadata,
+          originalUsageRights = processedImage.usageRights
+        )
       }
       yield ImageUpload(uploadRequest, finalImage)
     }


### PR DESCRIPTION
This should fix #971.

Essentially any cleanup we do on the metadata when loading an image should be stored both on `originalMetadata` and `metadata`. A mismatch between the two (where only `metadata` has the cleaned version) caused any edit to recomputed `metadata` from `originalMetadata`, which then erased any cleaning done at load time.

This was an oversight as we [already do this](https://github.com/guardian/grid/blob/master/media-api/app/controllers/MediaApi.scala#L199-L202) when reindexing. Reindexing images fix the issue.

Note that the discrepancy will be widespread in all the images we have. It can be fixed by reindexing all images, now or later.