### PR TITLE
Nodes as resources

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -36,12 +36,16 @@ object CollectionsController extends Controller with ArgoHelpers {
 
   def uri(u: String) = URI.create(u)
   val collectionUri = uri(s"$rootUri/collections")
-  def collectionUri(s: String = "") = uri(s"$rootUri/collections$s")
+  def collectionUri(s: String = "") = {
+    val post = if(s.nonEmpty) s"/$s" else s
+    uri(s"$rootUri/collections$post")
+  }
 
   val appIndex = AppIndex("media-collections", "The one stop shop for collections",
                   links = List(Link("collections", collectionUri.toString)))
+
   def addChildAction(pathId: String = ""): Option[Action] = Some(Action("add-child", collectionUri(pathId), "POST"))
-  def addChildAction(n: Node[Collection]): Option[Action] = addChildAction(s"/${n.pathId}")
+  def addChildAction(n: Node[Collection]): Option[Action] = addChildAction(n.pathId)
   def removeNodeAction(n: Node[Collection]) = if (n.children.nonEmpty) None else Some(
     Action("remove", collectionUri(n.pathId), "DELETE")
   )

--- a/collections/app/model/Node.scala
+++ b/collections/app/model/Node.scala
@@ -3,34 +3,43 @@ package model
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class Node[T](name: String, children: List[Node[T]], content: Option[T] = None)
+case class Node[T](name: String, children: List[Node[T]], pathId: String, content: Option[T] = None)
 
 object Node {
+  // TODO: generify with List[V].
+  // It's hard to do as the JSON parsers stop working
   type Path = List[String]
 
-  def buildTree[T](rootName: String, input: List[T], getPath: T => Path): Node[T] = {
-    val pathsWithContent = input.map(getPath).zip(input)
+  def buildTree[T](rootName: String, input: List[T], getPath: T => Path, getPathId: T => String): Node[T] = {
+    val zipped = (input.map(getPath), input.map(getPathId), input).zipped.toList
 
-    def loop(input: List[(Path, T)]): List[Node[T]] = {
+
+    def loop(input: List[(Path, String, T)]): List[Node[T]] = {
       input
-        .filter  { case (path, content) => path.nonEmpty }
-        .groupBy { case (path, content) => path.head }
+        // TODO: We could NonEmptyLists here
+        .filter  { case (path, _, _) => path.nonEmpty }
+        .groupBy { case (path, _, _) => path.head }
         .map { case (parentName, grouped) =>
-          val nextGroup = grouped.map{ case (path, content) => (path.tail, content) }
-          // TODO: There is a bug here that if we don't have content (it's an assumed path)
-          // we inherit the child's content.
-          val contentOpt = grouped.headOption.map{case (path, content) => content }
-          Node[T](parentName, loop(nextGroup), contentOpt)
+          val nextGroup = grouped.map{ case (path, pathId, content) => (path.tail, pathId, content) }
+          // TODO: Fix this hack
+          val nextId = grouped.headOption map { case (_, pathId, _) => pathId } getOrElse "can't get here"
+          val contentOpt = grouped.headOption flatMap { case (path, _, content) =>
+            // only attach the content if we actually have it, and it's not inherited
+            // from the child nodes
+            if (path.size == 1) Some(content) else None
+          }
+          Node[T](parentName, loop(nextGroup), nextId, contentOpt)
         }
         .toList
     }
 
-    Node[T](rootName, loop(pathsWithContent))
+    Node[T](rootName, loop(zipped), rootName)
   }
 
   implicit def nodeFormat[T: Format]: Format[Node[T]] = (
     (__ \ "name").format[String] ~
     (__ \ "children").lazyFormat(Reads.list(nodeFormat[T]), Writes.list(nodeFormat[T])) ~
+    (__ \ "pathId").format[String] ~
     (__ \ "content").formatNullable[T]
   )(Node.apply, unlift(Node.unapply))
 }

--- a/collections/conf/routes
+++ b/collections/conf/routes
@@ -2,7 +2,8 @@ GET     /                                               controllers.CollectionsC
 
 # Collections
 GET     /collections                                    controllers.CollectionsController.getCollections
-POST    /collections                                    controllers.CollectionsController.addCollectionFromJson
+POST    /collections                                    controllers.CollectionsController.addChildToRoot
+POST    /collections/*collection                        controllers.CollectionsController.addChildToCollection(collection: String)
 DELETE  /collections/*collection                        controllers.CollectionsController.removeCollection(collection: String)
 
 # Management

--- a/collections/test/model/NodeTest.scala
+++ b/collections/test/model/NodeTest.scala
@@ -3,7 +3,8 @@ package model
 import org.scalatest.{FunSpec, Matchers, OptionValues}
 
 class NodeTest extends FunSpec with Matchers with OptionValues {
-  val identifyBy = (list: List[String]) => list
+  val getPath = (list: List[String]) => list
+  val getPathId = (list: List[String]) => list.mkString("/")
   val collections = List(
     List("g2", "features"),
     List("g2", "food"),
@@ -18,21 +19,34 @@ class NodeTest extends FunSpec with Matchers with OptionValues {
   )
 
   describe("Node") {
+    def buildTree = Node.buildTree("motherwillow", collections, getPath, getPathId)
 
     it("should produce 2 children") {
-      val tree = Node.buildTree("motherwillow", collections, identifyBy)
+      val tree = buildTree
       tree.children.length shouldEqual 2
     }
 
     it("should have g2 as a child") {
-      val tree = Node.buildTree("motherwillow", collections, identifyBy)
+      val tree = buildTree
       tree.children.exists(_.name == "g2") shouldEqual true
     }
 
     it("should have second level children") {
-      val tree = Node.buildTree("motherwillow", collections, identifyBy)
+      val tree = buildTree
       val g2 = tree.children.find(_.name == "g2").value
       g2.children.map(_.name).toSet shouldEqual Set("features", "food", "health", "lifestyle")
+    }
+
+    it("should attach the content to the Node if available") {
+      val tree = buildTree
+      val obs = tree.children.find(_.content.contains(List("obs"))).value
+      obs.name shouldEqual "obs"
+    }
+
+    it("should not attach the content to the Node if not available") {
+      val tree = buildTree
+      val obs = tree.children.find(_.content.isEmpty).value
+      obs.name shouldEqual "g2"
     }
 
   }


### PR DESCRIPTION
After much jiggery pokery with the JSON parsers again, there's a way to have lists of `EmbeddedEntity`s with the Subtype of the same class that they're a list of. i.e.
`case class A(a: String, b: List[A]) ` => `ResposeEntity(data: List[EmbeddedEntity[A]])`

This should hopefully allow us to simplify the client code. Not a refactor, probably just a few subtractions.

CC: @tsop14 