### PR TITLE
Add new auth service to take over Panda-issuing role from kahuna

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -9,3 +9,4 @@ metadata-editor: sbt "project metadata-editor" "~ run 9007"
 imgops: cd imgops; ./dev-start.sh
 usage: sbt "project usage" "~ run 9009"
 collections: sbt "project collections" "~ run 9010"
+auth: sbt "project auth" "~ run 9011"

--- a/auth/app/Global.scala
+++ b/auth/app/Global.scala
@@ -1,0 +1,23 @@
+import scala.collection.JavaConverters._
+import com.typesafe.config.ConfigValue
+
+import play.api.{Logger, Application, GlobalSettings}
+import play.api.mvc.WithFilters
+import play.filters.gzip.GzipFilter
+
+import lib.Config
+
+import com.gu.mediaservice.lib.play.RequestLoggingFilter
+
+
+object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
+
+  override def beforeStart(app: Application) {
+
+    val allAppConfig: Seq[(String, ConfigValue)] =
+      Config.appConfig.underlying.entrySet.asScala.toSeq.map(entry => (entry.getKey, entry.getValue))
+
+    Logger.info("Play app config: \n" + allAppConfig.mkString("\n"))
+  }
+
+}

--- a/auth/app/controllers/Application.scala
+++ b/auth/app/controllers/Application.scala
@@ -1,0 +1,97 @@
+package controllers
+
+
+import java.net.URI
+
+import lib.Config
+import play.api.libs.json.Json
+import play.api.mvc.{Action, Controller}
+import com.gu.mediaservice.lib.auth.{ArgoErrorResponses, PanDomainAuthActions}
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.argo.model.Link
+import com.gu.mediaservice.lib.auth._
+import com.gu.pandomainauth.service.GoogleAuthException
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Success, Try, Failure}
+
+object Application extends Controller
+  with PanDomainAuthActions
+  with ArgoHelpers
+  with ArgoErrorResponses {
+
+  override lazy val authCallbackBaseUri = Config.rootUri
+  override lazy val loginUriTemplate    = Config.loginUriTemplate
+
+  import Config.{domainRoot, mediaApiUri, rootUri}
+
+  val Authenticated = new PandaAuthenticated(loginUriTemplate, authCallbackBaseUri)
+
+  val indexResponse = {
+    val indexData = Map("description" -> "This is the Auth API")
+    val indexLinks = List(
+      Link("root",          mediaApiUri),
+      Link("ui:logout",     s"$rootUri/logout")
+    )
+    respond(indexData, indexLinks)
+  }
+
+  def index = Authenticated { indexResponse }
+
+  def session = Authenticated { request =>
+    request.user match {
+      case PandaUser(email, firstName, lastName, avatarUrl) =>
+        respond(
+          Json.obj("user" ->
+            Json.obj(
+              "name"      -> s"$firstName $lastName",
+              "firstName" -> firstName,
+              "lastName"  -> lastName,
+              "email"     -> email,
+              "avatarUrl" -> avatarUrl
+            )
+          )
+        )
+      case _ =>
+        // Should never get in here
+        respondError(BadRequest, "non-user-session", "Unexpected non-user session")
+    }
+  }
+
+
+  def isOwnDomainAndSecure(uri: URI): Boolean = {
+    uri.getHost.endsWith(domainRoot) && uri.getScheme == "https"
+  }
+  def isValidDomain(inputUri: String): Boolean = {
+    Try(URI.create(inputUri)).filter(isOwnDomainAndSecure).isSuccess
+  }
+
+
+  // Trigger the auth cycle
+  // If a redirectUri is provided, redirect the browser there once auth'd,
+  // else return a dummy page (e.g. for automatically re-auth'ing in the background)
+  // FIXME: validate redirectUri before doing the auth
+  def doLogin(redirectUri: Option[String] = None) = AuthAction { req =>
+    redirectUri map {
+      case uri if isValidDomain(uri) => Redirect(uri)
+      case _ => Ok("logged in (not redirecting to external redirectUri)")
+    } getOrElse Ok("logged in")
+  }
+
+  def oauthCallback = Action.async { implicit request =>
+    // We use the `Try` here as the `GoogleAuthException` are thrown before we
+    // get to the asynchronicity of the `Future` it returns.
+    // We then have to flatten the Future[Future[T]]. Fiddly...
+    Future.fromTry(Try(processGoogleCallback)).flatMap(successF => successF).recover {
+      // This is when session session args are missing
+      case e: GoogleAuthException =>
+        respondError(BadRequest, "google-auth-exception", e.getMessage, loginLinks)
+    }
+  }
+
+  def logout = Action { implicit request =>
+    processLogout
+  }
+
+}

--- a/auth/app/lib/Config.scala
+++ b/auth/app/lib/Config.scala
@@ -13,9 +13,6 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
   val rootUri: String = services.authBaseUri
   val mediaApiUri: String = services.apiBaseUri
 
-  val awsCredentials: AWSCredentials =
-    new BasicAWSCredentials(properties("aws.id"), properties("aws.secret"))
-
   private lazy val corsAllowedOrigins = properties.getOrElse("cors.allowed.origins", "").split(",").toList
   lazy val corsAllAllowedOrigins: List[String] =
     services.kahunaBaseUri :: corsAllowedOrigins

--- a/auth/app/lib/Config.scala
+++ b/auth/app/lib/Config.scala
@@ -1,0 +1,22 @@
+package lib
+
+import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppConfig, CommonPlayAppProperties}
+import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
+
+object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
+
+  val appName = "auth"
+
+  val properties = Properties.fromPath("/etc/gu/auth.properties")
+
+  val loginUriTemplate: String = services.loginUriTemplate
+  val rootUri: String = services.authBaseUri
+  val mediaApiUri: String = services.apiBaseUri
+
+  val awsCredentials: AWSCredentials =
+    new BasicAWSCredentials(properties("aws.id"), properties("aws.secret"))
+
+  private lazy val corsAllowedOrigins = properties.getOrElse("cors.allowed.origins", "").split(",").toList
+  lazy val corsAllAllowedOrigins: List[String] =
+    services.kahunaBaseUri :: corsAllowedOrigins
+}

--- a/auth/app/lib/CorsFilter.scala
+++ b/auth/app/lib/CorsFilter.scala
@@ -1,0 +1,34 @@
+import java.net.URI
+
+import scala.util.Try
+
+import play.api.mvc._
+import lib.Config
+
+// TODO: share with the copy in other services...
+
+object CorsFilter extends Filter {
+  import scala.concurrent._
+  import ExecutionContext.Implicits.global
+
+  def isLocal(uri: String): Boolean =
+    Try(URI.create(uri)).toOption.exists(_.getHost == "localhost")
+
+  def isAllowed(origin: String) =
+    Config.corsAllAllowedOrigins.contains(origin) || isLocal(origin)
+
+  def apply(f: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
+
+    // Add CORS headers iff allowed origin
+    request.headers.get("Origin") match {
+      case Some(origin) if isAllowed(origin) =>
+        f(request).map { _.withHeaders(
+          "Access-Control-Allow-Credentials" -> "true",
+          "Access-Control-Allow-Origin" -> origin
+        ) }
+      case _ =>
+        f(request)
+    }
+  }
+
+}

--- a/auth/conf/application.conf
+++ b/auth/conf/application.conf
@@ -1,0 +1,19 @@
+# Note: application.secret unset in DEV, injected in TEST/PROD
+
+application.langs="en"
+
+session.httpOnly=false
+session.secure=true
+
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
+
+# Root logger:
+logger.root=INFO
+
+# Logger used by the framework:
+logger.play=INFO
+
+# Logger provided to your application:
+logger.application=DEBUG

--- a/auth/conf/auth.conf
+++ b/auth/conf/auth.conf
@@ -1,0 +1,26 @@
+env APP=auth
+
+env USER=media-service
+env USER_HOME=/home/media-service
+env JAR=/home/media-service/app.jar
+
+env JAVA_OPTS="-Dfile.encoding=UTF-8 -Xmx300m -XX:MaxPermSize=64m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:gc.log"
+
+env LOGFILE=/home/media-service/logs/stdout.log
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+# NB: setuid is only supported on recent versions of upstart - i.e.
+#  on ubuntu not on amazon linux
+
+setuid media-service
+
+chdir /home/media-service
+
+# automatically restart if the process dies
+# respawn
+
+script
+  /bin/bash /home/media-service/start.sh
+end script

--- a/auth/conf/deploy.json
+++ b/auth/conf/deploy.json
@@ -1,0 +1,24 @@
+{
+    "defaultStacks": ["media-service"],
+    "packages": {
+        "auth": {
+            "type": "autoscaling",
+            "data": {
+                "port": 9000,
+                "bucket": "media-service-dist",
+                "publicReadAcl": false
+            }
+        }
+    },
+    "recipes": {
+        "default": {
+            "depends": ["artifactUploadOnly", "deployOnly"]
+        },
+        "deployOnly": {
+            "actionsBeforeApp": ["auth.deploy"]
+        },
+        "artifactUploadOnly": {
+            "actionsBeforeApp": ["auth.uploadArtifacts"]
+        }
+    }
+}

--- a/auth/conf/routes
+++ b/auth/conf/routes
@@ -1,0 +1,17 @@
+# Routes
+# This file defines all application routes (Higher priority routes first)
+# ~~~~
+
+GET     /                           controllers.Application.index
+
+GET     /login                      controllers.Application.doLogin(redirectUri: Option[String])
+GET     /oauthCallback              controllers.Application.oauthCallback
+GET     /logout                     controllers.Application.logout
+GET     /session                    controllers.Application.session
+
+# Management
+GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
+GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+
+# Shoo robots away
+GET     /robots.txt                 controllers.Robots.disallowAll

--- a/auth/conf/start.sh
+++ b/auth/conf/start.sh
@@ -1,0 +1,13 @@
+DOMAIN_ROOT=`cat /etc/gu/domain-root`
+SESSION_DOMAIN=".$DOMAIN_ROOT"
+
+APP_SECRET=`cat /etc/gu/play-application-secret`
+
+# session.domain and application.secret are read by Play
+APP_OPTIONS="-Dsession.domain=$SESSION_DOMAIN -Dapplication.secret=$APP_SECRET"
+
+export JAVA_OPTS="$JAVA_OPTS $APP_OPTIONS"
+
+CMD="$USER_HOME/bin/$APP"
+echo "$CMD" > $USER_HOME/logs/cmd.txt
+$CMD > $LOGFILE 2>&1

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -15,6 +15,7 @@ class Services(domainRoot: String, ssl: Boolean) {
   val imgopsHost: String = s"$appName-imgops.$parentDomain"
   val usageHost: String = s"$appName-usage.$parentDomain"
   val collectionsHost: String = s"$appName-collections.$parentDomain"
+  val authHost: String     = s"$appName-auth.$parentDomain"
 
 
   val kahunaBaseUri      = baseUri(kahunaHost)
@@ -25,6 +26,7 @@ class Services(domainRoot: String, ssl: Boolean) {
   val imgopsBaseUri      = baseUri(imgopsHost)
   val usageBaseUri       = baseUri(usageHost)
   val collectionsBaseUri = baseUri(collectionsHost)
+  val authBaseUri        = baseUri(authHost)
 
 
   val loginUriTemplate = s"$kahunaBaseUri/login{?redirectUri}"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -12,8 +12,8 @@ class Services(domainRoot: String, ssl: Boolean) {
   val loaderHost: String   = s"loader.$domainRoot"
   val cropperHost: String  = s"cropper.$domainRoot"
   val metadataHost: String = s"$appName-metadata.$parentDomain"
-  val imgopsHost: String = s"$appName-imgops.$parentDomain"
-  val usageHost: String = s"$appName-usage.$parentDomain"
+  val imgopsHost: String   = s"$appName-imgops.$parentDomain"
+  val usageHost: String    = s"$appName-usage.$parentDomain"
   val collectionsHost: String = s"$appName-collections.$parentDomain"
   val authHost: String     = s"$appName-auth.$parentDomain"
 

--- a/docker/configs/generators/generators/resources/templates/dot-properties/auth.properties.template
+++ b/docker/configs/generators/generators/resources/templates/dot-properties/auth.properties.template
@@ -1,0 +1,3 @@
+domain.root={{domain_root}}
+aws.id={{AwsId}}
+aws.secret={{AwsSecret}}

--- a/docker/configs/generators/generators/resources/templates/dot-properties/auth.properties.template
+++ b/docker/configs/generators/generators/resources/templates/dot-properties/auth.properties.template
@@ -1,3 +1,4 @@
 domain.root={{domain_root}}
 aws.id={{AwsId}}
 aws.secret={{AwsSecret}}
+cors.allowed.origins={{cors}}

--- a/docker/configs/generators/generators/resources/templates/dot-properties/auth.properties.template
+++ b/docker/configs/generators/generators/resources/templates/dot-properties/auth.properties.template
@@ -1,4 +1,2 @@
 domain.root={{domain_root}}
-aws.id={{AwsId}}
-aws.secret={{AwsSecret}}
 cors.allowed.origins={{cors}}

--- a/nginx-mappings.yml
+++ b/nginx-mappings.yml
@@ -17,3 +17,5 @@ mappings:
     port: 9009
   - prefix: media-collections
     port: 9010
+  - prefix: media-auth
+    port: 9011

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -40,6 +40,9 @@ object Build extends Build {
   val kahuna = playProject("kahuna")
     .libraryDependencies(playWsDeps)
 
+  val auth = playProject("auth")
+    .libraryDependencies(playWsDeps)
+
   val mediaApi = playProject("media-api")
     .libraryDependencies(elasticsearchDeps ++ awsDeps ++
       scalazDeps ++ parsingDeps ++ uriTemplateDeps)

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,8 @@ x-terminal-emulator -T image-loader  -e "sbt 'project image-loader' 'run 9003'" 
 x-terminal-emulator -T ftp-loader    -e "sbt 'project ftp-watcher'  'run 9004'" &
 x-terminal-emulator -T kahuna        -e "sbt 'project kahuna'       'run 9005'" &
 x-terminal-emulator -T cropper       -e "sbt 'project cropper'      'run 9006'" &
+x-terminal-emulator -T metadata-editor -e "sbt 'project metadata-editor' 'run 9007'" &
 x-terminal-emulator -T usage         -e "sbt 'project usage'        'run 9009'" &
 x-terminal-emulator -T collections   -e "sbt 'project collections'  'run 9010'" &
-x-terminal-emulator -T metadata-editor -e "sbt 'project metadata-editor' 'run 9007'" &
+x-terminal-emulator -T auth          -e "sbt 'project auth'         'run 9011'" &
 x-terminal-emulator -T imgops        -e '/bin/bash -c "cd imgops; ./dev-start.sh"' &

--- a/the_pingler.sh
+++ b/the_pingler.sh
@@ -11,8 +11,9 @@ CROPPER="http://localhost:9006/management/healthcheck"
 METADATA="http://localhost:9007/management/healthcheck"
 USAGE="http://localhost:9009/management/healthcheck"
 COLLECTIONS="http://localhost:9010/"
+AUTH="http://localhost:9011/management/healthcheck"
 
-lu="$IMAGE_LOADER $CROPPER $METADATA $THRALL $FTP_WATCHER $KAHUNA $API $USAGE"
+lu="$IMAGE_LOADER $CROPPER $METADATA $THRALL $FTP_WATCHER $KAHUNA $API $USAGE $AUTH"
 
 echo "You have started the Pingler!"
 echo


### PR DESCRIPTION
This PR just adds a new auth microservice. It's not being used yet, and the next stage will be to change kahuna to auth via the auth service instead of kahuna.

Needs to be built and artifacted before https://github.com/guardian/grid-infra/pull/118 (CF change) can be applied.