### PR TITLE
Revert "Revert "add collections to image response""

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -1,10 +1,13 @@
 package com.gu.mediaservice.model
 
+import java.net.URI
+
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
 import com.gu.mediaservice.lib.collections.CollectionsManager
+import com.gu.mediaservice.lib.argo.model.{Action, EmbeddedEntity}
 
 case class Collection(path: List[String], actionData: ActionData) {
   val pathId = CollectionsManager.pathToString(path)
@@ -18,6 +21,17 @@ object Collection {
   ){ col: Collection => (col.pathId, col.path, col.actionData) }
 
   implicit val formats: Format[Collection] = Format(reads, writes)
+
+  def imageUri(rootUri: String, imageId: String, c: Collection) =
+    URI.create(s"$rootUri/images/$imageId/${c.pathId}")
+
+  def asImageEntity(rootUri: String, imageId: String, c: Collection) = {
+    // TODO: Currently the GET for this URI does nothing
+    val uri = imageUri(rootUri, imageId, c)
+    EmbeddedEntity(uri, Some(c), actions = List(
+      Action("remove", uri, "DELETE")
+    ))
+  }
 }
 
 // Following the crop structure

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -20,7 +20,8 @@ case class Image(
   originalMetadata:    ImageMetadata,
   usageRights:         UsageRights,
   originalUsageRights: UsageRights,
-  exports:             List[Crop]
+  exports:             List[Crop],
+  collections:         List[Collection] = Nil
 )
 
 object Image {
@@ -45,7 +46,8 @@ object Image {
       (__ \ "originalMetadata").readNullable[ImageMetadata].map(_ getOrElse ImageMetadata()) ~
       (__ \ "usageRights").readNullable[UsageRights].map(_ getOrElse NoRights) ~
       (__ \ "originalUsageRights").readNullable[UsageRights].map(_ getOrElse NoRights) ~
-      (__ \ "exports").readNullable[List[Crop]].map(_ getOrElse List())
+      (__ \ "exports").readNullable[List[Crop]].map(_ getOrElse Nil) ~
+      (__ \ "collections").readNullable[List[Collection]].map(_ getOrElse Nil)
     )(Image.apply _)
 
   implicit val ImageWrites: Writes[Image] = (
@@ -63,7 +65,8 @@ object Image {
       (__ \ "originalMetadata").write[ImageMetadata] ~
       (__ \ "usageRights").write[UsageRights] ~
       (__ \ "originalUsageRights").write[UsageRights] ~
-      (__ \ "exports").write[List[Crop]]
+      (__ \ "exports").write[List[Crop]] ~
+      (__ \ "collections").write[List[Collection]]
     )(unlift(Image.unapply))
 
 }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -220,9 +220,14 @@ object ImageResponse extends EditsResponse {
     (__ \ "usageRights").write[UsageRights] ~
     (__ \ "originalUsageRights").write[UsageRights] ~
     (__ \ "exports").write[List[Export]]
-      .contramap((crops: List[Crop]) => crops.map(Export.fromCrop(_:Crop)))
+      .contramap((crops: List[Crop]) => crops.map(Export.fromCrop(_:Crop))) ~
+    (__ \ "collections").write[List[EmbeddedEntity[Collection]]]
+      .contramap((collections: List[Collection]) => collections.map(c => collectionsEntity(id, c)))
 
   )(unlift(Image.unapply))
+
+  def collectionsEntity(id: String, c: Collection): EmbeddedEntity[Collection] =
+      Collection.asImageEntity(Config.collectionsUri, id, c)
 
   def fileMetadataEntity(id: String, expandFileMetaData: Boolean, fileMetadata: FileMetadata) = {
     val displayableMetadata = if(expandFileMetaData) Some(fileMetadata) else None


### PR DESCRIPTION
Reverts guardian/grid#1551

We now have the `collections` in the mappings.
This will store all new images to
```
{
  "image": {
    "collections": []
  }
}
```

But will also fall back to older images.