### PR TITLE
picdar-export fetch "get" rather than "scan"

### DIFF
--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
@@ -237,7 +237,7 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
 
   def fetch(env: String, system: String, dateRange: DateRange = DateRange.all, range: Option[Range] = None) = {
     val dynamo = getDynamo(env)
-    dynamo.getUnfetched(dateRange, Config.overwriteFlag) flatMap { urns =>
+    dynamo.getUnfetched(dateRange) flatMap { urns =>
       val updates = takeRange(urns, range).map { assetRef =>
         getPicdar(system).get(assetRef.urn) flatMap { asset =>
           dynamo.record(assetRef.urn, assetRef.dateLoaded, asset.file, asset.created, asset.modified, asset.metadata)
@@ -251,7 +251,7 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
 
   def ingest(env: String, dateRange: DateRange = DateRange.all, range: Option[Range] = None) = {
     val dynamo = getDynamo(env)
-    dynamo.scanFetchedNotIngested(dateRange) flatMap { assets =>
+    dynamo.getNotIngested(dateRange) flatMap { assets =>
       val updates = takeRange(assets, range).map { asset =>
         // .get on options here will induce intentional failure if not available
         getExportManager("library", env).ingest(
@@ -321,7 +321,7 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
   ) = {
     val dynamo = getDynamo(env)
 
-    dynamo.getNoUsage(dateRange, Config.overwriteFlag) flatMap { urns =>
+    dynamo.getNoUsage(dateRange) flatMap { urns =>
       val updates = takeRange(urns, range).map { assetRef =>
         UsageApi.get(assetRef.urn).flatMap { usages =>
           dynamo.recordUsage(assetRef.urn, assetRef.dateLoaded, usages)
@@ -338,7 +338,7 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
   ) = {
     val dynamo = getDynamo(env)
 
-    dynamo.getUsageNotRecorded(dateRange, Config.overwriteFlag) flatMap { urns =>
+    dynamo.getUsageNotRecorded(dateRange) flatMap { urns =>
       val updates = takeRange(urns, range).map { asset =>
         val mediaUri = asset.mediaUri.get
         val usage = asset.picdarUsage.get

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/PicdarExport.scala
@@ -237,7 +237,7 @@ object ExportApp extends App with ExportManagerProvider with ArgumentHelpers wit
 
   def fetch(env: String, system: String, dateRange: DateRange = DateRange.all, range: Option[Range] = None) = {
     val dynamo = getDynamo(env)
-    dynamo.scanUnfetched(dateRange) flatMap { urns =>
+    dynamo.getUnfetched(dateRange, Config.overwriteFlag) flatMap { urns =>
       val updates = takeRange(urns, range).map { assetRef =>
         getPicdar(system).get(assetRef.urn) flatMap { asset =>
           dynamo.record(assetRef.urn, assetRef.dateLoaded, asset.file, asset.created, asset.modified, asset.metadata)

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
@@ -241,7 +241,6 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
     val maxBatchSize = 100
 
     getUrnsForDateRange(dateRange).flatMap(assetRefs => {
-
       Future { assetRefs.grouped(maxBatchSize).flatMap(batch => {
         val batchSpec = batch.foldLeft(new TableKeysAndAttributes(tableName))(
           (keys: TableKeysAndAttributes, assetRef: AssetRef) => {
@@ -262,13 +261,12 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
     })
   }
 
-
   def getNoUsage(dateRange: DateRange) = {
     getUrnsForNotFilledFields[AssetRef](dateRange, Set("picdarUsage"))(
       (item: Item) => AssetRef(item))
   }
   def getUsageNotRecorded(dateRange: DateRange) = {
-    getUrnsForNotFilledFields(dateRange, Set("picdarUsage", "usageSent"))(
+    getUrnsForNotFilledFields(dateRange, Set("picdarUsage", "usageSent"), Set("mediaUri"))(
       (item: Item) => AssetRow(item))
   }
   def getUnfetched(dateRange: DateRange) = {

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
@@ -239,6 +239,12 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
     getUrnsForNotFilledFields(dateRange, notFilledSet)(
       (item: Item) => AssetRow(item))
   }
+  def getUnfetched(dateRange: DateRange, overwrite: Boolean) = {
+    val notFilledSet: Set[String] = if(overwrite) noopSet else Set("picdarAssetUrl", "picdarMetadataModified")
+
+    getUrnsForNotFilledFields(dateRange, notFilledSet)(
+      (item: Item) => AssetRef(item))
+  }
 
   def scanNoRights(dateRange: DateRange): Future[Seq[AssetRef]] = Future {
     val queryConds = List(fetchedCondition, noRightsCondition).withDateRange(dateRange)

--- a/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
+++ b/picdar-export/src/main/scala/com.gu.mediaservice.picdarexport/lib/db/ExportDynamoDB.scala
@@ -10,11 +10,14 @@ import com.amazonaws.services.dynamodbv2.document.utils.ValueMap
 import com.amazonaws.services.dynamodbv2.model.ReturnValue
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder.{S, N, M, BOOL}
+import com.amazonaws.services.dynamodbv2.document.Item
+import com.amazonaws.services.dynamodbv2.document.TableKeysAndAttributes
+import com.amazonaws.services.dynamodbv2.document.BatchGetItemOutcome
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes
 
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.model.{UsageRights, ImageMetadata}
 import com.gu.mediaservice.picdarexport.model.{PicdarUsageRecord, DateRange, AssetRef, PicdarDates}
-
 import com.gu.mediaservice.picdarexport.lib.Config
 
 import lib.MD5
@@ -214,14 +217,6 @@ class ExportDynamoDB(credentials: AWSCredentials, region: Region, tableName: Str
 
     items.map(AssetRef(_))
   }
-
-  // Set of never-matching elements to ensure overwrite proceeds
-  val noopSet = Set("noop")
-
-  import com.amazonaws.services.dynamodbv2.document.Item
-  import com.amazonaws.services.dynamodbv2.document.TableKeysAndAttributes
-  import com.amazonaws.services.dynamodbv2.document.BatchGetItemOutcome
-  import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes
 
   private def getUnprocessedItems(outcome: BatchGetItemOutcome): List[Item] = {
     val keys = outcome.getUnprocessedKeys()


### PR DESCRIPTION
Uses the get strategy to avoid the massive scan problem