### PR TITLE
Move batch results archiving to button in action bar

### DIFF
--- a/kahuna/public/js/components/gr-archiver/gr-archiver.css
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.css
@@ -1,0 +1,8 @@
+
+.batch-archive__button {
+    line-height: inherit;
+}
+
+.batch-archive__button:hover {
+    color: white;
+}

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -1,0 +1,24 @@
+<div class="batch-archive"
+     ng:switch="ctrl.archivedState">
+    <button ng:switch-when="archived"
+            type="button"
+            class="inner-clickable batch-archive__button"
+            ng:click="ctrl.unarchive()"
+            ng:disabled="ctrl.archiving">
+        <gr-icon-label gr-icon="lock_open">
+            <span ng:if="!ctrl.archiving">Remove from Library</span>
+            <span ng:if="ctrl.archiving">Removing from Library…</span>
+        </gr-icon-label>
+    </button>
+
+    <button ng:switch-when="unarchived"
+            type="button"
+            class="inner-clickable batch-archive__button"
+            ng:click="ctrl.archive()"
+            ng:disabled="ctrl.archiving">
+        <gr-icon-label gr-icon="lock">
+            <span ng:if="!ctrl.archiving">Keep in Library</span>
+            <span ng:if="ctrl.archiving">Keeping in Library…</span>
+        </gr-icon-label>
+    </button>
+</div>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -23,15 +23,14 @@ module.controller('grArchiverCtrl', [
 
         const ctrl = this;
 
-        $scope.$watchCollection(() => ctrl.images.toJS(), (images) => {
+        $scope.$watchCollection(getImageArray, (images) => {
             const allArchived = images.every(imageAccessor.isArchived);
             ctrl.archivedState = allArchived ? 'archived' : 'unarchived';
         });
 
         ctrl.archive = () => {
             ctrl.archiving = true;
-            var imageArray = Array.from(ctrl.images);
-            archiveService.batchArchive(imageArray)
+            archiveService.batchArchive(getImageArray())
                 .then(() => {
                     ctrl.archiving = false;
                 });
@@ -39,12 +38,16 @@ module.controller('grArchiverCtrl', [
 
         ctrl.unarchive = () => {
             ctrl.archiving = true;
-            var imageArray = Array.from(ctrl.images);
-            archiveService.batchUnarchive(imageArray)
+            archiveService.batchUnarchive(getImageArray())
                 .then(() => {
                     ctrl.archiving = false;
                 });
         };
+
+        function getImageArray() {
+            // Convert from Immutable Set to JS Array
+            return Array.from(ctrl.images);
+        }
     }
 ]);
 

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -34,7 +34,7 @@ module.controller('grArchiverCtrl', [
         ctrl.archive = () => {
             ctrl.archiving = true;
             archiveService.batchArchive(getImageArray())
-                .then(() => {
+                .finally(() => {
                     ctrl.archiving = false;
                 });
         };
@@ -42,7 +42,7 @@ module.controller('grArchiverCtrl', [
         ctrl.unarchive = () => {
             ctrl.archiving = true;
             archiveService.batchUnarchive(getImageArray())
-                .then(() => {
+                .finally(() => {
                     ctrl.archiving = false;
                 });
         };

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -1,0 +1,62 @@
+import angular from 'angular';
+import Rx from 'rx';
+
+import './gr-archiver.css!';
+import template from './gr-archiver.html!text';
+
+import '../../services/archive';
+import '../../services/image-accessor';
+
+
+export const module = angular.module('gr.archiver', [
+    'kahuna.services.archive',
+    'kahuna.services.image-accessor'
+]);
+
+module.controller('grArchiverCtrl', [
+    '$scope',
+    'archiveService',
+    'imageAccessor',
+    function ($scope,
+              archiveService,
+              imageAccessor) {
+
+        const ctrl = this;
+
+        $scope.$watchCollection(() => ctrl.images.toJS(), (images) => {
+            const allArchived = images.every(imageAccessor.isArchived);
+            ctrl.archivedState = allArchived ? 'archived' : 'unarchived';
+        });
+
+        ctrl.archive = () => {
+            ctrl.archiving = true;
+            var imageArray = Array.from(ctrl.images);
+            archiveService.batchArchive(imageArray)
+                .then(() => {
+                    ctrl.archiving = false;
+                });
+        };
+
+        ctrl.unarchive = () => {
+            ctrl.archiving = true;
+            var imageArray = Array.from(ctrl.images);
+            archiveService.batchUnarchive(imageArray)
+                .then(() => {
+                    ctrl.archiving = false;
+                });
+        };
+    }
+]);
+
+module.directive('grArchiver', [function () {
+    return {
+        restrict: 'E',
+        template: template,
+        scope: {
+            images: '=grImages'
+        },
+        controller: 'grArchiverCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true
+    };
+}]);

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -23,6 +23,9 @@ module.controller('grArchiverCtrl', [
 
         const ctrl = this;
 
+        ctrl.archivedState = 'unarchived';
+        ctrl.archiving = false;
+
         $scope.$watchCollection(getImageArray, (images) => {
             const allArchived = images.every(imageAccessor.isArchived);
             ctrl.archivedState = allArchived ? 'archived' : 'unarchived';

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import Rx from 'rx';
 
 import './gr-archiver.css!';
 import template from './gr-archiver.html!text';

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -15,9 +15,11 @@ export const module = angular.module('gr.archiver', [
 
 module.controller('grArchiverCtrl', [
     '$scope',
+    '$window',
     'archiveService',
     'imageAccessor',
     function ($scope,
+              $window,
               archiveService,
               imageAccessor) {
 
@@ -34,6 +36,9 @@ module.controller('grArchiverCtrl', [
         ctrl.archive = () => {
             ctrl.archiving = true;
             archiveService.batchArchive(getImageArray())
+                .catch(() => {
+                    $window.alert('Failed to keep in Library, please try again.');
+                })
                 .finally(() => {
                     ctrl.archiving = false;
                 });
@@ -42,6 +47,9 @@ module.controller('grArchiverCtrl', [
         ctrl.unarchive = () => {
             ctrl.archiving = true;
             archiveService.batchUnarchive(getImageArray())
+                .catch(() => {
+                    $window.alert('Failed to remove from Library, please try again.');
+                })
                 .finally(() => {
                     ctrl.archiving = false;
                 });

--- a/kahuna/public/js/components/gr-panel/gr-panel.css
+++ b/kahuna/public/js/components/gr-panel/gr-panel.css
@@ -89,8 +89,3 @@
 .batch-label .labels {
     display: inline-block;
 }
-
-.batch-archive__archive:hover,
-.batch-archive__unarchive:hover {
-    color: white;
-}

--- a/kahuna/public/js/components/gr-panel/gr-panel.html
+++ b/kahuna/public/js/components/gr-panel/gr-panel.html
@@ -304,49 +304,5 @@
                 </li>
             </ul>
         </div>
-
-        <div class="image-info__group image-info__group--last batch-archive" ng:switch="ctrl.archivedState" ng:class="{'batch-archive--archiving': ctrl.archiving}">
-            <div ng:switch-when="mixed" class="flex-container batch-archive--mixed">
-                <div class="metadata-line flex-spacer">
-                    <gr-icon>lock_open</gr-icon>
-                    <span ng:if="!ctrl.archiving">{{ctrl.archivedCount}} kept in Library</span>
-                    <span ng:if="ctrl.archiving">Saving…</span>
-                </div>
-                <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                    <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>lock</gr-icon> all
-                    </button>
-                    <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>lock_open</gr-icon> none
-                    </button>
-                </span>
-            </div>
-
-            <div ng:switch-when="archived" class="flex-container batch-archive--all-archived">
-                <div class="metadata-line flex-spacer">
-                    <gr-icon>lock</gr-icon>
-                    <span ng:if="!ctrl.archiving">All kept in Library</span>
-                    <span ng:if="ctrl.archiving">Saving…</span>
-                </div>
-                <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                    <button class="button-shy batch-archive__unarchive" ng:click="ctrl.unarchive()">
-                        <gr-icon>lock_open</gr-icon> Remove all
-                    </button>
-                </span>
-            </div>
-
-            <div ng:switch-when="unarchived" class="flex-container batch-archive--all-unarchived">
-                <div class="metadata-line flex-spacer">
-                    <gr-icon>lock_open</gr-icon>
-                    <span ng:if="!ctrl.archiving">None kept in Library</span>
-                    <span ng:if="ctrl.archiving">Saving…</span>
-                </div>
-                <span class="batch-archive__action" ng:if="!ctrl.archiving">
-                    <button class="button-shy batch-archive__archive" ng:click="ctrl.archive()">
-                        <gr-icon>lock</gr-icon> Keep all in Library
-                    </button>
-                </span>
-            </div>
-        </div>
     </div>
 </div>

--- a/kahuna/public/js/components/gr-panel/gr-panel.js
+++ b/kahuna/public/js/components/gr-panel/gr-panel.js
@@ -13,7 +13,6 @@ import '../../forms/gr-xeditable/gr-xeditable';
 import '../../util/rx';
 
 export var grPanel = angular.module('grPanel', [
-    'kahuna.services.archive',
     'kahuna.services.image-accessor',
     'kahuna.services.image-list',
     'kahuna.services.label',
@@ -34,10 +33,8 @@ grPanel.controller('GrPanel', [
     'mediaApi',
     'imageAccessor',
     'imageList',
-    'selection',
     'selectedImagesList$',
     'labelService',
-    'archiveService',
     'editsService',
     'editsApi',
     function (
@@ -50,10 +47,8 @@ grPanel.controller('GrPanel', [
         mediaApi,
         imageAccessor,
         imageList,
-        selection,
         selectedImagesList$,
         labelService,
-        archiveService,
         editsService,
         editsApi) {
 
@@ -68,21 +63,6 @@ grPanel.controller('GrPanel', [
               map(imageList.getOccurrences);
         inject$($scope, selectedCosts$, ctrl, 'selectedCosts');
 
-
-        const archivedCount$ = selectedImagesList$.map(imageList.archivedCount);
-        const archivedState$ = Rx.Observable.combineLatest(
-            archivedCount$,
-            selection.count$,
-            (archivedCount, selectedCount) => {
-                switch (archivedCount) {
-                case 0:              return 'unarchived';
-                case selectedCount:  return 'archived';
-                default:             return 'mixed';
-                }
-            }
-        );
-        inject$($scope, archivedCount$, ctrl, 'archivedCount');
-        inject$($scope, archivedState$, ctrl, 'archivedState');
 
         const selectedLabels$ = selectedImagesList$.
               map(imageList.getLabels).
@@ -193,24 +173,6 @@ grPanel.controller('GrPanel', [
         ctrl.removeLabel = function (label) {
             var imageArray = Array.from(ctrl.selectedImages);
             labelService.batchRemove(imageArray, label);
-        };
-
-        ctrl.archive = () => {
-            ctrl.archiving = true;
-            var imageArray = Array.from(ctrl.selectedImages);
-            archiveService.batchArchive(imageArray)
-                .then(() => {
-                    ctrl.archiving = false;
-                });
-        };
-
-        ctrl.unarchive = () => {
-            ctrl.archiving = true;
-            var imageArray = Array.from(ctrl.selectedImages);
-            archiveService.batchUnarchive(imageArray)
-                .then(() => {
-                    ctrl.archiving = false;
-                });
         };
     }
 ]);

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -92,6 +92,11 @@
                                  ng:if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0">
                 </gr-delete-image>
 
+                <gr-archiver class="results-toolbar-item results-toolbar-item--right"
+                             gr:images="ctrl.selectedImages"
+                             ng:if="ctrl.selectionCount > 0">
+                </gr-archiver>
+
                 <gr-panel-button
                     class="results-toolbar-item results-toolbar-item--no-hover results-toolbar-item--right"
                     gr:panel="ctrl.metadataPanel"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -9,6 +9,7 @@ import '../util/async';
 import '../util/rx';
 import '../util/seq';
 import '../components/gu-lazy-table/gu-lazy-table';
+import '../components/gr-archiver/gr-archiver';
 import '../components/gr-delete-image/gr-delete-image';
 import '../components/gr-downloader/gr-downloader';
 import '../components/gr-panel-button/gr-panel-button';
@@ -20,6 +21,7 @@ export var results = angular.module('kahuna.search.results', [
     'util.rx',
     'util.seq',
     'gu.lazyTable',
+    'gr.archiver',
     'gr.downloader',
     'gr.deleteImage',
     'gr.panelButton'


### PR DESCRIPTION
I also extracted the logic into a new component.

Note that we now have two similar components, one for batch-archiving on the results page and another one for archiving on the image page. They have slightly different semantics, which isn't ideal, but we could unify them as a separate phase, since at least they're more aligned now.

# Before

![image](https://cloud.githubusercontent.com/assets/36964/12092397/d1399ecc-b2f4-11e5-8b36-0e947a965e0a.png)

# After

![image](https://cloud.githubusercontent.com/assets/36964/12092389/c1b4b20c-b2f4-11e5-8acd-d683637e5ad1.png)
