### PR TITLE
fix slight regression in calendar button styling

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.css
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.css
@@ -1,6 +1,5 @@
 .gu-date-range__display {
     font-size: 14px;
-    height: 14px;
     line-height: 14px;
     padding: 5px;
     border: 1px solid #999;
@@ -13,7 +12,7 @@
 }
 
 .gu-date-range__display__icon__toggle {
-    float: right;
+    display: inline-block;
     margin-left: 5px;
 }
 


### PR DESCRIPTION
Slight regression by turning it into a button.
Back to normal (and less floats).
![anytimebutton](https://cloud.githubusercontent.com/assets/31692/12326961/bbe49516-bacb-11e5-8980-2c6493c05f46.png)
