### PR TITLE
add collections and actiondata models

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -1,0 +1,19 @@
+package com.gu.mediaservice.model
+
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+case class Collection(path: List[String], actionData: ActionData)
+object Collection {
+  implicit def formats: Format[Collection] = Json.format[Collection]
+}
+
+// Following the crop structure
+// TODO: Use this in crop too
+case class ActionData(author: String, date: DateTime)
+object ActionData {
+  implicit def formats: Format[ActionData] = Json.format[ActionData]
+  // TODO: Use the generic formats for DateTime
+  implicit val dateWrites = Writes.jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+  implicit val dateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+}


### PR DESCRIPTION
Been working with @tsop14 around creating a collection model.

From that we decided we'd need to track who created it (or added it to an image) - so there's a small attempt to try and standardise action data.

I have looked for a standard around this - [Schema.org has one](schema.org/Action) - but it's too verbose (it uses `startTime` and `endTime`).

This is in common lib as it'll be needed for `Image` and `Edits` soon enough.