### PR TITLE
Splits dateRange on load for picdar-export

### DIFF
--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/model/Model.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/model/Model.scala
@@ -50,4 +50,6 @@ object DateRange {
   val defaultEndDate   = DateTime.now()
 
   val all = DateRange(None, None)
+  def apply(start: DateTime, end: DateTime): DateRange =
+    DateRange(Some(start), Some(end))
 }


### PR DESCRIPTION
Prevents "too many results" exception by splitting `DateRange` into day
chunks.