### PR TITLE
Revert "set content disposition header on S3 image urls... again"

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -104,8 +104,8 @@ object ImageResponse extends EditsResponse {
     // TODO: do we really need these expiration tokens? they kill our ability to cache...
     val expiration = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
     val fileUri = new URI((source \ "source" \ "file").as[String])
-    val secureUrl = S3Client.signUrl(Config.imageBucket, fileUri, image, expiration)
-    val secureThumbUrl = S3Client.signUrl(Config.thumbBucket, fileUri, image, expiration)
+    val secureUrl = S3Client.signUrl(Config.imageBucket, fileUri, expiration)
+    val secureThumbUrl = S3Client.signUrl(Config.thumbBucket, fileUri, expiration)
 
     val valid = ImageExtras.isValid(source \ "metadata")
 


### PR DESCRIPTION
Reverts guardian/grid#1711

D'oh, the filename in the content disposition header needs escaping! We're seeing broken images with this response from the S3 request:

```xml
<Error>
<Code>InvalidArgument</Code>
<Message>Header value cannot be represented using ISO-8859-1.</Message>
<ArgumentName>response-content-disposition</ArgumentName>
<ArgumentValue>attachment; filename="Chris Evans &amp; Father Bryan D’Arcy (46dfc37339848cc7369653c94fe83cbd8a28ae40).jpg"</ArgumentValue>
<RequestId>A134CC749F8CB3A9</RequestId>
<HostId>jqMbu71GrLmkQsX6xZ/iYusKbhWo8AdLWg41kxvMcv7rozl8L5iVo/2X7H8N4/ZrbyS37OPuMSE=</HostId>
</Error>
```

:sob: 