### PR TITLE
Avoid double scrollbars w meta panel

### DIFF
--- a/kahuna/public/js/components/gr-panels/gr-panels.css
+++ b/kahuna/public/js/components/gr-panels/gr-panels.css
@@ -28,7 +28,7 @@
 }
 .gr-panel__content--hidden {
     width: 0;
-    overflow-x: hidden;
+    overflow: hidden;
 }
 .gr-panel__content--left {
     left: 0;


### PR DESCRIPTION
Fixes when a selection is present and the meta panel hidden:
![image](https://cloud.githubusercontent.com/assets/36964/12120136/56a27e08-b3c7-11e5-81f8-2889ec253733.png)

cc @jamesgorrie was there any reason why only the `x` overflow was being hidden?