### PR TITLE
userMetadataLastModified into image root

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -120,8 +120,7 @@ object Mappings {
       "archived"    -> boolean,
       "labels"      -> nonAnalysedList("label"),
       "metadata"    -> metadataMapping,
-      "usageRights" -> usageRightsMapping,
-      "lastModified" -> dateFormat
+      "usageRights" -> usageRightsMapping
     )
 
   val uploadInfoMapping =
@@ -193,6 +192,7 @@ object Mappings {
           "source" -> assetMapping,
           "thumbnail" -> assetMapping,
           "userMetadata" -> userMetadataMapping,
+          "userMetadataLastModified" -> dateFormat,
           "fileMetadata" -> dynamicObj,
           "exports" -> exportsMapping,
           "uploadTime" -> dateFormat,

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -138,9 +138,9 @@ object ElasticSearch extends ElasticSearchClient with ImageFields {
         "lastModified" -> asGroovy(lastModified)
       ).asJava)
       .setScript(
-        s""" | if (!(ctx._source.userMetadata.lastModified && ctx._source.userMetadata.lastModified > lastModified)) {
+        s""" | if (!(ctx._source.userMetadataLastModified && ctx._source.userMetadataLastModified > lastModified)) {
             |   ctx._source.userMetadata = userMetadata;
-            |   ctx._source.userMetadata.lastModified = lastModified;
+            |   ctx._source.userMetadataLastModified = lastModified;
             |   $updateLastModifiedScript
             | }
       """.stripMargin +


### PR DESCRIPTION
This is so that if we add similar fields to exports and usages (which are arrays not objects) we can be consistent