### PR TITLE
Stupid ui router

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -35,8 +35,8 @@
       "uri-templates": "npm:uri-templates@0.1.5"
     },
     "devDependencies": {
-      "traceur": "github:jmcriffey/bower-traceur@0.0.91",
-      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.91"
+      "traceur": "github:jmcriffey/bower-traceur@0.0.92",
+      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.92"
     },
     "overrides": {
       "github:dbushell/Pikaday@1.3.2": {

--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -36,8 +36,8 @@ System.config({
     "text": "github:systemjs/plugin-text@0.0.2",
     "theseus": "npm:theseus@0.5.1",
     "theseus-angular": "npm:theseus-angular@0.3.0",
-    "traceur": "github:jmcriffey/bower-traceur@0.0.91",
-    "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.91",
+    "traceur": "github:jmcriffey/bower-traceur@0.0.92",
+    "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.92",
     "ua-parser-js": "npm:ua-parser-js@0.7.3",
     "uri-templates": "npm:uri-templates@0.1.5",
     "github:angular-ui/ui-router@0.2.15": {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -38,8 +38,8 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     // see: https://github.com/angular-ui/ui-router/issues/1119#issuecomment-64696060
     // TODO: Fix this
     $urlMatcherFactoryProvider.type('Slashed', {
-        encode: val => val || '',
-        decode: val => val || '',
+        encode: val => angular.isDefined(val) ? val : undefined,
+        decode: val => angular.isDefined(val) ? val : undefined,
         // We want to always match this type. If we match on slash, it won't update
         // the `stateParams`.
         is: () => true

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -24,14 +24,26 @@ export var search = angular.module('kahuna.search', [
     'data-structure.list-factory',
     'data-structure.ordered-set-factory',
     'gr.topBar',
-    'grPanel'
+    'grPanel',
+    'ui.router'
 ]);
 
 // TODO: add a resolver here so that if we error (e.g. 401) we don't keep trying
 // to render - similar to the image controller see:
 // https://github.com/guardian/media-service/pull/478
-search.config(['$stateProvider',
-               function($stateProvider) {
+search.config(['$stateProvider', '$urlMatcherFactoryProvider',
+               function($stateProvider, $urlMatcherFactoryProvider) {
+
+    // Query params slashes are encoded that mess up our seach query when we search for e.g. `24/7`.
+    // see: https://github.com/angular-ui/ui-router/issues/1119#issuecomment-64696060
+    // TODO: Fix this
+    $urlMatcherFactoryProvider.type('Slashed', {
+        encode: val => val || '',
+        decode: val => val || '',
+        // We want to always match this type. If we match on slash, it won't update
+        // the `stateParams`.
+        is: () => true
+    });
 
     $stateProvider.state('search', {
         // FIXME [1]: This state should be abstract, but then we can't navigate to
@@ -51,7 +63,7 @@ search.config(['$stateProvider',
     });
 
     $stateProvider.state('search.results', {
-        url: 'search?query&ids&since&nonFree&uploadedBy&until&orderBy',
+        url: 'search?{query:Slashed}&ids&since&nonFree&uploadedBy&until&orderBy',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -59,7 +59,7 @@ query.controller('SearchQueryCtrl',
     // URL parameters are not decoded when taken out of the params.
     // Might be fixed with: https://github.com/angular-ui/ui-router/issues/1759
     // Pass undefined to the state on empty to remove the QueryString
-    function valOrUndefined(str) { return str ? decodeURIComponent(str) : undefined; }
+    function valOrUndefined(str) { return str ? str : undefined; }
 
     function setAndWatchParam(key) {
         ctrl.filter[key] = valOrUndefined($stateParams[key]);
@@ -101,6 +101,10 @@ query.directive('searchQuery', [function() {
         template: template
     };
 }]);
+
+query.filter('grUriDecode', function() {
+    return s => decodeURIComponent(s);
+});
 
 query.directive('gridFocusOn', function() {
    return function(scope, elem, attr) {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -102,10 +102,6 @@ query.directive('searchQuery', [function() {
     };
 }]);
 
-query.filter('grUriDecode', function() {
-    return s => decodeURIComponent(s);
-});
-
 query.directive('gridFocusOn', function() {
    return function(scope, elem, attr) {
       scope.$on(attr.gridFocusOn, () => {


### PR DESCRIPTION
Slashes keep breaking - now they look right, but are double encoded when read from the `stateParams`.
[Following the following advice](https://github.com/angular-ui/ui-router/issues/1119#issuecomment-134603427), this seems to work in all cases.

Sorry @akash1810 - I think this is what you did the first time.