### PR TITLE
use more efficient || over |

### DIFF
--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -44,7 +44,7 @@ trait SearchFilters extends ImageFields {
   val nonFreeFilter = freeFilter.map(filters.not)
 
   lazy val freeToUseCategories: List[String] =
-    UsageRights.all.filter(ur => ur.defaultCost.exists(cost => cost == Free | cost == Conditional)).map(ur => ur.category)
+    UsageRights.all.filter(ur => ur.defaultCost.exists(cost => cost == Free || cost == Conditional)).map(ur => ur.category)
 
   val persistedCategories = NonEmptyList(
     StaffPhotographer.category,


### PR DESCRIPTION
As picked up by @theefer [here](https://github.com/guardian/grid/pull/1662#discussion_r50240084).