### PR TITLE
Unify wording to always be 'Add to Library'

### DIFF
--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -17,8 +17,8 @@
             ng:click="ctrl.archive()"
             ng:disabled="ctrl.archiving">
         <gr-icon-label gr-icon="lock">
-            <span ng:if="!ctrl.archiving">Keep in Library</span>
-            <span ng:if="ctrl.archiving">Keeping in Library…</span>
+            <span ng:if="!ctrl.archiving">Add to Library</span>
+            <span ng:if="ctrl.archiving">Adding to Library…</span>
         </gr-icon-label>
     </button>
 </div>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -36,7 +36,7 @@ module.controller('grArchiverCtrl', [
             ctrl.archiving = true;
             archiveService.batchArchive(getImageArray())
                 .catch(() => {
-                    $window.alert('Failed to keep in Library, please try again.');
+                    $window.alert('Failed to add to Library, please try again.');
                 })
                 .finally(() => {
                     ctrl.archiving = false;


### PR DESCRIPTION
I'd introduced an inconsistency in the action label for archiving things. It should read "Add to Library" as elsewhere.