### PR TITLE
delete all indexes of collections in dynamo

### DIFF
--- a/collections/app/controllers/ImageCollectionsController.scala
+++ b/collections/app/controllers/ImageCollectionsController.scala
@@ -51,11 +51,10 @@ object ImageCollectionsController extends Controller with ArgoHelpers {
       CollectionsManager.findIndexes(path, collections) match {
         case Nil =>
           Future.successful(respondNotFound(s"Collection $collectionString not found"))
-        case indexes => {
+        case indexes =>
           dynamo.listRemoveIndexes[Collection](id, "collections", indexes)
             .map(publish(id))
             .map(cols => respond(cols))
-        }
       }
     } recover {
       case NoItemFound => respondNotFound("No collections found")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -180,10 +180,10 @@ class DynamoDB(credentials: AWSCredentials, region: Region, tableName: String) {
     }
   }
 
-  def listRemoveIndex[T](id: String, key: String, index: Int)
-                     (implicit ex: ExecutionContext, rjs: Reads[T]): Future[List[T]] =
+  def listRemoveIndexes[T](id: String, key: String, indexes: List[Int])
+                          (implicit ex: ExecutionContext, rjs: Reads[T]): Future[List[T]] =
     update(
-      id, s"REMOVE $key[$index]"
+      id, s"REMOVE ${indexes.map(i => s"$key[$i]").mkString(",")}"
     ) map(j => (j \ key).as[List[T]])
 
   def objPut[T](id: String, key:String, value: T)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -22,10 +22,9 @@ object CollectionsManager {
   def find(path: List[String], collections: List[Collection]): Option[Collection] =
     collections.find(col => col.path == path)
 
-  def findIndex(path: List[String], collections: List[Collection]): Option[Int] =
-    collections.indexWhere(_.path == path) match {
-      case -1    => None
-      case index => Some(index)
+  def findIndexes(path: List[String], collections: List[Collection]): List[Int] =
+    collections.zipWithIndex.collect {
+      case (collection, i) if collection.path == path => i
     }
 
   def onlyLatest(collections: List[Collection]): List[Collection] =

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
@@ -72,14 +72,18 @@ class CollectionsManagerTest extends FunSpec with Matchers {
       val collections = List(
         Collection.build(List("g2"), actionData),
         Collection.build(List("g2", "art"), actionData),
-        Collection.build(List("g2", "art", "paintings"), actionData)
+        Collection.build(List("g2", "art", "paintings"), actionData),
+        Collection.build(List("observer", "feature"), actionData),
+        Collection.build(List("observer", "feature"), actionData)
       )
 
-      val index = CollectionsManager.findIndex(List("g2", "art"), collections)
-      val noIndex = CollectionsManager.findIndex(List("not", "there"), collections)
+      val index = CollectionsManager.findIndexes(List("g2", "art"), collections)
+      val noIndex = CollectionsManager.findIndexes(List("not", "there"), collections)
+      val multiIndex = CollectionsManager.findIndexes(List("observer", "feature"), collections)
 
-      index shouldBe Some(1)
-      noIndex shouldBe None
+      index shouldBe List(1)
+      noIndex shouldBe Nil
+      multiIndex shouldBe List(3, 4)
     }
 
   }


### PR DESCRIPTION
As we just add to the list of collections in dynamo (we can have two entries for one collection) - we need to make sure we delete all references to the path - this does that.