### PR TITLE
Keyboard shortcuts for discrete scrolling of results

### DIFF
--- a/kahuna/public/js/components/gr-keyboard-shortcut/gr-keyboard-shortcut.js
+++ b/kahuna/public/js/components/gr-keyboard-shortcut/gr-keyboard-shortcut.js
@@ -15,9 +15,9 @@ module.factory('keyboardShortcut', ['hotkeys', 'track', function (hotkeys, track
             return {
                 add: function (args) {
                     const hotKeyDefinition = angular.extend({}, args, {
-                        callback: function () {
+                        callback: function (...params) {
                             track.success('Keyboard shortcut', { shortcut: args.description });
-                            args.callback();
+                            args.callback(...params);
                         }
                     });
 

--- a/kahuna/public/js/components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts.js
+++ b/kahuna/public/js/components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts.js
@@ -6,7 +6,9 @@ export var lazyTableShortcuts = angular.module('gu.lazyTableShortcuts', [
     'gr.keyboardShortcut'
 ]);
 
-lazyTableShortcuts.directive('guLazyTableShortcuts', ['keyboardShortcut', function(keyboardShortcut) {
+lazyTableShortcuts.directive('guLazyTableShortcuts',
+                             ['keyboardShortcut',
+                              function(keyboardShortcut) {
     return {
         restrict: 'EA',
         require: '^guLazyTable',

--- a/kahuna/public/js/components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts.js
+++ b/kahuna/public/js/components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts.js
@@ -47,16 +47,15 @@ lazyTableShortcuts.directive('guLazyTableShortcuts',
                     allowIn: ['INPUT'],
                     callback: invoke('scrollNextPage')
                 })
+                // Home/End not allowed in text field as useful for input navigation
                 .add({
                     combo: 'home',
                     description: 'Scroll results to the start',
-                    allowIn: ['INPUT'],
                     callback: invoke('scrollStart')
                 })
                 .add({
                     combo: 'end',
                     description: 'Scroll results to the end',
-                    allowIn: ['INPUT'],
                     callback: invoke('scrollEnd')
                 });
         }

--- a/kahuna/public/js/components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts.js
+++ b/kahuna/public/js/components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts.js
@@ -1,0 +1,62 @@
+import angular from 'angular';
+
+import '../gr-keyboard-shortcut/gr-keyboard-shortcut';
+
+export var lazyTableShortcuts = angular.module('gu.lazyTableShortcuts', [
+    'gr.keyboardShortcut'
+]);
+
+lazyTableShortcuts.directive('guLazyTableShortcuts', ['keyboardShortcut', function(keyboardShortcut) {
+    return {
+        restrict: 'EA',
+        require: '^guLazyTable',
+        link: function (scope, element, attrs, lazyTableCtrl) {
+            function invoke(fnName) {
+                return (event) => {
+                    // Must cancel any scrolling caused by the key
+                    event.preventDefault();
+
+                    lazyTableCtrl[fnName]();
+                };
+            }
+
+            keyboardShortcut.bindTo(scope)
+                .add({
+                    combo: 'up',
+                    description: 'Scroll results up by one row',
+                    allowIn: ['INPUT'],
+                    callback: invoke('scrollPrevRow')
+                })
+                .add({
+                    combo: 'down',
+                    description: 'Scroll results down by one row',
+                    allowIn: ['INPUT'],
+                    callback: invoke('scrollNextRow')
+                })
+                .add({
+                    combo: 'pageup',
+                    description: 'Scroll results up by one page',
+                    allowIn: ['INPUT'],
+                    callback: invoke('scrollPrevPage')
+                })
+                .add({
+                    combo: 'pagedown',
+                    description: 'Scroll results down by one page',
+                    allowIn: ['INPUT'],
+                    callback: invoke('scrollNextPage')
+                })
+                .add({
+                    combo: 'home',
+                    description: 'Scroll results to the start',
+                    allowIn: ['INPUT'],
+                    callback: invoke('scrollStart')
+                })
+                .add({
+                    combo: 'end',
+                    description: 'Scroll results to the end',
+                    allowIn: ['INPUT'],
+                    callback: invoke('scrollEnd')
+                });
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -255,6 +255,10 @@ lazyTable.directive('guLazyTable', ['$window', 'observe$',
 
             // Model container and viewport properties
 
+            // Offset between container top and top of scrolling area (page)
+            // Read once as we assume it never changes
+            const containerTop = element[0].getClientRects()[0].top;
+
             const containerWidth$ = combine$(
                 viewportResized$,
                 elementResized$,
@@ -265,12 +269,11 @@ lazyTable.directive('guLazyTable', ['$window', 'observe$',
                 // For Chrome we need to read scrollTop on body, for
                 // other browser it's on the documentElement. Meh.
                 // https://miketaylr.com/posts/2014/11/document-body-scrollTop.html
-                const scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
-                return Math.max(scrollTop - element[0].offsetTop, 0);
+                return document.body.scrollTop || document.documentElement.scrollTop;
             }).shareReplay(1);
 
             const offsetHeight$ = combine$(viewportScrolled$, viewportResized$, () => {
-                return Math.max(document.documentElement.clientHeight - element[0].offsetTop, 0);
+                return Math.max(document.documentElement.clientHeight - containerTop, 0);
             }).shareReplay(1);
 
             const viewportTop$    = offsetTop$;

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -234,9 +234,9 @@ lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
 }]);
 
 
-lazyTable.directive('guLazyTable', ['$window', 'observe$', '$document',
+lazyTable.directive('guLazyTable', ['$window', 'observe$',
                                     'observeCollection$', 'subscribe$',
-                                    function($window, observe$, $document,
+                                    function($window, observe$,
                                              observeCollection$, subscribe$) {
 
     return {

--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -53,13 +53,15 @@ lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
     let ctrl = this;
 
     ctrl.init = function({items$, preloadedRows$, cellHeight$, cellMinWidth$,
-                          containerWidth$, viewportTop$, viewportBottom$}) {
+                          containerWidth$, viewportHeight$, viewportTop$}) {
         const itemsCount$ = items$.map(items => items.length).distinctUntilChanged();
 
         const columns$ = max$(floor$(div$(containerWidth$, cellMinWidth$)), 1);
         const rows$ = ceil$(div$(itemsCount$, columns$));
 
         const cellWidth$ = floor$(div$(containerWidth$, columns$));
+
+        const viewportBottom$ = add$(viewportTop$, viewportHeight$);
 
         const currentRowTop$    = floor$(div$(viewportTop$,    cellHeight$));
         const currentRowBottom$ = floor$(div$(viewportBottom$, cellHeight$));
@@ -277,12 +279,12 @@ lazyTable.directive('guLazyTable', ['$window', 'observe$',
             }).shareReplay(1);
 
             const viewportTop$    = offsetTop$;
-            const viewportBottom$ = add$(offsetTop$, offsetHeight$);
+            const viewportHeight$ = offsetHeight$;
 
 
             const {viewHeight$, rangeToLoad$, placeholderIndexes$} = ctrl.init({
                 items$, preloadedRows$, cellHeight$, cellMinWidth$,
-                containerWidth$, viewportTop$, viewportBottom$
+                containerWidth$, viewportTop$, viewportHeight$
             });
 
             // Table cells will be absolutely positioned within this container

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -117,7 +117,8 @@
             gu:lazy-table-cell-min-width="280"
             gu:lazy-table-cell-height="292"
             gu:lazy-table-preloaded-rows="4"
-            gu:lazy-table-load-range="ctrl.loadRange($start, $end)">
+            gu:lazy-table-load-range="ctrl.loadRange($start, $end)"
+            gu-lazy-table-shortcuts>
 
             <li ng:repeat="image in ctrl.images track by image.data.id"
                 gu:lazy-table-cell="image">

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -9,6 +9,7 @@ import '../util/async';
 import '../util/rx';
 import '../util/seq';
 import '../components/gu-lazy-table/gu-lazy-table';
+import '../components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts';
 import '../components/gr-archiver/gr-archiver';
 import '../components/gr-delete-image/gr-delete-image';
 import '../components/gr-downloader/gr-downloader';
@@ -22,6 +23,7 @@ export var results = angular.module('kahuna.search.results', [
     'util.rx',
     'util.seq',
     'gu.lazyTable',
+    'gu.lazyTableShortcuts',
     'gr.archiver',
     'gr.downloader',
     'gr.deleteImage',


### PR DESCRIPTION
Adds the following shortcuts:

![image](https://cloud.githubusercontent.com/assets/36964/12750363/9e26bf3a-c9ae-11e5-8c05-009103173dbc.png)

These shortcuts work from anywhere on the results page, including if the search field is focused. Previously, only Page Up/Down worked when the search input field was focused.

Rows and pages are scrolled discretely and the top-row is always aligned. When scrolling pages, we scroll the next bottom row (the bottom-most row that isn't fully displayed on the current page) to the top.

![recorded](https://cloud.githubusercontent.com/assets/36964/12750433/37f8b960-c9af-11e5-98e6-ca275eaa463b.gif)


cc @JonnyWeeks 

Will also show to Fiona & Roger, who asked for this about a century ago.