### PR TITLE
fixes highlight open collection

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -142,7 +142,7 @@ grCollectionsPanel.controller('GrNodeCtrl',
     }));
 
     ctrl.isSelected = ctrl.selectedCollections.some(col => {
-        return angular.equals(col, ctrl.node.data.fullPath);
+        return angular.equals(col, ctrl.node.data.data.pathId.split('/'));
     });
 
 }]);


### PR DESCRIPTION
Fixes broken open collection(s) highlight. 

Selected collections is an array of lower case strings created by parsing the query. 
Need to split the pathId string ('bear/brown') to be able to match the two. 

![highlight collection](https://cloud.githubusercontent.com/assets/8484757/12977107/9afb5154-d0c0-11e5-90b9-aeb146cec37a.gif)
