### PR TITLE
Bump panda to 0.2.9

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Panda.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Panda.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.auth
 
 import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.internal.StaticCredentialsProvider
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 
@@ -19,10 +20,12 @@ trait PanDomainAuthActions extends AuthActions {
   override def authCallbackUrl: String = s"$authCallbackBaseUri/oauthCallback"
 
   override lazy val domain: String = properties("panda.domain")
-  lazy val awsKeyId                = properties.get("panda.aws.key")
-  lazy val awsSecretAccessKey      = properties.get("panda.aws.secret")
+  lazy val awsKeyId                = properties("panda.aws.key")
+  lazy val awsSecretAccessKey      = properties("panda.aws.secret")
 
-  override lazy val awsCredentials = for (key <- awsKeyId; sec <- awsSecretAccessKey) yield {new BasicAWSCredentials(key, sec)}
+  override def awsCredentialsProvider = new StaticCredentialsProvider(
+    new BasicAWSCredentials(awsKeyId, awsSecretAccessKey)
+  )
 
   override val system: String = "media-service"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,8 +28,8 @@ object Dependencies {
   )
 
   val pandaDeps = Seq(
-    ("com.gu" %% "pan-domain-auth-core" % "0.2.7") exclude ("xpp3", "xpp3") exclude("com.google.guava", "guava-jdk5"),
-    ("com.gu" %% "pan-domain-auth-play" % "0.2.7")
+    ("com.gu" %% "pan-domain-auth-core" % "0.2.9") exclude ("xpp3", "xpp3") exclude("com.google.guava", "guava-jdk5"),
+    ("com.gu" %% "pan-domain-auth-play" % "0.2.9")
   )
 
   val guDeps = Seq(


### PR DESCRIPTION
Version bump in preparation for rolling out fixes merged into panda's master. I wanted to decouple these changes from upgrading to the current latest version.

Note that this keeps our existing panda infrastructure but we should eventually migrate to use:
- [ ] STS AssumeRole instead of panda credentials stored on disk.
- [ ] All services apart from kahuna/auth to use just the verification library and not the auth issuing library.
- [ ] Separate out auth from kahuna, making kahuna just static files and auth a standalone service much like [login.gutools](https://github.com/guardian/login.gutools).