### PR TITLE
Allow batch downloading lo-rez images

### DIFF
--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -1,16 +1,28 @@
-<button class="download"
-        type="button"
-        title="Download images"
-        ng:disabled="ctrl.downloading"
-        ng:if="ctrl.images.size > 1"
-        ng:click="ctrl.download()">
-    <gr-icon-label gr-icon="file_download">
-        Download<span ng:show="ctrl.downloading">ing</span>
-    </gr-icon-label>
-</button>
+<span class="download">
+    <button type="button"
+            title="Download images"
+            ng:disabled="ctrl.downloading"
+            ng:if="ctrl.images.size > 1"
+            ng:click="ctrl.download()">
+        <gr-icon-label gr-icon="file_download">
+            Download<span ng:show="ctrl.downloading">ing</span>
+        </gr-icon-label>
+    </button>
 
-<a class="download"
-   ng:if="ctrl.images.size == 1"
-   href="{{ ctrl.getFirstImageSource() | assetFile }}" download target="_blank">
-    <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
-</a>
+    <a ng:if="ctrl.images.size == 1"
+       href="{{ ctrl.firstImageUris.uris.secureUri }}" download target="_blank">
+        <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
+    </a>
+
+    <button class="drop-menu clickable inner-clickable side-padded button-right-side"
+            ng:click="showExpandedDownload = !showExpandedDownload">
+        <span>▾</span>
+        <a ng:if="showExpandedDownload"
+            ng:href="{{:: ctrl.lowResImageUri }}"
+            class="drop-menu__items drop-menu__items--nopad"
+            download
+            target="_blank">
+            <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
+        </a>
+    </button>
+</span>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -3,7 +3,7 @@
             title="Download images"
             ng:disabled="ctrl.downloading"
             ng:if="ctrl.images.size > 1"
-            ng:click="ctrl.download()">
+            ng:click="ctrl.download('secureUri')">
         <gr-icon-label gr-icon="file_download">
             Download<span ng:show="ctrl.downloading">ing</span>
         </gr-icon-label>
@@ -14,15 +14,28 @@
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
-    <button class="drop-menu clickable inner-clickable side-padded button-right-side"
+    <button ng:if="ctrl.images.size == 1"
+            class="drop-menu clickable inner-clickable side-padded button-right-side"
             ng:click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
         <a ng:if="showExpandedDownload"
-            ng:href="{{:: ctrl.lowResImageUri }}"
+            ng:href="{{:: ctrl.firstImageUris.uris.lowRezUri }}"
             class="drop-menu__items drop-menu__items--nopad"
             download
             target="_blank">
             <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
         </a>
     </button>
+
+    <button ng:if="ctrl.images.size > 1"
+            class="drop-menu clickable inner-clickable side-padded button-right-side"
+            ng:click="showExpandedDownload = !showExpandedDownload">
+        <span>▾</span>
+        <a ng:if="showExpandedDownload"
+            ng:click="ctrl.download('lowRezUri')"
+            class="drop-menu__items drop-menu__items--nopad">
+            <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
+        </a>
+    </button>
+
 </span>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -2,19 +2,19 @@
     <button type="button"
             title="Download images"
             ng:disabled="ctrl.downloading"
-            ng:if="ctrl.images.size > 1"
+            ng:if="ctrl.imageCount() > 1"
             ng:click="ctrl.download('secureUri')">
         <gr-icon-label gr-icon="file_download">
             Download<span ng:show="ctrl.downloading">ing</span>
         </gr-icon-label>
     </button>
 
-    <a ng:if="ctrl.images.size == 1"
+    <a ng:if="ctrl.imageCount() == 1"
        href="{{ ctrl.firstImageUris.uris.secureUri }}" download target="_blank">
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
-    <button ng:if="ctrl.images.size == 1"
+    <button ng:if="ctrl.imageCount() == 1"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
             ng:click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
@@ -27,7 +27,7 @@
         </a>
     </button>
 
-    <button ng:if="ctrl.images.size > 1"
+    <button ng:if="ctrl.imageCount() > 1"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
             ng:click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -28,11 +28,18 @@ const bytesToSize = (bytes) => {
 downloader.controller('DownloaderCtrl', [
     '$window',
     '$q',
+    '$scope',
+    'inject$',
     'imageDownloadsService',
 
-    function Controller($window, $q, imageDownloadsService) {
+    function Controller($window, $q, $scope, inject$, imageDownloadsService) {
 
     let ctrl = this;
+
+    const uris$ = imageDownloadsService.getDownloads(
+            Array.from(ctrl.images.values())[0]);
+
+    inject$($scope, uris$, ctrl, 'firstImageUris');
 
     ctrl.download = () => {
         ctrl.downloading = true;
@@ -80,7 +87,6 @@ downloader.controller('DownloaderCtrl', [
         });
     };
 
-    ctrl.getFirstImageSource = () => Array.from(ctrl.images)[0].data.source;
 }]);
 
 downloader.directive('grDownloader', function() {

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -41,10 +41,11 @@ downloader.controller('DownloaderCtrl', [
 
     inject$($scope, uris$, ctrl, 'firstImageUris');
 
-    ctrl.download = () => {
+    ctrl.download = (downloadKey) => {
+
         ctrl.downloading = true;
 
-        const downloads$ = imageDownloadsService.download(ctrl.images, 'lowRezUri');
+        const downloads$ = imageDownloadsService.download(ctrl.images, downloadKey || 'secureUri');
 
         downloads$.subscribe((zip) => {
             const file = zip.generate({ type: 'uint8array' });

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -11,25 +11,9 @@
                          images="[ctrl.image]">
         </gr-delete-image>
 
-        <span class="top-bar-item">
-            <a ng:href="{{:: ctrl.image.data.source | assetFile }}"
-               class="side-padded clickable inner-clickable"
-               download
-               target="_blank">
-                <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
-            </a>
-            <button class="drop-menu clickable inner-clickable side-padded button-right-side"
-                    ng:click="showExpandedDownload = !showExpandedDownload">
-                <span>▾</span>
-                <a ng:if="showExpandedDownload"
-                   ng:href="{{:: ctrl.lowResImageUri }}"
-                   class="drop-menu__items drop-menu__items--nopad"
-                   download
-                   target="_blank">
-                    <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
-                </a>
-            </button>
-        </span>
+        <gr-downloader class="top-bar-item"
+                       images="[ctrl.image]">
+        </gr-downloader>
 
         <gr-archiver class="top-bar-item"
                      gr:image="ctrl.image">

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -88,7 +88,7 @@
                 </a>
 
                 <gr-downloader class="results-toolbar-item results-toolbar-item--right"
-                    gr:images="ctrl.selectedImages"
+                    images="ctrl.selectedImages"
                     ng:if="ctrl.selectionCount > 0"></gr-downloader>
 
                 <gr-delete-image class="results-toolbar-item results-toolbar-item--right"

--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import Immutable from 'immutable';
+import JSZip from 'jszip';
 import Rx from 'rx';
 
 import '../../imgops/service';
@@ -8,7 +9,7 @@ export const imageDownloadsService = angular.module(
     'gr.image-downloads.service', ['kahuna.imgops']);
 
 
-imageDownloadsService.factory('imageDownloadsService', ['imgops', function(imgops) {
+imageDownloadsService.factory('imageDownloadsService', ['imgops', '$http', function(imgops, $http) {
     function stripExtension(filename) {
         return filename.replace(/\.[a-zA-Z]{3,4}$/, '');
     }
@@ -25,21 +26,45 @@ imageDownloadsService.factory('imageDownloadsService', ['imgops', function(imgop
         }
     }
 
+    function getDownloads(imageResource) {
+        const image$ = Rx.Observable.fromPromise(imageResource.getData());
+
+        const originalName$   = image$.map((image) => imageName(image));
+
+        const secureUri$     = image$.map((image) => image.source.secureUrl);
+        const lowRezUri$     = Rx.Observable.fromPromise(imgops.getLowResUri(imageResource));
+        const fullScreenUri$ = Rx.Observable.fromPromise(imgops.getFullScreenUri(imageResource));
+
+        return Rx.Observable.zip(originalName$, secureUri$, lowRezUri$, fullScreenUri$,
+                (originalName, secureUri, lowRezUri, fullScreenUri) => ({
+                    filename: originalName,
+                    uris: {secureUri, lowRezUri, fullScreenUri}
+                }));
+    }
+
+    function download(imageResources, downloadKey) {
+        const downloadObservablesIterable = imageResources
+            .map((image) => getDownloads(image));
+
+        const downloadObservablesArray = Array.from(
+                downloadObservablesIterable.values());
+
+        const downloads$ = Rx.Observable.merge(downloadObservablesArray);
+
+        const zip = new JSZip();
+        const imageHttp = url => $http.get(url, { responseType:'arraybuffer' });
+
+        const addDownloadsToZip$ = downloads$
+            .flatMap((downloads) => Rx.Observable
+                    .fromPromise(imageHttp(downloads.uris[downloadKey]))
+                    .map((resp) => zip.file(downloads.filename, resp.data))
+            ).toArray().map(() => zip);
+
+        return addDownloadsToZip$;
+    }
+
     return {
-        getDownloads: (imageResource) => {
-            const image$ = Rx.Observable.fromPromise(imageResource.getData());
-
-            const originalName$   = image$.map((image) => imageName(image))
-
-            const secureUri$     = image$.map((image) => image.source.secureUrl)
-            const lowRezUri$     = Rx.Observable.fromPromise(imgops.getLowResUri(imageResource))
-            const fullScreenUri$ = Rx.Observable.fromPromise(imgops.getFullScreenUri(imageResource))
-
-            return Rx.Observable.zip(originalName$, secureUri$, lowRezUri$, fullScreenUri$,
-                    (originalName, secureUri, lowRezUri, fullScreenUri) => ({
-                        filename: originalName,
-                        uris: {secureUri, lowRezUri, fullScreenUri}
-                    }));
-        }
+        download,
+        getDownloads
     };
 }]);

--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -1,0 +1,45 @@
+import angular from 'angular';
+import Immutable from 'immutable';
+import Rx from 'rx';
+
+import '../../imgops/service';
+
+export const imageDownloadsService = angular.module(
+    'gr.image-downloads.service', ['kahuna.imgops']);
+
+
+imageDownloadsService.factory('imageDownloadsService', ['imgops', function(imgops) {
+    function stripExtension(filename) {
+        return filename.replace(/\.[a-zA-Z]{3,4}$/, '');
+    }
+
+    function imageName(imageData) {
+        const filename = imageData.uploadInfo.filename;
+        const imageId = imageData.id;
+
+        if (filename) {
+            const basename = stripExtension(filename);
+            return `${basename} (${imageId}).jpg`;
+        } else {
+            return `${imageId}.jpg`;
+        }
+    }
+
+    return {
+        getDownloads: (imageResource) => {
+            const image$ = Rx.Observable.fromPromise(imageResource.getData());
+
+            const originalName$   = image$.map((image) => imageName(image))
+
+            const secureUri$     = image$.map((image) => image.source.secureUrl)
+            const lowRezUri$     = Rx.Observable.fromPromise(imgops.getLowResUri(imageResource))
+            const fullScreenUri$ = Rx.Observable.fromPromise(imgops.getFullScreenUri(imageResource))
+
+            return Rx.Observable.zip(originalName$, secureUri$, lowRezUri$, fullScreenUri$,
+                    (originalName, secureUri, lowRezUri, fullScreenUri) => ({
+                        filename: originalName,
+                        uris: {secureUri, lowRezUri, fullScreenUri}
+                    }));
+        }
+    };
+}]);

--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import Immutable from 'immutable';
 import JSZip from 'jszip';
 import Rx from 'rx';
 
@@ -43,13 +42,10 @@ imageDownloadsService.factory('imageDownloadsService', ['imgops', '$http', funct
     }
 
     function download(imageResources, downloadKey) {
-        const downloadObservablesIterable = imageResources
+        const downloadObservables = imageResources
             .map((image) => getDownloads(image));
 
-        const downloadObservablesArray = Array.from(
-                downloadObservablesIterable.values());
-
-        const downloads$ = Rx.Observable.merge(downloadObservablesArray);
+        const downloads$ = Rx.Observable.merge(downloadObservables);
 
         const zip = new JSZip();
         const imageHttp = url => $http.get(url, { responseType:'arraybuffer' });

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -423,6 +423,10 @@ textarea.ng-invalid {
     height: 50px;
 }
 
+.top-bar-item gr-icon-label {
+    padding: 0 10px;
+}
+
 .top-bar-item:first-child {
     margin-left: 0;
 }


### PR DESCRIPTION
This seems to be aprt of multiple peoples daily workflow so we should probably cater for them.

![screenshot from 2016-02-22 13 23 50](https://cloud.githubusercontent.com/assets/953792/13219375/9123537a-d967-11e5-9628-020e08f3376d.png)

Moves creating download urls to a service, uses Rx. 

This PR also replaces the download control on the image page with the shared component.