### PR TITLE
Use illustrator as byline too, not just credit

### DIFF
--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -9,8 +9,8 @@ object UsageRightsMetadataMapper {
       case u: StaffPhotographer        => ImageMetadata(byline = Some(u.photographer), credit = Some(u.publication))
       case u: ContractPhotographer     => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
-      case u: ContractIllustrator      => ImageMetadata(credit = Some(u.creator))
-      case u: CommissionedIllustrator  => ImageMetadata(credit = Some(u.creator))
+      case u: ContractIllustrator      => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
+      case u: CommissionedIllustrator  => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: Composite                => ImageMetadata(credit = Some(u.suppliers))
     }
 


### PR DESCRIPTION
Fixes https://github.com/guardian/grid/issues/1342

Currently, when selecting Illustrator as Usage Rights, the `creator` name gets copied to the `credit` field only. In practice it should also populate the `byline` field, especially now that Composer won't duplicate them in its output.

cc @jamesgorrie I don't think there was any reason not to do this (anymore?) ?