### PR TITLE
Show selected collection

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -1,8 +1,8 @@
 <div ng:init="node = ctrl.node">
     <div class="node__info flex-container"
+         ng:class="{'node__info--selected' : ctrl.isSelected}"
          ng:init="showChildren = true"
          gr:drop-into-collection="node.data.content.path">
-
         <div class="node__marker"></div>
 
         <div class="node__spacer" ng:if="node.data.children.length === 0">

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
@@ -29,7 +29,12 @@ gr-nodes, gr-node,
 }
 .node__info:hover,
 .collection-drop--drag-over {
+    background-color: #666;
+}
+
+.node__info--selected {
     background-color: #333;
+    color: white;
 }
 
 .node__name {

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -19,7 +19,8 @@
         </div>
         <gr-nodes gr:nodes="ctrl.collections"
                   gr:editing="editing"
-                  gr:selected-images="ctrl.selectedImages$">
+                  gr:selected-images="ctrl.selectedImages$"
+                  gr:selected-collections="ctrl.selectedCollections">
         </gr-nodes>
     </div>
 </div>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -17,8 +17,8 @@ export var grCollectionsPanel = angular.module('grCollectionsPanel', [
 ]);
 
 grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
-    'collections', 'selectedImages$',
-    function (collections, selectedImages$) {
+    'collections', 'selectedImages$', 'selectedCollections',
+    function (collections, selectedImages$, selectedCollections) {
 
     const ctrl = this;
 
@@ -34,6 +34,7 @@ grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
     }).catch(() => ctrl.error = true);
 
     ctrl.selectedImages$ = selectedImages$;
+    ctrl.selectedCollections = selectedCollections || [];
 }]);
 
 grCollectionsPanel.controller('GrNodeCtrl',
@@ -68,6 +69,10 @@ grCollectionsPanel.controller('GrNodeCtrl',
     inject$($scope, hasImagesSelected$, ctrl, 'hasImagesSelected');
 
 
+    ctrl.isSelected = ctrl.selectedCollections.some(col => {
+        return angular.equals(col, ctrl.node.data.content.path);
+    });
+
 }]);
 
 grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $compile) {
@@ -77,7 +82,8 @@ grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $
             node: '=grNode',
             nodeList: '=grNodeList',
             editing: '=grEditing',
-            selectedImages$: '=grSelectedImages'
+            selectedImages$: '=grSelectedImages',
+            selectedCollections: '=grSelectedCollections'
         },
         template: nodeTemplate,
         controller: 'GrNodeCtrl',
@@ -88,6 +94,7 @@ grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $
             // well with recursive templates.
             $compile(`<gr-nodes
                 gr:selected-images="ctrl.selectedImages$"
+                gr:selected-collections="ctrl.selectedCollections"
                 gr:editing="ctrl.editing"
                 ng:show="showChildren"
                 gr:nodes="ctrl.node.data.children"
@@ -111,13 +118,15 @@ grCollectionsPanel.directive('grNodes', function() {
         scope: {
             nodes: '=grNodes',
             editing: '=grEditing',
-            selectedImages$: '=grSelectedImages'
+            selectedImages$: '=grSelectedImages',
+            selectedCollections: '=grSelectedCollections'
         },
         template: `<ul>
             <li ng:repeat="node in nodes">
                 <gr-node
                     class="node"
                     gr:selected-images="selectedImages$"
+                    gr:selected-collections="selectedCollections"
                     gr:node="node"
                     gr:node-list="nodes"
                     gr:editing="editing"></gr-node>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -34,7 +34,7 @@ grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
     }).catch(() => ctrl.error = true);
 
     ctrl.selectedImages$ = selectedImages$;
-    ctrl.selectedCollections = selectedCollections || [];
+    ctrl.selectedCollections = selectedCollections;
 }]);
 
 grCollectionsPanel.controller('GrNodeCtrl',

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -28,7 +28,8 @@ export function getCollection(path) {
 }
 
 export function getCollectionsFromQuery(q) {
-    const collections =  querySplit(q) ? querySplit(q)
+    const query = querySplit(q);
+    const collections =  query ? query
         .filter(bit => bit.charAt(0) === '~')
         .map(path => path.replace(/('|"|~)/g, '').split('/'))
         : [];

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -7,6 +7,10 @@ function hasLabel(q, label) {
     return labelMatch(label).test(q);
 }
 
+function querySplit(q) {
+    return q.match(/((~|#)?'.*?'|(~|#)?".*?"|\S+)/g);
+}
+
 export function addLabel(q, label) {
     return hasLabel(q, label) ? q : `${(q || '').trim()} ${createLabel(label)}`;
 }
@@ -21,4 +25,13 @@ export function removeLabels(q, labels) {
 
 export function getCollection(path) {
     return createCollection(path);
+}
+
+export function getCollectionsFromQuery(q) {
+    const query = q || "";
+    const collections =  querySplit(query) ? querySplit(query)
+        .filter(bit => bit.charAt(0) === '~')
+        .map(path => path.replace(/('|"|~)/g, '').split('/')) : "";
+
+    return collections;
 }

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -28,10 +28,10 @@ export function getCollection(path) {
 }
 
 export function getCollectionsFromQuery(q) {
-    const query = q || "";
-    const collections =  querySplit(query) ? querySplit(query)
+    const collections =  querySplit(q) ? querySplit(q)
         .filter(bit => bit.charAt(0) === '~')
-        .map(path => path.replace(/('|"|~)/g, '').split('/')) : "";
+        .map(path => path.replace(/('|"|~)/g, '').split('/'))
+        : '';
 
     return collections;
 }

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -31,7 +31,7 @@ export function getCollectionsFromQuery(q) {
     const collections =  querySplit(q) ? querySplit(q)
         .filter(bit => bit.charAt(0) === '~')
         .map(path => path.replace(/('|"|~)/g, '').split('/'))
-        : '';
+        : [];
 
     return collections;
 }

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -3,6 +3,7 @@ import 'angular-ui-router-extras';
 import Rx from 'rx';
 import 'rx-dom';
 import Immutable from 'immutable';
+import {getCollectionsFromQuery} from '../search-query/query-syntax';
 
 import './query';
 import './results';
@@ -150,6 +151,12 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                 ).
                     distinctUntilChanged(angular.identity, Immutable.is).
                     shareReplay(1);
+            }],
+            selectedCollections: ['$stateParams', function($stateParams) {
+                const query = $stateParams.query || "";
+                const collections  = getCollectionsFromQuery(query);
+                console.log(collections);
+                return collections;
             }]
         },
         views: {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -153,9 +153,8 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                     shareReplay(1);
             }],
             selectedCollections: ['$stateParams', function($stateParams) {
-                const query = $stateParams.query || "";
+                const query = $stateParams.query || '';
                 const collections  = getCollectionsFromQuery(query);
-                console.log(collections);
                 return collections;
             }]
         },


### PR DESCRIPTION
Highlights collection(s) that result images belong to. It does not necessarily show all the images from a highlighted collection. 

~A: image1, image2
~B: image1, image3

search query: ~A ~B

will highlight ~A and ~B but only display image1

![highlight](https://cloud.githubusercontent.com/assets/8484757/12149847/f682bbdc-b49d-11e5-81a7-e9a5b1630594.gif)

