### PR TITLE
no longer splits collection query string

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -148,7 +148,7 @@ grCollectionsPanel.controller('GrNodeCtrl',
     }));
 
     ctrl.isSelected = ctrl.selectedCollections.some(col => {
-        return angular.equals(col, ctrl.node.data.data.pathId.split('/'));
+        return angular.equals(col, ctrl.node.data.data.pathId);
     });
 
 }]);

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -31,7 +31,7 @@ export function getCollectionsFromQuery(q) {
     const query = querySplit(q);
     const collections =  query ? query
         .filter(bit => bit.charAt(0) === '~')
-        .map(path => path.replace(/('|"|~)/g, '').split('/'))
+        .map(path => path.replace(/('|"|~)/g, ''))
         : [];
 
     return collections;


### PR DESCRIPTION
`getCollectionsFromQuery(q)` only used in gr-collections-panel.js - do not need to split the value in both places for comparison. 