### PR TITLE
Use the guAnalyser correctly

### DIFF
--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -24,6 +24,7 @@ class QueryBuilder(matchFields: Seq[String]) {
     new MultiMatchQueryBuilder(value, fields: _*).`type`(MultiMatchQueryBuilder.Type.PHRASE)
 
   def makeMultiQuery(value: Value, fields: Seq[String]) = value match {
+    // We only want to search the fields that are indexed with the `guAnalyser` with itself.
     case Words(string) => boolQuery().
       should(buildMultiMatchQuery(string, fields diff guAnalyzedFields)).
       should(buildMultiMatchQueryAnalyzed(string, guAnalyzedFields))

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -26,8 +26,8 @@ class QueryBuilder(matchFields: Seq[String]) {
   def makeMultiQuery(value: Value, fields: Seq[String]): BaseQueryBuilder = value match {
     // We only want to search the fields that are indexed with the `guAnalyser` with itself.
     case Words(string) => boolQuery().
-      should(buildMultiMatchQuery(string, fields diff guAnalyzedFields)).
-      should(buildMultiMatchQueryAnalyzed(string, guAnalyzedFields))
+      should(buildMultiMatchQuery(string, fields)).
+      should(buildMultiMatchQueryAnalyzed(string, fields))
     case Phrase(string) => multiMatchPhraseQuery(string, fields)
     // That's OK, we only do date queries on a single field at a time
     case DateRange(start, end) => throw InvalidQuery("Cannot do multiQuery on date range")

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -2,7 +2,7 @@ package lib.elasticsearch
 
 import com.gu.mediaservice.lib.elasticsearch.IndexSettings
 import lib.querysyntax._
-import org.elasticsearch.index.query.{BoolQueryBuilder, MatchQueryBuilder, MultiMatchQueryBuilder}
+import org.elasticsearch.index.query.{BaseQueryBuilder, BoolQueryBuilder, MatchQueryBuilder, MultiMatchQueryBuilder}
 import org.elasticsearch.index.query.QueryBuilders._
 
 
@@ -23,7 +23,7 @@ class QueryBuilder(matchFields: Seq[String]) {
   def multiMatchPhraseQuery(value: String, fields: Seq[String]) =
     new MultiMatchQueryBuilder(value, fields: _*).`type`(MultiMatchQueryBuilder.Type.PHRASE)
 
-  def makeMultiQuery(value: Value, fields: Seq[String]) = value match {
+  def makeMultiQuery(value: Value, fields: Seq[String]): BaseQueryBuilder = value match {
     // We only want to search the fields that are indexed with the `guAnalyser` with itself.
     case Words(string) => boolQuery().
       should(buildMultiMatchQuery(string, fields diff guAnalyzedFields)).


### PR DESCRIPTION
At the moment we index only `title` and `description` with the `english_s_stemmer`.
When we search on `Words` we apply the analyser to all fields. 

If a field hasn't been indexed with this analyser, it cannot be searched correctly with it. When searching for `byline`s that have an `s` in them e.g. "Charles Emerson" it then gets broken into "Charle Emerson" when using the `english_s_stemmer` as it hasn't been indexed to be searched like this.

This uses [this trick](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#CO114-1) to use the right search analyser dependant on how the field has been indexed.

So:

__Search:__ Jeremy Corbyn
__Matches:__
* description: Jeremy Corbyn's
* description: Jeremy Corbyn
* byline: Jeremy Corbyn

__Does not match__
* byline: Jeremy Corbyn's