### PR TITLE
Nested Usage & Date constraint

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -26,7 +26,20 @@ object Mappings {
 
   val dynamicObj = Json.obj("type" -> "object", "dynamic" -> true)
 
-  def nonDynamicObj(obj: (String, JsValueWrapper)*) = Json.obj("type" -> "object", "dynamic" -> "strict", "properties" -> Json.obj(obj:_*))
+  val nestedType = Json.obj(
+    "type" -> "nested",
+    "include_in_parent" -> true
+  )
+
+  def nonDynamicObjWithAttrs(obj: (String, JsValueWrapper)*)(attrs: JsObject = Json.obj()): JsObject =
+    nonDynamicObj(obj:_*) ++ attrs
+
+  def nonDynamicObj(obj: (String, JsValueWrapper)*) =
+    Json.obj(
+      "type" -> "object",
+      "dynamic" -> "strict",
+      "properties" -> Json.obj(obj:_*)
+    )
 
   def nonAnalysedList(indexName: String) = Json.obj("type" -> "string", "index" -> "not_analyzed", "index_name" -> indexName)
 
@@ -105,10 +118,11 @@ object Mappings {
       "assets" -> assetMapping
     )
 
-  val actionDataMapping = nonDynamicObj(
-    "author" -> nonAnalyzedString,
-    "date" -> dateFormat
-  )
+  val actionDataMapping =
+    nonDynamicObj(
+      "author" -> nonAnalyzedString,
+      "date" -> dateFormat
+    )
 
   val collectionMapping = withIndexName("collection", nonDynamicObj(
     "path" -> nonAnalysedList("collectionPath"),
@@ -170,7 +184,7 @@ object Mappings {
     )
 
   val usagesMapping =
-    nonDynamicObj(
+    nonDynamicObjWithAttrs(
       "id"           -> nonAnalyzedString,
       "title"        -> sStemmerAnalysedString,
       "references"   -> usageReference,
@@ -182,7 +196,7 @@ object Mappings {
       "lastModified" -> dateFormat,
       "printUsageMetadata" -> printUsageMetadata,
       "digitalUsageMetadata" -> digitalUsageMetadata
-    )
+    )(nestedType)
 
   val imageMapping: String =
     Json.stringify(Json.obj(

--- a/media-api/app/lib/querysyntax/model.scala
+++ b/media-api/app/lib/querysyntax/model.scala
@@ -2,9 +2,11 @@ package lib.querysyntax
 
 import org.joda.time.DateTime
 
+
 sealed trait Condition
 final case class Negation(m: Match) extends Condition
 final case class Match(field: Field, value: Value) extends Condition
+final case class Nested(parentField: Field, field: Field, value: Value) extends Condition
 
 sealed trait Field
 case object AnyField extends Field
@@ -15,4 +17,5 @@ final case class MultipleField(names: List[String]) extends Field
 sealed trait Value
 final case class Words(string: String) extends Value
 final case class Phrase(string: String) extends Value
-final case class DateRange(start: DateTime, end: DateTime) extends Value
+final case class Date(date: DateTime) extends Value
+final case class DateRange(startDate: DateTime, endDate: DateTime) extends Value

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -88,17 +88,6 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
 
     describe("exact") {
 
-      // it("should match exact ISO datetime") {
-      //   Parser.run("date:2014-01-01T01:23:45Z") should be (List(
-      //     Match(SingleField("uploaded"),
-      //       DateRange(
-      //         new DateTime("2014-01-01T01:23:45Z"),
-      //         new DateTime("2014-01-01T01:23:45Z")
-      //       )
-      //     ))
-      //   )
-      // }
-
       it("should match year") {
         Parser.run("date:2014") should be (List(
           Match(uploadTimeField,
@@ -246,39 +235,35 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
     }
 
 
-    describe("range") {
+    describe("date constraint") {
 
-    //   it("should match date range with --") {
-    //     Parser.run("date:2012--2014") should be (List(
-    //       Match(uploadTimeField,
-    //         DateRange(
-    //           new DateTime("2012-01-01T00:00:00.000Z"),
-    //           new DateTime("2014-12-31T23:59:59.999Z")
-    //         )
-    //       ))
-    //     )
-    //   }
+      it("should match date constraint") {
+        Parser.run("<date:2012-01-01") should be (List(
+          Match(SingleField("uploadTime"),
+            DateRange(
+              new DateTime("1970-01-01T01:00:00.000+01:00"),
+              new DateTime("2012-01-01T00:00:00.000Z")
+            )
+          ))
+        )
+      }
 
-    //   it("should match date range with 'to'") {
-    //     Parser.run("date:2012.to.2014") should be (List(
-    //       Match(uploadTimeField,
-    //         DateRange(
-    //           new DateTime("2012-01-01T00:00:00.000Z"),
-    //           new DateTime("2014-12-31T23:59:59.999Z")
-    //         )
-    //       ))
-    //     )
-    //   }
+      describe("nested") {
 
-      // TODO: date:12:13 to 12:18 (today)
-      // TODO: date:before.1.january.2012
-      // TODO: date:after.1.january.2012
-      // TODO: date:<1.january.2012
-      // TODO: date:>1.january.2012
+        it("should match date constraint with parent field") {
+          Parser.run("usage@<added:2012-01-01") should be (List(
+            Nested(SingleField("usage"), SingleField("dateAdded"),
+              DateRange(
+                new DateTime("1970-01-01T01:00:00.000+01:00"),
+                new DateTime("2012-01-01T00:00:00.000Z")
+              )
+            ))
+          )
+        }
+
+      }
 
     }
-
-
 
     describe("shortcut and facets") {
 


### PR DESCRIPTION
In order to allow us to query pending usage by supplier, we need to perform nested queries in Elasticsearch on Usage.

This PR allows queries like: `usages@status:pending usages@>added:2014-01-28 supplier:"Getty Images"`

To result in ES query like:

```json
{
  "bool" : {
    "must" : [ {
      "match" : {
        "usageRights.supplier" : {
          "query" : "Getty Images",
          "type" : "phrase"
        }
      }
    }, {
      "nested" : {
        "query" : {
          "bool" : {
            "must" : [ {
              "match" : {
                "usages.status" : {
                  "query" : "pending",
                  "type" : "boolean",
                  "operator" : "AND"
                }
              }
            }, {
              "range" : {
                "dateAdded" : {
                  "from" : "1970-01-01T01:00:00.000+01:00",
                  "to" : "2016-01-28T00:00:00.000Z",
                  "include_lower" : true,
                  "include_upper" : true
                }
              }
            } ]
          }
        },
        "path" : "usages"
      }
    } ]
  }
}
```

Depends: https://github.com/guardian/grid/pull/1760