### PR TITLE
Exclude PA from ftp-loader, ingest from S3 only

### DIFF
--- a/ftp-watcher/app/lib/Config.scala
+++ b/ftp-watcher/app/lib/Config.scala
@@ -20,7 +20,7 @@ object Config extends CommonPlayAppConfig {
   // As we move to using the S3 Watcher, we'll need to exclude paths
   val possibleFtpPaths: Set[String] =
     Set("aapimages", "ap", "email", "epa", "getty", "pa", "priorityftp", "reuters", "stingray")
-  val excludedFtpPaths: Set[String] = Set("stingray")
+  val excludedFtpPaths: Set[String] = Set("stingray", "pa")
   val ftpPaths: List[String] = (possibleFtpPaths -- excludedFtpPaths).toList
 
   val imageLoaderUri: String = properties("loader.uri")


### PR DESCRIPTION
Exclude PA from ftp-loader. Just a small step toward switching off all suppliers and the ftp-loader service entirely.

This should only be merged once Adrian has added all suppliers to the S3 ingestion.