### PR TITLE
use little CMS when installing graphicsmagick on a mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You will need to install:
 * JDK 8
 * Nginx
 * [GraphicsMagick](http://www.graphicsmagick.org/)
-`sudo apt-get install graphicsmagick` or `brew install graphicsmagick`.
+`sudo apt-get install graphicsmagick` or `brew install graphicsmagick --with-little-cms2`.
 * [awscli](https://aws.amazon.com/cli/)
 * [jq](https://stedolan.github.io/jq/)
 * [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool/)


### PR DESCRIPTION
It's needed for encoding.