### PR TITLE
only set credit on composites

### DIFF
--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -11,7 +11,7 @@ object UsageRightsMetadataMapper {
       case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: ContractIllustrator      => ImageMetadata(credit = Some(u.creator))
       case u: CommissionedIllustrator  => ImageMetadata(credit = Some(u.creator))
-      case u: Composite                => ImageMetadata(byline = Some(u.suppliers), credit = Some(u.suppliers))
+      case u: Composite                => ImageMetadata(credit = Some(u.suppliers))
     }
 
     // if we don't match, return None

--- a/metadata-editor/test/UsageRightsMetadataMapperTest.scala
+++ b/metadata-editor/test/UsageRightsMetadataMapperTest.scala
@@ -39,6 +39,12 @@ class UsageRightsMetadataMapperTest extends FunSpec with Matchers {
         Some(ImageMetadata(credit = Some("Roger Rabit")))
     }
 
+    it ("should convert Composites") {
+      val ur = Composite("REX/Getty Images")
+      usageRightsToMetadata(ur) should be
+        Some(ImageMetadata(credit = Some("REX/Getty Images")))
+    }
+
     it ("should not convert Agencies") {
       val ur = Agency("Rex Features")
       usageRightsToMetadata(ur) should be(None)


### PR DESCRIPTION
Not sure why we thought it should be in the `byline`.