### PR TITLE
Graceful fail for usage where image isn't found

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -93,8 +93,6 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
       }
   }
 
-  case class GracefulFail(msg: String)
-
   def updateImageUsages(id: String, usages: JsValue)(implicit ex: ExecutionContext): Future[Any] =
     prepareUpdateIfImageExists(id).map(requestBuilder => {
       requestBuilder.setScriptParams(Map(
@@ -108,10 +106,7 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
       .executeAndLog(s"updating usages on image $id")
       .incrementOnFailure(failedUsagesUpdates) { case e: VersionConflictEngineException => true }
     }).getOrElse(Future {
-      val fail = GracefulFail("Usage update failed, no document to update.")
-      Logger.info(fail.msg)
-
-      fail
+      Logger.info("Usage update failed, no document to update.")
     })
 
   def updateImageExports(id: String, exports: JsValue)(implicit ex: ExecutionContext): Future[UpdateResponse] =

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -103,7 +103,7 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
           updateLastModifiedScript,
         scriptType)
       .executeAndLog(s"updating usages on image $id")
-      .recover { case e: DocumentMissingException => {}}
+      .recover { case e: DocumentMissingException => Unit }
       .incrementOnFailure(failedUsagesUpdates) { case e: VersionConflictEngineException => true }
 
   def updateImageExports(id: String, exports: JsValue)(implicit ex: ExecutionContext): Future[UpdateResponse] =

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -8,7 +8,6 @@ import scala.util.Try
 
 import play.api.libs.json.JsError
 import play.api.Logger
-import play.api.Logger
 import play.api.mvc.Controller
 import play.api.mvc.Results._
 import play.api.mvc.Results._

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -10,7 +10,6 @@ import play.api.libs.json.JsError
 import play.api.Logger
 import play.api.mvc.Controller
 import play.api.mvc.Results._
-import play.api.mvc.Results._
 import play.api.mvc.{Controller, BodyParsers}
 import play.utils.UriEncoding
 


### PR DESCRIPTION
Performs a get request before attempting an upsert
Fails gracefully when no document found to update
i.e. message is deleted, no error logged