### PR TITLE
make collection colours visible by default

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
@@ -1,7 +1,5 @@
 gr-nodes, gr-node,
-.node__info:hover .node__marker,
-.node__info:hover .node__action,
-.collection-drop--drag-over .node__marker {
+.node__info:hover .node__action {
     display: block;
 }
 
@@ -15,11 +13,10 @@ gr-nodes, gr-node,
 
 .node__marker {
     position: absolute;
-    background: #00adee;
-    width: 3px;
+    background: #444;
+    width: 5px;
     height: 34px;
     left: 0;
-    display: none;
 }
 
 .node__info {


### PR DESCRIPTION
Some of the feedback was that the root collection was more useful when marking the image.

As discussed with @theefer and @tsop14, having only that show might hinder more complex / useful workflows later. 

To get around this, we can make the collection colours more prominent and permanent until people realise and understand what they are.

I ran this past a couple picture editors and they thought it would be clear enough. Let's see.

![collection-colours-stay](https://cloud.githubusercontent.com/assets/31692/12395462/a89dcab4-bdf9-11e5-92d8-572ffa20b5ea.png)
