### PR TITLE
Remove edition, layoutId from print usage metadata

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
@@ -28,7 +28,7 @@ case class PrintUsageMetadata(
   publicationCode: String,
   publicationName: String,
   layoutId: Option[Long] = None,
-  edition: Int,
+  edition: Option[Int],
   size: Option[PrintImageSize] = None,
   orderedBy: Option[String] = None,
   sectionCode: String,

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -35,7 +35,7 @@ object UsageMetadataBuilder {
         publicationCode = metadataMap.apply("publicationCode").asInstanceOf[String],
         publicationName = metadataMap.apply("publicationName").asInstanceOf[String],
         layoutId = metadataMap.get("layoutId").map(_.asInstanceOf[java.math.BigDecimal].intValue),
-        edition = metadataMap.apply("edition").asInstanceOf[java.math.BigDecimal].intValue,
+        edition = metadataMap.get("edition").map(_.asInstanceOf[java.math.BigDecimal].intValue),
         size = metadataMap.get("size")
           .map(_.asInstanceOf[JStringNumMap])
           .map(m => PrintImageSize(m.get("x").intValue, m.get("y").intValue)),

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -19,8 +19,6 @@ object UsageGroup {
   def buildId(printUsage: PrintUsageRecord) = s"print/${MD5.hash(List(
     Some(printUsage.mediaId),
     Some(printUsage.printUsageMetadata.pageNumber),
-    Some(printUsage.printUsageMetadata.edition),
-    Some(printUsage.printUsageMetadata.layoutId),
     Some(printUsage.printUsageMetadata.sectionCode),
     Some(printUsage.printUsageMetadata.issueDate)
   ).flatten.map(_.toString).mkString("_"))}"

--- a/usage/app/model/UsageId.scala
+++ b/usage/app/model/UsageId.scala
@@ -14,11 +14,8 @@ object UsageId {
   def build(printUsageRecord: PrintUsageRecord) = buildId(List(
     Some(printUsageRecord.mediaId),
     Some(printUsageRecord.printUsageMetadata.pageNumber),
-    Some(printUsageRecord.printUsageMetadata.edition),
-    Some(printUsageRecord.printUsageMetadata.layoutId),
-    Some(printUsageRecord.printUsageMetadata.issueDate),
     Some(printUsageRecord.printUsageMetadata.sectionCode),
-    Some(printUsageRecord.printUsageMetadata.size),
+    Some(printUsageRecord.printUsageMetadata.issueDate),
     Some(printUsageRecord.usageStatus)
   ))
 


### PR DESCRIPTION
As edition & layoutId are inconsistent when coming from Textporter & InDesign plugin we need to remove them from the group and usage identifiers,