### PR TITLE
add collections to query syntax

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -32,16 +32,19 @@ trait ImageFields {
   )
 
   val editsFields = List("archived", "labels")
+  val collectionsFields = List("path", "pathId", "pathHierarchy")
 
   def identifierField(field: String)  = s"identifiers.$field"
   def metadataField(field: String)    = s"metadata.$field"
   def editsField(field: String)       = s"userMetadata.$field"
   def usageRightsField(field: String) = s"usageRights.$field"
+  def collectionsField(field: String) = s"collections.$field"
 
   def getFieldPath(field: String) = field match {
     case f if metadataFields.contains(f)    => metadataField(f)
     case f if usageRightsFields.contains(f) => usageRightsField(f)
     case f if editsFields.contains(f)       => editsField(f)
+    case f if collectionsFields.contains(f) => collectionsField(f)
     case f => f
   }
 

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -33,6 +33,8 @@ class QueryBuilder(matchFields: Seq[String]) {
       case Phrase(value) => matchPhraseQuery(field, value)
       case DateRange(start, end) => rangeQuery(field).from(start.toString()).to(end.toString())
     }
+    case HierarchyField(field, value) =>
+        matchPhraseQuery(field, value).analyzer(IndexSettings.hierarchyAnalyserName)
   }
 
   def makeQuery(conditions: List[Condition]) = conditions match {

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -33,8 +33,7 @@ class QueryBuilder(matchFields: Seq[String]) {
       case Phrase(value) => matchPhraseQuery(field, value)
       case DateRange(start, end) => rangeQuery(field).from(start.toString()).to(end.toString())
     }
-    case HierarchyField(field, value) =>
-        matchPhraseQuery(field, value).analyzer(IndexSettings.hierarchyAnalyserName)
+    case HierarchyField(field, value) => termQuery(field, value)
   }
 
   def makeQuery(conditions: List[Condition]) = conditions match {

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -16,13 +16,14 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
 
 
   def Filter = rule {
-    ScopedMatch ~> Match | HashMatch |
+    ScopedMatch ~> Match | HashMatch | CollectionRule |
     DateMatch ~> Match | AtMatch |
     AnyMatch
   }
 
   def ScopedMatch = rule { MatchField ~ ':' ~ MatchValue }
-  def HashMatch = rule { '#' ~ MatchValue ~> (label => Match(SingleField(getFieldPath("labels")), label)) }
+  def HashMatch = rule      { '#' ~ MatchValue      ~> (label      => Match(SingleField(getFieldPath("labels")), label)) }
+  def CollectionRule = rule { '~' ~ ExactMatchValue ~> (collection => Match(HierarchyField(getFieldPath("pathHierarchy"), collection.string), collection)) }
 
   def MatchField = rule { capture(AllowedFieldName) ~> resolveNamedField _ }
 
@@ -57,6 +58,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
 
   def AnyMatch = rule { MatchValue ~> (v => Match(AnyField, v)) }
 
+  def ExactMatchValue = rule { QuotedString ~> Phrase | String ~> Phrase }
 
   // Note: order matters, check for quoted string first
   def MatchValue = rule { QuotedString ~> Phrase | String ~> Words }

--- a/media-api/app/lib/querysyntax/model.scala
+++ b/media-api/app/lib/querysyntax/model.scala
@@ -3,15 +3,16 @@ package lib.querysyntax
 import org.joda.time.DateTime
 
 sealed trait Condition
-case class Negation(m: Match) extends Condition
-case class Match(field: Field, value: Value) extends Condition
+final case class Negation(m: Match) extends Condition
+final case class Match(field: Field, value: Value) extends Condition
 
 sealed trait Field
 case object AnyField extends Field
-case class SingleField(name: String) extends Field
-case class MultipleField(names: List[String]) extends Field
+final case class HierarchyField(name: String, value: String) extends Field
+final case class SingleField(name: String) extends Field
+final case class MultipleField(names: List[String]) extends Field
 
 sealed trait Value
-case class Words(string: String) extends Value
-case class Phrase(string: String) extends Value
-case class DateRange(start: DateTime, end: DateTime) extends Value
+final case class Words(string: String) extends Value
+final case class Phrase(string: String) extends Value
+final case class DateRange(start: DateTime, end: DateTime) extends Value


### PR DESCRIPTION
Using `~` is by no means to final case, it just allows me to demo the collections more fully by adding something and then selecting the collection.

As this is programmatic it's not a tie in.