### PR TITLE
Css colours for collections

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -128,7 +128,7 @@ object CollectionsController extends Controller with ArgoHelpers {
           (seq => Json.toJson(seq))).contramap(collectionsEntity) ~
       (__ \ "fullPath").write[List[String]] ~
       (__ \ "data").writeNullable[Collection] ~
-      (__ \ "cssColour").write[String]
+      (__ \ "cssColour").write[Option[String]]
     )(node => (node.basename, node.children, node.fullPath, node.data, getCssColour(node.fullPath)))
 
 

--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -33,7 +33,7 @@ object CollectionsController extends Controller with ArgoHelpers {
 
   import lib.Config.rootUri
   import ControllerHelper.getUserFromReq
-  import CollectionsManager.{pathToUri, uriToPath, isValidPathBit}
+  import CollectionsManager.{pathToUri, uriToPath, isValidPathBit, getCssColour}
 
   val Authenticated = ControllerHelper.Authenticated
 
@@ -127,8 +127,9 @@ object CollectionsController extends Controller with ArgoHelpers {
           // This is so we don't have to rewrite the Write[Seq[T]]
           (seq => Json.toJson(seq))).contramap(collectionsEntity) ~
       (__ \ "fullPath").write[List[String]] ~
-      (__ \ "data").writeNullable[Collection]
-    )(node => (node.basename, node.children, node.fullPath, node.data))
+      (__ \ "data").writeNullable[Collection] ~
+      (__ \ "cssColour").write[String]
+    )(node => (node.basename, node.children, node.fullPath, node.data, getCssColour(node.fullPath)))
 
 
   def collectionsEntity(nodes: List[Node[Collection]]): CollectionsEntity = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -52,5 +52,5 @@ object CollectionsManager {
 
   def getCollectionColour(s: String) = collectionColours.get(s)
 
-  def getCssColour(path: List[String]): String = path.headOption.flatMap(getCollectionColour).getOrElse("#333333")
+  def getCssColour(path: List[String]) = path.headOption.flatMap(getCollectionColour)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -43,14 +43,14 @@ object CollectionsManager {
   // We could use `ValidationNel`s here, but that's overkill
   def isValidPathBit(s: String) = if (s.contains(delimiter)) false else true
 
-  // TODO: Find something that works off a palette, this is terrible.
-  def stringToCssRgb(s: String): String = {
-    val hash = s.hashCode
-    val r = (hash & 0xFF0000) >> 16
-    val g = (hash & 0x00FF00) >> 8
-    val b = hash & 0x0000FF
-    s"rgb($r, $g, $b)"
-  }
+  val collectionColours = Map(
+    "g2"           -> "#000000",
+    "observer"     -> "#006f94",
+    "culture"      -> "#d1008b",
+    "film & music" -> "#b1532f"
+  )
 
-  def getCssColour(path: List[String]): String = path.headOption.map(stringToCssRgb).getOrElse("#cccccc")
+  def getCollectionColour(s: String) = collectionColours.get(s)
+
+  def getCssColour(path: List[String]): String = path.headOption.flatMap(getCollectionColour).getOrElse("#cccccc")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -1,7 +1,11 @@
 package com.gu.mediaservice.lib.collections
 
+import java.awt.Color
+
 import com.gu.mediaservice.lib.net.URI.{encode, decode}
 import com.gu.mediaservice.model.Collection
+
+import scala.util.Try
 
 object CollectionsManager {
   val delimiter = "/"
@@ -38,4 +42,15 @@ object CollectionsManager {
 
   // We could use `ValidationNel`s here, but that's overkill
   def isValidPathBit(s: String) = if (s.contains(delimiter)) false else true
+
+  // TODO: Find something that works off a palette, this is terrible.
+  def stringToCssRgb(s: String): String = {
+    val hash = s.hashCode
+    val r = (hash & 0xFF0000) >> 16
+    val g = (hash & 0x00FF00) >> 8
+    val b = hash & 0x0000FF
+    s"rgb($r, $g, $b)"
+  }
+
+  def getCssColour(path: List[String]): String = path.headOption.map(stringToCssRgb).getOrElse("#cccccc")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -52,5 +52,5 @@ object CollectionsManager {
 
   def getCollectionColour(s: String) = collectionColours.get(s)
 
-  def getCssColour(path: List[String]): String = path.headOption.flatMap(getCollectionColour).getOrElse("#cccccc")
+  def getCssColour(path: List[String]): String = path.headOption.flatMap(getCollectionColour).getOrElse("#333333")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -1,15 +1,10 @@
 package com.gu.mediaservice.model
 
-import java.net.URI
-
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
 import com.gu.mediaservice.lib.collections.CollectionsManager
-import com.gu.mediaservice.lib.argo.model.{Action, EmbeddedEntity}
-
-import scalaz.NonEmptyList
 
 case class Collection private (path: List[String], actionData: ActionData, description: String) {
   val pathId = CollectionsManager.pathToString(path)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -24,35 +24,10 @@ object Collection {
     (__ \ "actionData").write[ActionData]
   ){ col: Collection => (col.path, col.pathId, col.description, col.actionData) }
 
-  // We use this only for when we respond so that aren't storing cssColour in our data
-  val responseWrites: Writes[Collection] = (
-    (__ \ "path").write[List[String]] ~
-    (__ \ "pathId").write[String] ~
-    (__ \ "description").write[String] ~
-    (__ \ "cssColour").write[String] ~
-    (__ \ "actionData").write[ActionData]
-  ){ col: Collection => (
-    col.path,
-    col.pathId,
-    col.description,
-    CollectionsManager.getCssColour(col.path),
-    col.actionData)
-  }
-
   implicit val formats: Format[Collection] = Format(reads, writes)
 
   def imageUri(rootUri: String, imageId: String, c: Collection) =
     URI.create(s"$rootUri/images/$imageId/${CollectionsManager.pathToUri(c.path)}")
-
-  // We send back a JsValue as we need to use a different Collection writer
-  def asImageEntity(rootUri: String, imageId: String, c: Collection): EmbeddedEntity[JsValue] = {
-    // TODO: Currently the GET for this URI does nothing
-    val uri = imageUri(rootUri, imageId, c)
-    val json = Some(Json.toJson(c)(responseWrites))
-    EmbeddedEntity(uri, json, actions = List(
-      Action("remove", uri, "DELETE")
-    ))
-  }
 
   // We use this to ensure we are creating valid `Collection`s
   def build(path: List[String], actionData: ActionData) = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -26,9 +26,6 @@ object Collection {
 
   implicit val formats: Format[Collection] = Format(reads, writes)
 
-  def imageUri(rootUri: String, imageId: String, c: Collection) =
-    URI.create(s"$rootUri/images/$imageId/${CollectionsManager.pathToUri(c.path)}")
-
   // We use this to ensure we are creating valid `Collection`s
   def build(path: List[String], actionData: ActionData) = {
     val lowerPath = path.map(_.toLowerCase)

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -2,7 +2,9 @@
     <div class="node__info flex-container"
          ng:class="{'node__info--selected' : ctrl.isSelected}"
          gr:drop-into-collection="node.data.fullPath">
-        <div class="node__marker"></div>
+
+        <div class="node__marker"
+             style="background: {{node.data.cssColour}}"></div>
 
         <div class="node__spacer" ng:if="node.data.children.length === 0">
             <gr-icon></gr-icon>

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -259,7 +259,7 @@ object ImageResponse extends EditsResponse {
 }
 
 // We're using this to slightly hydrate the json response
-case class CollectionResponse private (path: List[String], pathId: String, description: String, cssColour: String, actionData: ActionData)
+case class CollectionResponse private (path: List[String], pathId: String, description: String, cssColour: Option[String], actionData: ActionData)
 object CollectionResponse {
   implicit def writes: Writes[CollectionResponse] = Json.writes[CollectionResponse]
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -229,7 +229,7 @@ object ImageResponse extends EditsResponse {
       .contramap((crops: List[Crop]) => crops.map(Export.fromCrop(_:Crop))) ~
     (__ \ "usages").write[UsagesEntity]
       .contramap(usagesEntity(id, _: List[Usage])) ~
-    (__ \ "collections").write[List[EmbeddedEntity[Collection]]]
+    (__ \ "collections").write[List[EmbeddedEntity[JsValue]]]
       .contramap((collections: List[Collection]) => collections.map(c => collectionsEntity(id, c)))
   )(unlift(Image.unapply))
 
@@ -238,7 +238,7 @@ object ImageResponse extends EditsResponse {
 
   def usageEntity(usage: Usage) = EmbeddedEntity[Usage](usageUri(usage.id), Some(usage))
 
-  def collectionsEntity(id: String, c: Collection): EmbeddedEntity[Collection] =
+  def collectionsEntity(id: String, c: Collection): EmbeddedEntity[JsValue] =
       Collection.asImageEntity(Config.collectionsUri, id, c)
 
   def fileMetadataEntity(id: String, expandFileMetaData: Boolean, fileMetadata: FileMetadata) = {


### PR DESCRIPTION
I've added a CSS colour to the node and the idea of `CollectionGroup`s to the image response.

The problem is that users want to know that an image has been added to a collection, but also a hint at which collection. From chatting to others, and conversations @tsop14 has had with others, having an indication of the top level collection would be enough.

i.e. culture doesn't want to use something used by Observer.

We could potentially label them with some sort of abbreviation, similar to Google's monograms or Github's Identicons. 

As mentioned in the comment, the colour generator is crap, but it'd be good to see if adding this level of identification addresses the concerns of the users.

![collection-colours](https://cloud.githubusercontent.com/assets/31692/12293024/ac57e32a-b9e8-11e5-9eb5-87bd331f6159.gif)
