### PR TITLE
use updated amis

### DIFF
--- a/packer/imgops/imgops-ami.sh
+++ b/packer/imgops/imgops-ami.sh
@@ -15,7 +15,7 @@ mv /tmp/imgops_logrotate /etc/logrotate.d/imgops
 sudo chown root:root /etc/logrotate.d/imgops
 
 new_section "Updating package lists"
-apt-get -y update
+apt-get -y update && apt-get -y upgrade
 
 new_section "Installing nginx and nginx-extras (image filter)"
 apt-get -y install nginx nginx-extras

--- a/packer/imgops/imgops-ami.sh
+++ b/packer/imgops/imgops-ami.sh
@@ -20,6 +20,9 @@ apt-get -y update && apt-get -y upgrade
 new_section "Installing nginx and nginx-extras (image filter)"
 apt-get -y install nginx nginx-extras
 
+new_section "Installing imagemagick"
+apt-get -y install imagemagick
+
 rm /etc/nginx/sites-enabled/default
 
 new_section "Installing cloud watch monitoring scripts"

--- a/packer/imgops/provisioning.json
+++ b/packer/imgops/provisioning.json
@@ -1,14 +1,21 @@
 {
-    "description": "AMIs with nginx/image for the imgops service",
+    "variables": {
+        "machine_images_ami": "ami-6857e51b"
+    },
 
     "builders": [{
         "type": "amazon-ebs",
         "region": "eu-west-1",
-        "source_ami": "ami-6857e51b",
+        "source_ami": "{{user `machine_images_ami`}}",
         "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
-        "ami_name": "imgops_ebs-storage-cfn_{{timestamp}}",
-        "name": "imgops_ebd-storage-cfn_{{timestamp}}"
+        "ami_name": "imgops_ebs-storage-cfn_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ami_description": "AMIs with nginx, imagemagick for the imgops service",
+        "name": "imgops_ebs-storage-cfn_{{isotime \"2006/01/02_15-04-05\"}}",
+        "tags": {
+            "Name": "imgops_ebs-storage-cfn_{{isotime \"2006/01/02_15-04-05\"}}",
+            "SourceAMI": "{{user `machine_images_ami`}}"
+        }
     }],
 
     "provisioners": [

--- a/packer/imgops/provisioning.json
+++ b/packer/imgops/provisioning.json
@@ -4,7 +4,7 @@
     "builders": [{
         "type": "amazon-ebs",
         "region": "eu-west-1",
-        "source_ami": "ami-68e8ba1f",
+        "source_ami": "ami-6857e51b",
         "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ami_name": "imgops_ebs-storage-cfn_{{timestamp}}",

--- a/packer/media-service/media-service-ami.sh
+++ b/packer/media-service/media-service-ami.sh
@@ -13,7 +13,7 @@ mv /tmp/media-service_logrotate /etc/logrotate.d/media-service
 sudo chown root:root /etc/logrotate.d/media-service
 
 new_section "Updating package lists"
-apt-get -y update
+apt-get -y update && apt-get -y upgrade
 
 new_section "Installing graphicsmagick"
 apt-get -y install graphicsmagick graphicsmagick-imagemagick-compat

--- a/packer/media-service/provisioning.json
+++ b/packer/media-service/provisioning.json
@@ -4,7 +4,7 @@
     "builders": [{
         "type": "amazon-ebs",
         "region": "eu-west-1",
-        "source_ami": "ami-a682c5d1",
+        "source_ami": "ami-6857e51b",
         "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ami_name": "media-service_ebs-storage-cfn_{{timestamp}}",

--- a/packer/media-service/provisioning.json
+++ b/packer/media-service/provisioning.json
@@ -1,14 +1,21 @@
 {
-    "description": "Simple AMIs for the Grid",
+    "variables": {
+        "machine_images_ami": "ami-6857e51b"
+    },
 
     "builders": [{
         "type": "amazon-ebs",
         "region": "eu-west-1",
-        "source_ami": "ami-6857e51b",
+        "source_ami": "{{user `machine_images_ami`}}",
         "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
-        "ami_name": "media-service_ebs-storage-cfn_{{timestamp}}",
-        "name": "media-service_ebd-storage-cfn_{{timestamp}}"
+        "ami_name": "media-service_ebs-storage-cfn_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ami_description": "Simple AMIs for the Grid",
+        "name": "media-service_ebs-storage-cfn_{{isotime \"2006/01/02_15-04-05\"}}",
+        "tags": {
+            "Name": "media-service_ebs-storage-cfn_{{isotime \"2006/01/02_15-04-05\"}}",
+            "SourceAMI": "{{user `machine_images_ami`}}"
+        }
     }],
 
     "provisioners": [


### PR DESCRIPTION
Triggered by CVE-2015-7547.

Also:
- Tags built AMIs in AWS
- Uses pretty printed timestamp rather than time in milliseconds
- Builds our own imagemagick instance (previously we were using an AMI from frontend)

Post release:
- [ ] Delete old AMI and snapshots