### PR TITLE
small script to download permissions file from s3

### DIFF
--- a/scripts/get-permissions.sh
+++ b/scripts/get-permissions.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+STACK_NAME=$1
+
+if [ -z ${STACK_NAME} ];
+then
+    echo "Please specify a stack name."
+    echo "Pro tip: you can get your stack name by running:"
+    echo
+    echo "   $ aws cloudformation list-stacks | jq '.StackSummaries[] | select(.StackStatus == \"UPDATE_COMPLETE\") | .StackName'"
+    echo
+    exit 1
+fi
+
+BUCKET=`aws cloudformation describe-stack-resources --stack-name ${STACK_NAME} \
+    | jq '.StackResources[] | select(.LogicalResourceId == "ConfigBucket") | .PhysicalResourceId' \
+    | tr -d '"'`
+
+echo "Downloading permissions file to /tmp/permissions.properties. Edit it then replace it by:"
+echo
+echo "  $ aws s3 cp /tmp/permissions.properties s3://${BUCKET}/permissions.properties"
+echo
+
+aws s3 cp "s3://${BUCKET}/permissions.properties" /tmp/permissions.properties

--- a/scripts/get-stack-resource.sh
+++ b/scripts/get-stack-resource.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+STACK_NAME=$1
+STACK_RESOURCE=$2
+
+if [ -z $STACK_NAME ];
+then
+    echo "Please specify a stack name."
+    echo "Pro tip: you can get your stack name by running:"
+    echo
+    echo "   $ aws cloudformation list-stacks | jq '.StackSummaries[] | select(.StackStatus == \"UPDATE_COMPLETE\") | .StackName'"
+    echo
+    exit 1
+fi
+
+if [ -z $STACK_RESOURCE ];
+then
+    echo "Please specify a stack resource."
+    echo
+    exit 1
+fi
+
+JQ_FILTER="jq '.StackResources[] | select(.LogicalResourceId == \"$STACK_RESOURCE\") | .PhysicalResourceId'"
+
+aws cloudformation describe-stack-resources --stack-name ${STACK_NAME} | eval $JQ_FILTER | tr -d '"'


### PR DESCRIPTION
Helper script to download the `permissions.properties` file from any stack. Downloads to `/tmp` as its outside of the project directory so can't be checked in.

Usage: `./get-permissions.sh STACK_NAME`.

Not entirely convinced `/scripts` is the correct directory...