### PR TITLE
Preconnect to media-api and auth ahead of JS making requests to them

### DIFF
--- a/kahuna/app/controllers/Application.scala
+++ b/kahuna/app/controllers/Application.scala
@@ -12,6 +12,7 @@ object Application extends Controller {
     val returnUri = Config.rootUri + okPath
     Ok(views.html.main(
       Config.mediaApiUri,
+      Config.authUri,
       s"${Config.authUri}/login?redirectUri=$returnUri",
       Config.watUri,
       Config.sentryDsn))

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -1,4 +1,5 @@
 @(mediaApiUri: String,
+  authApiUri: String,
   reauthUri: String,
   watUri: Option[String],
   sentryDsn: Option[String])
@@ -9,6 +10,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title ui:title ui:title-suffix="the grid">the grid</title>
+
+    <!-- preconnect to core APIs ahead of JS making the requests -->
+    <link rel="preconnect" href="@mediaApiUri"/>
+    <link rel="preconnect" href="@authApiUri"/>
 
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/grid-favicon-32.png")"/>
     <link rel="assets" href="@routes.Assets.at("")"/>


### PR DESCRIPTION
Leverage the [link rel="preconnect"](https://www.w3.org/TR/resource-hints/#dfn-preconnect) draft spec implemented in Chrome and FF to "pre-warm" the connection to APIs (DNS lookup, TCP connection, TLS handshake) ahead of the JS app being downloaded, evaluated and executed to make requests against those APIs.

I'm only preconnecting to the media-api and auth API for now as these are the main two on the initial critical path for loading the search results.

I ran some WebPageTests to review the impact.

Note that both of these are on first render prior to any pre-existing DNS caching etc. They're run from NYC on a "cable connection" (the servers being in Ireland).

## Before (no preconnect)

![screenshot-2016-02-12t11 53 56](https://cloud.githubusercontent.com/assets/36964/13006387/a1b5dcb0-d180-11e5-8a92-1f36e8568622.png)

## After (with preconnect)

![screenshot-2016-02-12t11 54 42](https://cloud.githubusercontent.com/assets/36964/13006386/a1b45f84-d180-11e5-80ce-c8618646ec9a.png)

Notice the red highlights in the first example. I'm not focusing on the Document Complete latency, even though it's 1.5s faster with preconnect, because there seems to be some variation in the latency of the download of the `build.js` file (1 extra second in the first example) which should not be related to this.

Interestingly, even after running several tests, we can't seem to be getting much performance improvement on the `api.media.__` requests. With preconnect, according to these results, we don't get any DNS lookup/initial connection/TLS handshake penalty, but for reason the Content Download ends up being longer. I don't know why that is, whether it's a TCP artifact, or whether the results aren't quite correct.

We do shave off about 200ms on the `media-auth.__` request though.

I'm sure there is more to it, and given the unexpectedly similar latency on `api.media.__`, it's not a massive performance win, but still saves some time on the other preconnected request, so feels worth adding anyway.

PS: there is lots and lots more we could do to optimise the waterfall and load times (better caching, bundle more files together, better caching, tree shake the build.js to try and reduce its size, did I mention better caching?), but this looks like a small easy win (4 LOCs!) and generally good practice.

---

Kudos to @igrigorik who talked about this at LDNWebPerf yesterday evening.

cc @piuccio @OliverJAsh @jamesgorrie @phamann