### PR TITLE
adds a progress bar for http requests.

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -12,6 +12,7 @@
       "angular-ui-router": "github:angular-ui/ui-router@^0.2.15",
       "angular-ui-router-extras": "github:christopherthielen/ui-router-extras@^0.0.14",
       "angular-xeditable": "github:vitalets/angular-xeditable@^0.1.9",
+      "angular-loading-bar": "github:chieffancypants/angular-loading-bar@^0.8.0",
       "clean-css": "npm:clean-css@^3.3.5",
       "css": "github:systemjs/plugin-css@0.1.13",
       "github:tapmodo/Jcrop": "github:tapmodo/Jcrop@0.9.12",

--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -17,6 +17,7 @@ System.config({
     "angular-ui-router": "github:angular-ui/ui-router@0.2.15",
     "angular-ui-router-extras": "github:christopherthielen/ui-router-extras@0.0.14",
     "angular-xeditable": "github:vitalets/angular-xeditable@0.1.9",
+    "angular-loading-bar": "github:chieffancypants/angular-loading-bar@0.8.0",
     "clean-css": "npm:clean-css@3.3.6",
     "css": "github:systemjs/plugin-css@0.1.13",
     "github:tapmodo/Jcrop": "github:tapmodo/Jcrop@0.9.12",
@@ -45,6 +46,10 @@ System.config({
     },
     "github:angular/bower-angular-animate@1.4.3": {
       "angular": "github:angular/bower-angular@1.4.3"
+    },
+    "github:chieffancypants/angular-loading-bar@0.8.0": {
+      "angular": "github:angular/bower-angular@1.4.3",
+      "css": "github:systemjs/plugin-css@0.1.13"
     },
     "github:christopherthielen/ui-router-extras@0.0.14": {
       "angular": "github:angular/bower-angular@1.4.3"

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -2,6 +2,7 @@
 
 import angular from 'angular';
 import 'angular-ui-router';
+import 'angular-loading-bar';
 import 'pandular';
 import uriTemplates from 'uri-templates';
 import './services/api/media-api';
@@ -59,7 +60,8 @@ var kahuna = angular.module('kahuna', [
 
     // directives used throughout
     'gr.imageFadeOnLoad',
-    'grIcon'
+    'grIcon',
+    'angular-loading-bar'
 ]);
 
 
@@ -82,6 +84,9 @@ kahuna.config(['$urlRouterProvider',
     $urlRouterProvider.otherwise('/search');
 }]);
 
+kahuna.config(['cfpLoadingBarProvider', function (cfpLoadingBarProvider) {
+    cfpLoadingBarProvider.includeSpinner = false;
+}]);
 
 /* Perform an initial API request to detect 401 (not logged in) and
  * redirect browser for authentication if necessary.


### PR DESCRIPTION
Gives visibility on the progression of an image(s) download - there's a 2px progress bar at the top of the page.

I want to add toasts too, in a subsequent PR, using [`ng-messages`](https://docs.angularjs.org/api/ngMessages/directive/ngMessages). There'd need to be a bit of refactoring to the way we currently use `ng-messages` to display global errors however, so this felt like a very quick win.

There's an added bonus in that the progress bar is shown for any http request, e.g creating crops, metadata edits, search, upload (can be configured to ignore certain requests if needed).

![progress-bar](https://cloud.githubusercontent.com/assets/836140/11341215/5a0ca19e-91f9-11e5-960b-c43940627234.gif)
