### PR TITLE
positive positive on drag logicc

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -41,6 +41,8 @@ var config = {
     vndMimeTypes: new Map([
         ['gridImageData', 'application/vnd.mediaservice.image+json'],
         ['kahunaUri',     'application/vnd.mediaservice.kahuna.uri'],
+        // These two are internal hacks to help us identify when we're dragging internal assets
+        // They should definitely not be relied on externally.
         ['isGridLink',    'application/vnd.mediaservice.kahuna.link'],
         ['isGridImage' ,  'application/vnd.mediaservice.kahuna.image']
     ])
@@ -490,6 +492,8 @@ kahuna.directive('uiLocalstore', ['$window', function($window) {
     };
 }]);
 
+// These two are internal hacks to help us identify when we're dragging internal assets
+// They should definitely not be relied on externally.
 kahuna.directive('img', ['vndMimeTypes', function(vndMimeTypes) {
     return {
         restrict: 'E',
@@ -500,7 +504,6 @@ kahuna.directive('img', ['vndMimeTypes', function(vndMimeTypes) {
         }
     };
 }]);
-
 kahuna.directive('a', ['vndMimeTypes', function(vndMimeTypes) {
     return {
         restrict: 'E',

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -40,6 +40,7 @@
         <img class="preview__image"
              alt="{{::ctrl.image.data.metadata.description}}"
              ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
+             ui:drag-data="{{ctrl.image | asImageDragData}}"
              gr:image-fade-on-load />
     </span>
 

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -98,10 +98,8 @@ dndUploader.controller('DndUploaderCtrl',
  * This behaviour is pretty well observed:
  * https://code.google.com/p/chromium/issues/detail?id=131325
  */
-dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track',
-                       function($window, delay, safeApply, track) {
-
-    const gridImageMimeType = 'application/vnd.mediaservice.image+json';
+dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track', 'vndMimeTypes',
+                       function($window, delay, safeApply, track, vndMimeTypes) {
 
     return {
         restrict: 'E',
@@ -129,13 +127,17 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track',
             scope.$on('$destroy', clean);
 
             const hasType = (types, key) => types.indexOf(key) !== -1;
+            function hasGridMimetype(types) {
+                const mimeTypes = Array.from(vndMimeTypes.values());
+                return types.some(t => mimeTypes.indexOf(t) !== -1);
+            }
             function isGridFriendly(event) {
                 // we search through the types array as we don't have the `files`
                 // or `data` (uris etc) ondragenter, only drop.
                 const types       = Array.from(event.originalEvent.dataTransfer.types);
                 const isUri       = hasType(types, 'text/uri-list');
                 const hasFiles    = hasType(types, 'Files');
-                const isGridImage = hasType(types, gridImageMimeType);
+                const isGridImage = hasGridMimetype(types);
 
                 const isFriendly = (hasFiles || isUri) && !isGridImage;
 


### PR DESCRIPTION
# Problem
At the moment we enable dnd when we aren't dragging something with drag data from the grid. This will create false positives on elements (not `img` or `a`) that have `draggable=true` (which we will be needing for collections).

# Solution
We now look to see is we are able to accept the draggable, by looking through the `dataTransfer.types`.

# TODO
~~I am looking into what we do about elements that have `uri-list`s from the grid i.e. they don't have `drag-data` but are images or links. This is a problem we have on the Grid already, so not in the PR.~~