### PR TITLE
Use auth service instead of kahuna Panda

### DIFF
--- a/auth/app/controllers/Application.scala
+++ b/auth/app/controllers/Application.scala
@@ -31,6 +31,8 @@ object Application extends Controller
   val indexResponse = {
     val indexData = Map("description" -> "This is the Auth API")
     val indexLinks = List(
+      Link("login",         loginUriTemplate),
+      Link("session",       s"$rootUri/session"),
       Link("root",          mediaApiUri),
       Link("ui:logout",     s"$rootUri/logout")
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -29,7 +29,7 @@ class Services(domainRoot: String, ssl: Boolean) {
   val authBaseUri        = baseUri(authHost)
 
 
-  val loginUriTemplate = s"$kahunaBaseUri/login{?redirectUri}"
+  val loginUriTemplate = s"$authBaseUri/login{?redirectUri}"
 
   def baseUri(host: String) = {
     val protocol = if (ssl) "https" else "http"

--- a/kahuna/app/controllers/Application.scala
+++ b/kahuna/app/controllers/Application.scala
@@ -6,10 +6,19 @@ import lib.Config
 object Application extends Controller {
 
   def index(ignored: String) = Action { req =>
+    val okPath = routes.Application.ok.url
+    // If the auth is successful, we redirect to the kahuna domain so the iframe
+    // is on the same domain and can be read by the JS
+    val returnUri = Config.rootUri + okPath
     Ok(views.html.main(
       Config.mediaApiUri,
+      s"${Config.authUri}/login?redirectUri=$returnUri",
       Config.watUri,
       Config.sentryDsn))
+  }
+
+  def ok = Action { implicit request =>
+    Ok("ok")
   }
 
   // FIXME: Hack to serve asset under the erroneous URL it is requested at

--- a/kahuna/app/lib/Config.scala
+++ b/kahuna/app/lib/Config.scala
@@ -11,6 +11,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val rootUri: String = services.kahunaBaseUri
   val mediaApiUri: String = services.apiBaseUri
+  val authUri: String = services.authBaseUri
 
   val loginUriTemplate = services.loginUriTemplate
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -1,4 +1,5 @@
 @(mediaApiUri: String,
+  reauthUri: String,
   watUri: Option[String],
   sentryDsn: Option[String])
 <!DOCTYPE html>
@@ -12,6 +13,7 @@
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/grid-favicon-32.png")"/>
     <link rel="assets" href="@routes.Assets.at("")"/>
     <link rel="media-api-uri" href="@mediaApiUri" />
+    <link rel="reauth-uri" href="@reauthUri" />
 @watUri.map { uri =>
     <link rel="wat" href="@uri" />
 }

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -17,6 +17,8 @@ GET     /login                      controllers.Panda.doLogin(redirectUri: Optio
 GET     /oauthCallback              controllers.Panda.oauthCallback
 GET     /logout                     controllers.Panda.logout
 GET     /session                    controllers.Panda.session
+# Empty page to return to the same domain as the app
+GET     /ok                         controllers.Application.ok
 
 # Management
 GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -37,6 +37,7 @@ import {tooltip} from './components/gr-tooltip/gr-tooltip';
 
 // TODO: move to an async config to remove deps on play
 var apiLink = document.querySelector('link[rel="media-api-uri"]');
+var reauthLink = document.querySelector('link[rel="reauth-uri"]');
 var sentryDsnLink = document.querySelector('link[rel="sentry-dsn"]');
 var assetsRootLink = document.querySelector('link[rel="assets"]');
 
@@ -46,7 +47,8 @@ var config = {
     assetsRoot: assetsRootLink && assetsRootLink.getAttribute('href'),
 
     // Static config
-    'pandular.reAuthUri': '/login',
+    // TODO: use link in 4xx response to avoid having to hardcode in HTML page
+    'pandular.reAuthUri': reauthLink && reauthLink.getAttribute('href'),
 
     vndMimeTypes: new Map([
         ['gridImageData',  'application/vnd.mediaservice.image+json'],

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -39,7 +39,7 @@ import com.gu.mediaservice.model._
 
 object MediaApi extends Controller with ArgoHelpers {
 
-  import Config.{rootUri, cropperUri, loaderUri, metadataUri, kahunaUri, loginUriTemplate, collectionsUri}
+  import Config.{rootUri, cropperUri, loaderUri, metadataUri, authUri, loginUriTemplate, collectionsUri}
 
   val Authenticated = Authed.action
   val permissionStore = Authed.permissionStore
@@ -75,7 +75,7 @@ object MediaApi extends Controller with ArgoHelpers {
       Link("cropper",         cropperUri),
       Link("loader",          loaderUri),
       Link("edits",           metadataUri),
-      Link("session",         s"$kahunaUri/session"),
+      Link("session",         s"$authUri/session"),
       Link("witness-report",  s"https://n0ticeapis.com/2/report/{id}"),
       Link("collections",     collectionsUri),
       suggestedLabelsLink

--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -52,6 +52,7 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
   lazy val metadataUri: String = services.metadataBaseUri
   lazy val imgopsUri: String = services.imgopsBaseUri
   lazy val usageUri: String = services.usageBaseUri
+  lazy val authUri: String = services.authBaseUri
   lazy val loginUriTemplate: String = services.loginUriTemplate
   lazy val collectionsUri: String = services.collectionsBaseUri
 


### PR DESCRIPTION
Switch to use the new `auth` service instead of `kahuna`'s Panda endpoints to (re)auth in the kahuna web app.

Release order:
1. auth
2. media-api
3. kahuna