### PR TITLE
S3Watcher - Fix for not moving to fail bucket

### DIFF
--- a/s3watcher/S3Watcher.js
+++ b/s3watcher/S3Watcher.js
@@ -13,9 +13,7 @@ exports.handler = function(event, context) {
     });
 
     transfer.flatMap(function(t){
-        return t.operation().catch(function(e){
-            return t.fail(e);
-        }).flatMap(t.success);
+        return t.operation();
     }).subscribe(
         lambda.success,
         lambda.fail


### PR DESCRIPTION
Noticed that failed images were not getting moved to the fail bucket (although they were being logged as failed). 

This PR provides a (tested) fix this problem.

