### PR TITLE
Omit keywords if empty list

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -59,7 +59,7 @@ object ImageMetadata {
       (__ \ "suppliersReference").writeNullable[String] ~
       (__ \ "source").writeNullable[String] ~
       (__ \ "specialInstructions").writeNullable[String] ~
-      (__ \ "keywords").write[List[String]] ~
+      (__ \ "keywords").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l)) ~
       (__ \ "subLocation").writeNullable[String] ~
       (__ \ "city").writeNullable[String] ~
       (__ \ "state").writeNullable[String] ~


### PR DESCRIPTION
Fixes https://github.com/guardian/grid/issues/1425, which is a bug with overrides caused by keywords defaulting to empty list.

In theory, we should allow both to omit `keywords` and have it set to `[]` in the overrides, as a way to override the keywords in the originalMetadata. In practice, we never allowed the keywords to be edited in the first place so that point is kind of moot.

I can't think of any reason why this change could cause any issues, particularly given how little we use keywords.

Every single image that has metadata edits (i.e. overrides) will currently have `keywords: []` in ES both for `userMetadata` and `metadata`. We'll need to clean that data once this is released with some kind of ES cleanup task.