### PR TITLE
Memoize $compile'd template to reduce parseHTML overhead

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -132,6 +132,12 @@ grCollectionsPanel.controller('GrNodeCtrl',
 }]);
 
 grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $compile) {
+    const templateString = `<gr-nodes
+                                ng:if="ctrl.showChildren && ctrl.node.data.children.length > 0"
+                                gr:selected-images="ctrl.selectedImages$"
+                                gr:selected-collections="ctrl.selectedCollections"
+                                gr:editing="ctrl.editing"
+                                gr:nodes="ctrl.node.data.children"></gr-nodes>`;
     return {
         restrict: 'E',
         scope: {
@@ -145,23 +151,27 @@ grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $
         controller: 'GrNodeCtrl',
         controllerAs: 'ctrl',
         bindToController: true,
-        link: function(scope, element) {
-            // We compile the template on the fly here as angular doesn't deal
-            // well with recursive templates.
-            $compile(`<gr-nodes
-                ng:if="ctrl.showChildren && ctrl.node.data.children.length > 0"
-                gr:selected-images="ctrl.selectedImages$"
-                gr:selected-collections="ctrl.selectedCollections"
-                gr:editing="ctrl.editing"
-                gr:nodes="ctrl.node.data.children"></gr-nodes>
-            `)(scope, cloned => {
-                element.find('.node__children').append(cloned);
-            });
+        compile: function(element, attrs, transclude) {
+            // Memoize the `$compile` result for performance reasons
+            // (compile invoked once per reference, link invoked once
+            // per use)
+            let compiledTemplate;
+            return function link(scope, element) {
+                if (! compiledTemplate) {
+                    // We compile the template on the fly here as angular doesn't deal
+                    // well with recursive templates.
+                    compiledTemplate = $compile(templateString);
+                }
 
-            scope.clearForm = () => {
-                scope.active = false;
-                scope.childName = '';
-                scope.formError = null;
+                compiledTemplate(scope, cloned => {
+                    element.find('.node__children').append(cloned);
+                });
+
+                scope.clearForm = () => {
+                    scope.active = false;
+                    scope.childName = '';
+                    scope.formError = null;
+                };
             };
         }
     };


### PR DESCRIPTION
`$compile` is extremely expensive, and it was invoked for every node being rendered because it was done in the `link` function of the directive. [Learning a little bit about Angular](http://stackoverflow.com/a/15681173), we can leverage the `compile` function of the directive which is only run for every *reference* to the directive, i.e. when it appears in a given context (typically in the template of another directive or view).

It seems that memoizing the template in the `compile` phase (though still evaluating it every time in the `link` phase) vastly improves performance, by making it O(1) (technically O(r) where r is the number of times it occurs, which in practice is constant and equal to 4 currently) instead of O(n), for n the number of nodes rendered in the tree (easily ~100).

Inspired by http://stackoverflow.com/a/19172067.

# Before

![screenshot-2016-01-22t11 01 16](https://cloud.githubusercontent.com/assets/36964/12509838/5f5f17ac-c0fd-11e5-80fd-a224d9d4c240.png)

Notice the blue horizontal bars of parseHTML.

# After

![image](https://cloud.githubusercontent.com/assets/36964/12509834/561e1a44-c0fd-11e5-9fe9-4b6a53083816.png)

Much less parseHTML left.

Still too slow to my taste, but getting there.