### PR TITLE
change what's logged on upload

### DIFF
--- a/s3watcher/lambda/lib/Lambda.js
+++ b/s3watcher/lambda/lib/Lambda.js
@@ -55,12 +55,12 @@ module.exports = {
         });
 
         const fail = function(err) {
-            Logger.error(s3Event, err);
+            Logger.error(config.stage, s3Event, err);
             context.fail(err);
         };
 
         const success = function() {
-            Logger.log(Logger.messages.LAMBDA_SUCCESS, s3Event);
+            Logger.log(config.stage, Logger.messages.LAMBDA_SUCCESS, s3Event);
             context.succeed(s3Event);
         };
 

--- a/s3watcher/lambda/lib/Lambda.js
+++ b/s3watcher/lambda/lib/Lambda.js
@@ -55,12 +55,12 @@ module.exports = {
         });
 
         const fail = function(err) {
-            Logger.error(config.stage, s3Event, err);
+            Logger.logLambdaError(config.stage, s3Event, err);
             context.fail(err);
         };
 
         const success = function() {
-            Logger.log(config.stage, Logger.messages.LAMBDA_SUCCESS, s3Event);
+            Logger.logLambdaSuccess(config.stage, s3Event);
             context.succeed(s3Event);
         };
 

--- a/s3watcher/lambda/lib/Lambda.js
+++ b/s3watcher/lambda/lib/Lambda.js
@@ -1,6 +1,6 @@
 const Rx = require('rx');
 const S3Helper = require('./S3Helper');
-
+const Logger = require('./Logger');
 
 module.exports = {
     init: function(event, context) {
@@ -55,12 +55,12 @@ module.exports = {
         });
 
         const fail = function(err) {
-            console.log("Failed!", s3Event, err);
+            Logger.error(s3Event, err);
             context.fail(err);
         };
 
         const success = function() {
-            console.log("Finished successfully.", s3Event);
+            Logger.log(Logger.messages.LAMBDA_SUCCESS, s3Event);
             context.succeed(s3Event);
         };
 

--- a/s3watcher/lambda/lib/Logger.js
+++ b/s3watcher/lambda/lib/Logger.js
@@ -1,0 +1,41 @@
+const messages = {
+    DOWNLOAD: "Downloading from ingest bucket.",
+    UPLOAD: "Uploading to image-loader.",
+    DELETE: "Deleting from ingest bucket.",
+    COPY_TO_FAIL: "Copying to fail bucket.",
+    RECORD: "Recording result to Cloud Watch",
+    UPLOAD_FAIL: "Upload failed.",
+
+    LAMBDA_ERROR: "Lambda failure",
+    LAMBDA_SUCCESS: "Finished successfully."
+};
+
+const level = {
+    INFO: "INFO",
+    ERROR: "ERROR"
+};
+
+const baseMessage = function (message, level, state) {
+    return {
+        stack: "media-service",
+        app: "s3-watcher",
+        timestamp: new Date().toISOString(),
+        level: level,
+        message: message,
+        state: state
+    };
+};
+
+module.exports = {
+    messages: messages,
+
+    log: function (messageKey, state) {
+        console.log(baseMessage(messageKey, level.INFO, state));
+    },
+
+    error: function (state, err) {
+        const msg = baseMessage(messages.LAMBDA_ERROR, level.ERROR, state);
+        msg['error'] = err;
+        console.log(msg);
+    }
+};

--- a/s3watcher/lambda/lib/Logger.js
+++ b/s3watcher/lambda/lib/Logger.js
@@ -27,14 +27,46 @@ const baseMessage = function (stage, message, level, state) {
     };
 };
 
+const log = function (stage, message, state) {
+    console.log(baseMessage(stage, message, level.INFO, state));
+};
+
 module.exports = {
     messages: messages,
 
     log: function (stage, messageKey, state) {
-        console.log(baseMessage(stage, messageKey, level.INFO, state));
+        log(stage, messageKey, state)
     },
 
-    error: function (stage, state, err) {
+    logDownload: function (stage, state) {
+        log(state, messages.DOWNLOAD, state);
+    },
+
+    logUpload: function (stage, state) {
+        log(state, messages.UPLOAD, state);
+    },
+
+    logDelete: function (stage, state) {
+        log(state, messages.DELETE, state);
+    },
+
+    logCopyToFailBucket: function (stage, state) {
+        log(state, messages.COPY_TO_FAIL, state);
+    },
+
+    logRecordToCloudWatch: function (stage, state) {
+        log(state, messages.RECORD, state);
+    },
+
+    logUploadFail: function (stage, state) {
+        log(state, messages.UPLOAD_FAIL, state);
+    },
+
+    logLambdaSuccess: function (stage, state) {
+        log(state, messages.LAMBDA_SUCCESS, state);
+    },
+
+    logLambdaError: function (stage, state, err) {
         const msg = baseMessage(stage, messages.LAMBDA_ERROR, level.ERROR, state);
         msg['error'] = err;
         console.log(msg);

--- a/s3watcher/lambda/lib/Logger.js
+++ b/s3watcher/lambda/lib/Logger.js
@@ -15,8 +15,9 @@ const level = {
     ERROR: "ERROR"
 };
 
-const baseMessage = function (message, level, state) {
+const baseMessage = function (stage, message, level, state) {
     return {
+        stage: stage,
         stack: "media-service",
         app: "s3-watcher",
         timestamp: new Date().toISOString(),
@@ -29,12 +30,12 @@ const baseMessage = function (message, level, state) {
 module.exports = {
     messages: messages,
 
-    log: function (messageKey, state) {
-        console.log(baseMessage(messageKey, level.INFO, state));
+    log: function (stage, messageKey, state) {
+        console.log(baseMessage(stage, messageKey, level.INFO, state));
     },
 
-    error: function (state, err) {
-        const msg = baseMessage(messages.LAMBDA_ERROR, level.ERROR, state);
+    error: function (stage, state, err) {
+        const msg = baseMessage(stage, messages.LAMBDA_ERROR, level.ERROR, state);
         msg['error'] = err;
         console.log(msg);
     }

--- a/s3watcher/lambda/lib/Transfer.js
+++ b/s3watcher/lambda/lib/Transfer.js
@@ -2,7 +2,7 @@ const S3Helper     = require('./S3Helper');
 const CWHelper     = require('./CWHelper');
 const Metrics      = require('./Metrics');
 const Upload       = require('./Upload');
-
+const Logger       = require('./Logger');
 
 module.exports = {
     init: function(s3Event, config){
@@ -22,33 +22,18 @@ module.exports = {
 
         const upload = Upload.buildUpload(config, s3Event);
 
-        function log(key, state) {
-            const messages = {
-                "download": "Downloading from ingest bucket.",
-                "upload": "Uploading to image-loader.",
-                "delete": "Deleting from ingest bucket.",
-                "copy": "Copying to fail bucket.",
-                "record": "Recording result to Cloudwatch",
-                "failed": "Upload failed."
-            };
-
-            const stateMessage = messages[key] || "An error has occured";
-
-            console.log(stateMessage, state);
-        }
-
        const success = function(result) {
-            log("delete", s3Object);
+            Logger.log(Logger.messages.DELETE, s3Object);
 
             return S3Helper.deleteS3Object(s3Object);
         };
 
         const failGraceful = function(e) {
-            log("failed", e);
+            Logger.log(Logger.messages.UPLOAD_FAIL, e);
+            Logger.log(Logger.messages.COPY_TO_FAIL, s3CopyObject);
 
-            log("copy", s3CopyObject);
             return S3Helper.copyS3Object(s3CopyObject).flatMap(function(){
-                log("delete", s3Object);
+                Logger.log(Logger.messages.DELETE, s3Object);
 
                 return S3Helper.deleteS3Object(s3Object);
             });
@@ -56,14 +41,19 @@ module.exports = {
 
         // TODO: Use stream API
         const operation = function() {
-            log("download", s3Object);
+            Logger.log(Logger.messages.DOWNLOAD, s3Object);
 
             return S3Helper.getS3Object(s3Object).flatMap(function(data){
-                log("upload", upload);
+                Logger.log(Logger.messages.UPLOAD, {
+                    size: upload.size,
+                    filename: upload.params.filename,
+                    uploadedBy: upload.params.uploadedBy,
+                    stage: upload.params.stage
+                });
 
                 return Upload.postData(upload, data.Body);
             }).retry(5).flatMap(function(uploadResult){
-                log("record", uploadResult);
+                Logger.log(Logger.messages.RECORD, uploadResult);
 
                 return CWHelper.putMetricData(
                     Metrics.create(uploadResult)).map(

--- a/s3watcher/lambda/lib/Transfer.js
+++ b/s3watcher/lambda/lib/Transfer.js
@@ -23,17 +23,17 @@ module.exports = {
         const upload = Upload.buildUpload(config, s3Event);
 
        const success = function(result) {
-            Logger.log(Logger.messages.DELETE, s3Object);
+            Logger.log(config.stage, Logger.messages.DELETE, s3Object);
 
             return S3Helper.deleteS3Object(s3Object);
         };
 
         const failGraceful = function(e) {
-            Logger.log(Logger.messages.UPLOAD_FAIL, e);
-            Logger.log(Logger.messages.COPY_TO_FAIL, s3CopyObject);
+            Logger.log(config.stage, Logger.messages.UPLOAD_FAIL, e);
+            Logger.log(config.stage, Logger.messages.COPY_TO_FAIL, s3CopyObject);
 
             return S3Helper.copyS3Object(s3CopyObject).flatMap(function(){
-                Logger.log(Logger.messages.DELETE, s3Object);
+                Logger.log(config.stage, Logger.messages.DELETE, s3Object);
 
                 return S3Helper.deleteS3Object(s3Object);
             });
@@ -41,10 +41,10 @@ module.exports = {
 
         // TODO: Use stream API
         const operation = function() {
-            Logger.log(Logger.messages.DOWNLOAD, s3Object);
+            Logger.log(config.stage, Logger.messages.DOWNLOAD, s3Object);
 
             return S3Helper.getS3Object(s3Object).flatMap(function(data){
-                Logger.log(Logger.messages.UPLOAD, {
+                Logger.log(config.stage, Logger.messages.UPLOAD, {
                     size: upload.size,
                     filename: upload.params.filename,
                     uploadedBy: upload.params.uploadedBy,
@@ -53,7 +53,7 @@ module.exports = {
 
                 return Upload.postData(upload, data.Body);
             }).retry(5).flatMap(function(uploadResult){
-                Logger.log(Logger.messages.RECORD, uploadResult);
+                Logger.log(config.stage, Logger.messages.RECORD, uploadResult);
 
                 return CWHelper.putMetricData(
                     Metrics.create(uploadResult)).map(


### PR DESCRIPTION
We have been logging secrets :fearful:. This PR removes that and also changes the shape of what's logged for consumption by https://github.com/guardian/grid/pull/1521.

release notes:
- [ ] create new api key
- [ ] rotate keys in s3-watcher config
- [ ] check s3-watcher is still working
- [ ] delete old api key