### PR TITLE
Fix persistence explanation when used for single image

### DIFF
--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -2,7 +2,8 @@
      ng:switch="ctrl.archivedState">
     <span ng:switch-when="kept"
           class="side-padded batch-archive__button batch-archive__button--disabled"
-          gr:tooltip="Kept in Library because all selected images have been {{ctrl.archivedExplanation}}.">
+          gr:tooltip="{{ctrl.archivedExplanation}}"
+          gr:tooltip-updates>
         <gr-library-locked-icon class="batch-archive__icon"></gr-library-locked-icon>
         <span class="icon-label">Kept in Library</span>
     </span>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -42,7 +42,15 @@ module.controller('grArchiverCtrl', [
                 allPersisted ? 'archived' : 'unarchived';
 
             const explTokens = listAllPersistenceExplanations(images);
-            ctrl.archivedExplanation = humanJoin(explTokens, 'or');
+            let explanation, reason;
+            if (images.length === 1) {
+                reason = humanJoin(explTokens, 'and');
+                explanation = `Kept in Library because the image has been ${reason}.`;
+            } else {
+                reason = humanJoin(explTokens, 'or');
+                explanation = `Kept in Library because the images have been ${reason}.`;
+            }
+            ctrl.archivedExplanation = explanation;
         });
 
         ctrl.archive = () => {


### PR DESCRIPTION
The component is used on the individual image preview page, where it doesn't make sense to talk about "the selected images" and join the reasons with "or". This tunes the logic to correctly phrase the explanation on why an image or multiple images have been persisted.