### PR TITLE
make collections search case insensitive

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -85,7 +85,7 @@ object CollectionsController extends Controller with ArgoHelpers {
     (req.body \ "data").asOpt[String] map { child =>
       if (isValidPathBit(child)) {
         val path = collectionPathId.map(uriToPath).getOrElse(Nil) :+ child
-        val collection = Collection(path, ActionData(getUserFromReq(req), DateTime.now))
+        val collection = Collection.create(path, ActionData(getUserFromReq(req), DateTime.now))
         CollectionsStore.add(collection).map { collection =>
           val node = Node(collection.path.last, Nil, collection.path, Some(collection))
           respond(node, actions = getActions(node))

--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -85,7 +85,7 @@ object CollectionsController extends Controller with ArgoHelpers {
     (req.body \ "data").asOpt[String] map { child =>
       if (isValidPathBit(child)) {
         val path = collectionPathId.map(uriToPath).getOrElse(Nil) :+ child
-        val collection = Collection.create(path, ActionData(getUserFromReq(req), DateTime.now))
+        val collection = Collection.build(path, ActionData(getUserFromReq(req), DateTime.now))
         CollectionsStore.add(collection).map { collection =>
           val node = Node(collection.path.last, Nil, collection.path, Some(collection))
           respond(node, actions = getActions(node))

--- a/collections/app/controllers/ImageCollectionsController.scala
+++ b/collections/app/controllers/ImageCollectionsController.scala
@@ -34,7 +34,7 @@ object ImageCollectionsController extends Controller with ArgoHelpers {
 
   def addCollection(id: String) = Authenticated.async(parse.json) { req =>
     (req.body \ "data").asOpt[List[String]].map { path =>
-      val collection = Collection(path, ActionData(getUserFromReq(req), DateTime.now()))
+      val collection = Collection.create(path, ActionData(getUserFromReq(req), DateTime.now()))
       dynamo.listAdd(id, "collections", collection)
         .map(publish(id))
         .map(cols => respond(collection))

--- a/collections/app/controllers/ImageCollectionsController.scala
+++ b/collections/app/controllers/ImageCollectionsController.scala
@@ -34,7 +34,7 @@ object ImageCollectionsController extends Controller with ArgoHelpers {
 
   def addCollection(id: String) = Authenticated.async(parse.json) { req =>
     (req.body \ "data").asOpt[List[String]].map { path =>
-      val collection = Collection.create(path, ActionData(getUserFromReq(req), DateTime.now()))
+      val collection = Collection.build(path, ActionData(getUserFromReq(req), DateTime.now()))
       dynamo.listAdd(id, "collections", collection)
         .map(publish(id))
         .map(cols => respond(collection))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -7,7 +7,7 @@ object CollectionsManager {
   val delimiter = "/"
 
   def stringToPath(s: String) = s.split(delimiter).toList
-  def pathToString(path: List[String]) = path.mkString(delimiter)
+  def pathToString(path: List[String]) = path.mkString(delimiter).toLowerCase
   def pathToUri(path: List[String]) = pathToString(path.map(encode))
   def uriToPath(uri: String) = stringToPath(decode(uri))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -112,6 +112,7 @@ object Mappings {
     "path" -> nonAnalysedList("collectionPath"),
     "pathId" -> (nonAnalyzedString ++ copyTo("collections.pathHierarchy")),
     "pathHierarchy" -> hierarchyAnalysedString,
+    "description" -> nonAnalyzedString,
     "actionData" -> actionDataMapping
   ))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -38,7 +38,7 @@ object Collection {
   }
 
   // We use this to ensure we are creating valid `Collection`s
-  def create(path: List[String], actionData: ActionData) = {
+  def build(path: List[String], actionData: ActionData) = {
     val lowerPath = path.map(_.toLowerCase)
     // HACK: path should be an NonEmptyList, till then, this'll do
     val description = path.lastOption.getOrElse("")

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/DynamoDBTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/DynamoDBTest.scala
@@ -52,7 +52,7 @@ class DynamoDBTest extends FunSpec with Matchers {
     }
 
     it ("should convert a Collection to ValueMap") {
-      val collection = Collection(List("g2", "art", "batik"), ActionData("mighty.mouse@guardian.co.uk", DateTime.now))
+      val collection = Collection.create(List("g2", "art", "batik"), ActionData("mighty.mouse@guardian.co.uk", DateTime.now))
       val json = Json.toJson(collection).as[JsObject]
       val valueMap = DynamoDB.jsonToValueMap(json)
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/DynamoDBTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/DynamoDBTest.scala
@@ -52,7 +52,7 @@ class DynamoDBTest extends FunSpec with Matchers {
     }
 
     it ("should convert a Collection to ValueMap") {
-      val collection = Collection.create(List("g2", "art", "batik"), ActionData("mighty.mouse@guardian.co.uk", DateTime.now))
+      val collection = Collection.build(List("g2", "art", "batik"), ActionData("mighty.mouse@guardian.co.uk", DateTime.now))
       val json = Json.toJson(collection).as[JsObject]
       val valueMap = DynamoDB.jsonToValueMap(json)
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
@@ -42,7 +42,7 @@ class CollectionsManagerTest extends FunSpec with Matchers {
     describe("create") {
 
       it("should lowercase path on creation") {
-        val col = Collection.create(List("G2", "ArT", "CasECrazY"), ActionData("me@you.com", DateTime.now))
+        val col = Collection.build(List("G2", "ArT", "CasECrazY"), ActionData("me@you.com", DateTime.now))
         col.path shouldEqual List("g2", "art", "casecrazy")
         col.pathId shouldEqual "g2/art/casecrazy"
       }
@@ -54,9 +54,9 @@ class CollectionsManagerTest extends FunSpec with Matchers {
       val laterDate = date.minusDays(5)
       val evenLaterDate = laterDate.minusDays(5)
 
-      val collection1 = Collection.create(List("g2"), ActionData("me@you.com", date))
-      val collection2 = Collection.create(List("g2"), ActionData("you@me.com", laterDate))
-      val collection3 = Collection.create(List("g2"), ActionData("them@they.com", evenLaterDate))
+      val collection1 = Collection.build(List("g2"), ActionData("me@you.com", date))
+      val collection2 = Collection.build(List("g2"), ActionData("you@me.com", laterDate))
+      val collection3 = Collection.build(List("g2"), ActionData("them@they.com", evenLaterDate))
 
       val duped = List(collection2, collection1, collection3)
 
@@ -70,9 +70,9 @@ class CollectionsManagerTest extends FunSpec with Matchers {
     it ("should find the index of a collection in a list") {
       val actionData = ActionData("me@you.com", DateTime.now())
       val collections = List(
-        Collection.create(List("g2"), actionData),
-        Collection.create(List("g2", "art"), actionData),
-        Collection.create(List("g2", "art", "paintings"), actionData)
+        Collection.build(List("g2"), actionData),
+        Collection.build(List("g2", "art"), actionData),
+        Collection.build(List("g2", "art", "paintings"), actionData)
       )
 
       val index = CollectionsManager.findIndex(List("g2", "art"), collections)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
@@ -39,14 +39,24 @@ class CollectionsManagerTest extends FunSpec with Matchers {
 
     }
 
+    describe("create") {
+
+      it("should lowercase path on creation") {
+        val col = Collection.create(List("G2", "ArT", "CasECrazY"), ActionData("me@you.com", DateTime.now))
+        col.path shouldEqual List("g2", "art", "casecrazy")
+        col.pathId shouldEqual "g2/art/casecrazy"
+      }
+
+    }
+
     it ("should only show the latest collection with same ID") {
       val date = DateTime.now()
       val laterDate = date.minusDays(5)
       val evenLaterDate = laterDate.minusDays(5)
 
-      val collection1 = Collection(List("g2"), ActionData("me@you.com", date))
-      val collection2 = Collection(List("g2"), ActionData("you@me.com", laterDate))
-      val collection3 = Collection(List("g2"), ActionData("them@they.com", evenLaterDate))
+      val collection1 = Collection.create(List("g2"), ActionData("me@you.com", date))
+      val collection2 = Collection.create(List("g2"), ActionData("you@me.com", laterDate))
+      val collection3 = Collection.create(List("g2"), ActionData("them@they.com", evenLaterDate))
 
       val duped = List(collection2, collection1, collection3)
 
@@ -60,9 +70,9 @@ class CollectionsManagerTest extends FunSpec with Matchers {
     it ("should find the index of a collection in a list") {
       val actionData = ActionData("me@you.com", DateTime.now())
       val collections = List(
-        Collection(List("g2"), actionData),
-        Collection(List("g2", "art"), actionData),
-        Collection(List("g2", "art", "paintings"), actionData)
+        Collection.create(List("g2"), actionData),
+        Collection.create(List("g2", "art"), actionData),
+        Collection.create(List("g2", "art", "paintings"), actionData)
       )
 
       val index = CollectionsManager.findIndex(List("g2", "art"), collections)

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -20,7 +20,7 @@
 
         <a class="node__name flex-spacer"
            ui:sref="search.results({query: ctrl.getCollectionQuery(node.data.content.pathId)})">
-            {{node.data.name}}
+            {{node.data.content.description}}
         </a>
 
 

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -23,7 +23,8 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
 
   def ScopedMatch = rule { MatchField ~ ':' ~ MatchValue }
   def HashMatch = rule      { '#' ~ MatchValue      ~> (label      => Match(SingleField(getFieldPath("labels")), label)) }
-  def CollectionRule = rule { '~' ~ ExactMatchValue ~> (collection => Match(HierarchyField(getFieldPath("pathHierarchy"), collection.string), collection)) }
+  // All hierarchy values are lowercase as specified in the analyser
+  def CollectionRule = rule { '~' ~ ExactMatchValue ~> (collection => Match(HierarchyField(getFieldPath("pathHierarchy"), collection.string.toLowerCase), collection)) }
 
   def MatchField = rule { capture(AllowedFieldName) ~> resolveNamedField _ }
 


### PR DESCRIPTION
We're trying to not make the same mistake we made with labels.

Now, we will always analyse and search in lowercase, but I have added a `description` to the collections to allow for the user to chose their desired caps.

In short, if an image is in a collection `g2/art/paint`, `G2/art/PaiNt` or any other derivative would match.

If someone recreated your collection e.g. `g2/art/PaiNT`, the description will then appear as such.
