### PR TITLE
Style text inputs using classes, not element selector

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -17,7 +17,7 @@
         gr:search="ctrl.labelSearch(q)">
 
         <input type="text"
-               class="gr-add-label__form__input show-no-error"
+               class="text-input gr-add-label__form__input show-no-error"
                placeholder="label1, label2, label3…"
                gr:datalist-input
                gr:datalist-input-on-cancel="ctrl.cancel()"

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -68,7 +68,7 @@
 
     <form class="node__add-child" ng:if="active" ng:submit="ctrl.addChild(childName);">
         <input  gr:auto-focus
-                class="node__add-child-input"
+                class="text-input node__add-child-input"
                 type="text"
                 required
                 ng:model="childName"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -46,7 +46,9 @@
                     editable-textarea="ctrl.metadata.description"
                     onbeforesave="ctrl.updateMetadataField('description', $data)"
                     e:msd-elastic
-                    e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}"
+                    e:ng-class="{'image-info__editor--error': $error,
+                                 'image-info__editor--saving': descriptionEditForm.$waiting,
+                                 'text-input': true}"
                     e:form="descriptionEditForm">{{ctrl.metadata.description || "Unknown (click ✎ to add)"}}</dd>
             </div>
         </dl>
@@ -64,7 +66,8 @@
                 onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
                 e:msd-elastic
                 e:ng-class="{'image-info__editor--error': $error,
-                                     'image-info__editor--saving': specialInstructionsEditForm.$waiting}"
+                             'image-info__editor--saving': specialInstructionsEditForm.$waiting,
+                             'text-input': true}"
                 e:form="specialInstructionsEditForm">{{ctrl.metadata.specialInstructions}}</dd>
         </dl>
     </div>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -97,7 +97,9 @@
                          onbeforesave="ctrl.updateMetadataField('description', $data)"
                          e:msd-elastic
                          e:form="descriptionEditForm"
-                         e:ng-class="{'image-info__editor--error': $error, 'image-info__editor--saving': descriptionEditForm.$waiting}">
+                         e:ng-class="{'image-info__editor--error': $error,
+                                      'image-info__editor--saving': descriptionEditForm.$waiting,
+                                      'text-input': true}">
 
                         <div ng:if="ctrl.userCanEdit">
                             <dd class="image-info__description"
@@ -143,7 +145,8 @@
                      e:msd-elastic
                      e:form="specialInstructionsEditForm"
                      e:ng-class="{'image-info__editor--error': $error,
-                                 'image-info__editor--saving': specialInstructionsEditForm.$waiting}">
+                                  'image-info__editor--saving': specialInstructionsEditForm.$waiting,
+                                  'text-input': true}">
 
                     <div ng:if="ctrl.userCanEdit">
                         <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
@@ -31,7 +31,7 @@
         <gr-datalist class="related-labels__datalist"
                      gr:search="ctrl.suggestedLabelsSearch(q)">
           <input type="text"
-               class="show-no-error"
+               class="text-input show-no-error"
                placeholder="e.g. observer"
                required
                gr:auto-focus

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -3,7 +3,7 @@
         <gr-icon class="search-query__icon">search</gr-icon>
         <input type="text"
                placeholder="Search for images…"
-               class="search__query search-query__input"
+               class="text-input search__query search-query__input"
                autofocus="autofocus"
                ng:model="searchQuery.filter.query"
                ng:model-options="{ debounce: 400 }"

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -42,7 +42,8 @@
                                     class="related-labels__datalist"
                                 gr:search="ctrl.suggestedLabelSearch(q)">
                                 <!-- TODO: autogrow this element -->
-                                <input class="related-labels__parent" type="text"
+                                <input type="text"
+                                       class="text-input related-labels__parent"
                                        placeholder="e.g. observer"
                                        ng:model="ctrl.parentLabel"
                                        ng:model-options="{ updateOn: 'gr:datalist:update' }"

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -6,7 +6,7 @@
                 name="description"
                 placeholder="e.g. {{funnyDescription}}…"
                 required
-                class="job-info--editor__input job-info--editor__input--description"
+                class="text-input job-info--editor__input job-info--editor__input--description"
                 msd-elastic
                 ng:model="ctrl.metadata.description"
                 ng:controller="DescriptionPlaceholderCtrl"
@@ -31,7 +31,7 @@
                 type="text"
                 name="byline"
                 placeholder="e.g. Tom Jenkins…"
-                class="job-info--editor__input job-info--editor__input--byline"
+                class="text-input job-info--editor__input job-info--editor__input--byline"
                 ng:model="ctrl.metadata.byline"
                 ng:change="ctrl.save()"
                 ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
@@ -55,7 +55,7 @@
                 gr:search="ctrl.metadataSearch('credit', q)">
 
                 <input type="text"
-                    class="job-info__credit"
+                    class="text-input job-info__credit"
                     required
                     gr:datalist-input
                     ng:model="ctrl.metadata.credit"
@@ -77,7 +77,7 @@
                 type="text"
                 name="copyright"
                 placeholder="e.g. …"
-                class="job-info--editor__input job-info--editor__input--copyright"
+                class="text-input job-info--editor__input job-info--editor__input--copyright"
                 ng:model="ctrl.metadata.copyright"
                 ng:change="ctrl.save()"
                 ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -53,7 +53,7 @@
                     <!-- We don't allow you to set the restrictions if there are defaults.
                     This might not be the behaviour we want in the future, but works for now. -->
                     <textarea
-                        class="form-input-text"
+                        class="text-input form-input-text"
                         name="{{ property.name }}"
                         placeholder="What restrictions apply to this image? e.g. 'Use in relation to the Windsor Triathlon only'"
                         ng:switch-when="true"
@@ -61,7 +61,7 @@
                         ng:required="ctrl.showRestrictions"></textarea>
 
                     <textarea
-                        class="form-input-text"
+                        class="text-input form-input-text"
                         disabled="disabled"
                         ng:switch-default>{{ctrl.category.defaultRestrictions}}</textarea>
 
@@ -80,7 +80,7 @@
                     <div ng:switch-when="string">
                         <input
                             id="ure-field-{{::fieldUniqueId}}"
-                            class="form-input-text"
+                            class="text-input form-input-text"
                             type="text"
                             name="{{ property.name }}"
                             placeholder="e.g. {{ property.examples }}"
@@ -141,7 +141,7 @@
                             </select>
 
                             <input type="text"
-                                class="full-width"
+                                class="text-input full-width"
                                 id="ure-field-{{::fieldUniqueId}}"
                                 placeholder="e.g. {{ property.examples }}"
                                 ng:model="ctrl.model[property.name]"
@@ -156,7 +156,7 @@
                     </div>
 
                     <textarea
-                        class="form-input-text"
+                        class="text-input form-input-text"
                         id="ure-field-{{::fieldUniqueId}}"
                         name="{{ property.name }}"
                         placeholder="e.g. {{ property.examples }}"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -100,11 +100,7 @@ button {
     font-size: 1.4rem;
 }
 
-/* TODO: Remove generic styling, this should be a class,
-         as we need to override it to use text elements
-         anywhere else */
-input[type="text"],
-textarea {
+.text-input {
     background-color: #444;
     color: #ccc;
     border: 1px solid #999;


### PR DESCRIPTION
Minor CSS refactor to avoid styling text `input` and `textarea` directly, since this makes it hard to do anything with those without inheriting the styling. Use a class that's explicitly applied instead.

This is to help the upcoming search chips feature implementation.