### PR TITLE
initial step at not allowing / in collection name

### DIFF
--- a/collections/app/store/CollectionsStore.scala
+++ b/collections/app/store/CollectionsStore.scala
@@ -33,9 +33,8 @@ object CollectionsStore {
     case e => throw CollectionsStoreError(e)
   }
 
-  def remove(collectionPath: String): Future[Option[Collection]] = {
+  def remove(path: List[String]): Future[Option[Collection]] = {
     store.getData flatMap { json =>
-      val path = CollectionsManager.stringToPath(collectionPath)
       val collectionList = json.asOpt[List[Collection]]
 
       collectionList map { collections =>

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -1,18 +1,16 @@
 package com.gu.mediaservice.lib.collections
 
-import java.net.URLDecoder.decode
-import java.net.URLEncoder.encode
-
+import com.gu.mediaservice.lib.net.URI.{encode, decode}
 import com.gu.mediaservice.model.Collection
 
 object CollectionsManager {
   val delimiter = "/"
-  val enc = "UTF-8"
-  def decodePathBit(s: String) = decode(s, enc)
-  def encodePathBit(s: String) = encode(s, enc)
 
-  def stringToPath(s: String) = s.split(delimiter).map(decodePathBit).toList
-  def pathToString(path: List[String]) = path.map(encodePathBit).mkString(delimiter)
+  def stringToPath(s: String) = s.split(delimiter).toList
+  def pathToString(path: List[String]) = path.mkString(delimiter)
+  def pathToUri(path: List[String]) = path.map(encode).mkString(delimiter)
+  def pathIdToUri(pathId: String) = pathToUri(stringToPath(pathId))
+  def uriToPath(uri: String) = stringToPath(uri).map(decode)
 
   def sortBy(c: Collection) = c.pathId
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -8,9 +8,11 @@ import play.api.libs.functional.syntax._
 
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.lib.argo.model.{Action, EmbeddedEntity}
+import com.gu.mediaservice.lib.net.URI.encode
 
 case class Collection(path: List[String], actionData: ActionData) {
   val pathId = CollectionsManager.pathToString(path)
+  val pathUri = CollectionsManager.pathToUri(path)
 }
 object Collection {
   val reads: Reads[Collection] = Json.reads[Collection]
@@ -23,7 +25,7 @@ object Collection {
   implicit val formats: Format[Collection] = Format(reads, writes)
 
   def imageUri(rootUri: String, imageId: String, c: Collection) =
-    URI.create(s"$rootUri/images/$imageId/${c.pathId}")
+    URI.create(s"$rootUri/images/$imageId/${encode(c.pathId)}")
 
   def asImageEntity(rootUri: String, imageId: String, c: Collection) = {
     // TODO: Currently the GET for this URI does nothing

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
@@ -13,16 +13,8 @@ class CollectionsManagerTest extends FunSpec with Matchers {
       CollectionsManager.pathToString(List("g2", "art", "film")) shouldBe "g2/art/film"
     }
 
-    it ("should URL encode / in path bit in a string") {
-      CollectionsManager.pathToString(List("g2", "art", "24/7")) shouldBe "g2/art/24%2F7"
-    }
-
     it ("should convert a string to a path") {
       CollectionsManager.stringToPath("g2/art/film") shouldBe List("g2", "art", "film")
-    }
-
-    it ("should convert a URL encoded string to a valid path") {
-      CollectionsManager.stringToPath("g2/art/24%2F7") shouldBe List("g2", "art", "24/7")
     }
 
     it ("should only show the latest collection with same ID") {


### PR DESCRIPTION
Reason:
```
path: List("guide", "this that")
pathId: "guide/this+that"
search: ~"guide/this+that"
```

```
path: List("guide", "this/that")
pathId: "guide/this%2Fthat"
search: ~"guide/this%2Fthat"
```

My suggestion is that we don't allow slashes in the collection name. Every other tree system I've looked at seems to use this, bar mac, that does a `replace("/", ":")`. 

We could be intelligent and if someone does input `this/that` we just create it as a `this` with child of `that`.

Another option would be to keep it as is and have the `media-api` encode collection queries, but then we've landed up with the encoding/decoding being across multiple systems. We would also still have the problem of searching for `List("guide", "this that", "this/that")`. 