### PR TITLE
Add usageStatus and usagePlatform media-api query params

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -33,18 +33,21 @@ trait ImageFields {
 
   val editsFields = List("archived", "labels")
   val collectionsFields = List("path", "pathId", "pathHierarchy")
+  val usagesFields = List("status", "platform")
 
   def identifierField(field: String)  = s"identifiers.$field"
   def metadataField(field: String)    = s"metadata.$field"
   def editsField(field: String)       = s"userMetadata.$field"
   def usageRightsField(field: String) = s"usageRights.$field"
   def collectionsField(field: String) = s"collections.$field"
+  def usagesField(field: String)      = s"usages.$field"
 
   def getFieldPath(field: String) = field match {
     case f if metadataFields.contains(f)    => metadataField(f)
     case f if usageRightsFields.contains(f) => usageRightsField(f)
     case f if editsFields.contains(f)       => editsField(f)
     case f if collectionsFields.contains(f) => collectionsField(f)
+    case f if usagesFields.contains(f)      => usagesField(f)
     case f => f
   }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -48,7 +48,7 @@ object MediaApi extends Controller with ArgoHelpers {
     "since", "until", "modifiedSince", "modifiedUntil", "takenSince", "takenUntil",
     "uploadedBy", "archived", "valid", "free",
     "hasExports", "hasIdentifier", "missingIdentifier", "hasMetadata",
-    "persisted").mkString(",")
+    "persisted", "usageStatus", "usagePlatform").mkString(",")
 
   val searchLinkHref = s"$rootUri/images{?$searchParamList}"
 
@@ -352,7 +352,9 @@ case class SearchParams(
   uploadedBy: Option[String],
   labels: List[String],
   hasMetadata: List[String],
-  persisted: Option[Boolean]
+  persisted: Option[Boolean],
+  usageStatus: List[String],
+  usagePlatform: List[String]
 )
 
 case class InvalidUriParams(message: String) extends Throwable
@@ -398,7 +400,9 @@ object SearchParams {
       request.getQueryString("uploadedBy"),
       commaSep("labels"),
       commaSep("hasMetadata"),
-      request.getQueryString("persisted") flatMap parseBooleanFromQuery
+      request.getQueryString("persisted") flatMap parseBooleanFromQuery,
+      commaSep("usageStatus"),
+      commaSep("usagePlatform")
     )
   }
 
@@ -424,7 +428,9 @@ object SearchParams {
       "uploadedBy"        -> searchParams.uploadedBy,
       "labels"            -> listToCommas(searchParams.labels),
       "hasMetadata"       -> listToCommas(searchParams.hasMetadata),
-      "persisted"         -> searchParams.persisted.map(_.toString)
+      "persisted"         -> searchParams.persisted.map(_.toString),
+      "usageStatus"       -> listToCommas(searchParams.usageStatus),
+      "usagePlatform"     -> listToCommas(searchParams.usagePlatform)
     ).foldLeft(Map[String, String]()) {
       case (acc, (key, Some(value))) => acc + (key -> value)
       case (acc, (_,   None))        => acc

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -101,10 +101,14 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
       case false  => nonPersistedFilter
     }
 
+    val usageFilter =
+      params.usageStatus.toNel.map(filters.terms(usagesField("status"), _)) ++
+      params.usagePlatform.toNel.map(filters.terms(usagesField("platform"), _))
+
     val filterOpt = (
       metadataFilter.toList ++ persistFilter ++ labelFilter ++ archivedFilter ++
       uploadedByFilter ++ idsFilter ++ validityFilter ++ costFilter ++
-      hasExports ++ hasIdentifier ++ missingIdentifier ++ dateFilter
+      hasExports ++ hasIdentifier ++ missingIdentifier ++ dateFilter ++ usageFilter
     ).toNel.map(filter => filter.list.reduceLeft(filters.and(_, _)))
     val filter = filterOpt getOrElse filters.matchAll
 


### PR DESCRIPTION
Allows to filter by usage information, e.g.

`/images?orderBy=-usages.lastModified&usageStatus=pending,published&usagePlatform=digital`
(note that custom ordering is already supported)

cc @kenoir 