### PR TITLE
Mimics "preset" functionality from Picdar

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -13,6 +13,7 @@ trait ImageFields {
     "copyright",
     "copyrightNotice",
     "suppliersReference",
+    "subject",
     "source",
     "specialInstructions",
     "keywords",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -13,7 +13,7 @@ trait ImageFields {
     "copyright",
     "copyrightNotice",
     "suppliersReference",
-    "subject",
+    "subjects",
     "source",
     "specialInstructions",
     "keywords",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -69,7 +69,7 @@ object Mappings {
     "copyright" -> standardAnalysedString,
     "copyrightNotice" -> standardAnalysedString,
     "suppliersReference" -> standardAnalysedString,
-    "subject" -> standardAnalysedString,
+    "subjects" -> nonAnalysedList("subject"),
     "source" -> nonAnalyzedString,
     "specialInstructions" -> nonAnalyzedString,
     "keywords" -> nonAnalysedList("keyword"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -69,6 +69,7 @@ object Mappings {
     "copyright" -> standardAnalysedString,
     "copyrightNotice" -> standardAnalysedString,
     "suppliersReference" -> standardAnalysedString,
+    "subject" -> standardAnalysedString,
     "source" -> nonAnalyzedString,
     "specialInstructions" -> nonAnalyzedString,
     "keywords" -> nonAnalysedList("keyword"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -31,7 +31,7 @@ object ImageMetadataConverter {
       state               = fileMetadata.iptc.get("Province/State"),
       country             = fileMetadata.iptc.get("Country/Primary Location Name"),
       subject             = fileMetadata.iptc.get("Category")
-                              .map(Subject.create)
+                              .flatMap(Subject.create)
                               .map(_.toString)
     )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -7,6 +7,7 @@ import scala.util.Try
 
 import com.gu.mediaservice.model.{FileMetadata, ImageMetadata}
 
+
 object ImageMetadataConverter {
 
   def fromFileMetadata(fileMetadata: FileMetadata): ImageMetadata =
@@ -28,9 +29,11 @@ object ImageMetadataConverter {
       subLocation         = fileMetadata.iptc.get("Sub-location"),
       city                = fileMetadata.iptc.get("City"),
       state               = fileMetadata.iptc.get("Province/State"),
-      country             = fileMetadata.iptc.get("Country/Primary Location Name")
+      country             = fileMetadata.iptc.get("Country/Primary Location Name"),
+      subject             = fileMetadata.iptc.get("Category")
+                              .map(Subject.create)
+                              .map(_.toString)
     )
-
 
   // Note: because no timezone is given, we have to assume UTC :-(
   lazy val colonDateFormat = DateTimeFormat.forPattern("yyyy:MM:dd HH:mm:ss")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
@@ -24,7 +24,7 @@ object Subject extends Enumeration {
   val Unknown = Value("unknown")
 
   // These category codes are now deprecated but still populated
-  def create(category: String) = category match {
+  def create(category: String): Option[Subject.Value] = category match {
     // ANPA-1312 Codes: https://en.wikipedia.org/wiki/ANPA-1312
     case "F" => Some(Finance)
     case "L" => Some(Lifestyle)
@@ -61,6 +61,11 @@ object Subject extends Enumeration {
     case "ENT" => Some(Arts)
     case "CEL" => Some(Arts)
     case "ODD" => Some(Lifestyle)
+
+    // Other vaues used in supplemental categories
+    case "Entertainment" => Some(Arts)
+    case "Fashion" => Some(Arts)
+    case "Showbiz" => Some(Arts)
 
     case _ => None
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
@@ -21,7 +21,6 @@ object Subject extends Enumeration {
   val Sport = Value("sport")
   val War = Value("war")
   val Weather = Value("weather")
-  val Unknown = Value("unknown")
 
   // These category codes are now deprecated but still populated
   def create(category: String): Option[Subject.Value] = category match {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
@@ -1,0 +1,55 @@
+package com.gu.mediaservice.lib.metadata
+
+
+object Subject extends Enumeration {
+  type SupplierCategory = Value
+  val Arts = Value("arts")
+  val Crime = Value("crime")
+  val Disaster = Value("disaster")
+  val Finance = Value("finance")
+  val Education = Value("education")
+  val Environment = Value("environment")
+  val Health = Value("health")
+  val Human = Value("human")
+  val Labour = Value("labour")
+  val Lifestyle = Value("lifestyle")
+  val Politics = Value("politics")
+  val Religion = Value("religion")
+  val Science = Value("science")
+  val Social = Value("social")
+  val Sport = Value("sport")
+  val War = Value("war")
+  val Weather = Value("weather")
+  val Unknown = Value("unknown")
+
+  // These category codes are now deprecated but still populated
+  def create(category: String) = category match {
+    // ANPA-1312 Codes: https://en.wikipedia.org/wiki/ANPA-1312
+    case "F" => Finance
+    case "L" => Lifestyle
+    case "E" => Arts
+    case "S" => Sport
+    case "O" => Weather
+    case "P" => Politics
+
+    // See: https://www.iptc.org/std/photometadata/documentation/GenericGuidelines/index.htm#!Documents/guidelineformappingcategorycodestosubjectnewscodes.htm
+    case "ACE" => Arts
+    case "CLJ" => Crime
+    case "DIS" => Disaster
+    case "FIN" => Finance
+    case "EDU" => Education
+    case "EVN" => Environment
+    case "HTH" => Health
+    case "HUM" => Human
+    case "LAB" => Labour
+    case "LIF" => Lifestyle
+    case "POL" => Politics
+    case "REL" => Religion
+    case "SCI" => Science
+    case "SOI" => Social
+    case "SPO" => Sport
+    case "WAR" => War
+    case "WEA" => Weather
+    case _ => Unknown
+  }
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
@@ -25,31 +25,31 @@ object Subject extends Enumeration {
   // These category codes are now deprecated but still populated
   def create(category: String) = category match {
     // ANPA-1312 Codes: https://en.wikipedia.org/wiki/ANPA-1312
-    case "F" => Finance
-    case "L" => Lifestyle
-    case "E" => Arts
-    case "S" => Sport
-    case "O" => Weather
-    case "P" => Politics
+    case "F" => Some(Finance)
+    case "L" => Some(Lifestyle)
+    case "E" => Some(Arts)
+    case "S" => Some(Sport)
+    case "O" => Some(Weather)
+    case "P" => Some(Politics)
 
     // See: https://www.iptc.org/std/photometadata/documentation/GenericGuidelines/index.htm#!Documents/guidelineformappingcategorycodestosubjectnewscodes.htm
-    case "ACE" => Arts
-    case "CLJ" => Crime
-    case "DIS" => Disaster
-    case "FIN" => Finance
-    case "EDU" => Education
-    case "EVN" => Environment
-    case "HTH" => Health
-    case "HUM" => Human
-    case "LAB" => Labour
-    case "LIF" => Lifestyle
-    case "POL" => Politics
-    case "REL" => Religion
-    case "SCI" => Science
-    case "SOI" => Social
-    case "SPO" => Sport
-    case "WAR" => War
-    case "WEA" => Weather
-    case _ => Unknown
+    case "ACE" => Some(Arts)
+    case "CLJ" => Some(Crime)
+    case "DIS" => Some(Disaster)
+    case "FIN" => Some(Finance)
+    case "EDU" => Some(Education)
+    case "EVN" => Some(Environment)
+    case "HTH" => Some(Health)
+    case "HUM" => Some(Human)
+    case "LAB" => Some(Labour)
+    case "LIF" => Some(Lifestyle)
+    case "POL" => Some(Politics)
+    case "REL" => Some(Religion)
+    case "SCI" => Some(Science)
+    case "SOI" => Some(Social)
+    case "SPO" => Some(Sport)
+    case "WAR" => Some(War)
+    case "WEA" => Some(Weather)
+    case _ => None
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
@@ -13,6 +13,7 @@ object Subject extends Enumeration {
   val Human = Value("human")
   val Labour = Value("labour")
   val Lifestyle = Value("lifestyle")
+  val Nature = Value("nature")
   val Politics = Value("politics")
   val Religion = Value("religion")
   val Science = Value("science")
@@ -50,6 +51,17 @@ object Subject extends Enumeration {
     case "SPO" => Some(Sport)
     case "WAR" => Some(War)
     case "WEA" => Some(Weather)
+
+    // Added from an internally supplied list
+    case "ANI" => Some(Nature)
+    case "NAT" => Some(Nature)
+    case "WLD" => Some(Nature)
+    case "BIZ" => Some(Finance)
+    case "MAX" => Some(Finance)
+    case "ENT" => Some(Arts)
+    case "CEL" => Some(Arts)
+    case "ODD" => Some(Lifestyle)
+
     case _ => None
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -23,7 +23,7 @@ case class ImageMetadata(
   city:                Option[String]   = None,
   state:               Option[String]   = None,
   country:             Option[String]   = None,
-  subject:             Option[String]   = None
+  subjects:            List[String]     = Nil
 )
 
 object ImageMetadata {
@@ -45,7 +45,7 @@ object ImageMetadata {
       (__ \ "city").readNullable[String] ~
       (__ \ "state").readNullable[String] ~
       (__ \ "country").readNullable[String] ~
-      (__ \ "subject").readNullable[String]
+      (__ \ "subjects").readNullable[List[String]].map(_ getOrElse Nil)
     )(ImageMetadata.apply _)
 
   implicit val IptcMetadataWrites: Writes[ImageMetadata] = (
@@ -66,7 +66,7 @@ object ImageMetadata {
       (__ \ "city").writeNullable[String] ~
       (__ \ "state").writeNullable[String] ~
       (__ \ "country").writeNullable[String] ~
-      (__ \ "subject").writeNullable[String]
+      (__ \ "subjects").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l))
     )(unlift(ImageMetadata.unapply))
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -22,7 +22,8 @@ case class ImageMetadata(
   subLocation:         Option[String]   = None,
   city:                Option[String]   = None,
   state:               Option[String]   = None,
-  country:             Option[String]   = None
+  country:             Option[String]   = None,
+  subject:             Option[String]   = None
 )
 
 object ImageMetadata {
@@ -43,7 +44,8 @@ object ImageMetadata {
       (__ \ "subLocation").readNullable[String] ~
       (__ \ "city").readNullable[String] ~
       (__ \ "state").readNullable[String] ~
-      (__ \ "country").readNullable[String]
+      (__ \ "country").readNullable[String] ~
+      (__ \ "subject").readNullable[String]
     )(ImageMetadata.apply _)
 
   implicit val IptcMetadataWrites: Writes[ImageMetadata] = (
@@ -63,7 +65,8 @@ object ImageMetadata {
       (__ \ "subLocation").writeNullable[String] ~
       (__ \ "city").writeNullable[String] ~
       (__ \ "state").writeNullable[String] ~
-      (__ \ "country").writeNullable[String]
+      (__ \ "country").writeNullable[String] ~
+      (__ \ "subject").writeNullable[String]
     )(unlift(ImageMetadata.unapply))
 
 }

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -48,7 +48,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     case "uploader"            => "uploadedBy"
     case "label"               => "labels"
     case "collection"          => "suppliersCollection"
-    case "subject"             => "subject"
+    case "subject"             => "subjects"
     case "location"            => "subLocation"
     case "by" | "photographer" => "byline"
     case "keyword"             => "keywords"

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -37,6 +37,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     "copyright" |
     "source" |
     "category" |
+    "subject" |
     "supplier" |
     "collection" |
     "keyword" |
@@ -47,6 +48,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     case "uploader"            => "uploadedBy"
     case "label"               => "labels"
     case "collection"          => "suppliersCollection"
+    case "subject"             => "subject"
     case "location"            => "subLocation"
     case "by" | "photographer" => "byline"
     case "keyword"             => "keywords"

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -241,7 +241,8 @@ object EditsController extends Controller with ArgoHelpers with DynamoEdits with
       "subLocation" -> trueOptional(text),
       "city" -> trueOptional(text),
       "state" -> trueOptional(text),
-      "country" -> trueOptional(text)
+      "country" -> trueOptional(text),
+      "subject" -> trueOptional(text)
     )(ImageMetadata.apply)(ImageMetadata.unapply))
   )
 

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -242,7 +242,7 @@ object EditsController extends Controller with ArgoHelpers with DynamoEdits with
       "city" -> trueOptional(text),
       "state" -> trueOptional(text),
       "country" -> trueOptional(text),
-      "subject" -> trueOptional(text)
+      "subjects" -> default(list(text), List())
     )(ImageMetadata.apply)(ImageMetadata.unapply))
   )
 


### PR DESCRIPTION
Looks for IPTC category codes and applies a suppliersCategory.

**Note:** This PR requires `updateMapping` be runon ES  before deployment.