### PR TITLE
allow es host to be configured in .properties file

### DIFF
--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -24,7 +24,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val elasticsearchHost: String =
     if (stage == "DEV")
-      string("es.host")
+      properties.getOrElse("es.host", "localhost")
     else
       findElasticsearchHost(ec2Client, Map(
         "Stage" -> Seq(stage),

--- a/media-api/conf/application.conf
+++ b/media-api/conf/application.conf
@@ -4,7 +4,6 @@ session.httpOnly=false
 session.secure=true
 
 es.cluster = "media-service"
-es.host = "localhost"
 es.port = 9300
 
 # Logger

--- a/thrall/app/lib/Config.scala
+++ b/thrall/app/lib/Config.scala
@@ -29,7 +29,7 @@ object Config extends CommonPlayAppConfig {
 
   val elasticsearchHost: String =
     if (stage == "DEV")
-      string("es.host")
+      properties.getOrElse("es.host", "localhost")
     else
       findElasticsearchHost(ec2Client, Map(
         "Stage" -> Seq(stage),

--- a/thrall/conf/application.conf
+++ b/thrall/conf/application.conf
@@ -1,7 +1,6 @@
 application.langs="en"
 
 es.cluster = "media-service"
-es.host = "localhost"
 es.port = 9300
 
 # Logger


### PR DESCRIPTION
Finally got https://github.com/guardian/grid/pull/1586 working last night with native like perf on osx! Planning to break up https://github.com/guardian/grid/pull/1586 to make the diff smaller. ~~Although that's the main motivation, reading `es.host` from `.properties` means we can connect to other environments more easily too.~~

NB: `es.port` and `es.cluster` are static, so haven't moved them.