### PR TITLE
adds tracking to create full frame button

### DIFF
--- a/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.html
+++ b/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.html
@@ -1,3 +1,4 @@
-<div ng:click="ctrl.callCrop(); $event.stopPropagation();">
+<div ng:click="ctrl.callCrop(); $event.stopPropagation();"
+     gr:track-click="Full frame button">
         <gr-icon-label gr-icon="crop"></gr-icon-label> Creat<span ng:hide="ctrl.cropping">e</span><span ng:if="ctrl.cropping">ing</span> full frame<span ng:if="ctrl.cropping">…</span>
 </div>

--- a/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.js
+++ b/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 
 import template from './gr-export-original-image.html!text';
-import "../../analytics/track";
+import '../../analytics/track';
 
 export const exportOriginalImage = angular.module('gr.exportOriginalImage', [
     'analytics.track'

--- a/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.js
+++ b/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.js
@@ -1,8 +1,11 @@
 import angular from 'angular';
 
 import template from './gr-export-original-image.html!text';
+import "../../analytics/track";
 
-export const exportOriginalImage = angular.module('gr.exportOriginalImage', []);
+export const exportOriginalImage = angular.module('gr.exportOriginalImage', [
+    'analytics.track'
+]);
 
 exportOriginalImage.controller('grExportOriginalImageCtrl', [
     '$scope', '$rootScope', '$state', '$stateParams', 'mediaCropper',


### PR DESCRIPTION
> In fact, could we make it a rule to add tracking wherever we add new features we expected being used. An obvious example would be the usage tab, as well as the "full frame" button (cc @tsop14).

Done. 