### PR TITLE
Reduce alpha of unlocked panels

### DIFF
--- a/kahuna/public/js/components/gr-panels/gr-panels.css
+++ b/kahuna/public/js/components/gr-panels/gr-panels.css
@@ -20,22 +20,25 @@
 .gr-panel__content {
     width: 290px;
     position: fixed;
-    background: #444;
+    background: rgba(68, 68, 68, 0.9);
     overflow: auto;
     transition: width 0.2s;
 }
+
+.gr-panel--locked .gr-panel__content {
+    background: rgba(68,68,68,1)
+}
+
 .gr-panel__content--hidden {
     width: 0;
     overflow: hidden;
 }
 .gr-panel__content--left {
     left: 0;
-    opacity: 0.9;
 }
 
 .gr-panel__content--right {
     right: 0;
-    opacity: 0.9;
 }
 
 .gr-panelled-content {

--- a/kahuna/public/js/components/gr-panels/gr-panels.css
+++ b/kahuna/public/js/components/gr-panels/gr-panels.css
@@ -30,10 +30,12 @@
 }
 .gr-panel__content--left {
     left: 0;
+    opacity: 0.9;
 }
 
 .gr-panel__content--right {
     right: 0;
+    opacity: 0.9;
 }
 
 .gr-panelled-content {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1406,7 +1406,6 @@ FIXME: what to do with touch devices
     box-sizing: border-box;
     font-size: 1.3rem;
     overflow: auto;
-    background-color: #444;
 }
 /* HACK: This is here until we start using the panelled-content here */
 .image-details--full-image {


### PR DESCRIPTION
In order that we can see what's underneath so as not to hide images.


![screenshot from 2016-02-17 11 22 18](https://cloud.githubusercontent.com/assets/953792/13108064/ba858876-d568-11e5-88d9-e3d22624b721.png)
