### PR TITLE
fix date picker

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.css
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.css
@@ -43,7 +43,7 @@
 }
 
 .gu-date-range__overlay__preset__button {
-    margin: 0px 5px;
+    margin: 0px 3px;
 }
 
 .gu-date-range__overlay__preset__button:first-child {


### PR DESCRIPTION
before
<img width="532" alt="screen shot 2016-01-14 at 10 57 08" src="https://cloud.githubusercontent.com/assets/836140/12322690/96136c86-baad-11e5-8961-ffd78d510147.png">

after
<img width="534" alt="screen shot 2016-01-14 at 10 56 37" src="https://cloud.githubusercontent.com/assets/836140/12322686/89ae9f10-baad-11e5-8f82-d1f4e629ae84.png">

(using `flex-box` would be better...)