### PR TITLE
move crop initials off thumbnail.

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -73,13 +73,15 @@
                     <a draggable="true"
                        ui:sref="{ crop: ctrl.fullCrop.id }"
                        ng:init="extremeAssets = (crop | getExtremeAssets)">
-                        <span class="image-crop__creator" title="Cropped by {{crop.author}} at {{crop.date | date:'medium'}}">{{crop.author | getInitials}}</span>
                         <img class="image-crop__image"
                              alt="full frame image thumbnail"
                              ng:src="{{ extremeAssets.smallest | assetFile }}" />
-                        <div class="image-crop__aspect-ratio"
-                             ng:class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
+
+                        <div class="flex-container image-crop__info image-crop__more-info"
+                             ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
                             {{crop.specification.bounds.width}} &times; {{crop.specification.bounds.height}}
+                            <span class="flex-spacer"></span>
+                            <span class="image-crop__creator" title="Cropped by {{crop.author}} at {{crop.date | date:'medium'}}">{{crop.author | getInitials}}</span>
                         </div>
                     </a>
                 </div>
@@ -99,19 +101,23 @@
                                ui:sref="{crop: crop.id}"
                                ui:drag-data="{{ctrl.image | asImageAndCropsDragData:crop}}"
                                ui:drag-image="{{extremeAssets.smallest | assetFile}}">
-                                <span class="image-crop__creator" title="Cropped by {{crop.author}} at {{crop.date | date:'medium'}}">{{crop.author | getInitials}}</span>
+
                                 <img class="image-crop__image"
                                      alt="cropped image thumbnail"
                                      ng:src="{{extremeAssets.smallest | assetFile}}" />
-                                <div class="image-crop__aspect-ratio"
-                                    ng:class="{'image-crop__aspect-ratio--selected': crop == ctrl.crop}">
-                                    <ul>
-                                        <li>
-                                            {{crop.specification.aspectRatio | asAspectRatioWord}}
-                                            <span ng:if="crop.specification.aspectRatio">({{crop.specification.aspectRatio}})</span>
-                                        </li>
-                                        <li>{{crop.specification.bounds.width}} &times; {{crop.specification.bounds.height}}</li>
-                                    </ul>
+                                <div class="image-crop__info"
+                                    ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
+                                    <div class="flex-container">
+                                        {{crop.specification.aspectRatio | asAspectRatioWord}}
+                                        <span class="flex-spacer"></span>
+                                        <span ng:if="crop.specification.aspectRatio">({{crop.specification.aspectRatio}})</span>
+                                    </div>
+
+                                    <div class="flex-container image-crop__more-info">
+                                        {{crop.specification.bounds.width}} &times; {{crop.specification.bounds.height}}
+                                        <span class="flex-spacer"></span>
+                                        <span class="image-crop__creator" title="Cropped by {{crop.author}} at {{crop.date | date:'medium'}}">{{crop.author | getInitials}}</span>
+                                    </div>
                                 </div>
                             </a>
                         </li>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1652,10 +1652,7 @@ FIXME: what to do with touch devices
 }
 
 .image-crop__creator {
-    position: absolute;
     display: none;
-    margin: 1px;
-    padding: 2px;
     border-radius: 50%;
     background-color: #6E6E6E;
     opacity: 0.5;
@@ -1676,13 +1673,17 @@ FIXME: what to do with touch devices
     margin: 0 auto;
 }
 
-.image-crop__aspect-ratio {
+.image-crop__info {
     background: #333;
     padding: 2px;
     font-size: 1.2rem;
 }
 
-.image-crop__aspect-ratio--selected {
+.image-crop__more-info {
+    line-height: 22px;
+}
+
+.image-crop__info--selected {
     color: #FFFFFF;
 }
 


### PR DESCRIPTION
makes it a bit clearer when the thumbnail is grey.

![crop-initials](https://cloud.githubusercontent.com/assets/836140/11588026/86d689d6-9a75-11e5-84da-a39cfbd9aea6.gif)
