### PR TITLE
Allow picking the date field to filter by (uploaded, taken, modified)

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.css
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.css
@@ -16,8 +16,13 @@
     margin-left: 5px;
 }
 
-.gu-date-range__overlay__pikaday {
-    padding-top: 20px;
+.gu-date-range__overlay__title {
+    margin-bottom: 5px;
+}
+
+.gu-date-range__overlay__fieldset {
+    margin-bottom: 20px;
+    display: inline-block;
 }
 
 .gu-date-range__overlay__pikaday__wrapper {

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -6,6 +6,7 @@
             gr:track-click-data="{ 'Action': 'Show Hide' }">
         <gr-icon>event</gr-icon>
         <div class="gu-date-range__display--value">
+            {{ctrl.guSelectedField}}
             <span ng:if="ctrl.guDisplayStartDate !== ctrl.guAnyTimeText && !ctrl.guDisplayEndDate">from </span>
             {{ctrl.guDisplayStartDate}}
             <span ng:if="ctrl.guDisplayEndDate">to {{ctrl.guDisplayEndDate}}</span>

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -18,8 +18,28 @@
     </button>
 
     <div class="gu-date-range__overlay search__overlay" ng:show="ctrl.showOverlay">
+        <h2 class="gu-date-range__overlay__title search__overlay__title">Field</h2>
+        <div class="gu-date-range__overlay__fieldset">
+            <div class="radio-list">
+                <div ng:repeat="field in ctrl.guFields track by field.name"
+                     class="radio-list__item">
+                    <input type="radio"
+                           id="gu-date-range__field__{{:: field.name}}"
+                           class="radio-list__circle"
+                           name="field-uploaded"
+                           ng:value=":: field.value"
+                           ng:model="ctrl.guDisplayField">
+                    <label for="gu-date-range__field__{{:: field.name}}" class="radio-list__label"
+                           ng:class="{'radio-list--selected': ctrl.guDisplayField === field.value}">
+                        <div class="radio-list__selection-state"></div>
+                        <div class="radio-list__label-value">{{:: field.label}}</div>
+                    </label>
+                </div>
+            </div>
+        </div>
+
         <h2 class="gu-date-range__overlay__title search__overlay__title">Presets</h2>
-        <div class="gu-date-range__overlay__presets">
+        <div class="gu-date-range__overlay__fieldset">
             <button type="button"
                     class="gu-date-range__overlay__preset__button button"
                     ng:repeat="presetDate in ctrl.guPresetDates"
@@ -31,7 +51,6 @@
         </div>
 
         <div class="gu-date-range__overlay__pikaday">
-            <h2 class="gu-date-range__overlay__title search__overlay__title">Custom date range</h2>
             <span class="gu-date-range__overlay__pikaday__wrapper">
                 <h2 class="gu-date-range__overlay__title search__overlay__title">From</h2>
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--start"/>

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.js
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.js
@@ -26,11 +26,14 @@ guDateRange.controller('GuDateRangeCtrl', [function () {
         ctrl.guDisplayEndDate = angular.isDefined(ctrl.guEndDate) ?
             moment(ctrl.guEndDate).format(ctrl.guDateFormat) :
             undefined;
+
+        ctrl.guDisplayField = ctrl.guSelectedField;
     };
 
     ctrl.setDateRange = function (start, end) {
         ctrl.guStartDate = getDateISOString(start);
         ctrl.guEndDate = getDateISOString(end);
+        ctrl.guSelectedField = ctrl.guDisplayField;
     };
 
     ctrl.closeOverlay = () => {
@@ -52,6 +55,8 @@ guDateRange.directive('guDateRange', [function () {
             guStartDate: '=',
             guEndDate: '=',
             guPresetDates: '=',
+            guSelectedField: '=',
+            guFields: '=',
             guDateFormat: '=?',
             guAnyTimeText: '=?',
             guFirstDay: '=?'

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -129,7 +129,8 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     });
 
     $stateProvider.state('search.results', {
-        url: 'search?{query:Query}&ids&since&nonFree&uploadedBy&until&orderBy&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil',
+        url: 'search?{query:Query}&ids&since&nonFree&uploadedBy&until&orderBy' +
+             '&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -129,7 +129,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     });
 
     $stateProvider.state('search.results', {
-        url: 'search?{query:Query}&ids&since&nonFree&uploadedBy&until&orderBy',
+        url: 'search?{query:Query}&ids&since&nonFree&uploadedBy&until&orderBy&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -56,12 +56,14 @@
             </li>
 
             <li class="search__modifier-item">
-            <gu-date-range class="search__date"
-                gu:start-date="searchQuery.filter.since"
-                gu:end-date="searchQuery.filter.until"
-                gu:preset-dates="searchQuery.sinceOptions"
-                gu:first-day="1">
-            </gu-date-range>
+                <gu-date-range class="search__date"
+                               gu:start-date="searchQuery.dateFilter.since"
+                               gu:end-date="searchQuery.dateFilter.until"
+                               gu:preset-dates="searchQuery.sinceOptions"
+                               gu:selected-field="searchQuery.dateFilter.field"
+                               gu:fields="searchQuery.filterDateFieldsOptions"
+                               gu:first-day="1">
+                </gu-date-range>
             </li>
         </ul>
     </div>

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -103,7 +103,7 @@ query.controller('SearchQueryCtrl',
 
     // Init and apply date-related changes in $stateParams to ctrl.dateFilter
     $scope.$watchCollection(() => $stateParams, () => {
-        switch($stateParams.dateField) {
+        switch ($stateParams.dateField) {
         case 'taken':
             ctrl.dateFilter.since = $stateParams.takenSince;
             ctrl.dateFilter.until = $stateParams.takenUntil;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -35,6 +35,10 @@ query.controller('SearchQueryCtrl',
         uploadedByMe: false
     };
 
+    ctrl.dateFilter = {
+        // filled in by the watcher below
+    };
+
     ctrl.resetQueryAndFocus = resetQueryAndFocus;
 
     // Note that this correctly uses local datetime and returns
@@ -54,8 +58,21 @@ query.controller('SearchQueryCtrl',
         {label: 'Past year',     value: pastYear}
     ];
 
-    Object.keys($stateParams)
-          .forEach(setAndWatchParam);
+    ctrl.filterDateFieldsOptions = [
+        {label: 'Upload time',   name: 'uploaded'}, // value: undefined
+        {label: 'Date taken',    name: 'taken',        value: 'taken'},
+        {label: 'Last modified', name: 'modified',     value: 'modified'}
+    ];
+
+    const dateFilterParams = [
+        'dateField', 'since', 'until', 'takenSince', 'takenUntil',
+        'modifiedSince', 'modifiedUntil'
+    ];
+
+    Object.keys($stateParams).
+        // Exclude date-related filters, managed separately in dateFilter
+        filter(key => dateFilterParams.indexOf(key) === -1).
+        forEach(setAndWatchParam);
 
     // URL parameters are not decoded when taken out of the params.
     // Might be fixed with: https://github.com/angular-ui/ui-router/issues/1759
@@ -84,14 +101,49 @@ query.controller('SearchQueryCtrl',
         }));
     }
 
+    // Init and apply date-related changes in $stateParams to ctrl.dateFilter
+    $scope.$watchCollection(() => $stateParams, () => {
+        switch($stateParams.dateField) {
+        case 'taken':
+            ctrl.dateFilter.since = $stateParams.takenSince;
+            ctrl.dateFilter.until = $stateParams.takenUntil;
+            ctrl.dateFilter.field = 'taken';
+            break;
+        case 'modified':
+            ctrl.dateFilter.since = $stateParams.modifiedSince;
+            ctrl.dateFilter.until = $stateParams.modifiedUntil;
+            ctrl.dateFilter.field = 'modified';
+            break;
+        default: // uploaded (default so represented as `undefined`)
+            ctrl.dateFilter.since = $stateParams.since;
+            ctrl.dateFilter.until = $stateParams.until;
+            ctrl.dateFilter.field = undefined;
+            break;
+        }
+    });
+
+
     $scope.$watchCollection(() => ctrl.filter, onValChange(filter => {
         filter.uploadedBy = filter.uploadedByMe ? ctrl.user.email : undefined;
         $state.go('search.results', filter);
     }));
 
-     $scope.$watch(() => ctrl.ordering.orderBy, onValChange(newVal => {
-         $state.go('search.results', {orderBy: newVal});
-     }));
+    $scope.$watch(() => ctrl.ordering.orderBy, onValChange(newVal => {
+        $state.go('search.results', {orderBy: newVal});
+    }));
+
+    $scope.$watchCollection(() => ctrl.dateFilter, ({field, since, until}) => {
+        // Translate dateFilter to actual state and query params
+        $state.go('search.results', {
+            since:         field === undefined  ? since : null,
+            until:         field === undefined  ? until : null,
+            takenSince:    field === 'taken'    ? since : null,
+            takenUntil:    field === 'taken'    ? until : null,
+            modifiedSince: field === 'modified' ? since : null,
+            modifiedUntil: field === 'modified' ? until : null,
+            dateField:     field
+        });
+    });
 
     // we can't user dynamic values in the ng:true-value see:
     // https://docs.angularjs.org/error/ngModel/constexpr

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -375,6 +375,10 @@ results.controller('SearchResultsCtrl', [
                 // The nonFree state param is the inverse of the free API param
                 free:       $stateParams.nonFree === 'true' ? undefined: true,
                 uploadedBy: $stateParams.uploadedBy,
+                takenSince: $stateParams.takenSince,
+                takenUntil: $stateParams.takenUntil,
+                modifiedSince: $stateParams.modifiedSince,
+                modifiedUntil: $stateParams.modifiedUntil,
                 until:      until,
                 since:      since,
                 offset:     offset,

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -14,19 +14,25 @@ mediaApi.factory('mediaApi',
     var session;
 
     function search(query = '', {ids, since, until, archived, valid,
-                                 free, uploadedBy, offset, length, orderBy} = {}) {
+                                 free, uploadedBy, offset, length, orderBy,
+                                 takenSince, takenUntil,
+                                 modifiedSince, modifiedUntil} = {}) {
         return root.follow('search', {
-          q:          query,
-          ids:        ids,
-          since:      since,
-          until:      until,
-          uploadedBy: uploadedBy,
-          valid:      valid,
-          archived:   archived,
-          free:       free,
-          offset:     offset,
-          length:     angular.isDefined(length) ? length : 50,
-          orderBy:    getOrder(orderBy)
+            q:          query,
+            since:      since,
+            until:      until,
+            takenSince: takenSince,
+            takenUntil: takenUntil,
+            modifiedSince: modifiedSince,
+            modifiedUntil: modifiedUntil,
+            ids:        ids,
+            uploadedBy: uploadedBy,
+            valid:      valid,
+            archived:   archived,
+            free:       free,
+            offset:     offset,
+            length:     angular.isDefined(length) ? length : 50,
+            orderBy:    getOrder(orderBy)
         }).get();
     }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/36964/13009109/69be6cac-d192-11e5-8a86-3bfcc561acc9.png)

This is done by adding a new `dateField` and `{taken,uploaded}{Since,Until}` parameters to the state (kahuna URI), and sending them along to the media-api using the already supported `{taken,uploaded}{Since,Until}` parameters.

cc @blishen 