### PR TITLE
move location of settings.ini to outside of the repo to avoid accidental committing.

### DIFF
--- a/scripts/dot-properties/README.md
+++ b/scripts/dot-properties/README.md
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 
 ### Configure
 
-You need to create the file `settings/settings.ini` using [`settings/settings.ini.template`](./settings/settings.ini.template) as a template.
+You need to create the file `/etc/gu/grid-settings.ini` using [`settings/settings.ini.template`](./settings/settings.ini.template) as a template.
 
 Additionally, the `aws` section can have the values:
  * `profile-name` which is the name of an [AWS CLI Profile](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) and is defaulted to `media-service`
@@ -65,12 +65,7 @@ Additionally, the `aws` section can have the values:
 To generate the .properties files, run the command:
 
 ```sh
-./main.py
-```
-
-NB: If you've set `directory` to a location not writable by the current user (e.g. `/etc/gu`),
-you can run:
-
-```sh
 sudo ./main.py
 ```
+
+NB: `sudo` is needed as we write to `/etc/gu/`.

--- a/scripts/dot-properties/main.py
+++ b/scripts/dot-properties/main.py
@@ -3,7 +3,8 @@
 from ConfigParser import ConfigParser
 from generate import generate_files
 
-CONFIG_FILE = 'settings/settings.ini'
+CONFIG_FILE = '/etc/gu/grid-settings.ini'
+OUTPUT_DIR = '/etc/gu'
 
 def _default_option(config, section, option, default=None):
     return config.get(section, option) \
@@ -21,11 +22,9 @@ def main():
     if not cf_stack:
         raise Exception('No stack found in {}'.format(CONFIG_FILE))
 
-    output_dir = _default_option(config, 'output', 'directory', 'output')
-
     properties = config._sections['properties']
 
-    generate_files(aws_profile_name, aws_region, cf_stack, output_dir, properties)
+    generate_files(aws_profile_name, aws_region, cf_stack, OUTPUT_DIR, properties)
 
 if __name__ == '__main__':
     main()

--- a/scripts/dot-properties/settings/settings.ini.template
+++ b/scripts/dot-properties/settings/settings.ini.template
@@ -1,7 +1,3 @@
-[output]
-; Directory to write files to (defaults to ./output). Generated files need to be put in /etc/gu/
-directory =
-
 [aws]
 ; Cloudformation stackname. Hint aws cloudformation list-stacks | grep "media-service-"
 stack-name =


### PR DESCRIPTION
move location of settings.ini to outside of the repo to avoid accidental committing.