### PR TITLE
Rename travel to trv, which they use instead

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -339,7 +339,7 @@ object MediaApi extends Controller with ArgoHelpers {
   def suggestLabels(q: Option[String]) = Authenticated {
 
     val pseudoFamousLabels = List(
-      "cities", "family", "filmandmusic", "lr", "pp", "saturdayreview", "travel",
+      "cities", "family", "filmandmusic", "lr", "pp", "saturdayreview", "trv",
 
       "culturearts", "culturebooks", "culturefilm", "culturestage", "culutremusic",
 


### PR DESCRIPTION
Feel free to ship this small change tomorrow, it just matches up the list with the label actually used by travel.