### PR TITLE
use viewport height instead of setting the px height

### DIFF
--- a/kahuna/public/js/components/gr-panels/gr-panels.js
+++ b/kahuna/public/js/components/gr-panels/gr-panels.js
@@ -54,19 +54,16 @@ panels.directive('grPanel', ['$timeout', '$window', 'inject$', 'subscribe$',
         link: function(scope, element) {
             function setElementHeight() {
                 setFullHeight(element);
-                scope.panelHeight = element.height();
+                scope.panelHeight = element[0].style.height;
             }
             const panel = scope.panel;
             const winScroll$ = Rx.DOM.fromEvent($window, 'scroll');
-            const winResize$ = Rx.DOM.fromEvent($window, 'resize');
+
             // This is done to make sure we trigger on the template being rendered,
             // if we don't we get the semi-rendered template offset
             $timeout(setElementHeight, 0);
 
             inject$(scope, panel.state$, scope, 'state');
-
-            // Reset the panel heights
-            subscribe$(scope, winResize$.debounce(100), setElementHeight);
 
             // If we are quickly window scrolling whilst visible and unlocked
             const scrollWhileVisAndUnlocked$ = winScroll$.


### PR DESCRIPTION
This means we can let the browser do the working by setting it to use `vh`.

It also means we can stop using the debounce, which is causing a bug by setting the height at the wrong interval.