### PR TITLE
sets nonFree value as string to match type elsewhere

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -42,8 +42,7 @@
                 <input type="checkbox"
                     ng:model="searchQuery.filter.nonFree"
                     ng:true-value="undefined"
-                    ng:false-value="true"
-                    ng:checked="{{!searchQuery.filter.nonFree}}" />
+                    ng:false-value="'true'" />
                 Free to use only
             </label>
             </li>


### PR DESCRIPTION
FIXES unnecessary extra state change. 

The 'nonFree' value from the URL was a string, the value set by the radio button was a boolean; '"true"' would not match 'true'. This was causing the state to change to update to the 'new' value.

