### PR TITLE
Add source to screengrab

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -3,7 +3,7 @@ package com.gu.mediaservice.model
 import play.api.libs.json._
 
 sealed trait UsageRights {
-  // These two properties are use to infer cost
+  // These two properties are used to infer cost
   // TODO: Remove these as they have nothing to do with the model really
   val restrictions: Option[String]
   val defaultCost: Option[Cost]
@@ -208,7 +208,9 @@ object Handout extends UsageRightsSpec {
 }
 
 
-final case class Screengrab(restrictions: Option[String] = None) extends UsageRights {
+// TODO: `source` should not be an Option, but because we added it later, we would need to backfill
+// the data
+final case class Screengrab(source: Option[String], restrictions: Option[String] = None) extends UsageRights {
   val defaultCost = Screengrab.defaultCost
 }
 object Screengrab extends UsageRightsSpec {

--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -12,6 +12,7 @@ object UsageRightsMetadataMapper {
       case u: ContractIllustrator      => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: CommissionedIllustrator  => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: Composite                => ImageMetadata(credit = Some(u.suppliers))
+      case u: Screengrab               => ImageMetadata(credit = u.source)
     }
 
     // if we don't match, return None

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -101,6 +101,10 @@ object UsageRightsProperty {
       requiredStringField("suppliers", "Suppliers", examples = Some("REX/Getty Images/Corbis, Corbis/Reuters"))
     )
 
+    case Screengrab => List(
+      requiredStringField("source", "Source", examples = Some("BBC News, HBO, ITV"))
+    )
+
     case _ => List()
   }
 }

--- a/metadata-editor/test/UsageRightsMetadataMapperTest.scala
+++ b/metadata-editor/test/UsageRightsMetadataMapperTest.scala
@@ -45,6 +45,12 @@ class UsageRightsMetadataMapperTest extends FunSpec with Matchers {
         Some(ImageMetadata(credit = Some("REX/Getty Images")))
     }
 
+    it ("should convert Screengrabs") {
+      val ur = Screengrab(Some("BBC News"))
+      usageRightsToMetadata(ur) should be
+        Some(ImageMetadata(credit = Some("BBC News")))
+    }
+
     it ("should not convert Agencies") {
       val ur = Agency("Rex Features")
       usageRightsToMetadata(ur) should be(None)


### PR DESCRIPTION
We still need to think about what we do with past information without this.
There are 1995 images. This will at least stop people carry on without adding it.

