### PR TITLE
don't rely on awscli

### DIFF
--- a/s3watcher/build.sh
+++ b/s3watcher/build.sh
@@ -2,14 +2,15 @@
 
 set -e
 
-get_function_name() {
-    echo $(aws cloudformation list-stack-resources --stack-name $1 \
-        | jq ".StackResourceSummaries[] | select(.LogicalResourceId == \"S3WatcherLamdbaFunction\") | .PhysicalResourceId" \
-        | tr -d '"')
-}
+if [ -z $TEST_FUNC_NAME ]; then
+    echo 'TEST_FUNC_NAME is unset';
+    exit 1
+fi
 
-TEST_FUNC_NAME=$(get_function_name media-service-TEST)
-PROD_FUNC_NAME=$(get_function_name media-service-PROD)
+if [ -z $PROD_FUNC_NAME ]; then
+    echo 'PROD_FUNC_NAME is unset';
+    exit 1
+fi
 
 cd lambda
 npm install


### PR DESCRIPTION
Following https://github.com/guardian/grid/pull/1514.

@theefer pointed out that all we actually need to get s3watcher building in CI are the lambda function names.

Talking to aws to get this means creating a user with a strict policy: 

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Stmt1449062475000",
            "Effect": "Allow",
            "Action": [
                "cloudformation:DescribeStackResource"
            ],
            "Resource": [
                "arn:aws:cloudformation:eu-west-1:<ACCOUNT_NUMBER>:stack/media-service-TEST/*",
                "arn:aws:cloudformation:eu-west-1:<ACCOUNT_NUMBER>:stack/media-service-PROD/*"
            ]
        }
    ]
}
```

However, that policy also means the user can see all the params used!

Setting the function names as env vars is a lot nicer!