### PR TITLE
Add drag data for multiple images

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -39,12 +39,13 @@ var config = {
     'pandular.reAuthUri': '/login',
 
     vndMimeTypes: new Map([
-        ['gridImageData', 'application/vnd.mediaservice.image+json'],
-        ['kahunaUri',     'application/vnd.mediaservice.kahuna.uri'],
+        ['gridImageData',  'application/vnd.mediaservice.image+json'],
+        ['gridImagesData', 'application/vnd.mediaservice.images+json'],
+        ['kahunaUri',      'application/vnd.mediaservice.kahuna.uri'],
         // These two are internal hacks to help us identify when we're dragging internal assets
         // They should definitely not be relied on externally.
-        ['isGridLink',    'application/vnd.mediaservice.kahuna.link'],
-        ['isGridImage' ,  'application/vnd.mediaservice.kahuna.image']
+        ['isGridLink',     'application/vnd.mediaservice.kahuna.link'],
+        ['isGridImage' ,   'application/vnd.mediaservice.kahuna.image']
     ])
 };
 

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -140,11 +140,12 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                              function($scope, $window, vndMimeTypes, selectedImages$) {
 
                     const windowDrag$ = Rx.DOM.fromEvent($window, 'dragstart');
-                    const dragData$ = windowDrag$.withLatestFrom(selectedImages$, (event, imageList) => {
-                        const images = imageList.map(i => i.data);
-                        const dt = event.dataTransfer;
-                        return {images, dt};
-                    });
+                    const dragData$ = windowDrag$.
+                        withLatestFrom(selectedImages$, (event, imageList) => {
+                            const images = imageList.map(i => i.data);
+                            const dt = event.dataTransfer;
+                            return {images, dt};
+                        });
 
                     const sub = dragData$.subscribe(({ images, dt }) => {
                         if (images.size > 0) {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -141,8 +141,6 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
 
                     const windowDrag$ = Rx.DOM.fromEvent($window, 'dragstart');
                     const dragData$ = selectedImages$.combineLatest(windowDrag$, (images, event) => {
-
-
                         const data = JSON.stringify(images.map(i => i.data));
                         const dt = event.dataTransfer;
                         return {data, dt};
@@ -151,7 +149,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                     const sub = dragData$.subscribe(({ data, dt }) => {
                         dt.setData(vndMimeTypes.get('gridImagesData'), data);
                     });
-                                 
+
                     $scope.$on('$destroy', () => sub.dispose());
                 }]
             }

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -132,6 +132,21 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                             shareReplay(1);
                     }]
                 }
+            },
+            multiDrag: {
+                template: `<div class="multidrag"></div>`,
+                controller: ['$window', 'vndMimeTypes', 'selectedImages$', function($window, vndMimeTypes, selectedImages$) {
+                    const $w = angular.element($window);
+                    var images = [];
+                    selectedImages$.subscribe(is => images = is.toJSON());
+
+                    $w.on('dragstart', e => {
+                        const dt = e.originalEvent.dataTransfer;
+                        const imageData = images.map(i => i.data);
+
+                        dt.setData(vndMimeTypes.get('gridImagesData'), JSON.stringify(imageData));
+                    });
+                }]
             }
         }
     });

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -140,14 +140,16 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                              function($scope, $window, vndMimeTypes, selectedImages$) {
 
                     const windowDrag$ = Rx.DOM.fromEvent($window, 'dragstart');
-                    const dragData$ = selectedImages$.combineLatest(windowDrag$, (images, event) => {
-                        const data = JSON.stringify(images.map(i => i.data));
+                    const dragData$ = windowDrag$.withLatestFrom(selectedImages$, (event, imageList) => {
+                        const images = imageList.map(i => i.data);
                         const dt = event.dataTransfer;
-                        return {data, dt};
+                        return {images, dt};
                     });
 
-                    const sub = dragData$.subscribe(({ data, dt }) => {
-                        dt.setData(vndMimeTypes.get('gridImagesData'), data);
+                    const sub = dragData$.subscribe(({ images, dt }) => {
+                        if (images.size > 0) {
+                            dt.setData(vndMimeTypes.get('gridImagesData'), JSON.stringify(images));
+                        }
                     });
 
                     $scope.$on('$destroy', () => sub.dispose());

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -18,4 +18,5 @@
 
 <ui-view name="results"></ui-view>
 <ui-view name="panel"></ui-view>
+<ui-view name="multiDrag"></ui-view>
 <dnd-uploader></dnd-uploader>


### PR DESCRIPTION
I've stuck it in the results view as that's where we resolve the `selectedImages$`. This becomes a little weird as we can only have them as deps on the view.

This will now allow us to have clients of the drop data use the information of the selection.

__Next__
Theseus work to deserialise this into resources again.

e.g.
```JavaScript
window.addEventListener('drop', ev => {
  const t = ev.dataTransfer.getData(vndMimeTypes.get('gridImagesData'));
  console.log(t);
});
```