### PR TITLE
Rename ui-archiver everywhere for consistency

### DIFF
--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.css
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.css
@@ -1,35 +1,35 @@
-.ui-archiver--archived {
+.gr-archiver-status--archived {
     color: #ccc;
     fill: #ccc; /* svg icons */
 }
 
-.ui-archiver--unarchived {
+.gr-archiver-status--unarchived {
     color: #666;
     fill: #666; /* svg icons */
 }
 
-.ui-archiver--interactive:hover {
+.gr-archiver-status--interactive:hover {
     color: white;
     fill: white; /* svg icons */
 }
 
-.ui-archiver--archived gr-library-added-icon,
-.ui-archiver--archived:hover gr-library-remove-icon {
+.gr-archiver-status--archived gr-library-added-icon,
+.gr-archiver-status--archived:hover gr-library-remove-icon {
     display: inline;
 }
 
-.ui-archiver--archived:hover gr-library-added-icon,
-.ui-archiver--archived gr-library-remove-icon {
+.gr-archiver-status--archived:hover gr-library-added-icon,
+.gr-archiver-status--archived gr-library-remove-icon {
     display: none;
 }
 
 /* undo disabled button styling */
-.ui-archiver__button[disabled] {
+.gr-archiver-status__button[disabled] {
     background-color: transparent;
     box-shadow: none;
 }
 
-.ui-archiver__icon svg {
+.gr-archiver-status__icon svg {
     /* odd one, but the only one that seems to do the trick ;_; */
     vertical-align: middle;
 }

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
@@ -1,39 +1,39 @@
 <span ng:if="! ctrl.readonly"
       ng:switch="ctrl.archivedState"
-      class="ui-archiver"
-      ng:class="{'ui-archiver--interactive': ctrl.archivedState !== 'kept',
-                 'ui-archiver--archived':    ctrl.archivedState !== 'unarchived',
-                 'ui-archiver--unarchived':  ctrl.archivedState === 'unarchived'}">
+      class="gr-archiver-status"
+      ng:class="{'gr-archiver-status--interactive': ctrl.archivedState !== 'kept',
+                 'gr-archiver-status--archived':    ctrl.archivedState !== 'unarchived',
+                 'gr-archiver-status--unarchived':  ctrl.archivedState === 'unarchived'}">
     <span ng:switch-when="kept"
           title="Kept in Library because the image has been {{ctrl.archivedExplanation}}.">
-        <gr-library-locked-icon class="ui-archiver__icon"></gr-library-locked-icon>
+        <gr-library-locked-icon class="gr-archiver-status__icon"></gr-library-locked-icon>
     </span>
     <button ng:switch-when="archived"
             type="button"
-            class="ui-archiver__button inner-clickable"
+            class="gr-archiver-status__button inner-clickable"
             title="Remove from Library"
             ng:click="ctrl.unarchive()"
             ng:disabled="ctrl.archiving">
-        <gr-library-added-icon class="ui-archiver__icon"></gr-library-added-icon>
-        <gr-library-remove-icon class="ui-archiver__icon"></gr-library-remove-icon>
+        <gr-library-added-icon class="gr-archiver-status__icon"></gr-library-added-icon>
+        <gr-library-remove-icon class="gr-archiver-status__icon"></gr-library-remove-icon>
     </button>
     <button ng:switch-when="unarchived"
             type="button"
-            class="ui-archiver__button inner-clickable"
+            class="gr-archiver-status__button inner-clickable"
             title="Add to Library"
             ng:click="ctrl.archive()"
             ng:disabled="ctrl.archiving">
-        <gr-library-add-icon class="ui-archiver__icon"></gr-library-add-icon>
+        <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
     </button>
 </span>
 
 <span ng:if="ctrl.readonly"
       ng:switch="ctrl.archivedState"
-      class="ui-archiver ui-archiver--archived">
+      class="gr-archiver-status gr-archiver-status--archived">
     <span ng:switch-when="kept">
-        <gr-library-locked-icon class="ui-archiver__icon"></gr-library-locked-icon>
+        <gr-library-locked-icon class="gr-archiver-status__icon"></gr-library-locked-icon>
     </span>
     <span ng:switch-when="archived">
-        <gr-library-added-icon class="ui-archiver__icon"></gr-library-added-icon>
+        <gr-library-added-icon class="gr-archiver-status__icon"></gr-library-added-icon>
     </span>
 </span>

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
@@ -47,7 +47,7 @@ archiver.controller('ArchiverCtrl',
     }
 }]);
 
-archiver.directive('uiArchiver', [function() {
+archiver.directive('grArchiverStatus', [function() {
     return {
         restrict: 'E',
         controller: 'ArchiverCtrl',

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -71,9 +71,9 @@
                 </span>
             </div>
 
-            <ui-archiver class="result-editor__archiver"
-                         image="ctrl.image">
-            </ui-archiver>
+            <gr-archiver-status class="result-editor__archiver"
+                                image="ctrl.image">
+            </gr-archiver-status>
         </div>
         <span class="result-editor__save-status-container">
             <span class="result-editor__save-status"

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -110,10 +110,10 @@
             </span>
         </div>
         <div>
-            <ui-archiver class="bottom-bar__action"
-                         image="ctrl.image"
-                         readonly="ctrl.selectionMode">
-            </ui-archiver>
+            <gr-archiver-status class="bottom-bar__action"
+                                image="ctrl.image"
+                                readonly="ctrl.selectionMode">
+            </gr-archiver-status>
 
             <div class="bottom-bar__action bottom-bar__action--cost preview__cost"
                  ng:if="ctrl.states.cost !== 'free'"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -428,10 +428,6 @@ textarea.ng-invalid {
     border-right: 2px solid #565656;
 }
 
-.top-bar-item ui-archiver .archiver {
-    color: #ccc;
-}
-
 .user-actions {
     margin-right: -10px;
     padding: 0 5px;
@@ -833,15 +829,15 @@ input.search-query__input {
     color: #00adee;
 }
 
-/* Hacky: Hide ui-archiver "Add to Library" (unarchived state) unless hovering */
-.result .ui-archiver--unarchived {
+/* Hacky: Hide gr-archiver-status "Add to Library" (unarchived state) unless hovering */
+.result .gr-archiver-status--unarchived {
     display: none;
 }
 
 .result:hover .result__select,
 .result:hover .preview__fade,
 .result:hover .image-actions,
-.result:hover .ui-archiver--unarchived {
+.result:hover .gr-archiver-status--unarchived {
     display: block;
 }
 


### PR DESCRIPTION
I realised the directive and classes were still called `ui-archiver` even thought I'd renamed the component to `gr-archiver-status`. This makes things consistent.

No functionality change.