### PR TITLE
symlink config generators to `scripts` directory at project root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ cd cloud-formation/scripts
 ./create-dev-stack.sh
 ```
 
-### .properties files
+### Generate .properties files
 
 Generate your .properties files for the various media-service services using the
-[dot-properties generator](./docker/configs/generators/README.md)
+[dot-properties generator](./scripts/config-generators/README.md)
 
 This will also create a ```panda.properties``` file that configures the
 [pan-domain authentication](https://github.com/guardian/pan-domain-authentication)
@@ -255,6 +255,13 @@ From the project root:
 * all commands take either "all" or a space-delimited list of apps
 
 you can see the different application names in the Procfile (in project root)
+
+### Running wih Docker
+The Grid can be run within Docker containers!
+
+NB: this has only been tested in DEV.
+
+To do so, follow the [README](./docker/README.md#setup).
 
 ## Troubleshooting
 

--- a/scripts/config-generators
+++ b/scripts/config-generators
@@ -1,0 +1,1 @@
+../docker/configs/generators


### PR DESCRIPTION
The generators are currently in the `docker` directory, which isn't the most obvious place if you're running the Grid w/out Docker.

Symlinked because there are generators that are specific to Docker (imgops, nginx, osx_hosts_file) within the [generators package](https://github.com/guardian/grid/tree/aa-config-gen-symlink/docker/configs/generators/generators), so wouldn't make sense to move the generators directory to project root...