### PR TITLE
uncheck restriction deletes the property from the model

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -135,6 +135,11 @@ usageRightsEditor.controller(
         const data = ctrl.category.value ?
             angular.extend({}, ctrl.model, { category: ctrl.category.value }) : {};
 
+        // unchecking restrictions will remove restriction on save
+        if (! ctrl.showRestrictions && data.restrictions) {
+            delete data.restrictions;
+        }
+
         save(data).
             catch(uiError).
             finally(saveComplete);


### PR DESCRIPTION
Allows restriction removal by unchecking the checkbox and saving. Previously you had to delete the value in the text area then save.

Weekend do this a lot. It looks really painful! Especially if you haven't yet learnt how to get the combination just right (as shown in the before gif).

Before
![restrictions-before](https://cloud.githubusercontent.com/assets/836140/13013088/d16e1754-d1a5-11e5-810e-8e9526b88215.gif)

After
![restrictions-after](https://cloud.githubusercontent.com/assets/836140/13013089/d70d65e8-d1a5-11e5-848e-b9b15e68a834.gif)
