### PR TITLE
Remove all remaining mentions of "archive" and replaced with Library

### DIFF
--- a/kahuna/public/js/components/gr-image-persist-status/gr-image-persist-status.html
+++ b/kahuna/public/js/components/gr-image-persist-status/gr-image-persist-status.html
@@ -1,6 +1,6 @@
 <gr-icon-label ng:if="! ctrl.states.canArchive" gr-icon="lock"
-    title="Kept in library because image is: {{ctrl.states.persistedReasons}}.">
-    <span ng:show="ctrl.withText">Kept in library</span>
+    title="Kept in Library because image is: {{ctrl.states.persistedReasons}}.">
+    <span ng:show="ctrl.withText">Kept in Library</span>
 </gr-icon-label>
 
 <ui-archiver ng:if="ctrl.states.canArchive"

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -301,7 +301,7 @@
             <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
                 <div class="metadata-line flex-spacer">
                     <gr-icon>star_half</gr-icon>
-                    <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} archived</span>
+                    <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} kept in Library</span>
                     <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
@@ -317,12 +317,12 @@
             <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
                 <div class="metadata-line flex-spacer">
                     <gr-icon>star</gr-icon>
-                    <span ng:if="!ctrl.archiving">All archived</span>
+                    <span ng:if="!ctrl.archiving">All kept in Library</span>
                     <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
                     <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>star_border</gr-icon> Unarchive all
+                        <gr-icon>star_border</gr-icon> Remove all from Library
                     </button>
                 </span>
             </div>
@@ -330,12 +330,12 @@
             <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
                 <div class="metadata-line flex-spacer">
                     <gr-icon>star_border</gr-icon>
-                    <span ng:if="!ctrl.archiving">All unarchived</span>
+                    <span ng:if="!ctrl.archiving">None kept in Library</span>
                     <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
                     <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>star</gr-icon> Archive all
+                        <gr-icon>star</gr-icon> Keep all in Library
                     </button>
                 </span>
             </div>

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -300,42 +300,42 @@
         <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
             <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
                 <div class="metadata-line flex-spacer">
-                    <gr-icon>star_half</gr-icon>
+                    <gr-icon>lock_open</gr-icon>
                     <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} kept in Library</span>
                     <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
                     <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>star</gr-icon> all
+                        <gr-icon>lock</gr-icon> all
                     </button>
                     <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>star_border</gr-icon> none
+                        <gr-icon>lock_open</gr-icon> none
                     </button>
                 </span>
             </div>
 
             <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
                 <div class="metadata-line flex-spacer">
-                    <gr-icon>star</gr-icon>
+                    <gr-icon>lock</gr-icon>
                     <span ng:if="!ctrl.archiving">All kept in Library</span>
                     <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
                     <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>star_border</gr-icon> Remove all
+                        <gr-icon>lock_open</gr-icon> Remove all
                     </button>
                 </span>
             </div>
 
             <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
                 <div class="metadata-line flex-spacer">
-                    <gr-icon>star_border</gr-icon>
+                    <gr-icon>lock_open</gr-icon>
                     <span ng:if="!ctrl.archiving">None kept in Library</span>
                     <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
                     <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>star</gr-icon> Keep all in Library
+                        <gr-icon>lock</gr-icon> Keep all in Library
                     </button>
                 </span>
             </div>

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -322,7 +322,7 @@
                 </div>
                 <span class="batch-archive__action" ng:if="!ctrl.archiving">
                     <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>star_border</gr-icon> Remove all from Library
+                        <gr-icon>star_border</gr-icon> Remove all
                     </button>
                 </span>
             </div>

--- a/kahuna/public/js/edits/ui-archiver/archiver.html
+++ b/kahuna/public/js/edits/ui-archiver/archiver.html
@@ -12,7 +12,7 @@
             <span ng:show="ctrl.withText">
                 <span ng:show="! ctrl.archiving">
                     <span ng:show="! hover">Kept in Library</span>
-                    <span ng:show="hover">Remove from Library?</span>
+                    <span ng:show="hover">Remove from Library</span>
                 </span>
                 <span ng:show="ctrl.archiving">Removing from Library</span>
             </span>

--- a/kahuna/public/js/edits/ui-archiver/archiver.html
+++ b/kahuna/public/js/edits/ui-archiver/archiver.html
@@ -7,22 +7,22 @@
         ng:mouseleave="hover = false"
         ng:init="hover = false">
     <!-- TODO: Start looking at a new loader to replace our "ing…" loader -->
-    <span ng:show="ctrl.isArchived" title="Remove from library">
+    <span ng:show="ctrl.isArchived" title="Remove from Library">
         <gr-icon-label gr-icon="lock_outline">
             <span ng:show="ctrl.withText">
                 <span ng:show="! ctrl.archiving">
-                    <span ng:show="! hover">Kept in library</span>
-                    <span ng:show="hover">Remove from library?</span>
+                    <span ng:show="! hover">Kept in Library</span>
+                    <span ng:show="hover">Remove from Library?</span>
                 </span>
-                <span ng:show="ctrl.archiving">Removing from library</span>
+                <span ng:show="ctrl.archiving">Removing from Library</span>
             </span>
         </gr-icon-label>
     </span>
-    <span ng:show="! ctrl.isArchived" title="Add to library">
+    <span ng:show="! ctrl.isArchived" title="Add to Library">
         <gr-icon-label gr-icon="lock_open">
             <span ng:show="ctrl.withText">
-                <span ng:show="! ctrl.archiving">Add to library</span>
-                <span ng:show="ctrl.archiving">Adding to library</span>
+                <span ng:show="! ctrl.archiving">Add to Library</span>
+                <span ng:show="ctrl.archiving">Adding to Library</span>
             </span>
         </gr-icon-label>
     </span>


### PR DESCRIPTION
In particular, the meta panel still read "archive". Updated:

![image](https://cloud.githubusercontent.com/assets/36964/10797614/667e3c52-7d9b-11e5-8acd-000b0f0ef1bd.png)
![image](https://cloud.githubusercontent.com/assets/36964/10797668/ad5d627e-7d9b-11e5-9ff5-63bac70d0e1d.png)
![image](https://cloud.githubusercontent.com/assets/36964/10797686/bc0f4a80-7d9b-11e5-8069-3f2f911adfb6.png)

The end goal would be to move them as actions in the action bar alongside Download etc, but requires more work due to the various states this can be in.

Also capitalised Library everywhere and removed `?` in `Remove from Library`.
