### PR TITLE
collections panel refactor

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -19,7 +19,13 @@
             <gr-icon ng:hide="ctrl.showChildren">chevron_right</gr-icon>
         </button>
 
-        <a class="node__name flex-spacer"
+        <button ng:if="ctrl.hasCustomSelect"
+                ng:click="ctrl.select()">
+           <span class="node__name flex-spacer">{{:: node.data.data.description}}</span>
+        </button>
+
+        <a ng:if="! ctrl.hasCustomSelect"
+           class="node__name flex-spacer"
            ui:sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId)})">
             {{:: node.data.data.description}}
         </a>
@@ -27,7 +33,7 @@
 
         <button class="node__action clickable" type="button"
                 title="Delete this collection"
-                ng:if="ctrl.deletable && ctrl.editing"
+                ng:if="ctrl.deletable && grCollectionTreeCtrl.editing"
                 ng:click="ctrl.remove()">
             <gr-icon-label gr-icon="delete"></gr-icon-label>
         </button>
@@ -35,7 +41,7 @@
         <button class="node__action clickable"
                 type="button"
                 title="Add a new sub-collection"
-                ng:if="ctrl.editing"
+                ng:if="grCollectionTreeCtrl.editing"
                 ng:click="$parent.active = !$parent.active">
             <gr-icon>create_new_folder</gr-icon>
         </button>
@@ -48,13 +54,13 @@
 
         <button class="node__action clickable hover-child"
                 title="Remove selected images from this collection"
-                ng:if="!ctrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
+                ng:if="!grCollectionTreeCtrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
                 ng:click="ctrl.removeImagesFromCollection()">
             <gr-icon>indeterminate_check_box</gr-icon>
         </button>
         <button class="node__action clickable hover-child"
                 title="Add selected images to this collection"
-                ng:if="!ctrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
+                ng:if="!grCollectionTreeCtrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
                 ng:click="ctrl.addImagesToCollection()">
             <gr-icon>add_to_photos</gr-icon>
         </button>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -20,10 +20,10 @@
                                gr:icon="check">Finished</gr-icon-label>
             </button>
         </div>
-        <gr-nodes gr:nodes="ctrl.collections"
+        <gr-collection-tree gr:nodes="ctrl.collections"
                   gr:editing="editing"
                   gr:selected-images="ctrl.selectedImages$"
                   gr:selected-collections="ctrl.selectedCollections">
-        </gr-nodes>
+        </gr-collection-tree>
     </div>
 </div>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -67,7 +67,6 @@ grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
 
     const ctrl = this;
 
-    ctrl.isVisible = false;
     ctrl.error = false;
 
     collections.getCollections().then(collections => {
@@ -99,6 +98,14 @@ grCollectionsPanel.controller('GrNodeCtrl',
     ctrl.removing = false;
     ctrl.deletable = false;
     ctrl.showChildren = collectionsTreeState.getState(pathId);
+
+    ctrl.selectedImages$ = angular.isDefined(ctrl.selectedImages$) ?
+        ctrl.selectedImages$ :
+        Rx.Observable.empty();
+
+    ctrl.selectedCollections = angular.isDefined(ctrl.selectedCollections) ?
+        ctrl.selectedCollections :
+        [];
 
     ctrl.formError = null;
     ctrl.addChild = childName => {

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -117,7 +117,6 @@ grCollectionsPanel.controller('GrNodeCtrl',
 
     ctrl.init = function(grCollectionTreeCtrl) {
         const selectedImages$ = grCollectionTreeCtrl.selectedImages$;
-
         const selectedCollections = grCollectionTreeCtrl.selectedCollections;
 
         // TODO: move this somewhere sensible, we probably don't want an observable for each node.
@@ -132,7 +131,8 @@ grCollectionsPanel.controller('GrNodeCtrl',
         };
 
         subscribe$($scope, pathWithImages$, ({path, images}) => {
-           collections.addToCollectionUsingImageResources(images, path).then(() => ctrl.saving = false);
+           collections.addToCollectionUsingImageResources(images, path)
+           .then(() => ctrl.saving = false);
         });
 
         const remove$ = new Rx.Subject();
@@ -141,7 +141,7 @@ grCollectionsPanel.controller('GrNodeCtrl',
 
         ctrl.removeImagesFromCollection = () => {
             ctrl.removing = true;
-            remove$.onNext(ctrl.node.data.data.pathId);
+            remove$.onNext(pathId);
         };
 
         subscribe$($scope, pathToRemoveWithImages$, ({path, images}) => {
@@ -150,17 +150,17 @@ grCollectionsPanel.controller('GrNodeCtrl',
 
         inject$($scope, hasImagesSelected$, ctrl, 'hasImagesSelected');
 
-
         ctrl.isSelected = selectedCollections.some(col => {
-            return angular.equals(col, ctrl.node.data.data.pathId);
+            return angular.equals(col, pathId);
         });
 
         ctrl.hasCustomSelect = !! grCollectionTreeCtrl.onSelect;
 
-        ctrl.select = function() {
+        ctrl.select = () => {
             grCollectionTreeCtrl.onSelect({$collection: ctrl.node.data.data.path});
-        }
-    }
+        };
+
+    };
 }]);
 
 grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $compile) {

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -98,83 +98,82 @@ grCollectionsPanel.controller('GrNodeCtrl',
     ctrl.removing = false;
     ctrl.deletable = false;
     ctrl.showChildren = collectionsTreeState.getState(pathId);
-
-    ctrl.selectedImages$ = angular.isDefined(ctrl.selectedImages$) ?
-        ctrl.selectedImages$ :
-        Rx.Observable.empty();
-
-    ctrl.selectedCollections = angular.isDefined(ctrl.selectedCollections) ?
-        ctrl.selectedCollections :
-        [];
-
     ctrl.formError = null;
+
     ctrl.addChild = childName => {
         return collections.addChildTo(ctrl.node, childName).
-                 then($scope.clearForm).
-                 catch(e => $scope.formError = e.body && e.body.errorMessage);
+        then($scope.clearForm).
+        catch(e => $scope.formError = e.body && e.body.errorMessage);
     };
 
     collections.isDeletable(ctrl.node).then(d => ctrl.deletable = d);
 
     ctrl.remove = () => collections.removeFromList(ctrl.node, ctrl.nodeList);
-
     ctrl.getCollectionQuery = path => getCollection(path);
 
-    // TODO: move this somewhere sensible, we probably don't want an observable for each node.
-    const add$ = new Rx.Subject();
-    const pathWithImages$ =
-            add$.withLatestFrom(ctrl.selectedImages$, (path, images) => ({path, images}));
-
-    const hasImagesSelected$ = ctrl.selectedImages$.map(i => i.size > 0);
-    ctrl.addImagesToCollection = () => {
-        ctrl.saving = true;
-        add$.onNext(ctrl.node.data.fullPath);
-    };
-
-    subscribe$($scope, pathWithImages$, ({path, images}) => {
-       collections.addToCollectionUsingImageResources(images, path).then(() => ctrl.saving = false);
-    });
-
-    const remove$ = new Rx.Subject();
-    const pathToRemoveWithImages$ =
-            remove$.withLatestFrom(ctrl.selectedImages$, (path, images) => ({path, images}));
-
-    ctrl.removeImagesFromCollection = () => {
-        ctrl.removing = true;
-        remove$.onNext(ctrl.node.data.data.pathId);
-    };
-
-    subscribe$($scope, pathToRemoveWithImages$, ({path, images}) => {
-        collections.batchRemove(images, path).then(() => ctrl.removing = false);
-    });
-
-    inject$($scope, hasImagesSelected$, ctrl, 'hasImagesSelected');
-
     $scope.$watch('ctrl.showChildren', onValChange(show => {
-        collectionsTreeState.setState(pathId, show);
+            collectionsTreeState.setState(pathId, show);
     }));
 
-    ctrl.isSelected = ctrl.selectedCollections.some(col => {
-        return angular.equals(col, ctrl.node.data.data.pathId);
-    });
+    ctrl.init = function(grCollectionTreeCtrl) {
+        const selectedImages$ = grCollectionTreeCtrl.selectedImages$;
 
+        const selectedCollections = grCollectionTreeCtrl.selectedCollections;
+
+        // TODO: move this somewhere sensible, we probably don't want an observable for each node.
+        const add$ = new Rx.Subject();
+        const pathWithImages$ =
+                add$.withLatestFrom(selectedImages$, (path, images) => ({path, images}));
+        const hasImagesSelected$ = selectedImages$.map(i => i.size > 0);
+
+        ctrl.addImagesToCollection = () => {
+            ctrl.saving = true;
+            add$.onNext(ctrl.node.data.fullPath);
+        };
+
+        subscribe$($scope, pathWithImages$, ({path, images}) => {
+           collections.addToCollectionUsingImageResources(images, path).then(() => ctrl.saving = false);
+        });
+
+        const remove$ = new Rx.Subject();
+        const pathToRemoveWithImages$ =
+                remove$.withLatestFrom(selectedImages$, (path, images) => ({path, images}));
+
+        ctrl.removeImagesFromCollection = () => {
+            ctrl.removing = true;
+            remove$.onNext(ctrl.node.data.data.pathId);
+        };
+
+        subscribe$($scope, pathToRemoveWithImages$, ({path, images}) => {
+            collections.batchRemove(images, path).then(() => ctrl.removing = false);
+        });
+
+        inject$($scope, hasImagesSelected$, ctrl, 'hasImagesSelected');
+
+
+        ctrl.isSelected = selectedCollections.some(col => {
+            return angular.equals(col, ctrl.node.data.data.pathId);
+        });
+
+        ctrl.hasCustomSelect = !! grCollectionTreeCtrl.onSelect;
+
+        ctrl.select = function() {
+            grCollectionTreeCtrl.onSelect({$collection: ctrl.node.data.data.path});
+        }
+    }
 }]);
 
 grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $compile) {
     const templateString = `<gr-nodes
                                 ng:if="ctrl.showChildren && ctrl.node.data.children.length > 0"
-                                gr:selected-images="ctrl.selectedImages$"
-                                gr:selected-collections="ctrl.selectedCollections"
-                                gr:editing="ctrl.editing"
-                                gr:nodes="ctrl.node.data.children"></gr-nodes>`;
+                                gr:nodes="ctrl.node.data.children"
+                                ></gr-nodes>`;
     return {
         restrict: 'E',
+        require: ['grNode', '^^grCollectionTree'],
         scope: {
             node: '=grNode',
-            nodeList: '=grNodeList',
-            editing: '=grEditing',
-            selectedImages$: '=grSelectedImages',
-            selectedCollections: '=grSelectedCollections'
+            nodeList: '=grNodeList'
         },
         template: nodeTemplate,
         controller: 'GrNodeCtrl',
@@ -185,7 +184,7 @@ grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $
             // (compile invoked once per reference, link invoked once
             // per use)
             let compiledTemplate;
-            return function link(scope, element) {
+            return function link(scope, element, attrs, [grNodeCtrl, grCollectionTreeCtrl]) {
                 if (! compiledTemplate) {
                     // We compile the template on the fly here as angular doesn't deal
                     // well with recursive templates.
@@ -195,6 +194,11 @@ grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $
                 compiledTemplate(scope, cloned => {
                     element.find('.node__children').append(cloned);
                 });
+
+                grNodeCtrl.init(grCollectionTreeCtrl);
+
+                //so editing can toggle - used to show add & remove collection buttons
+                scope.grCollectionTreeCtrl = grCollectionTreeCtrl;
 
                 scope.clearForm = () => {
                     scope.active = false;
@@ -211,22 +215,50 @@ grCollectionsPanel.directive('grNodes', function() {
     return {
         restrict: 'E',
         scope: {
-            nodes: '=grNodes',
-            editing: '=grEditing',
-            selectedImages$: '=grSelectedImages',
-            selectedCollections: '=grSelectedCollections'
+            nodes: '=grNodes'
         },
+        controller: function(){},
+        controllerAs: 'grNodesCtrl',
+        bindToController: true,
         template: `<ul>
-            <li ng:repeat="node in nodes">
+            <li ng:repeat="node in grNodesCtrl.nodes">
                 <gr-node
                     class="node"
-                    gr:selected-images="selectedImages$"
-                    gr:selected-collections="selectedCollections"
                     gr:node="node"
-                    gr:node-list="nodes"
-                    gr:editing="editing"></gr-node>
+                    gr:node-list="grNodesCtrl.nodes"
+                    ></gr-node>
             </li>
         </ul>`
+    };
+});
+
+grCollectionsPanel.directive('grCollectionTree', function() {
+    return {
+        restrict: 'E',
+        scope: {
+            nodes: '=grNodes',
+            editing: '=?grEditing',
+            selectedImages$: '=?grSelectedImages',
+            selectedCollections: '=?grSelectedCollections',
+            selectionMode: '=?grSelectionMode',
+            onSelect: '&?grOnSelect'
+        },
+        controller: function(){
+            const grCollectionTreeCtrl = this;
+
+            if (! grCollectionTreeCtrl.selectedImages$) {
+                grCollectionTreeCtrl.selectedImages$ = Rx.Observable.empty();
+            }
+
+            if (! grCollectionTreeCtrl.selectedCollections) {
+                grCollectionTreeCtrl.selectedCollections = [];
+            }
+
+
+        },
+        controllerAs: 'grCollectionTreeCtrl',
+        bindToController: true,
+        template: `<gr-nodes gr:nodes="grCollectionTreeCtrl.nodes"></gr-nodes>`
     };
 });
 


### PR DESCRIPTION
Creates parent directive grCollectionsTree which takes the attributes needed to construct grNodes and grNode. 

grNodes and grNode reference this parent directive for unchanging attributes - rather than setting them again in scope object. 

Adds ability to add a custom select event - for future non-navigation uses of the collections tree.  🌲

