### PR TITLE
add note to create a permissions file

### DIFF
--- a/cloud-formation/README.md
+++ b/cloud-formation/README.md
@@ -10,6 +10,11 @@ As the usage-api is tightly coupled to the Guardian, there are two stacks to run
 
 To create a stack, use the corresponding script in the [`scripts`](./scripts/) directory.
 
+Once you have created the core stack, you'll need to create a permissions file:
+
+```sh
+./initialise-permissions.sh
+```
 
 ## Updating Stack
 

--- a/cloud-formation/scripts/initialise-permissions.sh
+++ b/cloud-formation/scripts/initialise-permissions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source ./stack-name.sh
+
+CONFIG_BUCKET=`aws cloudformation list-stack-resources --stack-name $STACK_NAME | jq '.StackResourceSummaries[] | select(.LogicalResourceId == "ConfigBucket") | .PhysicalResourceId' | tr -d '"'`
+
+aws s3 cp permissions.properties s3://$CONFIG_BUCKET/permissions.properties

--- a/cloud-formation/scripts/permissions.properties
+++ b/cloud-formation/scripts/permissions.properties
@@ -1,0 +1,3 @@
+editMetadata=
+deleteImage=
+deleteCrops=


### PR DESCRIPTION
media-api will complain if this file doesn't exist.

`initialise-permissions.sh` is not run automatically because the stack creation needs to have finished (we could poll the cli, but that sounds a bit much...)

cc @nickpapacostas
