### PR TITLE
Usage: Better logging on usage table update fail

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/PrintUsageMetadata.scala
@@ -61,5 +61,3 @@ object PrintUsageMetadata {
   implicit val reads: Reads[PrintUsageMetadata] = Json.reads[PrintUsageMetadata]
   implicit val writes: Writes[PrintUsageMetadata] = Json.writes[PrintUsageMetadata]
 }
-
-

--- a/usage/app/model/UsageTable.scala
+++ b/usage/app/model/UsageTable.scala
@@ -10,6 +10,7 @@ import com.amazonaws.services.dynamodbv2.document.{KeyAttribute, DeleteItemOutco
 import scalaz.syntax.id._
 
 import play.api.libs.json._
+import play.api.Logger
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
@@ -137,5 +138,10 @@ object UsageTable extends DynamoDB(
 
     table.updateItem(updateSpec)
 
-  }).map(asJsObject)
+  })
+  .onErrorResumeNext(e => {
+    Logger.error(s"Dynamo update fail for $record!", e)
+    Observable.error(e)
+  })
+  .map(asJsObject)
 }


### PR DESCRIPTION
This is an attempt to provide better visibility to dynamo update fail errors.