### PR TITLE
Improved performance (avoid big serialisation, more one-time bindings and ng:if)

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -13,7 +13,7 @@
         <button type="button"
                 class="node__toggler clickable"
                 ng:click="ctrl.showChildren = !ctrl.showChildren"
-                ng:show="node.data.children.length > 0">
+                ng:if="node.data.children.length > 0">
 
             <gr-icon ng:show="ctrl.showChildren">expand_more</gr-icon>
             <gr-icon ng:hide="ctrl.showChildren">chevron_right</gr-icon>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -4,7 +4,7 @@
          gr:drop-into-collection="node.data.fullPath">
 
         <div class="node__marker"
-             style="background: {{node.data.cssColour}}"></div>
+             style="background: {{:: node.data.cssColour}}"></div>
 
         <div class="node__spacer" ng:if="node.data.children.length === 0">
             <gr-icon></gr-icon>
@@ -21,7 +21,7 @@
 
         <a class="node__name flex-spacer"
            ui:sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId)})">
-            {{node.data.data.description}}
+            {{:: node.data.data.description}}
         </a>
 
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -189,7 +189,7 @@
             full metadata
         </button>
 
-        <div ng:show="metadataExpanded" class="metadata metadata-line image-info__group--dl">
+        <div ng:if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
             <dl ng:repeat="(key, value) in ctrl.metadata" ng:if="ctrl.isUsefulMetadata(key)" class="metadata__body image-info__group--dl">
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -5,9 +5,9 @@
             ng:if="!ctrl.state.hidden"
             ng:click="ctrl.hidePanel()"
             ng:class="{'bg-light': !ctrl.state.hidden}"
-            gr:tooltip="Hide {{ctrl.name}} panel"
-            gr:tooltip-position="{{ctrl.toolTipPosition()}}"
-            gr:track-click="{{ctrl.trackingName}}"
+            gr:tooltip="Hide {{:: ctrl.name}} panel"
+            gr:tooltip-position="{{:: ctrl.toolTipPosition()}}"
+            gr:track-click="{{:: ctrl.trackingName}}"
             gr:track-click-data="ctrl.trackingData('Hide panel')">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
@@ -16,9 +16,9 @@
             type="button"
             ng:if="ctrl.state.hidden"
             ng:click="ctrl.showPanel()"
-            gr:tooltip="Show {{ctrl.name}} panel"
-            gr:tooltip-position="{{ctrl.toolTipPosition()}}"
-            gr:track-click="{{ctrl.trackingName}}"
+            gr:tooltip="Show {{:: ctrl.name}} panel"
+            gr:tooltip-position="{{:: ctrl.toolTipPosition()}}"
+            gr:track-click="{{:: ctrl.trackingName}}"
             gr:track-click-data="ctrl.trackingData('Show panel')">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
@@ -28,7 +28,7 @@
                 type="button"
                 ng:if="!ctrl.state.locked"
                 ng:click="ctrl.lockPanel()"
-                gr:track-click="{{ctrl.trackingName}}"
+                gr:track-click="{{:: ctrl.trackingName}}"
                 gr:track-click-data="ctrl.trackingData('Lock panel')">
             <gr-icon>lock_open</gr-icon>
         </button>
@@ -37,7 +37,7 @@
                 ng:if="ctrl.state.locked"
                 ng:click="ctrl.unlockPanel()"
                 ng:class="{'bg-light': ctrl.state.locked}"
-                gr:track-click="{{ctrl.trackingName}}"
+                gr:track-click="{{:: ctrl.trackingName}}"
                 gr:track-click-data="ctrl.trackingData('Unlock panel')">
             <gr-icon>lock</gr-icon>
         </button>

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -6,9 +6,9 @@
             gr:track-click-data="{ 'Action': 'Show Hide' }">
         <gr-icon>event</gr-icon>
         <div class="gu-date-range__display--value">
-            <span ng:show="ctrl.guDisplayStartDate !== ctrl.guAnyTimeText && !ctrl.guDisplayEndDate">from </span>
+            <span ng:if="ctrl.guDisplayStartDate !== ctrl.guAnyTimeText && !ctrl.guDisplayEndDate">from </span>
             {{ctrl.guDisplayStartDate}}
-            <span ng-show="ctrl.guDisplayEndDate">to {{ctrl.guDisplayEndDate}}</span>
+            <span ng:if="ctrl.guDisplayEndDate">to {{ctrl.guDisplayEndDate}}</span>
         </div>
 
         <div class="gu-date-range__display__icon gu-date-range__display__icon__toggle">

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -12,7 +12,7 @@
 
                 <img class="result-editor__img"
                      alt="original image thumbnail"
-                     ng:src="{{ctrl.image.data.thumbnail | assetFile}}"
+                     ng:src="{{:: ctrl.image.data.thumbnail | assetFile}}"
                      gr:image-fade-on-load
                  />
             </a>
@@ -20,7 +20,7 @@
             <img class="result-editor__img"
                  alt="original image thumbnail"
                  ng:switch-default
-                 ng:src="{{ctrl.image.data.thumbnail | assetFile}}"
+                 ng:src="{{:: ctrl.image.data.thumbnail | assetFile}}"
                  gr:image-fade-on-load
              />
 
@@ -30,7 +30,7 @@
                     <a class="image-action image-action--first"
                        target="_blank"
                        title="Pop out"
-                       ng:href="/images/{{ctrl.image.data.id}}">
+                       ng:href="/images/{{:: ctrl.image.data.id}}">
                         <gr-icon>open_in_new</gr-icon>
                     </a>
                 </li>
@@ -138,9 +138,9 @@
                 ></ui-labeller>
             </div>
         </div>
-        <div class="result-editor__field-container" ng:if="ctrl.image.data.uploadInfo.filename">
+        <div class="result-editor__field-container" ng:if=":: ctrl.image.data.uploadInfo.filename">
             <div class="result-editor__field-label text-small">File name</div>
-            <div class="result-editor__field-value">{{ctrl.image.data.uploadInfo.filename}}</div>
+            <div class="result-editor__field-value">{{:: ctrl.image.data.uploadInfo.filename}}</div>
         </div>
 
     </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -8,7 +8,7 @@
             <a class="result-editor__img-link"
                ng:switch-when="true"
                ui:sref="image({imageId: ctrl.image.data.id})"
-               ui:drag-data="{{ctrl.image | asImageDragData}}">
+               ui:drag-data="ctrl.image | asImageDragData">
 
                 <img class="result-editor__img"
                      alt="original image thumbnail"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -74,8 +74,8 @@
                        ng:init="extremeAssets = (crop | getExtremeAssets)"
                        ng:click="ctrl.cropSelected(crop)"
                        ui:sref="{ crop: crop.id }"
-                       ui:drag-data="{{ctrl.image | asImageAndCropsDragData:crop}}"
-                       ui:drag-image="{{extremeAssets.smallest | assetFile}}">
+                       ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                       ui:drag-image="extremeAssets.smallest | assetFile">
                         <img class="image-crop__image"
                              alt="full frame image thumbnail"
                              ng:src="{{ extremeAssets.smallest | assetFile }}" />
@@ -102,8 +102,8 @@
                                ng:init="extremeAssets = (crop | getExtremeAssets)"
                                ng:click="ctrl.cropSelected(crop)"
                                ui:sref="{crop: crop.id}"
-                               ui:drag-data="{{ctrl.image | asImageAndCropsDragData:crop}}"
-                               ui:drag-image="{{extremeAssets.smallest | assetFile}}">
+                               ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                               ui:drag-image="extremeAssets.smallest | assetFile">
 
                                 <img class="image-crop__image"
                                      alt="cropped image thumbnail"
@@ -193,7 +193,7 @@
                  grid:track-image-location="original"
                  grid:track-image-loadtime
                  gr:image-fade-on-load
-                 ui:drag-data="{{ctrl.image | asImageDragData}}" />
+                 ui:drag-data="ctrl.image | asImageDragData" />
         </div>
 
 
@@ -203,8 +203,8 @@
                class="easel__image-container"
                ng:init="extremeAssets = (ctrl.crop | getExtremeAssets)"
                ui:sref="{crop: ctrl.cropKey}"
-               ui:drag-data="{{ctrl.image | asImageAndCropsDragData:ctrl.crop}}"
-               ui:drag-image="{{extremeAssets.smallest | assetFile}}">
+               ui:drag-data="ctrl.image | asImageAndCropsDragData:ctrl.crop"
+               ui:drag-image="extremeAssets.smallest | assetFile">
                 <!-- TODO: Add tracking to crop -->
                 <img class="easel__image"
                      alt="cropped image"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -12,7 +12,7 @@
         </gr-delete-image>
 
         <span class="top-bar-item">
-            <a ng:href="{{ ctrl.image.data.source | assetFile }}"
+            <a ng:href="{{:: ctrl.image.data.source | assetFile }}"
                class="side-padded clickable inner-clickable"
                download
                target="_blank">
@@ -22,7 +22,7 @@
                     ng:click="showExpandedDownload = !showExpandedDownload">
                 <span>▾</span>
                 <a ng:if="showExpandedDownload"
-                   ng:href="{{ ctrl.lowResImageUri }}"
+                   ng:href="{{:: ctrl.lowResImageUri }}"
                    class="drop-menu__items drop-menu__items--nopad"
                    download
                    target="_blank">
@@ -45,7 +45,7 @@
     <div class="image-info">
         <div class="image-info__group">
             <dl>
-                <dt class="image-info__heading">Original <span class="image-info__file-size"> {{ctrl.image.data.source.size | asFileSize}}</span></dt>
+                <dt class="image-info__heading">Original <span class="image-info__file-size"> {{:: ctrl.image.data.source.size | asFileSize}}</span></dt>
                     <dd class="image-info__heading--crops">
                         <div class="image-crop"
                              ng:class="{'image-crop--selected': !ctrl.crop}">
@@ -53,10 +53,10 @@
                                 ui:sref="{ crop: null }">
                                 <img class="image-crop__image"
                                      alt="original image thumbnail"
-                                     ng:src="{{ ctrl.image.data.thumbnail | assetFile }}" />
+                                     ng:src="{{:: ctrl.image.data.thumbnail | assetFile }}" />
                                 <div class="image-crop__aspect-ratio"
                                     ng:class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
-                                    {{ctrl.image.data.source.dimensions.width}} &times; {{ctrl.image.data.source.dimensions.height}}
+                                    {{::ctrl.image.data.source.dimensions.width}} &times; {{::ctrl.image.data.source.dimensions.height}}
                                 </div>
                             </a>
                         </div>
@@ -78,13 +78,13 @@
                        ui:drag-image="extremeAssets.smallest | assetFile">
                         <img class="image-crop__image"
                              alt="full frame image thumbnail"
-                             ng:src="{{ extremeAssets.smallest | assetFile }}" />
+                             ng:src="{{:: extremeAssets.smallest | assetFile }}" />
 
                         <div class="flex-container image-crop__info image-crop__more-info"
                              ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
-                            {{crop.specification.bounds.width}} &times; {{crop.specification.bounds.height}}
+                            {{:: crop.specification.bounds.width}} &times; {{:: crop.specification.bounds.height}}
                             <span class="flex-spacer"></span>
-                            <span class="image-crop__creator" title="Cropped by {{crop.author}} at {{crop.date | date:'medium'}}">{{crop.author | getInitials}}</span>
+                            <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
                         </div>
                     </a>
                 </div>
@@ -107,19 +107,19 @@
 
                                 <img class="image-crop__image"
                                      alt="cropped image thumbnail"
-                                     ng:src="{{extremeAssets.smallest | assetFile}}" />
+                                     ng:src="{{:: extremeAssets.smallest | assetFile}}" />
                                 <div class="image-crop__info"
                                     ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
                                     <div class="flex-container">
-                                        {{crop.specification.aspectRatio | asAspectRatioWord}}
+                                        {{:: crop.specification.aspectRatio | asAspectRatioWord}}
                                         <span class="flex-spacer"></span>
-                                        <span ng:if="crop.specification.aspectRatio">({{crop.specification.aspectRatio}})</span>
+                                        <span ng:if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
                                     </div>
 
                                     <div class="flex-container image-crop__more-info">
-                                        {{crop.specification.bounds.width}} &times; {{crop.specification.bounds.height}}
+                                        {{:: crop.specification.bounds.width}} &times; {{:: crop.specification.bounds.height}}
                                         <span class="flex-spacer"></span>
-                                        <span class="image-crop__creator" title="Cropped by {{crop.author}} at {{crop.date | date:'medium'}}">{{crop.author | getInitials}}</span>
+                                        <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
                                     </div>
                                 </div>
                             </a>
@@ -188,7 +188,7 @@
         <div class="easel__canvas" ng:if="!ctrl.crop">
             <img class="easel__image"
                  alt="preview of original image"
-                 ng:src="{{ctrl.optimisedImageUri}}"
+                 ng:src="{{:: ctrl.optimisedImageUri}}"
                  grid:track-image="ctrl.image"
                  grid:track-image-location="original"
                  grid:track-image-loadtime
@@ -208,7 +208,7 @@
                 <!-- TODO: Add tracking to crop -->
                 <img class="easel__image"
                      alt="cropped image"
-                     ng:src="{{extremeAssets.largest | assetFile}}"
+                     ng:src="{{:: extremeAssets.largest | assetFile}}"
                 />
             </a>
         </div>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -48,13 +48,13 @@
         <div class="flex-container">
             <ul class="bottom-bar__meta-item preview__collections">
                 <li class="preview__collections__collection"
-                    ng:repeat="collection in ctrl.image.data.collections"
-                    gr-tooltip="Click to open collection: {{collection.data.path.join(' ▸ ')}}"
+                    ng:repeat="collection in ctrl.image.data.collections track by collection.data.pathId"
+                    gr-tooltip="Click to open collection: {{::collection.data.path.join(' ▸ ')}}"
                     gr-tooltip-position="top">
                     <a ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
                        ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                        class="preview__collections__collection__value">
-                        {{collection.data.description}}
+                        {{::collection.data.description}}
                     </a>
                 </li>
             </ul>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -27,7 +27,7 @@
 
     <a ng:if="! ctrl.selectionMode" class="preview__link"
        ui:sref="image({imageId: ctrl.image.data.id})"
-       ui:drag-data="{{ctrl.image | asImageDragData}}">
+       ui:drag-data="ctrl.image | asImageDragData">
        <div class="preview__fade"></div>
        <img class="preview__image"
             alt="{{::ctrl.image.data.metadata.description}}"
@@ -40,7 +40,7 @@
         <img class="preview__image"
              alt="{{::ctrl.image.data.metadata.description}}"
              ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
-             ui:drag-data="{{ctrl.image | asImageDragData}}"
+             ui:drag-data="ctrl.image | asImageDragData"
              gr:image-fade-on-load />
     </span>
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -22,7 +22,7 @@
             <div class="results-toolbar-item results-toolbar-item--static
                         image-results-count">
                 {{ctrl.totalResults | toLocaleString}} matches
-                <button ng:show="ctrl.newImagesCount > 0"
+                <button ng:if="ctrl.newImagesCount > 0"
                         ng:click="ctrl.revealNewImages()"
                         class="image-results-count__new"
                         gr-tooltip="{{ctrl.newImagesCount}} new images as of {{ctrl.lastestTimeMoment}}"


### PR DESCRIPTION
Did some performance analysis again and identified that we were serialising massing blobs of JSON representing the image and the crops for each search result, which is slow and expensive. This was done in case it is needed to put in the DataTransfer object if the image is dragged. Instead I've made it lazily evaluated so we only incur the cost on the one image the user starts dragging.

Also changed more bindings to be one-time bindings if the data is never expected to change. Changed some ng:show/hide to ng:if.

The bottom line is that we have in the order of 2000-5000 watch expressions (you can get that number using ngStats or the Batarang extension), based on what the user is doing. The recommended upper limit to keep an app smooth is 2000.

It's not trivial to remove watches, so more work is needed. The collections panel alone seems to setup quite a lot of watch expressions, even when only partially expanded. Not sure if it's another cost incurred from the recursive directive, or if it's expected.

I might do more performance analysis based on the Timeline. I suspect the fade-on-load directive on images isn't helping.

I don't have reliable numbers on the improvements this PR brings, only transient numbers I witnessed while testing with tools open. Also seems to feel smoother.

We'll want to do an extensive regression test before shipping this PR.