### PR TITLE
Adds usage to picdar-export tool

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -29,6 +29,10 @@ class DynamoDB(credentials: AWSCredentials, region: Region, tableName: String) {
 
   val IdKey = "id"
 
+  def exists(id: String)(implicit ex: ExecutionContext): Future[Boolean] = Future {
+      table.getItem(new GetItemSpec().withPrimaryKey(IdKey, id))
+  } map(Option(_).isDefined)
+
   def get(id: String)
          (implicit ex: ExecutionContext): Future[JsObject] = Future {
     table.getItem(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -154,7 +154,9 @@ object Mappings {
       "edition" -> integer,
       "size" -> printUsageSize,
       "orderedBy" -> nonAnalyzedString,
-      "sectionCode" -> nonAnalyzedString
+      "sectionCode" -> nonAnalyzedString,
+      "notes" -> nonAnalyzedString,
+      "source" -> nonAnalyzedString
     )
 
   val digitalUsageMetadata =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
@@ -13,7 +13,7 @@ case class PrintImageSize(
   def toMap = Map(
     "x" -> x,
     "y" -> y
-  ).asJava
+  )
 }
 object PrintImageSize {
   implicit val reads: Reads[PrintImageSize] = Json.reads[PrintImageSize]
@@ -27,12 +27,19 @@ case class PrintUsageMetadata(
   storyName: String,
   publicationCode: String,
   publicationName: String,
-  layoutId: Long,
+  layoutId: Option[Long] = None,
   edition: Int,
-  size: PrintImageSize,
-  orderedBy: String,
-  sectionCode: String
+  size: Option[PrintImageSize] = None,
+  orderedBy: Option[String] = None,
+  sectionCode: String,
+  notes: Option[String] = None,
+  source: Option[String] = None
 ) {
+
+  type MapStringIntElement = List[(String, Map[String, Int])]
+  type StringElement = List[(String,String)]
+  type LongElement = List[(String,Long)]
+
   def toMap = Map(
     "sectionName" -> sectionName,
     "issueDate" -> issueDate.toString,
@@ -40,12 +47,12 @@ case class PrintUsageMetadata(
     "storyName" -> storyName,
     "publicationCode" -> publicationCode,
     "publicationName" -> publicationName,
-    "layoutId" -> layoutId,
     "edition" -> edition,
-    "size" -> size.toMap,
-    "orderedBy" -> orderedBy,
     "sectionCode" -> sectionCode
-  )
+    ) ++ size.foldLeft[MapStringIntElement](Nil)((_,m) => List("size" -> m.toMap)) ++
+      orderedBy.foldLeft[StringElement](Nil)((_,s) => List("orderedBy" -> s)) ++
+      layoutId.foldLeft[LongElement](Nil)((_,l) => List("layoutId" -> l)) ++
+      notes.foldLeft[StringElement](Nil)((_,s) => List("notes" -> s))
 }
 object PrintUsageMetadata {
   implicit val dateTimeFormat = DateFormat

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageRequest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageRequest.scala
@@ -1,12 +1,13 @@
-package model
+package com.gu.mediaservice.model
 
 import org.joda.time.DateTime
-import com.gu.mediaservice.model.{PrintUsageMetadata, DateFormat}
 import play.api.libs.json._
+
 
 case class PrintUsageRequest(printUsageRecords: List[PrintUsageRecord])
 object PrintUsageRequest {
   implicit val reads: Reads[PrintUsageRequest] = Json.reads[PrintUsageRequest]
+  implicit val writes: Writes[PrintUsageRequest] = Json.writes[PrintUsageRequest]
 }
 case class PrintUsageRecord(
   dateAdded: DateTime,
@@ -18,6 +19,8 @@ case class PrintUsageRecord(
 )
 object PrintUsageRecord {
   implicit val dateTimeFormat = DateFormat
+
   implicit val reads: Reads[PrintUsageRecord] = Json.reads[PrintUsageRecord]
+  implicit val writes: Writes[PrintUsageRecord] = Json.writes[PrintUsageRecord]
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
@@ -1,4 +1,4 @@
-package model
+package com.gu.mediaservice.model
 
 import org.joda.time.DateTime
 import play.api.libs.json._
@@ -11,15 +11,15 @@ trait UsageStatus {
 }
 
 object UsageStatus {
-  implicit val reads: Reads[UsageStatus] = JsPath.read[String].map {
+  def apply(status: String): UsageStatus = status match {
     case "pending" => PendingUsageStatus()
     case "published" => PublishedUsageStatus()
   }
 
+  implicit val reads: Reads[UsageStatus] = JsPath.read[String].map(UsageStatus(_))
+
   implicit val writer = new Writes[UsageStatus] {
-    def writes(usageStatus: UsageStatus): JsValue = {
-      Json.obj("usageStatus" -> usageStatus.toString)
-    }
+    def writes(usageStatus: UsageStatus) = JsString(usageStatus.toString)
   }
 }
 

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
@@ -2,9 +2,11 @@ package com.gu.mediaservice.picdarexport
 
 import java.net.URI
 
+import play.api.libs.json._
+
 import com.gu.mediaservice.model.{UsageRights, ImageMetadata}
 import com.gu.mediaservice.picdarexport.lib.cleanup.{UsageRightsOverride, MetadataOverrides}
-import com.gu.mediaservice.picdarexport.lib.db.ExportDynamoDB
+import com.gu.mediaservice.picdarexport.lib.db._
 import com.gu.mediaservice.picdarexport.lib.media._
 import com.gu.mediaservice.picdarexport.lib.picdar.{PicdarError, PicdarClient}
 import com.gu.mediaservice.picdarexport.lib.{Config, MediaConfig}
@@ -12,20 +14,31 @@ import com.gu.mediaservice.picdarexport.model._
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits._
 
+import com.gu.mediaservice.picdarexport.lib.usage.PrintUsageRequestFactory
+import com.gu.mediaservice.model.PrintUsageRequest
+
 import scala.concurrent.Future
 import scala.language.postfixOps
 import org.joda.time.DateTime
 
+
 class ArgumentError(message: String) extends Error(message)
 
-
-class ExportManager(picdar: PicdarClient, loader: MediaLoader, mediaApi: MediaApi) {
+class ExportManager(picdar: PicdarClient, loader: MediaLoader, mediaApi: MediaApi, usageApi: UsageApi) {
 
   def ingest(assetUri: URI, picdarUrn: String, uploadTime: DateTime): Future[URI] =
     for {
       data   <- picdar.getAssetData(assetUri)
       uri    <- loader.upload(data, picdarUrn, uploadTime)
     } yield uri
+
+  def sendUsage(mediaUri: URI, usage: List[PicdarUsageRecord]): Future[Unit] = {
+    for {
+      imageResource <- mediaApi.getImageResource(mediaUri)
+      printUsageRequest = PrintUsageRequestFactory.create(usage, imageResource.data.id)
+      _ <- usageApi.postPrintUsage(printUsageRequest)
+    } yield Unit
+  }
 
   def overrideMetadata(mediaUri: URI, picdarMetadata: ImageMetadata): Future[Boolean] =
     for {
@@ -57,7 +70,6 @@ class ExportManager(picdar: PicdarClient, loader: MediaLoader, mediaApi: MediaAp
       overridden    <- applyRightsOverridesIfAny(image, overridesOpt)
     } yield overridden
   }
-
 
   private def applyRightsOverrides(image: Image, overrides: UsageRights): Future[Unit] = {
     mediaApi.overrideUsageRights(image.usageRightsOverrideUri, overrides)
@@ -93,6 +105,11 @@ trait ExportManagerProvider {
     override val mediaApiKey = config.apiKey
   }
 
+  def usageApiInstance(config: MediaConfig) = new UsageApi {
+    override val mediaApiKey = config.apiKey
+    override val postPrintUsageEndpointUrl = config.usageUrl
+  }
+
   def getPicdar(system: String) = system match {
     case "desk"    => picdarDesk
     case "library" => picdarLib
@@ -101,14 +118,19 @@ trait ExportManagerProvider {
 
   def getLoader(env: String) = loaderInstance(Config.mediaConfig(env))
   def getMediaApi(env: String) = mediaApiInstance(Config.mediaConfig(env))
+  def getUsageApi(env: String) = usageApiInstance(Config.mediaConfig(env))
 
   def getExportManager(picdarSystem: String, mediaEnv: String) =
-    new ExportManager(getPicdar(picdarSystem), getLoader(mediaEnv), getMediaApi(mediaEnv))
+    new ExportManager(
+      getPicdar(picdarSystem),
+      getLoader(mediaEnv),
+      getMediaApi(mediaEnv),
+      getUsageApi(mediaEnv)
+    )
 
   def getDynamo(env: String) = {
     new ExportDynamoDB(Config.awsCredentials(env), Config.dynamoRegion, Config.picdarExportTable(env))
   }
-
 }
 
 trait ArgumentHelpers {
@@ -168,14 +190,14 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
       println(
         s"""
            |urn: ${asset.urn}
-            |file: ${asset.file}
-            |created: ${asset.created}
-            |modified: ${asset.modified getOrElse ""}
-            |infoUri: ${asset.infoUri getOrElse ""}
-            |metadata:
-            |${asset.metadata}
-            |rights:
-            |${asset.usageRights}
+           |file: ${asset.file}
+           |created: ${asset.created}
+           |modified: ${asset.modified getOrElse ""}
+           |infoUri: ${asset.infoUri getOrElse ""}
+           |metadata:
+           |${asset.metadata}
+           |rights:
+           |${asset.usageRights}
         """.stripMargin
       )
     }
@@ -231,7 +253,12 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
     val dynamo = getDynamo(env)
     dynamo.scanFetchedNotIngested(dateRange) flatMap { assets =>
       val updates = takeRange(assets, range).map { asset =>
-        getExportManager("library", env).ingest(asset.picdarAssetUrl, asset.picdarUrn, asset.picdarCreatedFull) flatMap { mediaUri =>
+        // .get on options here will induce intentional failure if not available
+        getExportManager("library", env).ingest(
+          asset.picdarAssetUrl.get,
+          asset.picdarUrn,
+          asset.picdarCreatedFull.get
+        ) flatMap { mediaUri =>
           Logger.info(s"Ingested ${asset.picdarUrn} to $mediaUri")
           dynamo.recordIngested(asset.picdarUrn, asset.picdarCreated, mediaUri)
         } recover { case e: Throwable =>
@@ -275,10 +302,47 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
     dynamo.scanNoRights(dateRange) flatMap { urns =>
       val updates = takeRange(urns, range).map { assetRef =>
         getPicdar(system).get(assetRef.urn) flatMap { asset =>
-          Logger.info(s"Fetching usage rights for image ${asset.urn} to: ${asset.usageRights.map(_.category).getOrElse("none")}")
+          Logger.info(s"Fetching usage rights for image ${asset.urn}")
           dynamo.recordRights(assetRef.urn, assetRef.dateLoaded, asset.usageRights)
         } recover { case PicdarError(message) =>
           Logger.warn(s"Picdar error during fetch: $message")
+        }
+      }
+      Future.sequence(updates)
+    }
+  }
+
+  import com.gu.mediaservice.picdarexport.lib.picdar.UsageApi
+
+  def fetchUsage(env: String, dateRange: DateRange = DateRange.all, range: Option[Range] = None) = {
+    val dynamo = getDynamo(env)
+
+    dynamo.getNoUsage(dateRange) flatMap { urns =>
+      val updates = takeRange(urns, range).map { assetRef =>
+        UsageApi.get(assetRef.urn).flatMap { usages =>
+          dynamo.recordUsage(assetRef.urn, assetRef.dateLoaded, usages)
+        }
+      }
+      Future.sequence(updates)
+    }
+  }
+
+  def sendUsage(env: String, dateRange: DateRange = DateRange.all, range: Option[Range] = None) = {
+    val dynamo = getDynamo(env)
+
+    dynamo.getUsageNotRecorded(dateRange) flatMap { urns =>
+      val updates = takeRange(urns, range).map { asset =>
+        // These will obviously error if the attributes aren't filled
+        // TODO: Explore failure modes!
+        val mediaUri = asset.mediaUri.get
+        val usage = asset.picdarUsage.get
+
+        getExportManager("desk", env).sendUsage(mediaUri, usage).flatMap { _ =>
+          Logger.info(s"Usage sent successfully for ${asset.picdarUrn}")
+          dynamo.recordUsageSent(asset.picdarUrn, asset.picdarCreated)
+        } recover { case e: Throwable =>
+            Logger.warn(s"Usage send error for ${asset.picdarUrn}: $e")
+            e.printStackTrace()
         }
       }
       Future.sequence(updates)
@@ -468,6 +532,26 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
       overrideRights(env, parseDateRange(date), parseQueryRange(rangeStr))
     }
 
+    case "+usage:fetch" :: env :: Nil => terminateAfter {
+      fetchUsage(env)
+    }
+    case "+usage:fetch" :: env :: date :: Nil => terminateAfter {
+      fetchUsage(env, parseDateRange(date))
+    }
+    case "+usage:fetch" :: env :: date :: rangeStr :: Nil => terminateAfter {
+      fetchUsage(env, parseDateRange(date), parseQueryRange(rangeStr))
+    }
+
+    case "+usage:send" :: env :: Nil => terminateAfter {
+      sendUsage(env)
+    }
+    case "+usage:send" :: env :: date :: Nil => terminateAfter {
+      sendUsage(env, parseDateRange(date))
+    }
+    case "+usage:send" :: env :: date :: rangeStr :: Nil => terminateAfter {
+      sendUsage(env, parseDateRange(date), parseQueryRange(rangeStr))
+    }
+
     case _ => println(
       """
         |usage: :count-loaded    <dev|test|prod> [dateLoaded]
@@ -475,17 +559,20 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
         |       :count-ingested  <dev|test|prod> [dateLoaded]
         |       :count-overriden <dev|test|prod> [dateLoaded]
         |
-        |       :show   <desk|library> <picdarUrl>
-        |       :query  <desk|library> <created|modified|taken> <date> [query]
-        |       :stats  <dev|test|prod> [dateLoaded]
-        |       +load   <dev|test|prod> <desk|library> <created|modified|taken> <date> [range] [query]
-        |       +fetch  <dev|test|prod> <desk|library> [dateLoaded] [range]
-        |       +ingest <dev|test|prod> [dateLoaded] [range]
+        |       :show     <desk|library>  <picdarUrl>
+        |       :query    <desk|library>  <created|modified|taken> <date> [query]
+        |       +load     <dev|test|prod> <desk|library> <created|modified|taken> <date> [range] [query]
+        |       +fetch    <dev|test|prod> <desk|library> [dateLoaded] [range]
+        |       +ingest   <dev|test|prod> [dateLoaded] [range]
         |       +override <dev|test|prod> [dateLoaded] [range]
-        |       +clear  <dev|test|prod> [dateLoaded]
+        |       +clear    <dev|test|prod> [dateLoaded]
+        |       :stats    <dev|test|prod> [dateLoaded]
         |
         |       +rights:fetch    <dev|test|prod> <desk|library> [dateLoaded] [range]
         |       +rights:override <dev|test|prod> [dateLoaded] [range]
+        |
+        |       +usage:fetch     <dev|test|prod> [dateLoaded] [range]
+        |       +usage:send      <dev|test|prod> [dateLoaded] [range]
       """.stripMargin
     )
   }

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/Config.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/Config.scala
@@ -4,7 +4,7 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.regions.{Regions, Region}
 import com.gu.mediaservice.lib.config.Properties
 
-case class MediaConfig(apiKey: String, loaderUrl: String)
+case class MediaConfig(apiKey: String, loaderUrl: String, usageUrl: String)
 
 object Config {
   val properties = Properties.fromPath("/etc/gu/picdar-export.properties")
@@ -12,10 +12,12 @@ object Config {
   def awsAccessId(env: String)       = properties(s"aws.$env.id")
   def awsAccessSecret(env: String)   = properties(s"aws.$env.secret")
   def picdarExportTable(env: String) = properties(s"aws.$env.picdarexport.table")
+  def picdarUsageTable(env: String)  = properties(s"aws.$env.picdarusage.table")
 
   def awsCredentials(env: String) = new BasicAWSCredentials(awsAccessId(env), awsAccessSecret(env))
   val dynamoRegion = Region.getRegion(Regions.EU_WEST_1)
 
+  def picdarUsageApiUrl  = properties(s"picdar.usageapi.url")
 
   val picdarDeskUrl      = properties("picdar.desk.url")
   val picdarDeskUsername = properties("picdar.desk.username")
@@ -48,7 +50,8 @@ object Config {
   def mediaConfig(env: String): MediaConfig = try {
     val apiKey    = properties(s"media.$env.apiKey")
     val loaderUrl = properties(s"media.$env.loaderUrl")
-    MediaConfig(apiKey, loaderUrl)
+    val usageUrl  = properties(s"media.$env.usageUrl")
+    MediaConfig(apiKey, loaderUrl, usageUrl)
   } catch {
     case _: Throwable => throw new Error(s"Invalid media environment name: $env")
   }

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/ExecutionContexts.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/ExecutionContexts.scala
@@ -10,4 +10,5 @@ object ExecutionContexts {
   implicit val picdarAsset  = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Config.concurrencyPicdarAsset))
   implicit val mediaLoader  = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Config.concurrencyMediaLoader))
   implicit val mediaApi     = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Config.concurrencyMediaApi))
+  implicit val usageApi     = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Config.concurrencyMediaApi))
 }

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
@@ -4,51 +4,95 @@ import java.net.URI
 
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.regions.Region
-import com.amazonaws.services.dynamodbv2.document.{ScanOutcome, ItemCollection}
-import com.amazonaws.services.dynamodbv2.document.spec.{ScanSpec, UpdateItemSpec}
+import com.amazonaws.services.dynamodbv2.document.{KeyAttribute, ScanOutcome, ItemCollection, Item}
+import com.amazonaws.services.dynamodbv2.document.spec.{GetItemSpec, ScanSpec, UpdateItemSpec}
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap
 import com.amazonaws.services.dynamodbv2.model.ReturnValue
+import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
+import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder.{S, N, M, BOOL}
+
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.model.{UsageRights, ImageMetadata}
-import com.gu.mediaservice.picdarexport.model.{DateRange, AssetRef}
+import com.gu.mediaservice.picdarexport.model.{PicdarUsageRecord, DateRange, AssetRef, PicdarDates}
+
+import lib.MD5
 
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json.{Writes, Json, JsObject}
 import play.api.libs.concurrent.Execution.Implicits._
 
+import scala.collection.JavaConverters._
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
-case class AssetRow(
-  picdarUrn: String,
-  picdarCreated: DateTime,
-  picdarCreatedFull: DateTime,
-  picdarAssetUrl: URI,
-  mediaUri: Option[URI] = None,
-  picdarMetadata: Option[ImageMetadata] = None,
-  picdarRights: Option[UsageRights] = None
-)
+import scalaz.syntax.id._
 
-class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: String)
-  extends DynamoDB(credentials, region, tableName) {
 
-  override val IdKey = "picdarUrn"
-  val RangeKey = "picdarCreated"
-
-  def insert(id: String, range: DateTime): Future[JsObject] = Future {
-    val baseUpdateSpec = new UpdateItemSpec().
-      withPrimaryKey(IdKey, id, RangeKey, asRangeString(range)).
-      withReturnValues(ReturnValue.ALL_NEW)
-
-    table.updateItem(baseUpdateSpec)
-  } map asJsObject
-
+trait DynamoDates {
   val rangeDateFormat = ISODateTimeFormat.date
   def asRangeString(dateTime: DateTime) = rangeDateFormat print dateTime
 
   val timestampDateFormat = ISODateTimeFormat.dateTimeNoMillis
   def asTimestampString(dateTime: DateTime) = timestampDateFormat print dateTime
+}
+
+case class AssetRow(
+  picdarUrn: String,
+  picdarCreated: DateTime,
+  picdarCreatedFull: Option[DateTime],
+  picdarAssetUrl: Option[URI],
+  mediaUri: Option[URI] = None,
+  picdarMetadata: Option[ImageMetadata] = None,
+  picdarRights: Option[UsageRights] = None,
+  picdarUsage: Option[List[PicdarUsageRecord]] = None
+)
+object AssetRow extends DynamoDates {
+  def apply(item: Item): AssetRow = {
+    val picdarCreated =
+      rangeDateFormat.parseDateTime(item.getString("picdarCreated"))
+    val picdarCreatedFull =
+      Option(item.getString("picdarCreatedFull")).map(timestampDateFormat.parseDateTime)
+
+    val mediaUri = Option(item.getString("mediaUri"))
+      .map(URI.create)
+    val picdarMetadata = Option(item.getJSON("picdarMetadata"))
+      .map(json => Json.parse(json).as[ImageMetadata])
+    val picdarRights = Option(item.getJSON("picdarRights"))
+      .map(json => Json.parse(json).as[UsageRights])
+    val picdarAssetUrl = Option(item.getString("picdarAssetUrl"))
+      .map(URI.create)
+    val picdarUsage = Option(item.getString("picdarUsage"))
+      .map(json => Json.parse(json).as[List[PicdarUsageRecord]])
+
+    AssetRow(
+      picdarUrn = item.getString("picdarUrn"),
+      picdarCreated = picdarCreated,
+      picdarCreatedFull = picdarCreatedFull,
+      picdarAssetUrl = picdarAssetUrl,
+      mediaUri = mediaUri,
+      picdarMetadata = picdarMetadata,
+      picdarRights = picdarRights,
+      picdarUsage = picdarUsage
+    )
+  }
+}
+
+class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: String)
+  extends DynamoDB(credentials, region, tableName) with DynamoDates {
+
+  val picdarCreatedIndex = "picdarCreated-index"
+
+  override val IdKey = "picdarUrn"
+  val RangeKey = "picdarCreated"
+
+  def insert(id: String, range: DateTime): Future[JsObject] = Future {
+    val baseUpdateSpec = new UpdateItemSpec()
+      .withPrimaryKey(IdKey, id, RangeKey, asRangeString(range))
+      .withReturnValues(ReturnValue.ALL_NEW)
+
+    table.updateItem(baseUpdateSpec)
+  } map asJsObject
 
 
   val fetchFields = List("picdarAssetUrl", "picdarMetadataModified")
@@ -92,11 +136,7 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
 
     val projectionAttrs = List("picdarUrn", "picdarCreated", "picdarCreatedFull", "picdarAssetUrl")
     val items = scan(queryConds, projectionAttrs, values)
-    items.iterator.map { item =>
-      val picdarCreated = rangeDateFormat.parseDateTime(item.getString("picdarCreated"))
-      val picdarCreatedFull = timestampDateFormat.parseDateTime(item.getString("picdarCreatedFull"))
-      AssetRow(item.getString("picdarUrn"), picdarCreated, picdarCreatedFull, URI.create(item.getString("picdarAssetUrl")))
-    }.toSeq
+    items.iterator.map(AssetRow(_)).toSeq
   }
 
   def scanIngestedNotOverridden(dateRange: DateRange): Future[Seq[AssetRow]] = Future {
@@ -111,13 +151,7 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
 
     val projectionAttrs = List("picdarUrn", "picdarCreated", "picdarCreatedFull", "picdarAssetUrl", "mediaUri", "picdarMetadata")
     val items = scan(queryConds, projectionAttrs, values)
-    items.iterator.map { item =>
-      val picdarCreated = rangeDateFormat.parseDateTime(item.getString("picdarCreated"))
-      val picdarCreatedFull = timestampDateFormat.parseDateTime(item.getString("picdarCreatedFull"))
-      val mediaUri = Option(item.getString("mediaUri")).map(URI.create)
-      val picdarMetadata = Option(item.getJSON("picdarMetadata")).map(json => Json.parse(json).as[ImageMetadata])
-      AssetRow(item.getString("picdarUrn"), picdarCreated, picdarCreatedFull, URI.create(item.getString("picdarAssetUrl")), mediaUri, picdarMetadata)
-    }.toSeq
+    items.iterator.map(AssetRow(_)).toSeq
   }
 
   def scanOverridden(dateRange: DateRange): Future[Seq[AssetRow]] = Future {
@@ -132,12 +166,7 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
 
     val projectionAttrs = List("picdarUrn", "picdarCreated", "picdarCreatedFull", "picdarAssetUrl", "mediaUri")
     val items = scan(queryConds, projectionAttrs, values)
-    items.iterator.map { item =>
-      val picdarCreated = rangeDateFormat.parseDateTime(item.getString("picdarCreated"))
-      val picdarCreatedFull = timestampDateFormat.parseDateTime(item.getString("picdarCreatedFull"))
-      val mediaUri = Option(item.getString("mediaUri")).map(URI.create)
-      AssetRow(item.getString("picdarUrn"), picdarCreated, picdarCreatedFull, URI.create(item.getString("picdarAssetUrl")), mediaUri)
-    }.toSeq
+    items.iterator.map(AssetRow(_)).toSeq
   }
 
   type Conditions = List[String]
@@ -154,17 +183,80 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
       dateRange.end.map(asRangeString).map(":endDate" -> _)
   }
 
+  def getRow(ref: AssetRef) = Future {
+    table.getItem(
+      new GetItemSpec().
+      withPrimaryKey(
+        IdKey, ref.urn,
+        RangeKey, PicdarDates.dynamoDbFormat.print(ref.dateLoaded)
+      )
+    )
+  }
+
+  def getUrnsForDateRange(dateRange: DateRange) = Future {
+    val imageIndex = table.getIndex(picdarCreatedIndex)
+
+    val items = for {
+      date  <- dateRange.dateList
+
+      dateString = PicdarDates.dynamoDbFormat.print(date)
+      key = new KeyAttribute(RangeKey, dateString)
+      query = imageIndex.query(key).pages.asScala
+
+      pages <- query
+      items <- pages
+    } yield items
+
+    items.map(AssetRef(_))
+  }
+
+  // Type this method so we can coerce items into whatever you want!
+  import com.amazonaws.services.dynamodbv2.document.Item
+  def getUrnsForNotFilledFields[T](dateRange: DateRange, attrs: Set[String])(f: Item => T): Future[Seq[T]] = {
+    getUrnsForDateRange(dateRange).flatMap(assetRefs => {
+      Future.traverse(assetRefs) {
+        case ref: AssetRef => getRow(ref)
+      }.map(
+        _.filter(row => {
+          !(attrs.subsetOf(row.attributes.map(_.getKey).toSet))
+        })
+        .map(f(_)))
+    })
+  }
+
+  def getNoUsage(dateRange: DateRange) =
+    getUrnsForNotFilledFields[AssetRef](dateRange, Set("picdarUsage"))(
+      (item: Item) => AssetRef(item))
+  def getUsageNotRecorded(dateRange: DateRange) =
+    getUrnsForNotFilledFields(dateRange, Set("picdarUsage","usageSent"))(
+      (item: Item) => AssetRow(item))
+
   def scanNoRights(dateRange: DateRange): Future[Seq[AssetRef]] = Future {
     val queryConds = List(fetchedCondition, noRightsCondition).withDateRange(dateRange)
     val values = Map[String, String]().withDateRangeValues(dateRange)
 
     val projectionAttrs = List("picdarUrn", "picdarCreated", "picdarCreatedFull", "picdarAssetUrl")
     val items = scan(queryConds, projectionAttrs, values)
-    items.iterator.map { item =>
-      val picdarCreated = rangeDateFormat.parseDateTime(item.getString("picdarCreated"))
-      val picdarCreatedFull = timestampDateFormat.parseDateTime(item.getString("picdarCreatedFull"))
-      AssetRef(item.getString("picdarUrn"), rangeDateFormat.parseDateTime(item.getString("picdarCreated")))
-    }.toSeq
+    items.iterator.map(AssetRef(_)).toSeq
+  }
+
+  def recordUsageSent(urn: String, range: DateTime) = Future {
+    val now = asTimestampString(new DateTime)
+
+    val spec = (new ExpressionSpecBuilder() <| (xspec => {
+      List(
+        BOOL("usageSent").set(true),
+        S("usageSentModified").set(now)
+      ).foreach(xspec.addUpdate(_))
+
+    })).buildForUpdate
+
+    val baseUpdateSpec = new UpdateItemSpec()
+      .withPrimaryKey(IdKey, urn, RangeKey, asRangeString(range))
+      .withExpressionSpec(spec)
+      .withReturnValues(ReturnValue.ALL_NEW)
+
+    table.updateItem(baseUpdateSpec)
   }
 
   def scanRightsFetchedNotOverridden(dateRange: DateRange): Future[Seq[AssetRow]] = Future {
@@ -174,13 +266,7 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
 
     val projectionAttrs = List("picdarUrn", "picdarCreated", "picdarCreatedFull", "picdarAssetUrl", "mediaUri", "picdarRights")
     val items = scan(queryConds, projectionAttrs, values)
-    items.iterator.map { item =>
-      val picdarCreated = rangeDateFormat.parseDateTime(item.getString("picdarCreated"))
-      val picdarCreatedFull = timestampDateFormat.parseDateTime(item.getString("picdarCreatedFull"))
-      val mediaUri = Option(item.getString("mediaUri")).map(URI.create)
-      val picdarRights = Option(item.getJSON("picdarRights")).map(json => Json.parse(json).as[UsageRights])
-      AssetRow(item.getString("picdarUrn"), picdarCreated, picdarCreatedFull, URI.create(item.getString("picdarAssetUrl")), mediaUri, picdarRights = picdarRights)
-    }.toSeq
+    items.iterator.map(AssetRow(_)).toSeq
   }
 
   // TODO: get ImageMetadata object from Picdar?
@@ -238,6 +324,26 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
     caseClassOpt.map { caseClass =>
       Json.toJson(caseClass).as[Map[String, String]]
     }.getOrElse(Map())
+
+  def recordUsage(urn: String, range: DateTime, usages: List[PicdarUsageRecord]) = Future {
+    val data = Json.stringify(Json.toJson(usages))
+    val checksum = MD5.hash(data)
+
+    val spec = (new ExpressionSpecBuilder() <| (xspec => {
+      List(
+        S("picdarUsage").set(data),
+        S("picdarUsageChecksum").set(checksum)
+      ).foreach(xspec.addUpdate(_))
+
+    })).buildForUpdate
+
+    val baseUpdateSpec = new UpdateItemSpec()
+      .withPrimaryKey(IdKey, urn, RangeKey, asRangeString(range))
+      .withExpressionSpec(spec)
+      .withReturnValues(ReturnValue.ALL_NEW)
+
+    table.updateItem(baseUpdateSpec)
+  }
 
   def recordRights(urn: String, range: DateTime, rights: Option[UsageRights]) = Future {
     val baseUpdateSpec = new UpdateItemSpec().

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/media/UsageApi.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/media/UsageApi.scala
@@ -1,0 +1,49 @@
+package com.gu.mediaservice.picdarexport.lib.media
+
+import java.net.URI
+
+import scala.concurrent.Future
+
+import play.api.libs.json._
+import play.api.Logger
+
+import scalaj.http.{HttpOptions, Http}
+
+import com.gu.mediaservice.picdarexport.lib.ExecutionContexts.usageApi
+import com.gu.mediaservice.picdarexport.lib.{Config, LogHelper}
+import com.gu.mediaservice.model.PrintUsageRequest
+
+class UsageSendError(msg: String, e: Throwable = null) extends RuntimeException(msg, e)
+
+trait UsageApi extends LogHelper {
+
+  val mediaApiKey: String
+  val postPrintUsageEndpointUrl: String
+
+  import Config.{mediaApiConnTimeout, mediaApiReadTimeout}
+
+  def postPrintUsage(usageRequest: Option[PrintUsageRequest]): Future[Unit] = Future {
+    usageRequest.map(req => {
+      val usageData = Json.stringify(Json.toJson(usageRequest))
+
+      val expectedStatusCode = 202
+
+      val receivedStatusCode = logDuration("UsageApi.postPrintUsage") {
+        Http(postPrintUsageEndpointUrl)
+          .header("content-type", "application/json")
+          .header("X-Gu-Media-Key", mediaApiKey)
+          .timeout(mediaApiConnTimeout, mediaApiReadTimeout)
+          .postData(usageData)
+          .asString
+          .code
+      }
+
+      if (receivedStatusCode != expectedStatusCode){
+        throw new UsageSendError(
+          s"Usage update failed for POST to $postPrintUsageEndpointUrl for $usageData with status $receivedStatusCode!")
+      }
+
+    }).getOrElse(Unit)
+  }
+
+}

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/picdar/PicdarApi.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/picdar/PicdarApi.scala
@@ -6,7 +6,7 @@ import com.gu.mediaservice.lib.config.{MetadataConfig, PhotographersList}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.picdarexport.lib.cleanup.UsageRightsOverride
 import com.gu.mediaservice.picdarexport.lib.{Config, LogHelper, HttpClient}
-import com.gu.mediaservice.picdarexport.model.{AssetRef, Asset, DateRange}
+import com.gu.mediaservice.picdarexport.model.{PicdarDates, AssetRef, Asset, DateRange}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import play.api.Logger
@@ -104,7 +104,7 @@ trait PicdarApi extends HttpClient with PicdarInterface with LogHelper {
   }
 
   // No timezone lol
-  val picdarEsotericDateFormat = DateTimeFormat.forPattern("yyyyMMddHH:mm:ss")
+  val picdarEsotericDateFormat = PicdarDates.longFormat
 
   def fetchAsset(mak: String, urn: String): Future[Asset] = {
     post(messages.retrieveAsset(mak, urn)) flatMap { response =>

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/picdar/UsageApi.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/picdar/UsageApi.scala
@@ -1,0 +1,22 @@
+package com.gu.mediaservice.picdarexport.lib.picdar
+
+import scalaj.http._
+
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
+
+import com.gu.mediaservice.picdarexport.lib.usage.PicdarUsageRecordFactory
+import com.gu.mediaservice.picdarexport.model.PicdarUsageRecord
+
+
+object UsageApi {
+  import com.gu.mediaservice.picdarexport.lib.Config.picdarUsageApiUrl
+
+  def get(urn: String): Future[List[PicdarUsageRecord]] = Future {
+    val response = Http(s"$picdarUsageApiUrl").param("xurn",urn).asString
+    val responseString = response.body.trim
+    val responseBody = Option(responseString).filter(_.nonEmpty)
+
+    responseBody.map(PicdarUsageRecordFactory.create).getOrElse(List())
+  }
+}

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/usage/PicdarUsageRecordFactory.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/usage/PicdarUsageRecordFactory.scala
@@ -1,0 +1,51 @@
+package com.gu.mediaservice.picdarexport.lib.usage
+
+import scala.util.{Try, Success, Failure}
+
+import org.joda.time.DateTime
+
+import com.gu.mediaservice.model.UsageStatus
+import com.gu.mediaservice.picdarexport.model.{PicdarUsageRecord, PicdarDates}
+
+
+object PicdarUsageRecordFactory {
+
+  def create(responseString: String): List[PicdarUsageRecord] = {
+    val responseElements = ResponseParser.parse(responseString)
+
+    responseElements.flatMap( element => {
+
+      val defaultEdition = 1
+
+      def missingFieldException(field: String) =
+        new NoSuchElementException(s"Missing $field in $element")
+
+      def extractOrThrow(field: String) =
+        element.get(field).getOrElse { throw missingFieldException(field) }
+
+      Try {
+        PicdarUsageRecord(
+          urn          = extractOrThrow("_urn"),
+          dbParent     = extractOrThrow("_parent"),
+          createdDate  = PicdarDates.usageApiLongDateFormat
+            .parseDateTime(s"${extractOrThrow("_date")}-${extractOrThrow("_time")}"),
+          publicationDate = PicdarDates.usageApiShortDateFormat
+            .parseDateTime(extractOrThrow("publicationdate")),
+          productionName  = extractOrThrow("production"),
+          publicationName = extractOrThrow("publicationtext"),
+          page = extractOrThrow("page").toInt,
+          sectionName = extractOrThrow("sectiontext"),
+          edition = element.get("editiontext")
+            .foldLeft(defaultEdition)((_, e) => { Try { e.toInt }.getOrElse(defaultEdition) }),
+          status = element.get("status").map(UsageStatus(_)).getOrElse {
+            throw missingFieldException("status")
+          },
+          notes = element.get("notes")
+        )
+      } match {
+        case Success(record) => Some(record)
+        case Failure(f) => { println(f); None }
+      }
+    }).toList
+  }
+}

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/usage/PrintUsageRequestFactory.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/usage/PrintUsageRequestFactory.scala
@@ -1,0 +1,48 @@
+package com.gu.mediaservice.picdarexport.lib.usage
+
+import com.gu.mediaservice.picdarexport.model.PicdarUsageRecord
+import com.gu.mediaservice.model.{PrintUsageRequest, PrintUsageRecord, PrintUsageMetadata, PrintImageSize}
+
+import lib.MD5
+
+import org.joda.time.DateTime
+
+
+object PrintUsageRequestFactory {
+  def create(picdarUsageRecords: List[PicdarUsageRecord], mediaId: String): Option[PrintUsageRequest] = {
+    val printUsageRecords = picdarUsageRecords.zipWithIndex.map {
+      case (record: PicdarUsageRecord, i: Int) => {
+        val metadata = PrintUsageMetadata(
+          sectionName = record.sectionName,
+          issueDate = record.publicationDate,
+          pageNumber = record.page,
+          storyName = record.productionName,
+          publicationCode = record.publicationName match {
+            case "The Guardian" => "gdn"
+            case "The Observer" => "obs"
+            case _ => "xxx"
+          },
+          publicationName = record.publicationName,
+          edition = record.edition,
+          sectionCode = record.sectionName,
+          notes = record.notes,
+          source = Some("picdar")
+        )
+
+        PrintUsageRecord(
+          dateAdded = record.createdDate,
+          mediaId = mediaId,
+          printUsageMetadata = metadata,
+          containerId = MD5.hash(s"${record.productionName}_${mediaId}"),
+          usageId = MD5.hash(s"${record.productionName}_${mediaId}_${i}"),
+          usageStatus = record.status
+        )
+      }
+    }
+
+    printUsageRecords match {
+      case Nil => None
+      case _ => Some(PrintUsageRequest(printUsageRecords))
+    }
+  }
+}

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/usage/ResponseParser.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/usage/ResponseParser.scala
@@ -1,0 +1,47 @@
+package com.gu.mediaservice.picdarexport.lib.usage
+
+
+object ResponseParser {
+  private def clean(attr: String) = attr.trim.stripPrefix("\"").stripSuffix("\"")
+  private val splitLine = """^\s*(.*?)\s*=\s(\S[\s\S]*?)""".r
+
+  // Sample Picdar Usage API response:
+
+  /*
+   * _parent = 1871903 (0x1c901f) 34096377 (0x20844f9)
+   * _urn = 99999999 (0x3034499)
+   * _date = 02/01/2010
+   * _time = 05:04:08
+   * publicationtext = The Guardian
+   * production = production_name
+   * page = 14
+   * editiontext = First
+   * sectiontext = spr
+   * publicationdate = 02/01/2010
+   * notes =
+   * status = "published"
+   *
+   * _parent = 1871903 (0x1c901f) 42427178 (0x287632a)
+   * _urn = 99999998 (0x3034499)
+   * _date = 02/01/2010
+   * _time = 01:06:49
+   * publicationtext = The Guardian
+   * production = production_name
+   * page = 14
+   * editiontext = 1
+   * sectiontext = spr
+   * publicationdate = 02/01/2010
+   * notes = Usually Aname
+   * status = "pending"
+   */
+
+  def parse(response: String) = response
+    .split("\\n\\n")
+    .map(_.split("\\n").toList)
+    .map(
+      _.flatMap(_ match {
+        case splitLine(k,v) => Some(k,clean(v))
+        case _ => None
+      }).toMap
+    )
+}

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/model/Model.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/model/Model.scala
@@ -2,8 +2,12 @@ package com.gu.mediaservice.picdarexport.model
 
 import java.net.URI
 
+import com.amazonaws.services.dynamodbv2.document.Item
 import com.gu.mediaservice.model.{UsageRights, ImageMetadata}
+import org.joda.time.format.DateTimeFormat
 import org.joda.time.DateTime
+import org.joda.time.Days
+
 
 case class Asset(
   urn: String,
@@ -15,11 +19,35 @@ case class Asset(
   usageRights: Option[UsageRights]
 )
 
+object PicdarDates {
+  // It's really better not to ask.
+  val dynamoDbFormat =  DateTimeFormat.forPattern("yyyy-MM-dd")
+  val format =  DateTimeFormat.forPattern("yyyy/MM/dd")
+  val longFormat = DateTimeFormat.forPattern("yyyyMMddHH:mm:ss")
+  val usageApiShortDateFormat = DateTimeFormat.forPattern("dd/MM/yyyy")
+  val usageApiLongDateFormat = DateTimeFormat.forPattern("dd/MM/yyyy-HH:mm:ss")
+}
 
 case class AssetRef(urn: String, dateLoaded: DateTime)
+object AssetRef {
 
-case class DateRange(start: Option[DateTime], end: Option[DateTime])
+  def apply(item: Item): AssetRef =
+    AssetRef(
+      item.getString("picdarUrn"),
+      PicdarDates.dynamoDbFormat.parseDateTime(item.getString("picdarCreated"))
+    )
+}
 
+
+case class DateRange(start: Option[DateTime], end: Option[DateTime]) {
+  val startDay = start.getOrElse(DateRange.defaultStartDate)
+  val endDay   = end.getOrElse(DateRange.defaultEndDate)
+  val numDays  = Days.daysBetween(startDay, endDay).getDays();
+  val dateList = (0 to numDays).map(startDay.plusDays)
+}
 object DateRange {
+  val defaultStartDate = PicdarDates.format.parseDateTime("2010-01-01")
+  val defaultEndDate   = DateTime.now()
+
   val all = DateRange(None, None)
 }

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/model/PicdarUsageRecord.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/model/PicdarUsageRecord.scala
@@ -1,0 +1,28 @@
+package com.gu.mediaservice.picdarexport.model
+
+import com.gu.mediaservice.model.UsageStatus
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+
+case class PicdarUsageRecord(
+  urn: String,
+  dbParent: String,
+  createdDate: DateTime,
+  publicationDate: DateTime,
+  productionName: String,
+  publicationName: String,
+  page: Int,
+  sectionName: String,
+  edition: Int,
+  status: UsageStatus,
+  notes: Option[String]
+)
+
+object PicdarUsageRecord {
+  import com.gu.mediaservice.model.DateFormat
+
+  implicit val dateTimeFormat = DateFormat
+  implicit val reads: Reads[PicdarUsageRecord] = Json.reads[PicdarUsageRecord]
+  implicit val writes: Writes[PicdarUsageRecord] = Json.writes[PicdarUsageRecord]
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,6 +17,7 @@ object Build extends Build {
       scalaVersion := "2.11.6",
       scalaVersion in ThisBuild := "2.11.6",
       organization := "com.gu",
+      fork in run := true,
       version      := "0.1",
       resolvers ++= Seq(
         "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -20,7 +20,7 @@ import com.gu.mediaservice.lib.argo.model.{Action, Link, EntityReponse}
 import com.gu.mediaservice.lib.auth
 import com.gu.mediaservice.lib.auth.KeyStore
 import com.gu.mediaservice.lib.aws.NoItemFound
-import com.gu.mediaservice.model.Usage
+import com.gu.mediaservice.model.{Usage, PrintUsageRequest}
 
 import lib._
 import model._

--- a/usage/app/lib/UsageBuilder.scala
+++ b/usage/app/lib/UsageBuilder.scala
@@ -1,9 +1,9 @@
 package lib
 
 import org.joda.time.DateTime
-import com.gu.mediaservice.model.{Usage, UsageReference}
+import com.gu.mediaservice.model.{Usage, UsageReference, PublishedUsageStatus}
 
-import model.{PublishedUsageStatus, MediaUsage, UsageTableFullKey}
+import model.{MediaUsage, UsageTableFullKey}
 
 
 object UsageBuilder {

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -27,20 +27,22 @@ object UsageMetadataBuilder {
 
     Try {
       PrintUsageMetadata(
-        metadataMap.apply("sectionName").asInstanceOf[String],
-        metadataMap.get("issueDate").map(_.asInstanceOf[String])
+        sectionName = metadataMap.apply("sectionName").asInstanceOf[String],
+        issueDate = metadataMap.get("issueDate").map(_.asInstanceOf[String])
           .map(DateFormat.parser.parseDateTime).get,
-        metadataMap.apply("pageNumber").asInstanceOf[java.math.BigDecimal].intValue,
-        metadataMap.apply("storyName").asInstanceOf[String],
-        metadataMap.apply("publicationCode").asInstanceOf[String],
-        metadataMap.apply("publicationName").asInstanceOf[String],
-        metadataMap.apply("layoutId").asInstanceOf[java.math.BigDecimal].intValue,
-        metadataMap.apply("edition").asInstanceOf[java.math.BigDecimal].intValue,
-        metadataMap.get("size")
+        pageNumber = metadataMap.apply("pageNumber").asInstanceOf[java.math.BigDecimal].intValue,
+        storyName = metadataMap.apply("storyName").asInstanceOf[String],
+        publicationCode = metadataMap.apply("publicationCode").asInstanceOf[String],
+        publicationName = metadataMap.apply("publicationName").asInstanceOf[String],
+        layoutId = metadataMap.get("layoutId").map(_.asInstanceOf[java.math.BigDecimal].intValue),
+        edition = metadataMap.apply("edition").asInstanceOf[java.math.BigDecimal].intValue,
+        size = metadataMap.get("size")
           .map(_.asInstanceOf[JStringNumMap])
-          .map(m => PrintImageSize(m.get("x").intValue, m.get("y").intValue)).get,
-        metadataMap.apply("orderedBy").asInstanceOf[String],
-        metadataMap.apply("sectionCode").asInstanceOf[String]
+          .map(m => PrintImageSize(m.get("x").intValue, m.get("y").intValue)),
+        orderedBy = metadataMap.get("orderedBy").map(_.asInstanceOf[String]),
+        sectionCode = metadataMap.apply("sectionCode").asInstanceOf[String],
+        notes = metadataMap.get("notes").map(_.asInstanceOf[String]),
+        source = metadataMap.get("source").map(_.asInstanceOf[String])
       )
     }.toOption
   }

--- a/usage/app/lib/UsageStream.scala
+++ b/usage/app/lib/UsageStream.scala
@@ -4,6 +4,7 @@ import play.api.Logger
 
 import _root_.rx.lang.scala.Observable
 import com.gu.contentapi.client.model.v1.{Content, ElementType, Element}
+import com.gu.mediaservice.model.{PendingUsageStatus, PublishedUsageStatus}
 
 import model._
 

--- a/usage/app/model/ContentWrapper.scala
+++ b/usage/app/model/ContentWrapper.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.contentapi.client.model.v1.Content
+import com.gu.mediaservice.model.UsageStatus
 
 import org.joda.time.DateTime
 

--- a/usage/app/model/MediaUsage.scala
+++ b/usage/app/model/MediaUsage.scala
@@ -3,6 +3,7 @@ package model
 import com.amazonaws.services.dynamodbv2.document.Item
 import com.gu.contentapi.client.model.v1.{Content, Element}
 import com.gu.mediaservice.model.{PrintUsageMetadata, DigitalUsageMetadata, DateFormat}
+import com.gu.mediaservice.model.{PendingUsageStatus, PublishedUsageStatus, PrintUsageRecord, UsageStatus}
 import org.joda.time.DateTime
 import play.api.libs.json._
 

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.contentapi.client.model.v1.{Content, ElementType, Element}
+import com.gu.mediaservice.model.{PendingUsageStatus, PublishedUsageStatus, PrintUsageRecord, UsageStatus}
 
 import lib.MD5
 import org.joda.time.DateTime

--- a/usage/app/model/UsageId.scala
+++ b/usage/app/model/UsageId.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.mediaservice.model.PrintUsageRecord
 import lib.MD5
 
 

--- a/usage/app/model/UsageTable.scala
+++ b/usage/app/model/UsageTable.scala
@@ -23,6 +23,8 @@ import org.joda.time.DateTime
 
 import rx.lang.scala.Observable
 
+import com.gu.mediaservice.model.{PendingUsageStatus, PublishedUsageStatus}
+
 import lib.Config
 
 case class UsageTableFullKey(hashKey: String, rangeKey: String) {


### PR DESCRIPTION
Squashed commit of the following:

commit a4c9383345f492b21e0ba7f6bbc26d4ffcf86fed
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 16:03:18 2016 +0000

    Blat Action.scala updates from master

commit 512806a42145692ab3bb423941b638146295a923
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 15:51:57 2016 +0000

    Replace matching booleans by wrapping an option

commit 9d1e5d1e92de699a7be1c85522d166b6dc7b9fa4
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 15:49:37 2016 +0000

    Adds sample data to picdar usage ResponseParser

commit e4b599fd93879eb3c7dcff1c1976677696b5b504
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 15:43:14 2016 +0000

    reuse apply for reads in UsageStatus

commit 220744565202336dadcda8b80bf6975f09a5ed18
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 15:41:36 2016 +0000

    Don't need to pattern match can map directly by using isDefined

commit e90324afacc2c03001a2b89b485dbe33526e5a1b
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 15:39:01 2016 +0000

    record usage has been sent

commit 53eefb5225c0f747eda28b871c43827ee7fdb8d2
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 15:04:50 2016 +0000

    Modify PrintMetadata to accomodate Picdar

    - adds optional source field
    - makes layout optional

commit 2f8044343faa266e6c82b4636cbf8f54116a9df3
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 10:18:13 2016 +0000

    fork run tasks so system.exit behaves as expected

commit af741622e0a614f182e40be024468ad529e76a48
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 10:17:31 2016 +0000

    Send PrintUsageRequest to UsageAPI

commit 11b5649275a3a9399820da064ef80c9b3dd20c64
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 15 10:15:53 2016 +0000

    Remove writes from Action as no longer needed

commit 1f8b0ea030e832b856d17022f39ebf37a7587b18
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Thu Jan 14 14:10:20 2016 +0000

    Revert "Add add-print-usage to image actions"

    This reverts commit b777df6472602c8a8038c963ce5ce7a39a891843.

commit 37892cdf6fae68a088bac55e523dff2829d28e75
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Wed Jan 13 16:49:46 2016 +0000

    Create factory for PrintUsageRequest from PicdarUsageRecord

commit d039134ac65e7e9dcfa9a0ca6d05e89036ec6c8e
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Wed Jan 13 15:34:08 2016 +0000

    moving PrintUsageRequest to common-lib as it will be required by picdar-export

commit 30216ecaffcc82c711430c30d41b4f7c1155ea60
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Wed Jan 13 14:30:41 2016 +0000

    Request image from MediaApi per usage update, extract print update URI

commit b777df6472602c8a8038c963ce5ce7a39a891843
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Wed Jan 13 14:29:46 2016 +0000

    Add add-print-usage to image actions

commit f00284b8919e4949469f6f9819ee8162845a2dac
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Wed Jan 13 14:28:58 2016 +0000

    add reads to argo actions

commit 2953359044b116cfb71588452109f010ebc53bbe
Merge: f26e2c6 9d13917
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Wed Jan 13 12:45:44 2016 +0000

    Merge branch 'master' of github.com:guardian/grid into picdar-usage

commit f26e2c6dba5519bf1ea8cc9be3164d3b41741de1
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Tue Jan 12 16:52:13 2016 +0000

    Reading mediaUrl from database in sendUsage

    Adds apply methods to AssetRef and AssetRow

commit a3268fb770b22d64ab65fba73e440e9c27465e47
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Tue Jan 12 14:29:37 2016 +0000

    make not filled fields a set

commit 64eb5099ae7d98fc2bbb35ecae3a58d9194ec7c8
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Tue Jan 12 14:29:18 2016 +0000

    sort out imports

commit d6ded74e66b9d8983d03d178b3ad76690acb3c59
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Tue Jan 12 14:04:57 2016 +0000

    Store usage in export table

commit 2438241e1bd198f96b13b5ed56b72dcbeb556dbb
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Mon Jan 11 10:24:29 2016 +0000

    Parse "no usages" from Picdar API

    Picdar Usage API returns 200 with empty body for "no usages" so we need
    to handle that case.

commit e3b97ef10b370adc98ca924c3f39c9005ec53cac
Merge: cd95c3c f58bf37
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Mon Jan 11 09:53:57 2016 +0000

    Merge branch 'picdar-usage' of github.com:guardian/grid into picdar-usage

    Conflicts:
    	picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala

commit cd95c3c787678447d3b64804acbfd812420c49d0
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Fri Jan 8 12:51:58 2016 +0000

    use api over stub

commit bcec7291468de1ad7c8e549900787dec8061d457
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Thu Jan 7 16:54:56 2016 +0000

    parsing wip

commit f58bf370bc8ac1522730fdb60d1074132a4abada
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Thu Jan 7 16:54:56 2016 +0000

    parsing wip

commit 28539fce33cc25c7f6789a86935d17abbd5271a8
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Thu Jan 7 11:16:26 2016 +0000

    add dynamo table for picdar usage

commit 4fc4ec318ccdd8ae6cde3c358748d10f61a8f18e
Author: Robert Kenny <robert.kenny@guardian.co.uk>
Date:   Thu Jan 7 10:35:45 2016 +0000

    Adds usage to picdarExport tool

    This changeset starts adding functionality to the picdar export tool in
    order to additionally import usages.