### PR TITLE
dot-properties helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data
 .tern-port
 .DS_Store
 *.py[cod]
+.venv

--- a/docker/configs/generators/README.md
+++ b/docker/configs/generators/README.md
@@ -48,3 +48,5 @@ To generate the `.properties` files, run:
 ```sh
 python -m generators.dot_properties /etc/gu
 ```
+
+Or, alternatively, just run [`./generate-dot-properties.sh`](./generate-dot-properties.sh).

--- a/docker/configs/generators/generate-dot-properties.sh
+++ b/docker/configs/generators/generate-dot-properties.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 1 ]
+then
+    echo 'usage: generate-dot-properties <DESTINATION_DIR>'
+    exit 1
+fi
+
+DESTINATION=$1
+
+if [ ! -f ".venv/bin/python" ]; then
+    echo 'creating a virtualenv'
+    virtualenv --no-site-packages --quiet .venv
+fi
+
+source .venv/bin/activate
+pip install --quiet -r requirements.txt
+
+echo "creating dot-properties to ${DESTINATION}"
+python -m generators.dot_properties ${DESTINATION}

--- a/docker/configs/generators/generate-dot-properties.sh
+++ b/docker/configs/generators/generate-dot-properties.sh
@@ -2,7 +2,7 @@
 
 if [ $# -lt 1 ]
 then
-    echo 'usage: generate-dot-properties <DESTINATION_DIR>'
+    echo 'usage: generate-dot-properties.sh <DESTINATION_DIR>'
     exit 1
 fi
 

--- a/docker/configs/generators/generators/resources/templates/dot-properties/media-api.properties.template
+++ b/docker/configs/generators/generators/resources/templates/dot-properties/media-api.properties.template
@@ -9,4 +9,3 @@ cors.allowed.origins={{cors}}
 s3.config.bucket={{ConfigBucket}}
 persistence.identifier=picdarUrn
 mixpanel.token={{mixpanel_token}}
-es.host=elasticsearch

--- a/docker/configs/generators/generators/resources/templates/dot-properties/thrall.properties.template
+++ b/docker/configs/generators/generators/resources/templates/dot-properties/thrall.properties.template
@@ -7,4 +7,3 @@ sqs.message.min.frequency={{sqs_message_min_frequency}}
 persistence.identifier=picdarUrn
 es.index.alias=imagesAlias
 indexed.image.sns.topic.arn={{IndexedImageTopicArn}}
-es.host=elasticsearch

--- a/docker/entrypoints/configs.sh
+++ b/docker/entrypoints/configs.sh
@@ -8,4 +8,8 @@ python -m generators.dot_properties /configs/etc/gu
 python -m generators.nginx /configs/etc/nginx
 python -m generators.imgops /configs/imgops
 
+# as the containers are linked, their hosts file maps `elasticsearch` to the correct endpoint
+echo "\nes.host=elasticsearch" >> /configs/etc/gu/thrall.properties
+echo "\nes.host=elasticsearch" >> /configs/etc/gu/media-api.properties
+
 cp -r /root/.gu/grid/ssl /configs/etc/nginx/ssl


### PR DESCRIPTION
- **Don't** hardcode `es.host=elasticsearch` as it only applies in the context of docker.
- `generate-dot-properties.sh` helper script that will install a python venv for you, so you don't have to.

cc @theefer 