### PR TITLE
Update excluded Getty collections using list from 2015-12-02

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -4,9 +4,9 @@ object UsageRightsConfig {
 
   val payGettySourceList = List(
     "Arnold Newman Collection",
-    // Note: This is not excluded as we have a deal with Barcroft directly,
-    // and there are only a tiny amount from Getty.
-    // "Barcroft Media",
+    // Note: Even though we have a deal directly with Barcroft, it
+    // does not apply to images sourced through Getty. Silly, I know.
+    "Barcroft Media",
     "Catwalking",
     "Contour by Getty Images",
     "Contour Style",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -2,24 +2,23 @@ package com.gu.mediaservice.lib.config
 
 object UsageRightsConfig {
 
-  // Note: we filter exclusively on matching source, rather than combining credit=Getty and source=X
-  // this is assumed to be good enough as it's unlikely other provider will use the same source.
   val payGettySourceList = List(
-    // TODO: Remove once we are on the new UsageRights model
-    // This is not excluded as we have a deal with Barcroft,
-    // and there are only a tiny amount from Getty
+    "Arnold Newman Collection",
+    // Note: This is not excluded as we have a deal with Barcroft directly,
+    // and there are only a tiny amount from Getty.
     // "Barcroft Media",
     "Catwalking",
     "Contour by Getty Images",
     "Contour Style",
     "Edit",
-    "Fashion Window",
-    "Gamma-Legend",
+    "Ernst Haas",
+    "Gamma-Legends",
     "Gamma-Rapho",
-    "International Center of Photography",
-    "Lichfield Archive",
-    "MLB Major League Baseball Platinum",
+    "ICP",
+    "Lichfield Studios Limited",
+    "Major League Baseball Platinum",
     "Masters",
+    "Mondadori Portfolio Premium",
     "NBA Classic",
     "Neil Leifer Collection",
     "Papixs",
@@ -27,15 +26,15 @@ object UsageRightsConfig {
     "Paris Match Collection",
     "Premium Archive",
     "Reportage by Getty Images",
+    "Roger Viollet",
     "Sports Illustrated",
     "Sports Illustrated Classic",
     "Terry O'Neill",
-    "The Asahi Shimbun Premium Archive",
+    "The Asahi Shimbun Premium",
     "The LIFE Images Collection",
-    // On the Getty list this is called "The LIFE picture collection Editorial"
-    // whereas in their metadata they use the below
     "The LIFE Picture Collection",
-    "The LIFE Premium Collection"
+    "The LIFE Premium Collection",
+    "Ullstein Bild Premium"
   )
 
   // New rights model, will supersede `freeCreditList` soon

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -18,7 +18,7 @@ trait SearchFilters extends ImageFields {
   val invalidFilter = Config.requiredMetadata.map(metadataField).toNel.map(filters.anyMissing)
 
   // New Cost Model
-  import UsageRightsConfig.{ suppliersCollectionExcl, freeSuppliers, payGettySourceList }
+  import UsageRightsConfig.{ suppliersCollectionExcl, freeSuppliers }
 
   val (suppliersWithExclusions, suppliersNoExclusions) = freeSuppliers.partition(suppliersCollectionExcl.contains)
   val suppliersWithExclusionsFilters = for {


### PR DESCRIPTION
I've manually checked all the collections that have been changed (added or removed), tidying up some of them to ensure the collection always appears as supplierCollection in the usageRights. Some of the renames appear to be correct, in that they now match things and didn't before.

Going to check with Robert re Barcroft, as we could exclude them more precisely now we're in new rights model land.