### PR TITLE
No lowercase on collections

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -11,7 +11,7 @@ object CollectionsManager {
   val delimiter = "/"
 
   def stringToPath(s: String) = s.split(delimiter).toList
-  def pathToString(path: List[String]) = path.mkString(delimiter).toLowerCase
+  def pathToString(path: List[String]) = path.mkString(delimiter)
   def pathToUri(path: List[String]) = pathToString(path.map(encode))
   def uriToPath(uri: String) = stringToPath(decode(uri))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -1,11 +1,8 @@
 package com.gu.mediaservice.lib.collections
 
-import java.awt.Color
-
 import com.gu.mediaservice.lib.net.URI.{encode, decode}
 import com.gu.mediaservice.model.Collection
 
-import scala.util.Try
 
 object CollectionsManager {
   val delimiter = "/"

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -7,6 +7,7 @@ import play.api.libs.functional.syntax._
 import com.gu.mediaservice.lib.collections.CollectionsManager
 
 case class Collection private (path: List[String], actionData: ActionData, description: String) {
+  // We lowercase on pathId so that we can search case-insensitively
   val pathId = CollectionsManager.pathToString(path).toLowerCase
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -7,7 +7,7 @@ import play.api.libs.functional.syntax._
 import com.gu.mediaservice.lib.collections.CollectionsManager
 
 case class Collection private (path: List[String], actionData: ActionData, description: String) {
-  val pathId = CollectionsManager.pathToString(path)
+  val pathId = CollectionsManager.pathToString(path).toLowerCase
 }
 
 object Collection {
@@ -23,10 +23,10 @@ object Collection {
 
   // We use this to ensure we are creating valid `Collection`s
   def build(path: List[String], actionData: ActionData) = {
-    val lowerPath = path.map(_.toLowerCase)
+//    val lowerPath = path.map(_.toLowerCase)
     // HACK: path should be an NonEmptyList, till then, this'll do
     val description = path.lastOption.getOrElse("")
-    Collection(lowerPath, actionData, description)
+    Collection(path, actionData, description)
   }
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -24,7 +24,6 @@ object Collection {
 
   // We use this to ensure we are creating valid `Collection`s
   def build(path: List[String], actionData: ActionData) = {
-//    val lowerPath = path.map(_.toLowerCase)
     // HACK: path should be an NonEmptyList, till then, this'll do
     val description = path.lastOption.getOrElse("")
     Collection(path, actionData, description)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/collections/CollectionsManagerTest.scala
@@ -41,9 +41,9 @@ class CollectionsManagerTest extends FunSpec with Matchers {
 
     describe("create") {
 
-      it("should lowercase path on creation") {
+      it("should lowercase pathId on creation") {
         val col = Collection.build(List("G2", "ArT", "CasECrazY"), ActionData("me@you.com", DateTime.now))
-        col.path shouldEqual List("g2", "art", "casecrazy")
+        col.path shouldEqual List("G2", "ArT", "CasECrazY")
         col.pathId shouldEqual "g2/art/casecrazy"
       }
 


### PR DESCRIPTION
`pathId` becomes lowercase, we respect case in all other instances as the only place we want case insensitivity is search.