### PR TITLE
fix collection links

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -207,7 +207,7 @@
         <dt class="metadata-line__key">Collections</dt>
         <dd class="metadata-line__info flex-container"
             ng-repeat="collection in ctrl.image.data.collections">
-            <a ui:sref="search.results({query: '~'+collection.data.pathId})">
+            <a ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})">
                 {{collection.data.path.join(' ▸ ')}}
             </a>
             <span class="flex-spacer"></span>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -51,7 +51,7 @@
                     ng:repeat="collection in ctrl.image.data.collections"
                     gr-tooltip="Click to open collection: {{collection.data.path.join(' ▸ ')}}"
                     gr-tooltip-position="top">
-                    <a ui:sref="search.results({query: (collection.data.path | queryCollectionFilter)})"
+                    <a ui:sref="search.results({query: (collection.data.path.join('/') | queryCollectionFilter)})"
                        ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                        class="preview__collections__collection__value">
                         {{collection.data.description}}

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -51,7 +51,7 @@
                     ng:repeat="collection in ctrl.image.data.collections"
                     gr-tooltip="Click to open collection: {{collection.data.path.join(' ▸ ')}}"
                     gr-tooltip-position="top">
-                    <a ui:sref="search.results({query: (collection.data.path.join('/') | queryCollectionFilter)})"
+                    <a ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
                        ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                        class="preview__collections__collection__value">
                         {{collection.data.description}}

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -51,7 +51,7 @@
                     ng:repeat="collection in ctrl.image.data.collections"
                     gr-tooltip="Click to open collection: {{collection.data.path.join(' ▸ ')}}"
                     gr-tooltip-position="top">
-                    <a ui:sref="::(search.results({query: (collections.data.path | queryCollectionFilter)}))"
+                    <a ui:sref="search.results({query: (collection.data.path | queryCollectionFilter)})"
                        ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                        class="preview__collections__collection__value">
                         {{collection.data.description}}


### PR DESCRIPTION
Fixes link for non-root collections on preview page and image page.  
Removes one-time data binding as believe it's not possible to have on filtered values. 

https://github.com/angular/angular.js/issues/8605