### PR TITLE
Don't 500 if removing usageRights when there was no metadata edits

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -229,7 +229,7 @@ class DynamoDB(credentials: AWSCredentials, region: Region, tableName: String) {
   }
 
   def asJsObject(outcome: UpdateItemOutcome): JsObject =
-    asJsObject(outcome.getItem)
+    Option(outcome.getItem) map asJsObject getOrElse Json.obj()
 
   // FIXME: Dynamo accepts `null`, but not `""`. This is a well documented issue
   // around the community. This guard keeps the introduction of `null` fairly

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -212,7 +212,6 @@ class DynamoDB(credentials: AWSCredentials, region: Region, tableName: String) {
   def update(id: String, expression: String, valueMap: Option[ValueMap] = None)
             (implicit ex: ExecutionContext): Future[JsObject] = Future {
 
-
     val baseUpdateSpec = new UpdateItemSpec().
       withPrimaryKey(IdKey, id).
       withUpdateExpression(expression).
@@ -229,13 +228,7 @@ class DynamoDB(credentials: AWSCredentials, region: Region, tableName: String) {
     jsonWithNullAsEmptyString(Json.parse(item.toJSON)).as[JsObject] - IdKey
   }
 
-  def asJsObject(outcome: PutItemOutcome): JsObject =
-    asJsObject(outcome.getItem)
-
   def asJsObject(outcome: UpdateItemOutcome): JsObject =
-    asJsObject(outcome.getItem)
-
-  def asJsObject(outcome: DeleteItemOutcome): JsObject =
     asJsObject(outcome.getItem)
 
   // FIXME: Dynamo accepts `null`, but not `""`. This is a well documented issue


### PR DESCRIPTION
The item ended up being `null` causing a NPE. This makes things safer, though I want to review anything it may affect before shipping.