### PR TITLE
Remove excessive config call

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -156,15 +156,6 @@ kahuna.run(['$log', '$rootScope', 'mediaApi', function($log, $rootScope, mediaAp
         });
 }]);
 
-kahuna.run(['$rootScope', 'mediaApi', function($rootScope, mediaApi) {
-    // Ping API at init time to ensure we're logged in
-    mediaApi.root.get()
-        .then(index => {
-            $rootScope.$emit('events:config-loaded', index.data.configuration);
-        });
-}]);
-
-
 kahuna.run(['$rootScope', 'mediaApi',
             ($rootScope, mediaApi) => {
 


### PR DESCRIPTION
I can't think of why we do this here, when we do it [here](https://github.com/guardian/grid/blob/master/kahuna/public/js/main.js#L134).