### PR TITLE
Hide ui-archiver if unarchived unless hovering

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -833,14 +833,15 @@ input.search-query__input {
     color: #00adee;
 }
 
-.result ui-archiver .archiver--unarchived {
+/* Hacky: Hide ui-archiver "Add to Library" (unarchived state) unless hovering */
+.result .ui-archiver--unarchived {
     display: none;
 }
 
 .result:hover .result__select,
 .result:hover .preview__fade,
 .result:hover .image-actions,
-.result:hover .archiver {
+.result:hover .ui-archiver--unarchived {
     display: block;
 }
 


### PR DESCRIPTION
We don't want to show it all the time, as is now the case on TEST.