### PR TITLE
Always append image id to filename in downloaded ZIP

### DIFF
--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -66,9 +66,19 @@ downloader.controller('DownloaderCtrl',
     ctrl.getFirstImageSource = () => Array.from(ctrl.images)[0].data.source;
 
     function imageName(image) {
-        return image.data.uploadInfo.filename || `${image.data.id}.jpg`;
+        const filename = image.data.uploadInfo.filename;
+        const imageId = image.data.id;
+        if (filename) {
+            const basename = stripExtension(filename);
+            return `${basename} (${imageId}).jpg`;
+        } else {
+            return `${imageId}.jpg`;
+        }
     }
 
+    function stripExtension(filename) {
+        return filename.replace(/\.[a-zA-Z]{3,4}$/, '');
+    }
 }]);
 
 downloader.directive('grDownloader', function() {


### PR DESCRIPTION
This helps with the case where two images have the same filename.

Sample filenames:
* 505635752-b62f9f3bca65746d2a0cc53757398029d64156af.jpg
* DV2212354-40ebd8e5e222a7b940ec5ac9aad394a9196034a4.jpg

(Are those too cryptic?)

Unfortunately, it doesn't seem to be possible to rename the file we download when a single image is downloaded, so that remains just the image id :cry: 

cc @paperboyo 