### PR TITLE
Zero width space

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -43,6 +43,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     $urlMatcherFactoryProvider.type('Query', {
         encode: val => removeUtf8SpecialChars(val),
         decode: val => removeUtf8SpecialChars(val),
+        //call decode value that includes zero-width-space character
         is: val => val && (val.indexOf(zeroWidthSpace) === -1)
     });
 

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -35,16 +35,16 @@ export var search = angular.module('kahuna.search', [
 search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                function($stateProvider, $urlMatcherFactoryProvider) {
 
-    const zeroWidthSpace = '\u200B';
+    const zeroWidthSpace = /[\u200B]/g;
     function removeUtf8SpecialChars(val) {
-        return val && val.replace(zeroWidthSpace, '');
+        return angular.isDefined(val) && val.replace(zeroWidthSpace, '');
     }
 
     $urlMatcherFactoryProvider.type('Query', {
         encode: val => removeUtf8SpecialChars(val),
         decode: val => removeUtf8SpecialChars(val),
         //call decode value that includes zero-width-space character
-        is: val => angular.isDefined(val) && (val.indexOf(zeroWidthSpace) === -1)
+        is: val => angular.isDefined(val) && !zeroWidthSpace.test(val)
     });
 
     $stateProvider.state('search', {
@@ -115,7 +115,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                 ).
                     distinctUntilChanged(angular.identity, Immutable.is).
                     shareReplay(1);
-            }],
+            }]
         },
         views: {
             results: {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -44,7 +44,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         encode: val => removeUtf8SpecialChars(val),
         decode: val => removeUtf8SpecialChars(val),
         //call decode value that includes zero-width-space character
-        is: val => val && (val.indexOf(zeroWidthSpace) === -1)
+        is: val => angular.isDefined(val) && (val.indexOf(zeroWidthSpace) === -1)
     });
 
     $stateProvider.state('search', {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -116,12 +116,6 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                     distinctUntilChanged(angular.identity, Immutable.is).
                     shareReplay(1);
             }],
-            query: ['$stateParams', function($stateParams) {
-                return decodeURIComponent(
-                    encodeURIComponent($stateParams.query).replace(/%E2%80%8B/ig, ''))
-            }],
-
-
         },
         views: {
             results: {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -64,6 +64,8 @@ query.controller('SearchQueryCtrl',
     // URL parameters are not decoded when taken out of the params.
     // Might be fixed with: https://github.com/angular-ui/ui-router/issues/1759
     // Pass undefined to the state on empty to remove the QueryString
+    // The string replacement is for removing the invisible "zero-width-space" UTF-8
+    // causing queries to fail: https://en.wikipedia.org/wiki/Zero-width_space
     function valOrUndefined(str) { return str ? str.replace(/%E2%80%8B/ig, "%20") : undefined; }
 
     function setAndWatchParam(key) {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -64,7 +64,7 @@ query.controller('SearchQueryCtrl',
     // URL parameters are not decoded when taken out of the params.
     // Might be fixed with: https://github.com/angular-ui/ui-router/issues/1759
     // Pass undefined to the state on empty to remove the QueryString
-    function valOrUndefined(str) { return str ? str : undefined; }
+    function valOrUndefined(str) { return str ? str.replace(/%E2%80%8B/ig, "%20") : undefined; }
 
     function setAndWatchParam(key) {
         ctrl.filter[key] = valOrUndefined($stateParams[key]);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -64,9 +64,7 @@ query.controller('SearchQueryCtrl',
     // URL parameters are not decoded when taken out of the params.
     // Might be fixed with: https://github.com/angular-ui/ui-router/issues/1759
     // Pass undefined to the state on empty to remove the QueryString
-    // The string replacement is for removing the invisible "zero-width-space" UTF-8
-    // causing queries to fail: https://en.wikipedia.org/wiki/Zero-width_space
-    function valOrUndefined(str) { return str ? str.replace(/%E2%80%8B/ig, "%20") : undefined; }
+    function valOrUndefined(str) { return str ? str : undefined; }
 
     function setAndWatchParam(key) {
         ctrl.filter[key] = valOrUndefined($stateParams[key]);


### PR DESCRIPTION
small change to fix a problem some people were experiencing when copy-pasting from emails to search. 

Zero-width-space is a valid UTF-8 character but because it's invisible can cause confusion. I know it's a particularly specific fix, but it seemed better than doing something fancy. 