### PR TITLE
dynamic tooltip position

### DIFF
--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -5,7 +5,8 @@
             ng:if="!ctrl.state.hidden"
             ng:click="ctrl.hidePanel()"
             ng:class="{'bg-light': !ctrl.state.hidden}"
-            gr:tooltip="Hide {{ctrl.name}} panel">
+            gr:tooltip="Hide {{ctrl.name}} panel"
+            gr:tooltip-position="{{ctrl.toolTipPosition()}}">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
 
@@ -13,7 +14,8 @@
             type="button"
             ng:if="ctrl.state.hidden"
             ng:click="ctrl.showPanel()"
-            gr:tooltip="Show {{ctrl.name}} panel">
+            gr:tooltip="Show {{ctrl.name}} panel"
+            gr:tooltip-position="{{ctrl.toolTipPosition()}}">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
 

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button.js
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button.js
@@ -17,6 +17,17 @@ panelButton.controller('GrPanelButton', ['$scope', 'inject$', function($scope, i
         panel.setHidden(true);
     };
 
+    ctrl.toolTipPosition = () => {
+        switch (ctrl.position) {
+        case 'right':
+            return 'left';
+        case 'left':
+            return 'right';
+        default:
+            return 'bottom';
+        }
+    };
+
     inject$($scope, panel.state$, ctrl, 'state');
 }]);
 


### PR DESCRIPTION
if the panel is on the left, tooltips go on the right.
if the panel is on the right, tooltips go on the left.

before

![screen shot 2016-01-18 at 13 47 56](https://cloud.githubusercontent.com/assets/836140/12392833/e14f3376-bde9-11e5-8aab-1dd13320c0f5.jpeg)

after
![screen shot 2016-01-18 at 13 47 44](https://cloud.githubusercontent.com/assets/836140/12392836/e9dc634c-bde9-11e5-9abb-c72ea35f53b4.jpeg)