### PR TITLE
upload lambda artifact during deploy

### DIFF
--- a/s3watcher/build.sh
+++ b/s3watcher/build.sh
@@ -17,12 +17,17 @@ npm install
 
 npm test
 
-zip -r S3Watcher.zip *
+zip -r s3-watcher.zip *
 cd ..
 
 [ -d target ] && rm -rf target
 mkdir -p target/packages/lambda
-mv lambda/S3Watcher.zip target/packages/lambda/lambda.zip
+mkdir -p target/packages/s3-watcher
+
+cp lambda/s3-watcher.zip target/packages/lambda/lambda.zip
+cp lambda/s3-watcher.zip target/packages/s3-watcher/s3-watcher.zip
+
+rm lambda/s3-watcher.zip
 
 cat deploy.json \
     | jq ".packages.lambda.data.functions.TEST.name |= \"$TEST_FUNC_NAME\" | .packages.lambda.data.functions.PROD.name |= \"$PROD_FUNC_NAME\"" \

--- a/s3watcher/deploy.json
+++ b/s3watcher/deploy.json
@@ -11,12 +11,22 @@
                     "PROD": {
                         "name": "@PROD_ARN"
                     }
-                }
+                },
+                "bucket": "media-service-dist"
             }
         }
     },
     "recipes": {
         "default": {
+            "depends": [
+                "artifactUploadOnly",
+                "updateLambda"
+            ]
+        },
+        "artifactUploadOnly": {
+            "actions": ["lambda.uploadArtifacts"]
+        },
+        "updateLambda": {
             "actions": ["lambda.updateLambda"]
         }
     }

--- a/s3watcher/deploy.json
+++ b/s3watcher/deploy.json
@@ -11,23 +11,20 @@
                     "PROD": {
                         "name": "@PROD_ARN"
                     }
-                },
-                "bucket": "media-service-dist"
+                }
+            }
+        },
+        "s3-watcher": {
+            "type": "aws-s3",
+            "data": {
+                "bucket": "media-service-dist",
+                "cacheControl": "public, max-age=60"
             }
         }
     },
     "recipes": {
         "default": {
-            "depends": [
-                "artifactUploadOnly",
-                "updateLambda"
-            ]
-        },
-        "artifactUploadOnly": {
-            "actions": ["lambda.uploadArtifacts"]
-        },
-        "updateLambda": {
-            "actions": ["lambda.updateLambda"]
+            "actions": [ "s3-watcher.uploadStaticFiles", "lambda.updateLambda" ]
         }
     }
 }

--- a/s3watcher/deploy.json
+++ b/s3watcher/deploy.json
@@ -18,7 +18,8 @@
             "type": "aws-s3",
             "data": {
                 "bucket": "media-service-dist",
-                "cacheControl": "public, max-age=60"
+                "cacheControl": "public, max-age=60",
+                "publicReadAcl": false
             }
         }
     },


### PR DESCRIPTION
- When a lambda is created in cloudformation, we tell it where to find its code in S3. Let this be V1.
- When we run a riffraff deploy of the lambda, we update-function-code, which updates the code the lambda uses, but not the S3 object. Let this be V2.
- Any subsequent cloudformation updates will revert the lambda to run off V1 :cry: 

This fixes that as we keep the S3 object up-to-date.

TODO:
- [x] the upload artifact deploy type puts the file here: `/<bucketName>/<targetStage>/<packageName>/<filePathAndName>` this is different from our current path in cloudformation, so we need to update the path in our template.