### PR TITLE
clearer Collections edit button states

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -11,10 +11,13 @@
         <!-- We use $parent.editing here as ng:if creates it's own child scope -->
         <div class="flex-container collections-panel-heading text-small" ng:if="! ctrl.error">
             <div class="flex-spacer">Collections</div>
-            <button ng:click="$parent.editing = !$parent.editing">
-                <gr-icon>edit</gr-icon>
-                <span ng:hide="$parent.editing">Edit</span>
-                <span ng:show="$parent.editing">Finished editing</span>
+
+            <button ng:class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
+                    ng:click="$parent.editing = !$parent.editing">
+                <gr-icon-label ng:if="! $parent.editing"
+                               gr:icon="edit">Edit</gr-icon-label>
+                <gr-icon-label ng:if="$parent.editing"
+                               gr:icon="check">Finished</gr-icon-label>
             </button>
         </div>
         <gr-nodes gr:nodes="ctrl.collections"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -209,16 +209,19 @@ button[disabled],
     background-color: #008fc5;
 }
 
-.button-cancel {
+.button-cancel,
+.button-edit {
     background-color: #898989;
 }
 
-.button-cancel:hover {
+.button-cancel:hover,
+.button-edit:hover {
     background-color: #666666;
 }
 
 .button-save,
-.button-cancel {
+.button-cancel,
+.button-edit {
     padding: 0 5px;
     height: 24px;
     color: white;


### PR DESCRIPTION
Making it more obvious what state you're in.

# Before
![edit-button-before](https://cloud.githubusercontent.com/assets/836140/13005533/6917905c-d17a-11e5-822c-60d8755d90c3.gif)

# After
![edit-button](https://cloud.githubusercontent.com/assets/836140/13005502/3f4ee324-d17a-11e5-8ff8-817de0302930.gif)
