### PR TITLE
[WIP] Usage: Use usage URI in notification

### DIFF
--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -33,6 +33,8 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   val previewPollTable = properties("dynamo.tablename.previewPollTable")
   val usageRecordTable = properties("dynamo.tablename.usageRecordTable")
 
+  val topicArn = properties("sns.topic.arn")
+
   val dynamoRegion: Region = Region.getRegion(Regions.EU_WEST_1)
 
   val corsAllAllowedOrigins = List(services.kahunaBaseUri)

--- a/usage/app/lib/UsageNotifications.scala
+++ b/usage/app/lib/UsageNotifications.scala
@@ -1,0 +1,25 @@
+package lib
+
+import play.api.libs.json._
+import com.gu.mediaservice.lib.aws.SNS
+import model.UsageGroup
+
+
+object UsageNotifications extends SNS(Config.awsCredentials, Config.topicArn) {
+  val messageType = "update-image-usage"
+  def publishUsage(id: String) =
+    publish(buildMessage(id), messageType)
+
+  def publishFromUsageGroup(usageGroup: UsageGroup) = {
+    usageGroup.usages
+      .map(_.mediaId)
+      .toList.distinct
+      .map(publishUsage)
+  }
+
+  def buildMessage(mediaId: String) = Json.obj(
+    "id" -> mediaId,
+    "uri" -> s"http://www.example.com/usages/media/$mediaId"
+  )
+
+}

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -49,6 +49,8 @@ object UsageRecorder {
   def subscribe = UsageRecorder.observable.subscribe(subscriber)
 
   def recordUpdates(usageGroup: UsageGroup) = {
+    UsageNotifications.publishFromUsageGroup(usageGroup)
+
     UsageTable.matchUsageGroup(usageGroup).flatMap(dbUsageGroup => {
 
       val deletes = (dbUsageGroup.usages -- usageGroup.usages).map(UsageTable.delete)


### PR DESCRIPTION
I'd like to consider notifying by URI rather than including all the
content in the message. This means that Thrall makes an API call to
usage when it gets the update and pulls the state itself from the URI
included.

This lets us avoid having to worry about deserializing the content of
messages differently from API responses.

I think there may be other benefits too but haven't completely thought
through all the consequences of this approach.

Comments welcome.