### PR TITLE
Use correct stemmer

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -10,7 +10,7 @@ object Mappings {
   val nonAnalyzedString = Json.obj("type" -> "string", "index" -> "not_analyzed")
   val nonIndexedString  = Json.obj("type" -> "string", "index" -> "no")
 
-  val sStemmerAnalysedString = Json.obj("type" -> "string", "analyzer" -> IndexSettings.guAnalyzer)
+  val sStemmerAnalysedString = Json.obj("type" -> "string", "analyzer" -> IndexSettings.englishAnalyzerName)
   val standardAnalysedString = Json.obj("type" -> "string", "analyzer" -> "standard")
 
   val simpleSuggester = Json.obj(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Settings.scala
@@ -3,27 +3,26 @@ package com.gu.mediaservice.lib.elasticsearch
 import play.api.libs.json.Json
 
 object IndexSettings {
-  // TODO rename `english_s_stemmer` as its an analyzer not a stemmer - would require a reindex.
-  val guAnalyzer = "english_s_stemmer"
+  val englishAnalyzerName = "english_analyzer"
 
-  val englishSStemmer = Json.obj(
+  val englishAnalyzer = Json.obj(
     "type" -> "custom",
     "tokenizer" -> "standard",
     "filter" -> Json.arr(
-      "lowercase",
-      "asciifolding",
       "english_possessive_stemmer",
-      "gu_stopwords",
-      "s_stemmer"
+      "lowercase",
+      "english_stop",
+      "light_english_stemmer",
+      "asciifolding"
     )
   )
 
   val filter = Json.obj(
-    "s_stemmer" -> Json.obj(
+    "light_english_stemmer" -> Json.obj(
       "type" -> "stemmer",
-      "language" -> "minimal_english"
+      "language" -> "light_english"
     ),
-    "gu_stopwords" -> Json.obj(
+    "english_stop" -> Json.obj(
       "type" -> "stop",
       "stopwords" -> "_english_"
     ),
@@ -34,7 +33,7 @@ object IndexSettings {
   )
 
   val analyzer = Json.obj(
-    guAnalyzer -> englishSStemmer
+    englishAnalyzerName -> englishAnalyzer
   )
 
   val analysis = Json.obj(

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -18,7 +18,7 @@ class QueryBuilder(matchFields: Seq[String]) {
     case Words(string) => multiMatchQuery(string, fields: _*)
                           .operator(MatchQueryBuilder.Operator.AND)
                           .`type`(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                          .analyzer(IndexSettings.guAnalyzer)
+                          .analyzer(IndexSettings.englishAnalyzerName)
     case Phrase(string) => multiMatchPhraseQuery(string, fields)
     // That's OK, we only do date queries on a single field at a time
     case DateRange(start, end) => throw InvalidQuery("Cannot do multiQuery on date range")


### PR DESCRIPTION
In favour of #1424.

`minimal_english` is described as follows (bold for emphasis):

> The EnglishMinimalStemmer in Lucene, which __removes plurals__

This means "charles" becomes "charle" because it's stupid.

We've actually gone with the analyser [here](https://www.elastic.co/guide/en/elasticsearch/guide/current/algorithmic-stemmers.html). It seems to do everything we want it to.

A few re-namings too to hopefully make it more clear.

__NOTE:__
Reindex necessary.