### PR TITLE
Don't ingest Getty from ftp-watcher, now S3 only

### DIFF
--- a/ftp-watcher/app/lib/Config.scala
+++ b/ftp-watcher/app/lib/Config.scala
@@ -20,7 +20,7 @@ object Config extends CommonPlayAppConfig {
   // As we move to using the S3 Watcher, we'll need to exclude paths
   val possibleFtpPaths: Set[String] =
     Set("aapimages", "ap", "email", "epa", "getty", "pa", "priorityftp", "reuters", "stingray")
-  val excludedFtpPaths: Set[String] = Set("stingray", "pa")
+  val excludedFtpPaths: Set[String] = Set("stingray", "pa", "getty")
   val ftpPaths: List[String] = (possibleFtpPaths -- excludedFtpPaths).toList
 
   val imageLoaderUri: String = properties("loader.uri")


### PR DESCRIPTION
Once the PA change (#1727) has bedded in, we can ship this to get Getty from S3 only.