### PR TITLE
update jspm

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -55,7 +55,7 @@
     "htmllint-cli": "0.0.4",
     "jscs": "^1.13.0",
     "jshint": "^2.5.11",
-    "jspm": "~0.16.0"
+    "jspm": "~0.16.18"
   },
   "scripts": {
     "test": "npm run lint",


### PR DESCRIPTION
We've cached a dirty version (0.16.17) in TC that was fixed in 18 that took our `baseUrl` into consideration in the build (thus trying to include `file:///assets/js/main.js`). 

This forces the minor updates.