### PR TITLE
clearer "back to search" button

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -1,7 +1,7 @@
 <gr-top-bar>
     <gr-top-bar-nav>
         <a class="top-bar-item side-padded clickable" ui:sref="search" title="Back to search">
-            <gr-icon-label gr-icon="search">Search</gr-icon-label>
+            <gr-icon-label gr-icon="youtube_searched_for">Back to search</gr-icon-label>
         </a>
     </gr-top-bar-nav>
 


### PR DESCRIPTION
Guide requested the ability to be able to go back to a search within the embedded Grid (when used standalone, they use browser navigation).

I mentioned this button goes back to the search, which they were happy to hear! This PR makes it more obvious.

![screen shot 2016-02-05 at 12 34 42](https://cloud.githubusercontent.com/assets/836140/12846528/06e81a70-cc05-11e5-9de4-7dee82ed743f.jpeg)
