### PR TITLE
Allow single quotes through query filter

### DIFF
--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -3,11 +3,11 @@ import angular from 'angular';
 export var queryFilters = angular.module('kahuna.search.filters.query', []);
 
 var containsSpace = s => / /.test(s);
-var stripQuotes = s => s.replace(/["']/g, '');
+var stripDoubleQuotes = s => s.replace(/"/g, '');
 
 queryFilters.filter('queryFilter', function() {
     return (value, field) => {
-        let cleanValue = stripQuotes(value);
+        const cleanValue = stripDoubleQuotes(value);
         if (containsSpace(cleanValue)) {
             return `${field}:"${cleanValue}"`;
         } else {
@@ -18,7 +18,7 @@ queryFilters.filter('queryFilter', function() {
 
 queryFilters.filter('queryLabelFilter', function() {
     return (value) => {
-        let cleanValue = stripQuotes(value);
+        const cleanValue = stripDoubleQuotes(value);
         if (containsSpace(cleanValue)) {
             return `#"${cleanValue}"`;
         } else {


### PR DESCRIPTION
This does raise the question of what we do with double quotes. e.g. `by:Tony "Towers" Tetnowski`. We could match to see if there are double quotes, then use single quotes, but then what if we have both?

This is is a simple solution - I'd like to see if we have a double quote problem before we try fix it.