### PR TITLE
Bump panda to 0.2.10

### DIFF
--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -165,7 +165,7 @@ System.config({
     },
     "npm:pandular@0.1.5": {
       "angular": "github:angular/bower-angular@1.4.3",
-      "panda-session": "npm:panda-session@0.1.5"
+      "panda-session": "npm:panda-session@0.1.6"
     },
     "npm:path-browserify@0.0.0": {
       "process": "github:jspm/nodelibs-process@0.1.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,8 +28,8 @@ object Dependencies {
   )
 
   val pandaDeps = Seq(
-    ("com.gu" %% "pan-domain-auth-core" % "0.2.9") exclude ("xpp3", "xpp3") exclude("com.google.guava", "guava-jdk5"),
-    ("com.gu" %% "pan-domain-auth-play" % "0.2.9")
+    ("com.gu" %% "pan-domain-auth-core" % "0.2.10") exclude ("xpp3", "xpp3") exclude("com.google.guava", "guava-jdk5"),
+    ("com.gu" %% "pan-domain-auth-play" % "0.2.10")
   )
 
   val guDeps = Seq(


### PR DESCRIPTION
This should hopefully silence our 500s in kahuna.

This doesn't intrinsically solve the "anti-forgery token did not match" error, but it exposes it as a 400 to the client, which should then show it as a global error to the user, rather than failing silently.