### PR TITLE
Option to download low-res image

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -38,6 +38,7 @@ image.controller('ImageCtrl', [
     'image',
     'mediaApi',
     'optimisedImageUri',
+    'lowResImageUri',
     'cropKey',
     'mediaCropper',
     'imageService',
@@ -50,6 +51,7 @@ image.controller('ImageCtrl', [
               image,
               mediaApi,
               optimisedImageUri,
+              lowResImageUri,
               cropKey,
               mediaCropper,
               imageService) {
@@ -58,6 +60,7 @@ image.controller('ImageCtrl', [
 
         ctrl.image = image;
         ctrl.optimisedImageUri = optimisedImageUri;
+        ctrl.lowResImageUri = lowResImageUri;
 
         // TODO: we should be able to rely on ctrl.crop.id instead once
         // all existing crops are migrated to have an id (they didn't

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -43,6 +43,7 @@ image.config(['$stateProvider',
             }],
 
             optimisedImageUri: ['image', 'imgops', (image, imgops) => imgops.getUri(image)]
+            optimisedImageUri: ['image', 'imgops', (image, imgops) => imgops.getFullScreenUri(image)],
         }
     });
 

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -42,8 +42,8 @@ image.config(['$stateProvider',
                 });
             }],
 
-            optimisedImageUri: ['image', 'imgops', (image, imgops) => imgops.getUri(image)]
             optimisedImageUri: ['image', 'imgops', (image, imgops) => imgops.getFullScreenUri(image)],
+            lowResImageUri: ['image', 'imgops', (image, imgops) => imgops.getLowResUri(image)]
         }
     });
 

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -42,8 +42,10 @@ image.config(['$stateProvider',
                 });
             }],
 
-            optimisedImageUri: ['image', 'imgops', (image, imgops) => imgops.getFullScreenUri(image)],
-            lowResImageUri: ['image', 'imgops', (image, imgops) => imgops.getLowResUri(image)]
+            optimisedImageUri: ['image', 'imgops',
+                                (image, imgops) => imgops.getFullScreenUri(image)],
+            lowResImageUri: ['image', 'imgops',
+                             (image, imgops) => imgops.getLowResUri(image)]
         }
     });
 

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -11,9 +11,25 @@
                          images="[ctrl.image]">
         </gr-delete-image>
 
-        <a class="top-bar-item side-padded clickable" href="{{ ctrl.image.data.source | assetFile }}" download target="_blank">
-            <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
-        </a>
+        <span class="top-bar-item">
+            <a ng:href="{{ ctrl.image.data.source | assetFile }}"
+               class="side-padded clickable inner-clickable"
+               download
+               target="_blank">
+                <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
+            </a>
+            <button class="drop-menu clickable inner-clickable side-padded button-right-side"
+                    ng:click="showExpandedDownload = !showExpandedDownload">
+                <span>▾</span>
+                <a ng:if="showExpandedDownload"
+                   ng:href="{{ ctrl.lowResImageUri }}"
+                   class="drop-menu__items drop-menu__items--nopad"
+                   download
+                   target="_blank">
+                    <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
+                </a>
+            </button>
+        </span>
 
         <gr-image-persist-status class="top-bar-item"
                                  with-text="true"

--- a/kahuna/public/js/imgops/service.js
+++ b/kahuna/public/js/imgops/service.js
@@ -12,7 +12,7 @@ imgops.factory('imgops', ['$window', function($window) {
     function getFullScreenUri(image) {
         const { width: w, height: h } = $window.screen;
         return getOptimisedUri(image, { w, h, q: quality });
-    };
+    }
 
     function getLowResUri(image) {
         return getOptimisedUri(image, {
@@ -20,7 +20,7 @@ imgops.factory('imgops', ['$window', function($window) {
             h: lowResMaxHeight,
             q: quality
         });
-    };
+    }
 
     function getOptimisedUri(image, options) {
         return image.follow('optimised', options).getUri().catch(() => {

--- a/kahuna/public/js/imgops/service.js
+++ b/kahuna/public/js/imgops/service.js
@@ -3,16 +3,34 @@ import angular from 'angular';
 export var imgops = angular.module('kahuna.imgops', []);
 
 imgops.factory('imgops', ['$window', function($window) {
-    var quality = 85;
+    const quality = 85;
 
-    var getUri = image => {
-        var { width: w, height: h } = $window.screen;
+    const lowResMaxWidth  = 800;
+    const lowResMaxHeight = 800;
 
-        return image.follow('optimised', { w, h, q: quality }).getUri().catch(() => {
-            return image.source.secureUrl || image.source.file;
+
+    function getFullScreenUri(image) {
+        const { width: w, height: h } = $window.screen;
+        return getOptimisedUri(image, { w, h, q: quality });
+    };
+
+    function getLowResUri(image) {
+        return getOptimisedUri(image, {
+            w: lowResMaxWidth,
+            h: lowResMaxHeight,
+            q: quality
         });
     };
 
-    return { getUri };
+    function getOptimisedUri(image, options) {
+        return image.follow('optimised', options).getUri().catch(() => {
+            return image.source.secureUrl || image.source.file;
+        });
+    }
+
+    return {
+        getFullScreenUri,
+        getLowResUri
+    };
 
 }]);


### PR DESCRIPTION
Uses the imgops service to generate an image at most 800x800 pixels, useful for syndication so they can send a low res preview of an image before sending the original once paid for.

One caveat is that the imgops service doesn't work well with non-sRGB images (i.e. they don't get converted to sRGB), but I think it's no worse than sending the original.

![image](https://cloud.githubusercontent.com/assets/36964/11561085/c4456ab2-99bc-11e5-9422-3f13865038f9.png)

cc @paperboyo 
