### PR TITLE
warn of too big download.

### DIFF
--- a/kahuna/public/js/downloader/downloader.js
+++ b/kahuna/public/js/downloader/downloader.js
@@ -9,11 +9,12 @@ export const downloader = angular.module('gr.downloader', []);
 const maxBlobSize = 500 * 1024 * 1024;
 
 const bytesToSize = (bytes) => {
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
     if (bytes === 0) {
-        return 'n/a';
+        return '0 Bytes';
     }
-    const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
 
     return i === 0 ?
         `${bytes} ${sizes[i]}` :

--- a/kahuna/public/js/downloader/downloader.js
+++ b/kahuna/public/js/downloader/downloader.js
@@ -6,7 +6,7 @@ import template from './downloader.html!text';
 export const downloader = angular.module('gr.downloader', []);
 
 // blob URLs have a max size of 500MB - https://github.com/eligrey/FileSaver.js/#supported-browsers
-const max_blob_size = 500 * 1024 * 1024;
+const maxBlobSize = 500 * 1024 * 1024;
 
 const bytesToSize = (bytes) => {
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
@@ -40,18 +40,18 @@ downloader.controller('DownloaderCtrl',
             const file = zip.generate({ type: 'uint8array' });
             const blob = new Blob([file], { type: 'application/zip' });
 
-            if (blob.size <= max_blob_size) {
+            if (blob.size <= maxBlobSize) {
                 const url = $window.URL.createObjectURL(blob);
                 $window.location = url;
             }
             else {
-                const max_size = bytesToSize(max_blob_size);
-                const blob_size = bytesToSize(blob.size);
+                const maxSize = bytesToSize(maxBlobSize);
+                const blobSize = bytesToSize(blob.size);
 
                 // the things we do for a happy linter...
                 const message = [
                     'Download is too big!',
-                    `Max file size: ${max_size}. Your download: ${blob_size}.`,
+                    `Max file size: ${maxSize}. Your download: ${blobSize}.`,
                     'Consider downloading smaller batches.'
                 ].join('\n');
 


### PR DESCRIPTION
Blobs have a limit of 500MB - warn of download failure.

Adds to https://github.com/guardian/grid/pull/1484 to give feedback on downloads.