### PR TITLE
Fix meta panel height and horizontal scrollbars

### DIFF
--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -13,348 +13,348 @@
         </button>
     </div>
 
-    <div ng:if="ctrl.selectedImages.size > 0">
-        <div class="panel__top">
-            <ul class="costs">
-                <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
-                    <div ng:switch="cost.data">
-                        <div ng:switch-when="free"
-                             class="image-notice image-info__group status cost cost--free">
-                            {{cost.count}} free
-                        </div>
-
-                        <div ng:switch-when="pay"
-                             class="image-notice image-info__group status cost cost--pay">
-                            {{cost.count}} pay
-                        </div>
-
-                        <div ng:switch-when="conditional"
-                             class="image-notice image-info__group cost cost--conditional">
-                            {{cost.count}} restricted
-                        </div>
+    <div ng:if="ctrl.selectedImages.size > 0"
+         class="panel__top">
+        <ul class="costs">
+            <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
+                <div ng:switch="cost.data">
+                    <div ng:switch-when="free"
+                         class="image-notice image-info__group status cost cost--free">
+                        {{cost.count}} free
                     </div>
-                </li>
-            </ul>
+
+                    <div ng:switch-when="pay"
+                         class="image-notice image-info__group status cost cost--pay">
+                        {{cost.count}} pay
+                    </div>
+
+                    <div ng:switch-when="conditional"
+                         class="image-notice image-info__group cost cost--conditional">
+                        {{cost.count}} restricted
+                    </div>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+    <div ng:if="ctrl.selectedImages.size > 0"
+         class="panel__content">
+        <div class="image-info__group">
+            <dl class="image-info__wrap metadata-line image-info__usage-rights">
+                <dt class="metadata-line__key">Usage rights category</dt>
+                <gr-usage-rights-editor
+                    ng:if="ctrl.showUsageRights"
+                    gr:usage-rights="ctrl.usageRights"
+                    gr:on-save="ctrl.showUsageRights = false"
+                    gr:on-cancel="ctrl.showUsageRights = false">
+                </gr-usage-rights-editor>
+                <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
+                    {{ctrl.usageCategory || 'None'}}
+                </dd>
+
+                <button
+                    ng:click="ctrl.showUsageRights = true"
+                    ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
+                    class="image-info__edit">✎</button>
+            </dl>
         </div>
 
-        <div class="panel__content">
-            <div class="image-info__group">
-                <dl class="image-info__wrap metadata-line image-info__usage-rights">
-                    <dt class="metadata-line__key">Usage rights category</dt>
-                    <gr-usage-rights-editor
-                        ng:if="ctrl.showUsageRights"
-                        gr:usage-rights="ctrl.usageRights"
-                        gr:on-save="ctrl.showUsageRights = false"
-                        gr:on-cancel="ctrl.showUsageRights = false">
-                    </gr-usage-rights-editor>
-                    <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
-                        {{ctrl.usageCategory || 'None'}}
-                    </dd>
-
-                    <button
-                        ng:click="ctrl.showUsageRights = true"
-                        ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
-                        class="image-info__edit">✎</button>
-                </dl>
-            </div>
-
-            <div class="image-info__group">
-                <dl>
-                    <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="titleEditForm.$show()"
-                                ng:hide="titleEditForm.$visible">✎</button>
-                        <dt class="metadata-line metadata-line__key">Title</dt>
-                        <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
-                             editable-text="ctrl.metadata.title"
-                             onbeforesave="ctrl.updateMetadataField('title', $data)"
-                             e:form="titleEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}">
-
-                            <div ng:if="ctrl.userCanEdit">
-                                <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    Multiple titles (click ✎ to edit <strong>all</strong>)
-                                </dd>
-
-                                <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
-                                </dd>
-                            </div>
-
-                            <div ng:if="!ctrl.userCanEdit">
-                                <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    Multiple titles
-                                </dd>
-
-                                <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
-                                    {{ctrl.metadata.title || "unknown"}}
-                                </dd>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="image-info__wrap">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="descriptionEditForm.$show()"
-                                ng:hide="descriptionEditForm.$visible">✎</button>
-                        <dt class="metadata-line metadata-line__key">Description</dt>
-                        <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
-                             editable-textarea="ctrl.metadata.description"
-                             onbeforesave="ctrl.updateMetadataField('description', $data)"
-                             e:msd-elastic
-                             e:form="descriptionEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
-
-                            <div ng:if="ctrl.userCanEdit">
-                                <dd class="image-info__description"
-                                      ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >Multiple descriptions (click ✎ to edit <strong>all</strong>)
-                                </dd>
-
-                                <dd class="image-info__description"
-                                      ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
-                                </dd>
-                            </div>
-
-                            <div ng:if="!ctrl.userCanEdit">
-                                <dd class="image-info__description"
-                                      ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >Multiple descriptions
-                                </dd>
-
-                                <dd class="image-info__description"
-                                      ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                    >{{ctrl.metadata.description || "unknown"}}
-                                </dd>
-                            </div>
-                        </div>
-                    </div>
-
-                </dl>
-            </div>
-
-            <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
-                <dl class="image-info__wrap">
+        <div class="image-info__group">
+            <dl>
+                <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
                     <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
-                            ng:click="specialInstructionsEditForm.$show()"
-                            ng:hide="specialInstructionsEditForm.$visible">✎</button>
-                    <dt class="metadata-line metadata-line__key">Special instructions</dt>
-
-
-                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
-                         editable-textarea="ctrl.metadata.specialInstructions"
-                         onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
-                         e:msd-elastic
-                         e:form="specialInstructionsEditForm"
-                         e:ng-class="{'image-info__editor--error': $error,
-                                      'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
+                            ng:click="titleEditForm.$show()"
+                            ng:hide="titleEditForm.$visible">✎</button>
+                    <dt class="metadata-line metadata-line__key">Title</dt>
+                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
+                         editable-text="ctrl.metadata.title"
+                         onbeforesave="ctrl.updateMetadataField('title', $data)"
+                         e:form="titleEditForm"
+                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': titleEditForm.$waiting}">
 
                         <div ng:if="ctrl.userCanEdit">
-                            <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >Multiple special instructions (click ✎ to edit <strong>all</strong>)
+                            <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                Multiple titles (click ✎ to edit <strong>all</strong>)
                             </dd>
 
-                            <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >{{ctrl.metadata.specialInstructions}}
+                            <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
                             </dd>
                         </div>
 
                         <div ng:if="!ctrl.userCanEdit">
-                            <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >Multiple special instructions
+                            <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                Multiple titles
                             </dd>
 
-                            <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                                  class="image-info__special-instructions"
-                                >{{ctrl.metadata.specialInstructions}}
+                            <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                                {{ctrl.metadata.title || "unknown"}}
                             </dd>
                         </div>
                     </div>
-                </dl>
-            </div>
+                </div>
 
-            <div class="image-info__group">
-                <dl class="image-info__group--dl metadata-line">
-                    <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
-                    <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="bylineEditForm.$show()"
-                                ng:hide="bylineEditForm.$visible"
-                        >✎</button>
-                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
-                             editable-text="ctrl.metadata.byline"
-                             onbeforesave="ctrl.updateMetadataField('byline', $data)"
-                             e:form="bylineEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': bylineEditForm.$waiting}">
+                <div class="image-info__wrap">
+                    <button class="image-info__edit"
+                            ng:if="ctrl.userCanEdit"
+                            ng:click="descriptionEditForm.$show()"
+                            ng:hide="descriptionEditForm.$visible">✎</button>
+                    <dt class="metadata-line metadata-line__key">Description</dt>
+                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
+                         editable-textarea="ctrl.metadata.description"
+                         onbeforesave="ctrl.updateMetadataField('description', $data)"
+                         e:msd-elastic
+                         e:form="descriptionEditForm"
+                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
 
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
-                                Multiple bylines (click ✎ to edit <strong>all</strong>)
-                            </span>
+                        <div ng:if="ctrl.userCanEdit">
+                            <dd class="image-info__description"
+                                ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                >Multiple descriptions (click ✎ to edit <strong>all</strong>)
+                            </dd>
 
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
-                                Multiple bylines
-                            </span>
+                            <dd class="image-info__description"
+                                ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
+                            </dd>
+                        </div>
 
-                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
-                                <span ng:if="ctrl.metadata.byline">
-                                    <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
-                                </span>
+                        <div ng:if="!ctrl.userCanEdit">
+                            <dd class="image-info__description"
+                                ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                >Multiple descriptions
+                            </dd>
 
-                                <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
-                            </span>
+                            <dd class="image-info__description"
+                                ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                >{{ctrl.metadata.description || "unknown"}}
+                            </dd>
+                        </div>
+                    </div>
+                </div>
+
+            </dl>
+        </div>
+
+        <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
+            <dl class="image-info__wrap">
+                <button class="image-info__edit"
+                        ng:if="ctrl.userCanEdit"
+                        ng:click="specialInstructionsEditForm.$show()"
+                        ng:hide="specialInstructionsEditForm.$visible">✎</button>
+                <dt class="metadata-line metadata-line__key">Special instructions</dt>
+
+
+                <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
+                     editable-textarea="ctrl.metadata.specialInstructions"
+                     onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
+                     e:msd-elastic
+                     e:form="specialInstructionsEditForm"
+                     e:ng-class="{'image-info__editor--error': $error,
+                                 'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
+
+                    <div ng:if="ctrl.userCanEdit">
+                        <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                            class="image-info__special-instructions"
+                            >Multiple special instructions (click ✎ to edit <strong>all</strong>)
+                        </dd>
+
+                        <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                            class="image-info__special-instructions"
+                            >{{ctrl.metadata.specialInstructions}}
+                        </dd>
+                    </div>
+
+                    <div ng:if="!ctrl.userCanEdit">
+                        <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                            class="image-info__special-instructions"
+                            >Multiple special instructions
+                        </dd>
+
+                        <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                            class="image-info__special-instructions"
+                            >{{ctrl.metadata.specialInstructions}}
+                        </dd>
+                    </div>
+                </div>
+            </dl>
+        </div>
+
+        <div class="image-info__group">
+            <dl class="image-info__group--dl metadata-line">
+                <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
+                <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
+                    <button class="image-info__edit"
+                            ng:if="ctrl.userCanEdit"
+                            ng:click="bylineEditForm.$show()"
+                            ng:hide="bylineEditForm.$visible"
+                            >✎</button>
+                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
+                          editable-text="ctrl.metadata.byline"
+                          onbeforesave="ctrl.updateMetadataField('byline', $data)"
+                          e:form="bylineEditForm"
+                          e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': bylineEditForm.$waiting}">
+
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
+                            Multiple bylines (click ✎ to edit <strong>all</strong>)
                         </span>
-                    </dd>
 
-                    <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
-                    <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
-                        <button class="image-info__edit"
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
+                            Multiple bylines
+                        </span>
+
+                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
+                            <span ng:if="ctrl.metadata.byline">
+                                <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                            </span>
+
+                            <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
+                        </span>
+                    </span>
+                </dd>
+
+                <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
+                <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
+                    <button class="image-info__edit"
                             ng:if="ctrl.userCanEdit"
                             ng:click="creditEditForm.$show()"
                             ng:hide="creditEditForm.$visible"
-                        >✎</button>
+                            >✎</button>
 
-                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
-                              editable-text="ctrl.metadata.credit"
-                              e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
-                              onbeforesave="ctrl.updateMetadataField('credit', $data)"
-                              e:form="creditEditForm"
-                              e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': creditEditForm.$waiting}">
+                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
+                          editable-text="ctrl.metadata.credit"
+                          e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
+                          onbeforesave="ctrl.updateMetadataField('credit', $data)"
+                          e:form="creditEditForm"
+                          e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': creditEditForm.$waiting}">
 
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
-                                Multiple credits (click ✎ to edit <strong>all</strong>)
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
-                                Multiple credits
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
-                                <span ng:if="ctrl.metadata.credit">
-                                    <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
-                                </span>
-
-                                <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
-                            </span>
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
+                            Multiple credits (click ✎ to edit <strong>all</strong>)
                         </span>
-                    </dd>
 
-                    <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
-                    <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                        <button class="image-info__edit"
-                                ng:if="ctrl.userCanEdit"
-                                ng:click="copyrightEditForm.$show()"
-                                ng:hide="copyrightEditForm.$visible"
-                        >✎</button>
-                        <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
-                             editable-text="ctrl.metadata.copyright"
-                             onbeforesave="ctrl.updateMetadataField('copyright', $data)"
-                             e:form="copyrightEditForm"
-                             e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
-                                Multiple copyrights (click ✎ to edit <strong>all</strong>)
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
-                                Multiple copyrights
-                            </span>
-
-                            <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
-                                <span ng:if="ctrl.metadata.copyright">
-                                    <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
-                                </span>
-
-                                <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
-                            </span>
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
+                            Multiple credits
                         </span>
-                    </dd>
 
-                    <dt ng:if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Filename</dt>
-                    <dd ng:if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                        <span ng:if="ctrl.hasMultipleValues(ctrl.extraInfo.filename)">Multiple filenames</span>
-                        <span ng:if="!ctrl.hasMultipleValues(ctrl.extraInfo.filename)">{{ctrl.extraInfo.filename}}</span>
-                    </dd>
-                </dl>
+                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
+                            <span ng:if="ctrl.metadata.credit">
+                                <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                            </span>
+
+                            <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
+                        </span>
+                    </span>
+                </dd>
+
+                <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
+                <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                    <button class="image-info__edit"
+                            ng:if="ctrl.userCanEdit"
+                            ng:click="copyrightEditForm.$show()"
+                            ng:hide="copyrightEditForm.$visible"
+                            >✎</button>
+                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
+                          editable-text="ctrl.metadata.copyright"
+                          onbeforesave="ctrl.updateMetadataField('copyright', $data)"
+                          e:form="copyrightEditForm"
+                          e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': copyrightEditForm.$waiting}">
+
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
+                            Multiple copyrights (click ✎ to edit <strong>all</strong>)
+                        </span>
+
+                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
+                            Multiple copyrights
+                        </span>
+
+                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
+                            <span ng:if="ctrl.metadata.copyright">
+                                <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                            </span>
+
+                            <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
+                        </span>
+                    </span>
+                </dd>
+
+                <dt ng:if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Filename</dt>
+                <dd ng:if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                    <span ng:if="ctrl.hasMultipleValues(ctrl.extraInfo.filename)">Multiple filenames</span>
+                    <span ng:if="!ctrl.hasMultipleValues(ctrl.extraInfo.filename)">{{ctrl.extraInfo.filename}}</span>
+                </dd>
+            </dl>
+        </div>
+
+        <div class="image-info__group">
+            <div class="image-info__heading">
+                <span>Labels</span>
+                <gr-add-label ng:blur="ctrl.cancel"
+                              gr-small="true"
+                              images="ctrl.selectedImages">
+                </gr-add-label>
+            </div>
+            <ul class="labels">
+                <li class="label"
+                    ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
+                    ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
+                    <button ng:if="label.count < ctrl.selectedImages.size"
+                            class="label__add"
+                            title="Apply label to all"
+                            ng:click="ctrl.addLabel(label.data)">
+                        <gr-icon>library_add</gr-icon>
+                    </button>
+                    <span class="label__value">{{label.data}}</span>
+                    <button class="label__remove"
+                            title="Remove label from all"
+                            ng:click="ctrl.removeLabel(label.data)">
+                        <gr-icon>close</gr-icon>
+                    </button>
+                </li>
+            </ul>
+        </div>
+
+        <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
+            <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
+                <div class="metadata-line flex-spacer">
+                    <gr-icon>lock_open</gr-icon>
+                    <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} kept in Library</span>
+                    <span ng:if="ctrl.archiving">Saving…</span>
+                </div>
+                <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                    <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
+                        <gr-icon>lock</gr-icon> all
+                    </button>
+                    <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
+                        <gr-icon>lock_open</gr-icon> none
+                    </button>
+                </span>
             </div>
 
-            <div class="image-info__group">
-                <div class="image-info__heading">
-                    <span>Labels</span>
-                    <gr-add-label ng:blur="ctrl.cancel"
-                                  gr-small="true"
-                                  images="ctrl.selectedImages">
-                    </gr-add-label>
+            <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
+                <div class="metadata-line flex-spacer">
+                    <gr-icon>lock</gr-icon>
+                    <span ng:if="!ctrl.archiving">All kept in Library</span>
+                    <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
-                <ul class="labels">
-                    <li class="label"
-                        ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
-                        ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
-                        <button ng:if="label.count < ctrl.selectedImages.size"
-                                class="label__add"
-                                title="Apply label to all"
-                                ng:click="ctrl.addLabel(label.data)">
-                            <gr-icon>library_add</gr-icon>
-                        </button>
-                        <span class="label__value">{{label.data}}</span>
-                        <button class="label__remove"
-                                title="Remove label from all"
-                                ng:click="ctrl.removeLabel(label.data)">
-                            <gr-icon>close</gr-icon>
-                        </button>
-                    </li>
-                </ul>
+                <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                    <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
+                        <gr-icon>lock_open</gr-icon> Remove all
+                    </button>
+                </span>
             </div>
 
-            <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
-                <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
-                    <div class="metadata-line flex-spacer">
-                        <gr-icon>lock_open</gr-icon>
-                        <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} kept in Library</span>
-                        <span ng:if="ctrl.archiving">Saving…</span>
-                    </div>
-                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                        <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                            <gr-icon>lock</gr-icon> all
-                        </button>
-                        <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                            <gr-icon>lock_open</gr-icon> none
-                        </button>
-                    </span>
+            <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
+                <div class="metadata-line flex-spacer">
+                    <gr-icon>lock_open</gr-icon>
+                    <span ng:if="!ctrl.archiving">None kept in Library</span>
+                    <span ng:if="ctrl.archiving">Saving…</span>
                 </div>
-
-                <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
-                    <div class="metadata-line flex-spacer">
-                        <gr-icon>lock</gr-icon>
-                        <span ng:if="!ctrl.archiving">All kept in Library</span>
-                        <span ng:if="ctrl.archiving">Saving…</span>
-                    </div>
-                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                        <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                            <gr-icon>lock_open</gr-icon> Remove all
-                        </button>
-                    </span>
-                </div>
-
-                <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
-                    <div class="metadata-line flex-spacer">
-                        <gr-icon>lock_open</gr-icon>
-                        <span ng:if="!ctrl.archiving">None kept in Library</span>
-                        <span ng:if="ctrl.archiving">Saving…</span>
-                    </div>
-                    <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                        <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                            <gr-icon>lock</gr-icon> Keep all in Library
-                        </button>
-                    </span>
-                </div>
+                <span class="batch-archive__action" ng:if="!ctrl.archiving">
+                    <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
+                        <gr-icon>lock</gr-icon> Keep all in Library
+                    </button>
+                </span>
             </div>
         </div>
     </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1489,6 +1489,9 @@ FIXME: what to do with touch devices
 .image-info__wrap {
     position: relative;
     vertical-align: top;
+    /* cut long words */
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .image-info__wrap:hover .image-info__edit {


### PR DESCRIPTION
Noticed that the labels dropdown was being cropped when talking to a user. Also noticed that long filenames caused horizontal scrolling in the gr-panel. This fixes both.

## Before
![screenshot-2015-11-24t15 39 24](https://cloud.githubusercontent.com/assets/36964/11371711/ba45b97e-92c1-11e5-8be5-2d6868b519a6.png)
![screenshot-2015-11-24t15 38 09](https://cloud.githubusercontent.com/assets/36964/11371713/ba4be678-92c1-11e5-9774-93b6ce2b4947.png)

## After
![screenshot-2015-11-24t15 38 32](https://cloud.githubusercontent.com/assets/36964/11371712/ba4819ee-92c1-11e5-9701-de34ad57c58b.png)
![screenshot-2015-11-24t15 37 57](https://cloud.githubusercontent.com/assets/36964/11371710/ba4405fc-92c1-11e5-8e1f-9cce7d2c26a1.png)
