### PR TITLE
update to boto3.

### DIFF
--- a/scripts/dot-properties/README.md
+++ b/scripts/dot-properties/README.md
@@ -28,6 +28,12 @@ NB: From the virtualenvwrapper docs:
 
 > You will want to add the command to `source /usr/local/bin/virtualenvwrapper.sh` to your shell startup file, changing the path to virtualenvwrapper.sh depending on where it was installed by pip.
 
+So:
+
+```sh
+echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.profile
+```
+
 ## Usage
 
 ### Install requirements
@@ -56,9 +62,20 @@ pip install -r requirements.txt
 
 You need to create the file `/etc/gu/grid-settings.ini` using [`settings/settings.ini.template`](./settings/settings.ini.template) as a template.
 
-Additionally, the `aws` section can have the values:
- * `profile-name` which is the name of an [AWS CLI Profile](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) and is defaulted to `media-service`
- * `region` which is the region your CloudFormation is in. If none is specified it is defaulted to `eu-west-1`.
+Note that this script uses the [boto3](http://boto3.readthedocs.org/en/latest/index.html) library.
+boto3 uses the [same authentication as the aws-cli](http://boto3.readthedocs.org/en/latest/guide/configuration.html#guide-configuration).
+
+We expect you to have a `media-service` profile setup with the awscli:
+
+```sh
+aws configure --profile media-service
+```
+
+Note: As stated in the boto3 documentation, you must specify a region:
+
+> you **must** have AWS credentials and a region set in order to make requests.
+
+You can specify an alternative aws profile for this script to use by setting the `profile_name` value in `/etc/gu/grid-settings.ini` under the `aws` section.
 
 
 ### Generating .properties
@@ -68,4 +85,4 @@ To generate the .properties files, run the command:
 sudo ./main.py
 ```
 
-NB: `sudo` is needed as we write to `/etc/gu/`.
+Note: `sudo` is needed as we write to `/etc/gu/`.

--- a/scripts/dot-properties/main.py
+++ b/scripts/dot-properties/main.py
@@ -6,6 +6,7 @@ from generate import generate_files
 CONFIG_FILE = '/etc/gu/grid-settings.ini'
 OUTPUT_DIR = '/etc/gu'
 
+
 def _default_option(config, section, option, default=None):
     return config.get(section, option) \
         if config.has_option(section, option) else default
@@ -15,16 +16,10 @@ def main():
     config = ConfigParser()
     config.read(CONFIG_FILE)
 
-    aws_profile_name = _default_option(config, 'aws', 'profile-name', 'media-service')
-    aws_region = _default_option(config, 'aws', 'region', 'eu-west-1')
-    cf_stack = _default_option(config, 'aws', 'stack-name', None)
-
-    if not cf_stack:
-        raise Exception('No stack found in {}'.format(CONFIG_FILE))
-
+    aws_profile_name = _default_option(config, 'aws', 'profile_name', 'media-service')
     properties = config._sections['properties']
 
-    generate_files(aws_profile_name, aws_region, cf_stack, OUTPUT_DIR, properties)
+    generate_files(aws_profile_name, OUTPUT_DIR, properties)
 
 if __name__ == '__main__':
     main()

--- a/scripts/dot-properties/requirements.txt
+++ b/scripts/dot-properties/requirements.txt
@@ -1,3 +1,3 @@
-boto==2.37.0
+boto3==1.2.2
 Jinja2==2.7.3
 configparser==3.3.0.post2

--- a/scripts/dot-properties/settings/settings.ini.template
+++ b/scripts/dot-properties/settings/settings.ini.template
@@ -1,6 +1,6 @@
 [aws]
-; Cloudformation stackname. Hint aws cloudformation list-stacks | grep "media-service-"
-stack-name =
+; awscli profile name, defaulted to media-service Hint cat ~/.aws/credentials
+profile_name = media-service
 
 [properties]
 ; Domain root of your site, e.g. media.foobar.co.uk


### PR DESCRIPTION
From https://github.com/guardian/grid/issues/1477#issuecomment-159029232, I realised the properties generator was too configurable in comparison to other scripts in the project.

These changes mean:
- Only the profile can be configured via the settings file.
- The aws region is controlled by the value in the aws config file `~/.aws/config`, which is more conventional.
- The stack name is calculated in a similar way to [`stack-name.sh`](https://github.com/guardian/grid/blob/master/cloud-formation/scripts/stack-name.sh)

boto3 also logs more by default.