### PR TITLE
changes collection path to lower case when removing collection

### DIFF
--- a/collections/app/store/CollectionsStore.scala
+++ b/collections/app/store/CollectionsStore.scala
@@ -27,7 +27,7 @@ object CollectionsStore {
   }
 
   def remove(collectionPath: List[String]): Future[Unit] = {
-    val path = CollectionsManager.pathToString(collectionPath)
+    val path = CollectionsManager.pathToString(collectionPath).toLowerCase
     dynamo.deleteItem(path)
   } recover {
     case e => throw CollectionsStoreError(e)


### PR DESCRIPTION
Fixes broken remove collection - which was not working for any collection with a capital letter. 

In remove function, changes collection path to lowercase. 

