### PR TITLE
Style related labels scrollbar in Chrome to avoid overlap

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -989,7 +989,26 @@ input.related-labels__parent {
 .related-labels__labels {
     overflow-x: auto;
     overflow-y: hidden;
+    /* space below scrollbar */
+    margin-bottom: 3px;
 }
+
+/* style scrollbar to take less space */
+.related-labels__labels::-webkit-scrollbar-track {
+	border-radius: 10px;
+	background-color: #555;
+}
+
+.related-labels__labels::-webkit-scrollbar {
+    height: 5px;
+	background-color: #555;
+}
+
+.related-labels__labels::-webkit-scrollbar-thumb {
+	border-radius: 10px;
+	background-color: #888;
+}
+
 
 .related-labels__label {
     margin-left: 2px;


### PR DESCRIPTION
Should look something like:
![image](https://cloud.githubusercontent.com/assets/36964/10912678/6f79502a-8242-11e5-815b-ec64078dba9b.png)

Sadly it's seemingly impossible to style it in Firefox without re-implementing the scrollbar in JS, which is silly.