### PR TITLE
Don't render hidden collection sub-trees

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -149,12 +149,11 @@ grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $
             // We compile the template on the fly here as angular doesn't deal
             // well with recursive templates.
             $compile(`<gr-nodes
+                ng:if="ctrl.showChildren && ctrl.node.data.children.length > 0"
                 gr:selected-images="ctrl.selectedImages$"
                 gr:selected-collections="ctrl.selectedCollections"
                 gr:editing="ctrl.editing"
-                ng:show="ctrl.showChildren"
-                gr:nodes="ctrl.node.data.children"
-                ng:if="ctrl.node.data.children.length > 0"></gr-nodes>
+                gr:nodes="ctrl.node.data.children"></gr-nodes>
             `)(scope, cloned => {
                 element.find('.node__children').append(cloned);
             });


### PR DESCRIPTION
There is a huge performance hit of doing `$compile` for every single node in the collection tree. This mitigates that issue by avoiding to render hidden nodes (currently just hidden by CSS), so you only pay for the cost of however many nodes you have expanded.

This is a good reminder that often, and especially when the sub-DOM tree may be large, it's recommended to use `ng:if` over `ng:show`.

Sample difference. This test was done with only the Guide top-section expanded (not recursively).

# Before
![screenshot-2016-01-22t10 58 37](https://cloud.githubusercontent.com/assets/36964/12509023/9eb821e2-c0f7-11e5-92ba-59adec3a6996.png)

Notice the 6s long frames (!).

The blue horizontal bars at the bottom are `parseHTML` from the [`$compile` call](https://github.com/guardian/grid/blob/master/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js#L151-L160) in the mutually recursive node tree directives.

# After
![screenshot-2016-01-22t11 01 16](https://cloud.githubusercontent.com/assets/36964/12509022/9eb6bcd0-c0f7-11e5-9082-9460beec30e5.png)

Still some heavy parseHTML, but much less, because we don't have to do it for the entire tree anymore, just the displayed nodes.


## Remaining issues

- [ ] Some JS errors I've witnessed (looking up `pathId` from `undefined` object)
- [ ] Still heavy performance hit due to use of `$compile` for every node. Worst case (tree fully expanded) is as bad as now. Note that this is due to a limitation in Angular making it very hard to build recursive directives.
- [ ] Results seem to reload after a while, which causes a whole re-render of the results page. Very inefficient.

Will be looking into more of that next.