### PR TITLE
Unify and correct archive states

### DIFF
--- a/kahuna/public/js/components/gr-archiver/gr-archiver.css
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.css
@@ -6,3 +6,14 @@
 .batch-archive__button:hover {
     color: white;
 }
+
+.batch-archive__button--disabled,
+.batch-archive__button--disabled:hover {
+    color: #666;
+    cursor: default;
+}
+/* Hack: overlay the normal background color as the parent that has a
+   hover highlight isn't aware of the internal disabled state :-/ */
+.batch-archive__button--disabled:hover {
+    background-color: #333;
+}

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -5,7 +5,7 @@
             class="inner-clickable batch-archive__button"
             ng:click="ctrl.unarchive()"
             ng:disabled="ctrl.archiving">
-        <gr-icon-label gr-icon="lock_open">
+        <gr-icon-label gr-icon="lock_outline">
             <span ng:if="!ctrl.archiving">Remove from Library</span>
             <span ng:if="ctrl.archiving">Removing from Library…</span>
         </gr-icon-label>
@@ -16,7 +16,7 @@
             class="inner-clickable batch-archive__button"
             ng:click="ctrl.archive()"
             ng:disabled="ctrl.archiving">
-        <gr-icon-label gr-icon="lock">
+        <gr-icon-label gr-icon="lock_open">
             <span ng:if="!ctrl.archiving">Add to Library</span>
             <span ng:if="ctrl.archiving">Adding to Library…</span>
         </gr-icon-label>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -1,5 +1,13 @@
 <div class="batch-archive"
      ng:switch="ctrl.archivedState">
+    <span ng:switch-when="kept"
+          type="button"
+          class="inner-clickable batch-archive__button">
+        <gr-icon-label gr-icon="lock">
+            Kept in Library
+        </gr-icon-label>
+    </span>
+
     <button ng:switch-when="archived"
             type="button"
             class="inner-clickable batch-archive__button"

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -1,7 +1,6 @@
 <div class="batch-archive"
      ng:switch="ctrl.archivedState">
     <span ng:switch-when="kept"
-          type="button"
           class="inner-clickable batch-archive__button batch-archive__button--disabled"
           gr:tooltip="Kept in Library because all selected images have been {{ctrl.archivedExplanation}}.">
         <gr-icon-label gr-icon="lock">

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -2,7 +2,7 @@
      ng:switch="ctrl.archivedState">
     <span ng:switch-when="kept"
           type="button"
-          class="inner-clickable batch-archive__button"
+          class="inner-clickable batch-archive__button batch-archive__button--disabled"
           gr:tooltip="Kept in Library because all selected images have been {{ctrl.archivedExplanation}}.">
         <gr-icon-label gr-icon="lock">
             Kept in Library

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -2,7 +2,8 @@
      ng:switch="ctrl.archivedState">
     <span ng:switch-when="kept"
           type="button"
-          class="inner-clickable batch-archive__button">
+          class="inner-clickable batch-archive__button"
+          gr:tooltip="Kept in Library because all selected images have been {{ctrl.archivedExplanation}}.">
         <gr-icon-label gr-icon="lock">
             Kept in Library
         </gr-icon-label>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import {Set} from 'immutable';
 
 import './gr-archiver.css!';
 import template from './gr-archiver.html!text';
@@ -35,6 +36,9 @@ module.controller('grArchiverCtrl', [
             const allPersisted = images.every(imageAccessor.isPersisted);
             ctrl.archivedState = noneCanBeArchived ? 'kept' :
                 allPersisted ? 'archived' : 'unarchived';
+
+            const explTokens = listAllPersistenceExplanations(images);
+            ctrl.archivedExplanation = humanUnion(explTokens);
         });
 
         ctrl.archive = () => {
@@ -62,6 +66,21 @@ module.controller('grArchiverCtrl', [
         function getImageArray() {
             // Convert from Immutable Set to JS Array
             return Array.from(ctrl.images);
+        }
+
+        function listAllPersistenceExplanations(images) {
+            return images.
+                map(imageLogic.getPersistenceExplanation).
+                map(items => new Set(items)).
+                reduce((all, items) => all.union(items)).
+                toArray();
+        }
+
+        // Takes an array and generates a '1, 2, 3 or 4' string
+        function humanUnion(list) {
+            const allButLastTwo = list.slice(0, -2);
+            const lastTwo = list.slice(-2).join(' or ');
+            return allButLastTwo.concat(lastTwo).join(', ');
         }
     }
 ]);

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -9,7 +9,8 @@ import '../../services/image-accessor';
 
 export const module = angular.module('gr.archiver', [
     'kahuna.services.archive',
-    'kahuna.services.image-accessor'
+    'kahuna.services.image-accessor',
+    'kahuna.services.image-logic'
 ]);
 
 module.controller('grArchiverCtrl', [
@@ -17,10 +18,12 @@ module.controller('grArchiverCtrl', [
     '$window',
     'archiveService',
     'imageAccessor',
+    'imageLogic',
     function ($scope,
               $window,
               archiveService,
-              imageAccessor) {
+              imageAccessor,
+              imageLogic) {
 
         const ctrl = this;
 
@@ -28,8 +31,10 @@ module.controller('grArchiverCtrl', [
         ctrl.archiving = false;
 
         $scope.$watchCollection(getImageArray, (images) => {
-            const allArchived = images.every(imageAccessor.isArchived);
-            ctrl.archivedState = allArchived ? 'archived' : 'unarchived';
+            const noneCanBeArchived = ! images.some(imageLogic.canBeArchived);
+            const allPersisted = images.every(imageAccessor.isPersisted);
+            ctrl.archivedState = noneCanBeArchived ? 'kept' :
+                allPersisted ? 'archived' : 'unarchived';
         });
 
         ctrl.archive = () => {

--- a/kahuna/public/js/components/gr-image-persist-status/gr-image-persist-status.css
+++ b/kahuna/public/js/components/gr-image-persist-status/gr-image-persist-status.css
@@ -2,6 +2,11 @@ gr-image-persist-status {
     display: block;
 }
 
+.gr-image-persist-status__kept-label {
+    color: #666;
+    cursor: default;
+}
+
 gr-image-persist-status ui-archiver {
     display: inline-block;
     height: inherit;

--- a/kahuna/public/js/components/gr-image-persist-status/gr-image-persist-status.html
+++ b/kahuna/public/js/components/gr-image-persist-status/gr-image-persist-status.html
@@ -1,5 +1,8 @@
-<gr-icon-label ng:if="! ctrl.states.canArchive" gr-icon="lock" ng:class="{ 'side-padded': ctrl.withText}"
-    title="Kept in Library because image is: {{ctrl.states.persistedReasons}}.">
+<gr-icon-label ng:if="! ctrl.states.canArchive"
+               gr-icon="lock"
+               class="gr-image-persist-status__kept-label"
+               ng:class="{ 'side-padded': ctrl.withText }"
+               title="Kept in Library because image is: {{ctrl.states.persistedReasons}}.">
     <span ng:show="ctrl.withText">Kept in Library</span>
 </gr-icon-label>
 

--- a/kahuna/public/js/edits/ui-archiver/archiver.html
+++ b/kahuna/public/js/edits/ui-archiver/archiver.html
@@ -2,19 +2,13 @@
         ng:if="! ctrl.disabled"
         ng:class="{'archiver--archived': ctrl.isArchived, 'archiver--unarchived': ! ctrl.isArchived, 'side-padded': ctrl.withText, 'clickable':ctrl.withText }"
         ng:click="ctrl.toggleArchived(archived)"
-        ng:disabled="ctrl.archiving"
-        ng:mouseenter="hover = true"
-        ng:mouseleave="hover = false"
-        ng:init="hover = false">
+        ng:disabled="ctrl.archiving">
     <!-- TODO: Start looking at a new loader to replace our "ing…" loader -->
     <span ng:show="ctrl.isArchived" title="Remove from Library">
         <gr-icon-label gr-icon="lock_outline">
             <span ng:show="ctrl.withText">
-                <span ng:show="! ctrl.archiving">
-                    <span ng:show="! hover">Kept in Library</span>
-                    <span ng:show="hover">Remove from Library</span>
-                </span>
-                <span ng:show="ctrl.archiving">Removing from Library</span>
+                <span ng:show="! ctrl.archiving">Remove from Library</span>
+                <span ng:show="ctrl.archiving">Removing from Library…</span>
             </span>
         </gr-icon-label>
     </span>
@@ -22,7 +16,7 @@
         <gr-icon-label gr-icon="lock_open">
             <span ng:show="ctrl.withText">
                 <span ng:show="! ctrl.archiving">Add to Library</span>
-                <span ng:show="ctrl.archiving">Adding to Library</span>
+                <span ng:show="ctrl.archiving">Adding to Library…</span>
             </span>
         </gr-icon-label>
     </span>

--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -22,30 +22,13 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
     }
 
     function getStates(image) {
-        const persistReasons = image.data.persisted.reasons.map(reason => {
-            switch (reason) {
-                case 'exports':
-                    return 'cropped';
-                case 'persistence-identifier':
-                    return 'from Picdar';
-                case 'photographer-category':
-                    return 'categorised as photographer';
-                case 'illustrator-category':
-                    return 'categorised as illustrator';
-                case 'commissioned-agency':
-                    return 'categorised as agency commissioned';
-                default:
-                    return reason;
-            }
-        });
-
         return {
             cost: image.data.cost,
             hasCrops: image.data.exports && image.data.exports.length > 0,
             isValid: image.data.valid,
             canDelete: imageLogic.canBeDeleted(image),
             canArchive: imageLogic.canBeArchived(image),
-            persistedReasons: persistReasons.join('; ')
+            persistedReasons: imageLogic.getPersistenceExplanation(image).join('; ')
         };
     }
 

--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -1,10 +1,12 @@
 import angular from 'angular';
 
-import '../edits/service';
+import '../services/image-logic';
 
-export const imageService = angular.module('gr.image.service', ['kahuna.edits.service']);
+export const imageService = angular.module('gr.image.service', [
+    'kahuna.services.image-logic'
+]);
 
-imageService.factory('imageService', [function() {
+imageService.factory('imageService', ['imageLogic', function(imageLogic) {
     function forImage(image) {
         return {
             usageRights: usageRights(image),
@@ -41,9 +43,8 @@ imageService.factory('imageService', [function() {
             cost: image.data.cost,
             hasCrops: image.data.exports && image.data.exports.length > 0,
             isValid: image.data.valid,
-            canDelete: image.getAction('delete').then(action => !! action),
-            canArchive: image.data.persisted.value === false ||
-                (persistReasons.length === 1 && persistReasons[0] === 'archived'),
+            canDelete: imageLogic.canBeDeleted(image),
+            canArchive: imageLogic.canBeArchived(image),
             persistedReasons: persistReasons.join('; ')
         };
     }

--- a/kahuna/public/js/services/image-accessor.js
+++ b/kahuna/public/js/services/image-accessor.js
@@ -39,6 +39,14 @@ imageAccessor.factory('imageAccessor', function() {
         return image.data.usageRights;
     }
 
+    function readPersistedReasons(image) {
+        return image.data.persisted.reasons;
+    }
+
+    function isPersisted(image) {
+        return image.data.persisted.value;
+    }
+
     function isArchived(image) {
         const userMetadata = extractUserMetadata(image);
         return userMetadata.data.archived.data;
@@ -50,6 +58,8 @@ imageAccessor.factory('imageAccessor', function() {
         readMetadata,
         readExtraInfo,
         readUsageRights,
+        readPersistedReasons,
+        isPersisted,
         isArchived
     };
 });

--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -21,9 +21,30 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
             (persistReasons.length === 1 && persistReasons[0] === 'archived');
     }
 
+    function getPersistenceExplanation(image) {
+        const persistReasons = imageAccessor.readPersistedReasons(image);
+        return persistReasons.map(reason => {
+            switch (reason) {
+            case 'exports':
+                return 'cropped';
+            case 'persistence-identifier':
+                return 'from Picdar';
+            case 'photographer-category':
+                return 'categorised as photographer';
+            case 'illustrator-category':
+                return 'categorised as illustrator';
+            case 'commissioned-agency':
+                return 'categorised as agency commissioned';
+            default:
+                return reason;
+            }
+        });
+    }
+
     return {
         canBeDeleted,
-        canBeArchived
+        canBeArchived,
+        getPersistenceExplanation
     };
 }]);
 

--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -1,0 +1,30 @@
+import angular from 'angular';
+
+import '../services/image-accessor';
+
+const imageLogic = angular.module('kahuna.services.image-logic', [
+    'kahuna.services.image-accessor'
+]);
+
+/**
+ * Helpers to apply business logic on image resources.
+ */
+imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
+
+    function canBeDeleted(image) {
+        return image.getAction('delete').then(action => !! action);
+    }
+
+    function canBeArchived(image) {
+        const persistReasons = imageAccessor.readPersistedReasons(image);
+        return ! imageAccessor.isPersisted(image) ||
+            (persistReasons.length === 1 && persistReasons[0] === 'archived');
+    }
+
+    return {
+        canBeDeleted,
+        canBeArchived
+    };
+}]);
+
+export default imageLogic;


### PR DESCRIPTION
Rework archive buttons on search and image page to be more consistent throughout in the use of icons, actions available (if auto-persisted, just show disabled control with "Kept in Library"), etc.

Also move some logic into a new logic service that is more flexible than the current one-size-fits-all image-service.

![recorded](https://cloud.githubusercontent.com/assets/36964/12149335/1b610a10-b49b-11e5-99d0-e859135e825a.gif)

Once this is out, we can review what icon would be best to represent the three states of auto-persisted, manually archived or not archived at all.
