### PR TITLE
Revert "read aws region from property file"

### DIFF
--- a/collections/app/lib/Config.scala
+++ b/collections/app/lib/Config.scala
@@ -14,7 +14,7 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   val awsCredentials: AWSCredentials =
     new BasicAWSCredentials(properties("aws.id"), properties("aws.secret"))
 
-  val dynamoRegion: Region = Region.getRegion(Regions.valueOf(properties("aws.region")))
+  val dynamoRegion: Region = Region.getRegion(Regions.EU_WEST_1)
 
   val keyStoreBucket = properties("auth.keystore.bucket")
 

--- a/metadata-editor/app/lib/Config.scala
+++ b/metadata-editor/app/lib/Config.scala
@@ -14,7 +14,7 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   val awsCredentials: AWSCredentials =
     new BasicAWSCredentials(properties("aws.id"), properties("aws.secret"))
 
-  val dynamoRegion: Region = Region.getRegion(Regions.valueOf(properties("aws.region")))
+  val dynamoRegion: Region = Region.getRegion(Regions.EU_WEST_1)
 
   val keyStoreBucket = properties("auth.keystore.bucket")
   val collectionsBucket: String = properties("s3.collections.bucket")

--- a/scripts/dot-properties/generate.py
+++ b/scripts/dot-properties/generate.py
@@ -30,9 +30,7 @@ def _get_stack_outputs():
     cf_client = _get_client()
     stack = cf_client.describe_stacks(StackName=stack_name)
 
-    outputs = {
-        'region': boto3.DEFAULT_SESSION._session.get_config_variable('region')
-    }
+    outputs = {}
 
     LOGGER.info('Here is your CloudFormation Stack output')
 

--- a/scripts/dot-properties/templates/collections.properties.template
+++ b/scripts/dot-properties/templates/collections.properties.template
@@ -1,7 +1,7 @@
 domain.root={{domain_root}}
 aws.id={{AwsId}}
 aws.secret={{AwsSecret}}
-aws.region={{region}}
 auth.keystore.bucket={{KeyBucket}}
 s3.collections.bucket={{CollectionsBucket}}
 dynamo.table.imageCollections={{ImageCollectionsDynamoTable}}
+

--- a/scripts/dot-properties/templates/metadata-editor.properties.template
+++ b/scripts/dot-properties/templates/metadata-editor.properties.template
@@ -1,7 +1,6 @@
 domain.root={{domain_root}}
 aws.id={{AwsId}}
 aws.secret={{AwsSecret}}
-aws.region={{region}}
 auth.keystore.bucket={{KeyBucket}}
 s3.collections.bucket={{CollectionsBucket}}
 sns.topic.arn={{SnsTopicArn}}

--- a/scripts/dot-properties/templates/usage.properties.template
+++ b/scripts/dot-properties/templates/usage.properties.template
@@ -1,7 +1,6 @@
 domain.root={{domain_root}}
 aws.id={{AwsId}}
 aws.secret={{AwsSecret}}
-aws.region={{region}}
 auth.keystore.bucket={{KeyBucket}}
 capi.pollIntervalInSeconds={{capi_poll}}
 capi.live.url={{capi_live_url}}

--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -33,7 +33,7 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   val previewPollTable = properties("dynamo.tablename.previewPollTable")
   val usageRecordTable = properties("dynamo.tablename.usageRecordTable")
 
-  val dynamoRegion: Region = Region.getRegion(Regions.valueOf(properties("aws.region")))
+  val dynamoRegion: Region = Region.getRegion(Regions.EU_WEST_1)
 
   val corsAllAllowedOrigins = List(services.kahunaBaseUri)
 }


### PR DESCRIPTION
Reverts guardian/grid#1507

getting:

> Caused by: java.lang.IllegalArgumentException: No enum constant com.amazonaws.regions.Regions.eu-west-1

in the logs. I must be using a different version of the awssdk in dev!