### PR TITLE
remembers scroll position in collections panel

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -62,8 +62,8 @@ grCollectionsPanel.factory('collectionsTreeState', ['$window', function($window)
 }]);
 
 grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
-    'collections', 'selectedImages$', 'selectedCollections',
-    function (collections, selectedImages$, selectedCollections) {
+    '$scope', '$timeout', 'collections', 'selectedImages$', 'selectedCollections',
+    function ($scope, $timeout, collections, selectedImages$, selectedCollections) {
 
     const ctrl = this;
 
@@ -72,6 +72,12 @@ grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
 
     collections.getCollections().then(collections => {
         ctrl.collections = collections.data.children;
+        // this will trigger the remember-scroll-top directive to return
+        // users to their previous position on the collections panel
+        // once the tree has been rendered
+        $timeout(() => {
+            $scope.$emit('gr:remember-scroll-top:apply');
+        });
     }, () => {
         // TODO: More informative error handling
         // TODO: Stop error propagating to global error handler

--- a/kahuna/public/js/components/gr-panels/gr-panels.js
+++ b/kahuna/public/js/components/gr-panels/gr-panels.js
@@ -3,11 +3,17 @@ import Rx from 'rx';
 import 'rx-dom';
 
 import './gr-panels.css!';
-import '../../services/panel';
-import '../../util/rx';
-import '../../util/eq';
+import {panelService} from '../../services/panel';
+import {rxUtil} from '../../util/rx';
+import {eq} from '../../util/eq';
+import {rememberScrollTop} from '../../directives/gr-remember-scroll-top';
 
-export const panels = angular.module('gr.panels', ['kahuna.services.panel', 'util.rx', 'util.eq']);
+export const panels = angular.module('gr.panels', [
+    panelService.name,
+    rxUtil.name,
+    eq.name,
+    rememberScrollTop.name
+]);
 
 panels.directive('grPanels', [function() {
     return {
@@ -37,7 +43,8 @@ panels.directive('grPanel', ['$timeout', '$window', 'inject$', 'subscribe$',
         scope: {
             panel: '=grPanel',
             left: '=?grLeft',
-            right: '=?grRight'
+            right: '=?grRight',
+            rememberScroll: '=?grRememberScroll'
         },
         template:
             `<div class="gr-panel" ng:class="{'gr-panel--locked': state.locked}">
@@ -47,7 +54,8 @@ panels.directive('grPanel', ['$timeout', '$window', 'inject$', 'subscribe$',
                         'gr-panel__content--left': left,
                         'gr-panel__content--right': right
                      }"
-                     gr:panel-height>
+                     gr:panel-height
+                     gr:remember-scroll-top="rememberScroll">
                     <ng:transclude></ng:transclude>
                 </div>
             </div>`,

--- a/kahuna/public/js/directives/gr-remember-scroll-top.js
+++ b/kahuna/public/js/directives/gr-remember-scroll-top.js
@@ -1,0 +1,34 @@
+import angular from 'angular';
+import Rx from 'rx';
+import 'rx-dom';
+
+import {rxUtil} from '../util/rx';
+
+export const rememberScrollTop = angular.module('gr.rememberScrollTop', [
+    rxUtil.name
+]);
+
+rememberScrollTop.directive('grRememberScrollTop', ['subscribe$', function (subscribe$) {
+    const storageKey = 'gr:rememberScrollTop';
+
+    return {
+        restrict: 'A',
+        link: function(scope, element, attrs) {
+            // Only remember if attribute if truthy. This is an annoying workaround to the
+            // inability to add directives conditionally
+            if (scope.$eval(attrs.grRememberScrollTop)) {
+                const scrollEvents$ = Rx.DOM.fromEvent(element[0], 'scroll').debounce(500);
+                const scrollTop$ = scrollEvents$.map(ev => ev.target.scrollTop);
+                subscribe$(scope, scrollTop$, ev => {
+                    window.localStorage.setItem(storageKey, ev);
+                });
+
+                scope.$on('gr:remember-scroll-top:apply', () => {
+                    // Note: Number(null) -> 0
+                    const scrollTop = Number(window.localStorage.getItem(storageKey));
+                    element[0].scrollTop = scrollTop;
+                });
+            }
+        }
+    };
+}]);

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -17,7 +17,8 @@
 </gr-top-bar>
 
 <gr-panels class="search-panels">
-    <gr-panel gr:left="true" gr:panel="ctrl.collectionsPanel" gr:icon="collections">
+    <gr-panel gr:left="true" gr:panel="ctrl.collectionsPanel" gr:icon="collections"
+              gr:remember-scroll="true">
         <ui-view name="collectionPanel"></ui-view>
     </gr-panel>
 


### PR DESCRIPTION
Fixes: collections panel scrolling back to the top when opening a new collection / returning from an image page.

Adds directive remember-scroll-top to the collections-panel. This records the position scrolled to (using the element's scrollTop value) in localStorage, and assigns that value to the collection-panel element's scrollTop once the collections panel tree has been rendered. 

Because Zebras are important too.  

![remember scroll](https://cloud.githubusercontent.com/assets/8484757/12983260/68b27a2c-d0e0-11e5-9178-5c95e2a47bdf.gif)