### PR TITLE
Don't render results if search failed

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -5,7 +5,10 @@
 </div>
 
 <div ng:if="! ctrl.loading">
-    <div>
+    <div ng:if="ctrl.loadingError">
+        Error loading results: {{ctrl.loadingError}}
+    </div>
+    <div ng:if="! ctrl.loadingError">
         <div class="results-toolbar">
             <gr-panel-button class="results-toolbar-item results-toolbar-item--left results-toolbar-item--no-hover"
                              id="toggle-collections-button"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -154,6 +154,9 @@ results.controller('SearchResultsCtrl', [
             }
 
             return images;
+        }).catch(error => {
+            ctrl.loadingError = error;
+            return $q.reject(error);
         }).finally(() => {
             ctrl.loading = false;
         });


### PR DESCRIPTION
This should fix the Sentry errors we've seen recently.