### PR TITLE
Print styling enhancements

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -213,7 +213,7 @@
 <div class="image-info">
     <dl class="image-info__group image-info__wrap" ng:if="ctrl.metadata.keywords.length > 0">
         <dt class="image-info__heading image-info__wrap">Keywords</dt>
-        <dd>
+        <dd class="image-info__keywords">
             <ul>
                 <li class="image-info__keyword"
                     ng:repeat="keyword in ctrl.metadata.keywords track by $index">

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2131,6 +2131,7 @@ FIXME: what to do with touch devices
         max-width: 100%;
         max-height: 450px;
         transform: none;
+        position: static;
     }
 
     .image-canvas, .image-details {
@@ -2138,7 +2139,7 @@ FIXME: what to do with touch devices
         width: auto;
     }
 
-    .image-info__description {
+    dd {
         max-height: 85px;
         overflow: hidden;
     }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2133,7 +2133,7 @@ FIXME: what to do with touch devices
         transform: none;
     }
 
-    .image-details {
+    .image-canvas, .image-details {
         height: auto;
         width: auto;
     }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2139,7 +2139,7 @@ FIXME: what to do with touch devices
         width: auto;
     }
 
-    dd {
+    .image-info__description, .image-info__keyword {
         max-height: 85px;
         overflow: hidden;
     }


### PR DESCRIPTION
Keywords are sometimes really long and labels might be - delimits height of all metadata descriptions to try to keep things on the same page. 

Firefox had different display to Chrome - styling changes to make image appear in both. 