### PR TITLE
Handle notes and source as empty strings

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
@@ -53,7 +53,8 @@ case class PrintUsageMetadata(
       orderedBy.foldLeft[StringElement](Nil)((_,s) => List("orderedBy" -> s)) ++
       layoutId.foldLeft[LongElement](Nil)((_,l) => List("layoutId" -> l)) ++
       edition.foldLeft[IntElement](Nil)((_,i) => List("edition" -> i)) ++
-      notes.foldLeft[StringElement](Nil)((_,s) => List("notes" -> s))
+      notes.foldLeft[StringElement](Nil)((_,s) => if(s.isEmpty) Nil else List("notes" -> s)) ++
+      source.foldLeft[StringElement](Nil)((_,s) => if(s.isEmpty) Nil else List("source" -> s))
 }
 object PrintUsageMetadata {
   implicit val dateTimeFormat = DateFormat


### PR DESCRIPTION
When updating print usages we might occasionally be sent notes and
soruce fields with empty strings (which cannot be passed to DynamoDb as
it balks at empty strings in fields).

This PR updates the map generation to prevent empty string fields being
sent.