### PR TITLE
Move from assembly mega-JARs to native packager ZIPs

### DIFF
--- a/cropper/conf/cropper.conf
+++ b/cropper/conf/cropper.conf
@@ -5,7 +5,6 @@ env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
 env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
-env APP_OPTIONS=""
 
 env LOGFILE=/home/media-service/logs/stdout.log
 
@@ -17,7 +16,7 @@ stop on runlevel [016]
 
 setuid media-service
 
-chdir $USER_HOME
+chdir /home/media-service
 
 # automatically restart if the process dies
 # respawn

--- a/cropper/conf/cropper.conf
+++ b/cropper/conf/cropper.conf
@@ -1,8 +1,10 @@
+env APP=cropper
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
 env APP_OPTIONS=""
 
 env LOGFILE=/home/media-service/logs/stdout.log
@@ -15,13 +17,13 @@ stop on runlevel [016]
 
 setuid media-service
 
-chdir /home/media-service
+chdir $USER_HOME
 
 # automatically restart if the process dies
 # respawn
 
 script
-  CMD="java $JVM_OPTIONS -jar $JAR $APP_OPTIONS"
-  echo "$CMD" > /home/media-service/logs/cmd.txt
+  CMD="$USER_HOME/$APP/bin/$APP"
+  echo "$CMD" > $USER_HOME/logs/cmd.txt
   $CMD > $LOGFILE 2>&1
 end script

--- a/cropper/conf/cropper.conf
+++ b/cropper/conf/cropper.conf
@@ -23,7 +23,7 @@ chdir $USER_HOME
 # respawn
 
 script
-  CMD="$USER_HOME/$APP/bin/$APP"
+  CMD="$USER_HOME/bin/$APP"
   echo "$CMD" > $USER_HOME/logs/cmd.txt
   $CMD > $LOGFILE 2>&1
 end script

--- a/image-loader/conf/image-loader.conf
+++ b/image-loader/conf/image-loader.conf
@@ -1,10 +1,11 @@
+env APP=image-loader
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
 # Workaround for https://github.com/aws/aws-sdk-java/issues/123
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log  -Djdk.xml.entityExpansionLimit=0"
-env APP_OPTIONS=""
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log  -Djdk.xml.entityExpansionLimit=0"
 
 env LOGFILE=/home/media-service/logs/stdout.log
 
@@ -22,7 +23,7 @@ chdir /home/media-service
 # respawn
 
 script
-  CMD="java $JVM_OPTIONS -jar $JAR $APP_OPTIONS"
-  echo "$CMD" > /home/media-service/logs/cmd.txt
+  CMD="$USER_HOME/bin/$APP"
+  echo "$CMD" > $USER_HOME/logs/cmd.txt
   $CMD > $LOGFILE 2>&1
 end script

--- a/kahuna/conf/kahuna.conf
+++ b/kahuna/conf/kahuna.conf
@@ -1,8 +1,10 @@
+env APP=kahuna
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
 
 env LOGFILE=/home/media-service/logs/stdout.log
 

--- a/kahuna/conf/start.sh
+++ b/kahuna/conf/start.sh
@@ -6,6 +6,6 @@ APP_SECRET=`cat /etc/gu/play-application-secret`
 # session.domain and application.secret are read by Play
 APP_OPTIONS="-Dsession.domain=$SESSION_DOMAIN -Dapplication.secret=$APP_SECRET"
 
-CMD="java $JVM_OPTIONS $APP_OPTIONS -jar $JAR"
-echo "$CMD" > /home/media-service/logs/cmd.txt
+CMD="$USER_HOME/bin/$APP"
+echo "$CMD" > $USER_HOME/logs/cmd.txt
 $CMD > $LOGFILE 2>&1

--- a/kahuna/conf/start.sh
+++ b/kahuna/conf/start.sh
@@ -6,6 +6,8 @@ APP_SECRET=`cat /etc/gu/play-application-secret`
 # session.domain and application.secret are read by Play
 APP_OPTIONS="-Dsession.domain=$SESSION_DOMAIN -Dapplication.secret=$APP_SECRET"
 
+export JAVA_OPTS="$JAVA_OPTS $APP_OPTIONS"
+
 CMD="$USER_HOME/bin/$APP"
 echo "$CMD" > $USER_HOME/logs/cmd.txt
 $CMD > $LOGFILE 2>&1

--- a/media-api/conf/media-api.conf
+++ b/media-api/conf/media-api.conf
@@ -1,8 +1,10 @@
+env APP=media-api
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
 
 env LOGFILE=/home/media-service/logs/stdout.log
 
@@ -20,5 +22,7 @@ chdir /home/media-service
 # respawn
 
 script
-  /bin/bash /home/media-service/start.sh
+  CMD="$USER_HOME/bin/$APP"
+  echo "$CMD" > $USER_HOME/logs/cmd.txt
+  $CMD > $LOGFILE 2>&1
 end script

--- a/media-api/conf/start.sh
+++ b/media-api/conf/start.sh
@@ -1,3 +1,0 @@
-CMD="java $JVM_OPTIONS -jar $JAR "
-echo "$CMD" > /home/media-service/logs/cmd.txt
-$CMD > $LOGFILE 2>&1

--- a/metadata-editor/conf/metadata-editor.conf
+++ b/metadata-editor/conf/metadata-editor.conf
@@ -1,9 +1,10 @@
+env APP=metadata-editor
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
-env APP_OPTIONS=""
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
 
 env LOGFILE=/home/media-service/logs/stdout.log
 
@@ -21,7 +22,7 @@ chdir /home/media-service
 # respawn
 
 script
-  CMD="java $JVM_OPTIONS -jar $JAR $APP_OPTIONS"
-  echo "$CMD" > /home/media-service/logs/cmd.txt
+  CMD="$USER_HOME/bin/$APP"
+  echo "$CMD" > $USER_HOME/logs/cmd.txt
   $CMD > $LOGFILE 2>&1
 end script

--- a/project/PlayArtifact.scala
+++ b/project/PlayArtifact.scala
@@ -2,9 +2,8 @@ package sbt.plugins
 
 import sbt._
 import sbt.Keys._
-import sbtassembly.Plugin._
-import sbtassembly.Plugin.AssemblyKeys._
-import com.typesafe.sbt.packager
+import com.typesafe.sbt.SbtNativePackager._
+import com.typesafe.sbt.packager.Keys.dist
 
 object PlayArtifact extends Plugin {
 
@@ -16,79 +15,45 @@ object PlayArtifact extends Plugin {
 
   val magentaPackageName = SettingKey[String]("magenta-package-name", "Name of the magenta package")
 
-  lazy val playArtifactDistSettings = assemblySettings ++ Seq(
-    mainClass in assembly := Some("play.core.server.NettyServer"),
-    jarName in assembly := "app.jar",
+  val playArtifactDistSettings = Seq(
+    name in Universal := name.value,
 
-    // package config for Magenta and Upstart
-    playArtifactResources <<= (assembly, baseDirectory, name, magentaPackageName) map {
-      (assembly, base, name, packageName) => {
-        val common = Seq(
-          base / "conf" / "deploy.json" -> "deploy.json",
-          base / "conf" / "start.sh" -> s"packages/$packageName/start.sh",
-          base / "conf" / (name + ".conf") -> s"packages/$packageName/$name.conf",
-          assembly -> s"packages/$packageName/${assembly.getName}"
-        )
+    // don't package docs
+    sources in (Compile,doc) := Seq.empty,
+    publishArtifact in (Compile, packageDoc) := false,
 
-        val iccProfileAssets = Seq(
-          base / "cmyk.icc"      -> s"packages/$packageName/cmyk.icc",
-          base / "grayscale.icc" -> s"packages/$packageName/grayscale.icc",
-          base / "srgb.icc"      -> s"packages/$packageName/srgb.icc"
-        )
+    playArtifactResources := (Seq(
+      // upstart config file
+      baseDirectory.value / "conf" / (magentaPackageName.value + ".conf") ->
+        (s"packages/${magentaPackageName.value}/${magentaPackageName.value}.conf"),
 
-       name match {
-         case "cropper" | "image-loader" => common ++ iccProfileAssets
-         case default => common
-       }
-      }
-    },
+      baseDirectory.value / "conf" / "start.sh" -> s"packages/${magentaPackageName.value}/start.sh",
+
+      // the ZIP
+      dist.value -> s"packages/${magentaPackageName.value}/app.zip",
+
+      // and the riff raff deploy instructions
+      baseDirectory.value / "conf" / "deploy.json" -> "deploy.json"
+    ) ++ (name.value match {
+      case "cropper" | "image-loader" =>
+        Seq("cmyk.icc", "grayscale.icc", "srgb.icc").map { file =>
+          baseDirectory.value / file -> s"packages/${magentaPackageName.value}/$file"
+        }
+      case _ => Seq()
+    })),
 
     playArtifactFile := "artifacts.zip",
-    playArtifact <<= buildDeployArtifact,
-    packager.Keys.dist <<= buildDeployArtifact tag Tags.Disk,
-    assembly <<= assembly.tag(Tags.Disk),
-
-    mergeStrategy in assembly <<= (mergeStrategy in assembly) { current =>
-    {
-      // Take ours, i.e. MergeStrategy.first...
-      case "logger.xml" => MergeStrategy.first
-      case "version.txt" => MergeStrategy.first
-
-      // Merge play.plugins because we need them all
-      case "play.plugins" => MergeStrategy.filterDistinctLines
-
-      // Try to be helpful...
-      case "overview.html" => MergeStrategy.first
-      case "NOTICE" => MergeStrategy.first
-      case "LICENSE" => MergeStrategy.first
-      case meta if meta.startsWith("META-INF/") => MergeStrategy.first
-
-      case other => current(other)
-    }
-    },
-
-    excludedFiles in assembly := { (bases: Seq[File]) =>
-      bases flatMap { base => (base / "META-INF" * "*").get } collect {
-        case f if f.getName.toLowerCase == "license" => f
-        case f if f.getName.toLowerCase == "manifest.mf" => f
-        case f if f.getName.endsWith(".SF") => f
-        case f if f.getName.endsWith(".DSA") => f
-        case f if f.getName.endsWith(".RSA") => f
-      }
-    }
-  )
-
-  private def buildDeployArtifact = (streams, target, playArtifactResources, playArtifactFile, magentaPackageName) map {
-    (s, target, resources, artifactFileName, magentaPackageName) =>
-      val distFile = target / artifactFileName
-      s.log.info("Disting " + distFile)
+    playArtifact := {
+      val distFile = target.value / playArtifactFile.value
+      streams.value.log.info("Disting " + distFile)
 
       if (distFile.exists()) {
         distFile.delete()
       }
-      IO.zip(resources, distFile)
+      IO.zip(playArtifactResources.value, distFile)
 
-      s.log.info("Done disting.")
+      streams.value.log.info("Done disting.")
       distFile
-  }
+    }
+  )
 }

--- a/project/PlayArtifact.scala
+++ b/project/PlayArtifact.scala
@@ -3,7 +3,7 @@ package sbt.plugins
 import sbt._
 import sbt.Keys._
 import com.typesafe.sbt.SbtNativePackager._
-import com.typesafe.sbt.packager.Keys.dist
+import com.typesafe.sbt.packager.Keys._
 
 object PlayArtifact extends Plugin {
 
@@ -17,6 +17,9 @@ object PlayArtifact extends Plugin {
 
   val playArtifactDistSettings = Seq(
     name in Universal := name.value,
+
+    // don't nest everything within APP-VERSION directory
+    topLevelDirectory := None,
 
     // don't package docs
     sources in (Compile,doc) := Seq.empty,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.8")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.2")
 

--- a/thrall/conf/thrall.conf
+++ b/thrall/conf/thrall.conf
@@ -1,10 +1,11 @@
+env APP=thrall
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
 # Workaround for https://github.com/aws/aws-sdk-java/issues/123
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log -Djdk.xml.entityExpansionLimit=0"
-env APP_OPTIONS=""
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log -Djdk.xml.entityExpansionLimit=0"
 
 env LOGFILE=/home/media-service/logs/stdout.log
 
@@ -22,7 +23,7 @@ chdir /home/media-service
 # respawn
 
 script
-  CMD="java $JVM_OPTIONS -jar $JAR $APP_OPTIONS"
-  echo "$CMD" > /home/media-service/logs/cmd.txt
+  CMD="$USER_HOME/bin/$APP"
+  echo "$CMD" > $USER_HOME/logs/cmd.txt
   $CMD > $LOGFILE 2>&1
 end script

--- a/usage/conf/usage.conf
+++ b/usage/conf/usage.conf
@@ -1,10 +1,11 @@
+env APP=usage
+
 env USER=media-service
 env USER_HOME=/home/media-service
 env JAR=/home/media-service/app.jar
 
 # Workaround for https://github.com/aws/aws-sdk-java/issues/123
-env JVM_OPTIONS="-Dfile.encoding=UTF-8 -XX:MaxRAMFraction=2 -XX:InitialRAMFraction=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
-env APP_OPTIONS=""
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -XX:MaxRAMFraction=2 -XX:InitialRAMFraction=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
 
 env LOGFILE=/home/media-service/logs/stdout.log
 
@@ -22,7 +23,7 @@ chdir /home/media-service
 # respawn
 
 script
-  CMD="java $JVM_OPTIONS -jar $JAR $APP_OPTIONS"
-  echo "$CMD" > /home/media-service/logs/cmd.txt
+  CMD="$USER_HOME/bin/$APP"
+  echo "$CMD" > $USER_HOME/logs/cmd.txt
   $CMD > $LOGFILE 2>&1
 end script


### PR DESCRIPTION
Besides aligning with newer apps and Play convention, the main benefit is a faster build (quicker to ZIP files than merge loads of JARs) and leaner build config (no more resolving conflicts when merging JARs).

https://github.com/guardian/grid-infra/pull/163 needs to be applied first, and the TC build config need to be changed to run the `play-artifact` target instead of `dist` (tested on `cropper-native` build config, but needs to be applied to the original build config for each app).

## Steps

1. [x] Merge https://github.com/guardian/grid-infra/pull/163
2. [x] Push CF changes to TEST
3. [x] Create `*-native` build configs in TC for all components
4. [ ] Merge this PR, wait for master to build in `*-native` in TC
5. [ ] Deploy all `*-native` to TEST
6. [ ] Check everything is still working
7. [ ] Push CF changes to PROD
8. [ ] Deploy all `*-native` to PROD
9. [ ] Replace all build configs in TC with their `*-native` version
10. [ ] Everyone merges master into their branches
11. [ ] image-loader: add missing `test` step in TC? thrall: remove `clean` step in TC?