### PR TITLE
Set content disposition header on S3 urls, supporting UTF-8

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -57,7 +57,7 @@ class S3(credentials: AWSCredentials) {
     val key: Key = url.getPath.drop(1)
 
     // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987
-    // they'll fallback to `filename`, which will be a UTF-8 string decoded as Latin-1
+    // they'll fallback to `filename`, which will be a UTF-8 string decoded as Latin-1 - this is a rubbish string, but only rubbish browsers don't support RFC 5987 (IE8 back)
     // See http://tools.ietf.org/html/rfc6266#section-5
     val contentDisposition = s"""attachment; filename="${getContentDispositionFilename(image, CharSet.ISO8859)}"; filename*=UTF-8''${getContentDispositionFilename(image, CharSet.UTF8)}"""
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -36,7 +36,7 @@ class S3(credentials: AWSCredentials) {
     regex.replaceAllIn(filename, "")
   }
 
-  private def getDownloadFilename(image: Image, charset: CharSet): String = {
+  private def getContentDispositionFilename(image: Image, charset: CharSet): String = {
     val baseFilename: String = image.uploadInfo.filename match {
       case Some(f)  => s"${removeExtension(f)} (${image.id}).jpg"
       case _        => s"${image.id}.jpg"
@@ -58,7 +58,7 @@ class S3(credentials: AWSCredentials) {
 
     // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987 (they'll fallback to `filename`)
     // See http://tools.ietf.org/html/rfc6266#section-5
-    val contentDisposition = s"""attachment; filename="${getDownloadFilename(image, CharSet.ISO8859)}"; filename*=UTF-8''${getDownloadFilename(image, CharSet.UTF8)}"""
+    val contentDisposition = s"""attachment; filename="${getContentDispositionFilename(image, CharSet.ISO8859)}"; filename*=UTF-8''${getContentDispositionFilename(image, CharSet.UTF8)}"""
 
     val headers = new ResponseHeaderOverrides().withContentDisposition(contentDisposition)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -1,15 +1,16 @@
 package com.gu.mediaservice.lib.aws
 
-import java.util.Date
-import java.io.{FileInputStream, File}
+import java.io.File
 import java.net.URI
-import scala.concurrent.{ExecutionContext, Future}
-import scala.collection.JavaConverters._
 
 import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3}
-import com.amazonaws.services.s3.model.{S3ObjectSummary, ObjectMetadata, PutObjectRequest, GeneratePresignedUrlRequest, ListObjectsRequest}
+import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
+import com.gu.mediaservice.model.Image
 import org.joda.time.DateTime
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
 import scalaz.syntax.id._
 
 
@@ -29,10 +30,24 @@ class S3(credentials: AWSCredentials) {
   lazy val client: AmazonS3 =
     new AmazonS3Client(credentials) <| (_ setEndpoint s3Endpoint)
 
-  def signUrl(bucket: Bucket, url: URI, expiration: DateTime): String = {
+  private def removeExtension(filename: String): String = {
+    val regex = """\.[a-zA-Z]{3,4}$""".r
+    regex.replaceAllIn(filename, "")
+  }
+
+  def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime): String = {
     // get path and remove leading `/`
     val key: Key = url.getPath.drop(1)
-    val request = new GeneratePresignedUrlRequest(bucket, key).withExpiration(expiration.toDate)
+
+    val filename: String = image.uploadInfo.filename match {
+      case Some(f)  => s"${removeExtension(f)} (${image.id}).jpg"
+      case _        => s"${image.id}.jpg"
+    }
+
+    val headers = new ResponseHeaderOverrides()
+    headers.setContentDisposition(s"""attachment; filename="$filename"""")
+
+    val request = new GeneratePresignedUrlRequest(bucket, key).withExpiration(expiration.toDate).withResponseHeaders(headers)
     client.generatePresignedUrl(request).toExternalForm
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -56,7 +56,8 @@ class S3(credentials: AWSCredentials) {
     // get path and remove leading `/`
     val key: Key = url.getPath.drop(1)
 
-    // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987 (they'll fallback to `filename`)
+    // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987
+    // they'll fallback to `filename`, which will be a UTF-8 string decoded as Latin-1
     // See http://tools.ietf.org/html/rfc6266#section-5
     val contentDisposition = s"""attachment; filename="${getContentDispositionFilename(image, CharSet.ISO8859)}"; filename*=UTF-8''${getContentDispositionFilename(image, CharSet.UTF8)}"""
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -104,8 +104,8 @@ object ImageResponse extends EditsResponse {
     // TODO: do we really need these expiration tokens? they kill our ability to cache...
     val expiration = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
     val fileUri = new URI((source \ "source" \ "file").as[String])
-    val secureUrl = S3Client.signUrl(Config.imageBucket, fileUri, expiration)
-    val secureThumbUrl = S3Client.signUrl(Config.thumbBucket, fileUri, expiration)
+    val secureUrl = S3Client.signUrl(Config.imageBucket, fileUri, image, expiration)
+    val secureThumbUrl = S3Client.signUrl(Config.thumbBucket, fileUri, image, expiration)
 
     val valid = ImageExtras.isValid(source \ "metadata")
 


### PR DESCRIPTION
Fixes issues that caused https://github.com/guardian/grid/pull/1716

The `content-disposition` header spec supports the UTF-8 character set, however not all browsers implement it, so keep the fallback.

Tested with files named `boring.jpg` and `éxãmplę üpłøåd.jpg` in Chrome and FF with expected results!