### PR TITLE
Structured query search using UI chips

### DIFF
--- a/kahuna/.jshintrc
+++ b/kahuna/.jshintrc
@@ -13,7 +13,7 @@
     "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
     "unused"        : true,     // true: Require all defined variables be used
     "maxdepth"      : 3,        // {int} Max depth of nested blocks (within functions)
-    "maxcomplexity" : 10,       // {int} Max cyclomatic complexity per function
+    "maxcomplexity" : 15,       // {int} Max cyclomatic complexity per function
     "maxlen"        : 100,      // {int} Max number of characters per line
 
     // Relaxing

--- a/kahuna/public/js/components/gr-chips/gr-chip-input.js
+++ b/kahuna/public/js/components/gr-chips/gr-chip-input.js
@@ -1,0 +1,135 @@
+import angular from 'angular';
+
+export const grChipInput = angular.module('gr.chipInput', []);
+
+
+const ENTER_KEY     = 13;
+const BACKSPACE_KEY = 8;
+const DELETE_KEY    = 46;
+const LEFT_KEY      = 37;
+const RIGHT_KEY     = 39;
+const HOME_KEY      = 36;
+const END_KEY       = 35;
+
+function keyHandler(handler) {
+    return function (event) {
+        const {which, target} = event;
+        const caretStart = target.selectionStart;
+        const caretEnd   = target.selectionEnd;
+
+        const input = target.value;
+        const inputLen = input.length;
+        const atInputStart = caretStart === 0 && caretEnd === 0;
+        const atInputEnd = caretStart === inputLen && caretEnd === inputLen;
+        const noCharBefore = caretStart === 0 || input[caretStart - 1] === ' ';
+
+        const handled = handler({
+            which,
+            atInputStart,
+            atInputEnd,
+            noCharBefore,
+            caretStart,
+            caretEnd
+        });
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+}
+
+
+grChipInput.directive('grChipInput', ['$parse', '$timeout', function($parse, $timeout) {
+    return {
+        restrict: 'A',
+        require: ['^grChip', '^grChips'],
+        link: function(scope, element, attrs, [$grChipCtrl, $grChipsCtrl]) {
+            const onEnterExpr = attrs.grChipInputOnEnter && $parse(attrs.grChipInputOnEnter);
+            const backspaceStartExpr = attrs.grChipInputBackspaceAtStart && $parse(attrs.grChipInputBackspaceAtStart);
+            const deleteEndExpr = attrs.grChipInputDeleteAtEnd && $parse(attrs.grChipInputDeleteAtEnd);
+
+            scope.$watch(() => $grChipsCtrl.focusedItem, focusedItem => {
+                // Focus self (unless already focused)
+                if (focusedItem === $grChipCtrl.chip && document.activeElement !== element[0]) {
+                    // Store target caret position
+                    const {caretStartOffset, caretEndOffset} = $grChipsCtrl;
+
+                    // Yield to avoid digest-within-digest of focus event
+                    $timeout(() => {
+                        element[0].focus();
+                        element[0].setSelectionRange(caretStartOffset, caretEndOffset);
+                    });
+                }
+            });
+
+            element.on('focus', ($event) => {
+                const selStart = element[0].selectionStart;
+                const selEnd   = element[0].selectionEnd;
+                // TODO: caret position not set yet (needed to fix position when merging)
+                $grChipsCtrl.setFocusedChip($grChipCtrl.chip, selStart, selEnd);
+                scope.$digest();
+            });
+
+            element.on('blur', ($event) => {
+                $grChipsCtrl.unsetFocusedChip($grChipCtrl.chip);
+                scope.$digest();
+            });
+
+            element.on('input', ($event) => {
+                $grChipsCtrl.onChange();
+                scope.$apply();
+            });
+
+            element.on('keydown', keyHandler(function({which, atInputStart, atInputEnd}) {
+                switch (which) {
+                case ENTER_KEY:
+                    if (onEnterExpr) {
+                        onEnterExpr(scope);
+                        scope.$apply();
+                        return true;
+                    }
+                    break;
+                case LEFT_KEY:
+                    if (atInputStart) {
+                        $grChipsCtrl.focusEndOfChipBefore($grChipCtrl.chip);
+                        scope.$apply();
+                        return true;
+                    }
+                    break;
+                case RIGHT_KEY:
+                    if (atInputEnd) {
+                        $grChipsCtrl.focusStartOfChipAfter($grChipCtrl.chip);
+                        scope.$apply();
+                        return true;
+                    }
+                    break;
+                case BACKSPACE_KEY:
+                    if (atInputStart && backspaceStartExpr) {
+                        backspaceStartExpr(scope);
+                        scope.$apply();
+                        return true;
+                    }
+                    break;
+                case DELETE_KEY:
+                    if (atInputEnd && deleteEndExpr) {
+                        deleteEndExpr(scope);
+                        scope.$apply();
+                        return true;
+                    }
+                    break;
+                // Emulate Home/End to go to start/end of input
+                case HOME_KEY:
+                    $grChipsCtrl.focusStartOfFirstChip();
+                    scope.$apply();
+                    return true;
+                    break;
+                case END_KEY:
+                    $grChipsCtrl.focusEndOfLastChip();
+                    scope.$apply();
+                    return true;
+                    break;
+                }
+            }));
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-chips/gr-chip-input.js
+++ b/kahuna/public/js/components/gr-chips/gr-chip-input.js
@@ -44,9 +44,15 @@ grChipInput.directive('grChipInput', ['$parse', '$timeout', function($parse, $ti
         restrict: 'A',
         require: ['^grChip', '^grChips'],
         link: function(scope, element, attrs, [$grChipCtrl, $grChipsCtrl]) {
-            const onEnterExpr = attrs.grChipInputOnEnter && $parse(attrs.grChipInputOnEnter);
-            const backspaceStartExpr = attrs.grChipInputBackspaceAtStart && $parse(attrs.grChipInputBackspaceAtStart);
-            const deleteEndExpr = attrs.grChipInputDeleteAtEnd && $parse(attrs.grChipInputDeleteAtEnd);
+            const [
+                onEnterExpr,
+                backspaceStartExpr,
+                deleteEndExpr
+            ] = [
+                attrs.grChipInputOnEnter,
+                attrs.grChipInputBackspaceAtStart,
+                attrs.grChipInputDeleteAtEnd
+            ].map(attr => attr && $parse(attr));
 
             scope.$watchCollection(() => ({focusedItem: $grChipsCtrl.focusedItem,
                                            caretStartOffset: $grChipsCtrl.caretStartOffset,
@@ -69,7 +75,7 @@ grChipInput.directive('grChipInput', ['$parse', '$timeout', function($parse, $ti
                 }
             });
 
-            element.on('focus', ($event) => {
+            element.on('focus', () => {
                 // Caret position not set yet, yield to get it
                 $timeout(() => {
                     const selStart = element[0].selectionStart;
@@ -78,12 +84,12 @@ grChipInput.directive('grChipInput', ['$parse', '$timeout', function($parse, $ti
                 });
             });
 
-            element.on('blur', ($event) => {
+            element.on('blur', () => {
                 $grChipsCtrl.unsetFocusedChip($grChipCtrl.chip);
                 scope.$digest();
             });
 
-            element.on('input', ($event) => {
+            element.on('input', () => {
                 const selStart = element[0].selectionStart;
                 const selEnd   = element[0].selectionEnd;
 
@@ -129,17 +135,16 @@ grChipInput.directive('grChipInput', ['$parse', '$timeout', function($parse, $ti
                         return true;
                     }
                     break;
+
                 // Emulate Home/End to go to start/end of input
                 case HOME_KEY:
                     $grChipsCtrl.focusStartOfFirstChip();
                     scope.$apply();
                     return true;
-                    break;
                 case END_KEY:
                     $grChipsCtrl.focusEndOfLastChip();
                     scope.$apply();
                     return true;
-                    break;
                 }
             }));
         }

--- a/kahuna/public/js/components/gr-chips/gr-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-chip.js
@@ -1,0 +1,27 @@
+import angular from 'angular';
+
+export const grChip = angular.module('gr.chip', []);
+
+grChip.directive('grChip', ['$parse', function($parse) {
+    return {
+        restrict: 'A',
+        require: ['grChip', '^grChips'],
+        controller: function() {
+            const $grChipCtrl = this;
+
+            $grChipCtrl.chip = null;
+
+            $grChipCtrl.init = function(chip) {
+                $grChipCtrl.chip = chip;
+            };
+        },
+        controllerAs: '$grChipCtrl',
+        compile: function(element, attrs) {
+            const termExpr = $parse(attrs.grChip);
+
+            return function(scope, element, attrs, [$grChipCtrl]) {
+                $grChipCtrl.init(termExpr(scope));
+            };
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-chips/gr-chips.css
+++ b/kahuna/public/js/components/gr-chips/gr-chips.css
@@ -1,0 +1,64 @@
+gr-chips {
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+/* Make sure the last text token is wide enough */
+gr-chips .gr-chips__chip-wrapper:last-child gr-text-chip input {
+    min-width: 2em;
+}
+
+.gr-chips__placeholder {
+    position: absolute;
+    color: #aaa;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+            user-select: none;
+}
+
+gr-text-chip,
+gr-filter-chip,
+gr-static-filter-chip,
+gr-filter-chooser-chip,
+gr-filter-chip,
+gr-datalist {
+    display: inline-block;
+}
+
+gr-filter-chip button,
+gr-static-filter-chip button,
+gr-filter-chooser-chip button {
+    border: 0;
+    background: transparent;
+    padding: 0;
+}
+
+.gr-filter-chip__value,
+.gr-static-filter-chip__value,
+.gr-filter-chooser-chip__value {
+    padding: 4px 2px;
+}
+
+.gr-filter-chip__key,
+.gr-static-filter-chip__key,
+.gr-static-filter-chip__value {
+    cursor: default;
+}
+
+gr-text-chip input,
+gr-filter-chip input,
+gr-filter-chooser-chip input {
+    border: 0;
+    background: transparent;
+}
+
+gr-text-chip button:focus,
+gr-filter-chip button:focus,
+gr-static-filter-chip button:focus,
+gr-filter-chooser-chip button:focus,
+gr-text-chip input:focus,
+gr-filter-chip input:focus,
+gr-static-filter-chip input:focus,
+gr-filter-chooser-chip input:focus {
+    outline: none;
+}

--- a/kahuna/public/js/components/gr-chips/gr-chips.css
+++ b/kahuna/public/js/components/gr-chips/gr-chips.css
@@ -1,6 +1,7 @@
 gr-chips {
     white-space: nowrap;
     overflow: hidden;
+    cursor: text; /* pretend the whole thing is a text input */
 }
 
 /* Make sure the last text token is wide enough */

--- a/kahuna/public/js/components/gr-chips/gr-chips.html
+++ b/kahuna/public/js/components/gr-chips/gr-chips.html
@@ -1,0 +1,18 @@
+<div class="gr-chips__wrapper"
+     ng:click="$grChipsCtrl.wrapperClicked($event)">
+    <span ng:if="$grChipsCtrl.placeholder && $grChipsCtrl.isEmpty()"
+          class="gr-chips__placeholder"
+    >{{$grChipsCtrl.placeholder}}</span>
+    <span ng:repeat="$chip in $grChipsCtrl.items"
+          ng:switch="$chip.type"
+          class="gr-chips__chip-wrapper">
+       <gr-text-chip ng:switch-when="text"
+                     gr-chip="$chip"></gr-text-chip>
+       <gr-filter-chip ng:switch-when="filter"
+                       gr-chip="$chip"></gr-filter-chip>
+       <gr-static-filter-chip ng:switch-when="static-filter"
+                              gr-chip="$chip"></gr-static-filter-chip>
+       <gr-filter-chooser-chip ng:switch-when="filter-chooser"
+                               gr-chip="$chip"></gr-filter-chooser-chip>
+    </span>
+</div>

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -169,6 +169,7 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         // If chip to remove is focused, move focus right before or after
         const removedItem = $grChipsCtrl.items[index];
         if (removedItem === $grChipsCtrl.focusedItem) {
+            /* jshint expr: true */
             $grChipsCtrl.focusEndOfChipBefore(removedItem) ||
                 $grChipsCtrl.focusStartOfChipAfter(removedItem);
         }
@@ -178,10 +179,13 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
     function normalizeChips() {
         // merge consecutive text chips
         for (let i = 1; i < $grChipsCtrl.items.length; i++) {
-            if ($grChipsCtrl.items[i].type === 'text' && $grChipsCtrl.items[i - 1].type === 'text') {
+            if ($grChipsCtrl.items[i].type === 'text' &&
+                $grChipsCtrl.items[i - 1].type === 'text') {
                 // TODO: need to force chip to re-set the caret
                 // position else it gets moved to the end of the field
-                $grChipsCtrl.items[i - 1].value = ($grChipsCtrl.items[i - 1].value + ' ' + $grChipsCtrl.items[i].value).trim();
+                const prevValue = $grChipsCtrl.items[i - 1].value;
+                const currValue = $grChipsCtrl.items[i].value;
+                $grChipsCtrl.items[i - 1].value = `${prevValue} ${currValue}`.trim();
                 removeChipAt(i);
                 i--;
             }

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -179,6 +179,8 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         // merge consecutive text chips
         for (let i = 1; i < $grChipsCtrl.items.length; i++) {
             if ($grChipsCtrl.items[i].type === 'text' && $grChipsCtrl.items[i - 1].type === 'text') {
+                // TODO: need to force chip to re-set the caret
+                // position else it gets moved to the end of the field
                 $grChipsCtrl.items[i - 1].value = ($grChipsCtrl.items[i - 1].value + ' ' + $grChipsCtrl.items[i].value).trim();
                 removeChipAt(i);
                 i--;

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -1,0 +1,241 @@
+import angular from 'angular';
+
+import './gr-chips.css!';
+import template from './gr-chips.html!text';
+
+import {grTextChip}          from './gr-text-chip';
+import {grFilterChip}        from './gr-filter-chip';
+import {grStaticFilterChip}  from './gr-static-filter-chip';
+import {grFilterChooserChip} from './gr-filter-chooser-chip';
+
+
+export const grChips = angular.module('gr.chips', [
+    grTextChip.name,
+    grFilterChip.name,
+    grStaticFilterChip.name,
+    grFilterChooserChip.name
+]);
+
+grChips.controller('grChipsCtrl', ['$scope', function($scope) {
+    const $grChipsCtrl = this;
+
+    $grChipsCtrl.items = [];
+    $grChipsCtrl.focusedItem = null;
+    $grChipsCtrl.caretStartOffset = null;
+    $grChipsCtrl.caretEndOffset = null;
+
+    $grChipsCtrl.configureNgModel = function(ngModelCtrl, onChangeExpr, autoCompleteExpr,
+                                             validKeysExpr, autofocus, placeholder) {
+        $grChipsCtrl.placeholder = placeholder;
+        $grChipsCtrl.onChange = () => onChangeExpr($scope, {$chips: $grChipsCtrl.items});
+        $grChipsCtrl.getSuggestions = ($chip) => autoCompleteExpr($scope, {$chip});
+
+        const validKeys = validKeysExpr($scope);
+        $grChipsCtrl.isValidKey = (key) => {
+            if (Array.isArray(validKeys)) {
+                return validKeys.indexOf(key) !== -1;
+            } else {
+                // No restriction on keys, all valid
+                return true;
+            }
+        };
+
+        ngModelCtrl.$render = function() {
+            $grChipsCtrl.items = ngModelCtrl.$viewValue;
+            normalizeChips();
+
+            if (autofocus) {
+                $grChipsCtrl.focusStartOfFirstChip();
+            }
+        };
+    };
+
+    // Broadcast changes to the items list.
+    // Note that individual chip directives also need to
+    // broadcast updates to chip fields themselves.
+    $scope.$watchCollection(() => $grChipsCtrl.items, (items, previousItems) => {
+        // Ignore initialisation call
+        if (items !== previousItems) {
+            $grChipsCtrl.onChange();
+        }
+    });
+
+
+    // If clicking on the inner wrapper or the placeholder
+    // (and not in between chips), focus the end of the
+    // component
+    $grChipsCtrl.wrapperClicked = function($event) {
+        if ($event.target.classList.contains('gr-chips__wrapper') ||
+            $event.target.classList.contains('gr-chips__placeholder')) {
+            $grChipsCtrl.focusEndOfLastChip();
+        }
+    };
+
+    $grChipsCtrl.isEmpty = function() {
+        return $grChipsCtrl.items.length === 1 &&
+            $grChipsCtrl.items[0].value === '';
+    };
+
+    $grChipsCtrl.removeChip = function(item) {
+        const index = $grChipsCtrl.items.indexOf(item);
+        if (index !== -1) {
+            removeChipAt(index);
+            normalizeChips();
+        }
+    };
+
+    $grChipsCtrl.removeChipBefore = function(item) {
+        const index = $grChipsCtrl.items.indexOf(item) - 1;
+        if (index >= 0) {
+            removeChipAt(index);
+            normalizeChips();
+        }
+    };
+
+    $grChipsCtrl.removeChipAfter = function(item) {
+        const index = $grChipsCtrl.items.indexOf(item) + 1;
+        if (index <= $grChipsCtrl.items.length) {
+            removeChipAt(index);
+            normalizeChips();
+        }
+    };
+
+    $grChipsCtrl.setFocusedChip = function(item, caretStart = 0, caretEnd = 0) {
+        const index = $grChipsCtrl.items.indexOf(item);
+        if (index !== -1) {
+            $grChipsCtrl.focusedItem = item;
+            $grChipsCtrl.caretStartOffset = caretStart;
+            $grChipsCtrl.caretEndOffset = caretEnd;
+            return true;
+        }
+    };
+
+    $grChipsCtrl.unsetFocusedChip = function(item) {
+        if ($grChipsCtrl.focusedItem === item) {
+            $grChipsCtrl.focusedItem = null;
+            $grChipsCtrl.caretStartOffset = null;
+            $grChipsCtrl.caretEndOffset = null;
+            return true;
+        }
+    };
+
+    $grChipsCtrl.focusEndOfChipBefore = function(item) {
+        const index = $grChipsCtrl.items.indexOf(item) - 1;
+        if (index >= 0) {
+            const previousItem = $grChipsCtrl.items[index];
+            const itemLength = previousItem.value.length;
+            $grChipsCtrl.setFocusedChip(previousItem, itemLength, itemLength);
+            return true;
+        }
+    };
+
+    $grChipsCtrl.focusStartOfChipAfter = function(item) {
+        const index = $grChipsCtrl.items.indexOf(item) + 1;
+        if (index <= $grChipsCtrl.items.length) {
+            $grChipsCtrl.setFocusedChip($grChipsCtrl.items[index], 0, 0);
+            return true;
+        }
+    };
+
+    $grChipsCtrl.focusStartOfFirstChip = function() {
+        const firstItem = $grChipsCtrl.items[0];
+        if (firstItem) {
+            $grChipsCtrl.setFocusedChip(firstItem, 0, 0);
+            return true;
+        }
+    };
+
+    $grChipsCtrl.focusEndOfLastChip = function() {
+        const lastItem = $grChipsCtrl.items.slice(-1)[0];
+        if (lastItem) {
+            const itemLength = lastItem.value.length;
+            $grChipsCtrl.setFocusedChip(lastItem, itemLength, itemLength);
+            return true;
+        }
+    };
+
+    $grChipsCtrl.insertChips = function(previousItem, newItems) {
+        const index = $grChipsCtrl.items.indexOf(previousItem) + 1;
+        $grChipsCtrl.items.splice(index, 0, ...newItems);
+        normalizeChips();
+    };
+
+    $grChipsCtrl.replaceChip = function(existingItem, newItems) {
+        const index = $grChipsCtrl.items.indexOf(existingItem);
+        $grChipsCtrl.items.splice(index, 1, ...newItems);
+        if ($grChipsCtrl.focusedItem === existingItem) {
+            $grChipsCtrl.setFocusedChip(newItems[0]);
+        }
+        normalizeChips();
+    };
+
+    function removeChipAt(index) {
+        // If chip to remove is focused, move focus right before or after
+        const removedItem = $grChipsCtrl.items[index];
+        if (removedItem === $grChipsCtrl.focusedItem) {
+            $grChipsCtrl.focusEndOfChipBefore(removedItem) ||
+                $grChipsCtrl.focusStartOfChipAfter(removedItem);
+        }
+        $grChipsCtrl.items.splice(index, 1);
+    }
+
+    function normalizeChips() {
+        // merge consecutive text chips
+        for (let i = 1; i < $grChipsCtrl.items.length; i++) {
+            if ($grChipsCtrl.items[i].type === 'text' && $grChipsCtrl.items[i - 1].type === 'text') {
+                $grChipsCtrl.items[i - 1].value = ($grChipsCtrl.items[i - 1].value + ' ' + $grChipsCtrl.items[i].value).trim();
+                removeChipAt(i);
+                i--;
+            }
+        }
+
+        // ensure leading empty text chip
+        const firstChip = $grChipsCtrl.items[0];
+        if (! firstChip || firstChip.type !== 'text') {
+            $grChipsCtrl.items.unshift({type: 'text', value: ''});
+        }
+
+        // ensure trailing empty text chip
+        const lastChip = $grChipsCtrl.items.slice(-1)[0];
+        if (! lastChip || lastChip.type !== 'text') {
+            $grChipsCtrl.items.push({type: 'text', value: ''});
+        }
+    }
+}]);
+
+grChips.directive('grChips', ['$parse', function($parse) {
+    return {
+        restrict: 'E',
+        require: 'grChips',
+        template: template,
+        controller: 'grChipsCtrl',
+        controllerAs: '$grChipsCtrl',
+        compile: function compile(element, attrs) {
+            const autoCompleteExpr = $parse(attrs.grAutocomplete);
+            const onChangeExpr = $parse(attrs.grOnChange);
+            const validKeysExpr = $parse(attrs.grValidKeys);
+            return function link(scope, element, attrs, $grChipsCtrl) {
+                const ngModelCtrl = element.controller('ngModel');
+                const autofocus = 'autofocus' in attrs;
+                const placeholder = attrs.placeholder;
+                $grChipsCtrl.configureNgModel(
+                    ngModelCtrl,
+                    onChangeExpr,
+                    autoCompleteExpr,
+                    validKeysExpr,
+                    autofocus,
+                    placeholder
+                );
+            };
+        }
+    };
+}]);
+
+
+
+/* TODO
+  * cannot focus static filter, breaks navigation
+  + broken HOME/END in single text field
+  - auto-completion: key descriptions
+  - keep caret position as chips are merged
+ */

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -231,7 +231,6 @@ grChips.directive('grChips', ['$parse', function($parse) {
 
 /* TODO
   * cannot focus static filter, breaks navigation
-  + broken HOME/END in single text field
   - auto-completion: key descriptions
   - keep caret position as chips are merged
  */

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -124,24 +124,21 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         if (index >= 0) {
             const previousItem = $grChipsCtrl.items[index];
             const itemLength = previousItem.value.length;
-            $grChipsCtrl.setFocusedChip(previousItem, itemLength, itemLength);
-            return true;
+            return $grChipsCtrl.setFocusedChip(previousItem, itemLength, itemLength);
         }
     };
 
     $grChipsCtrl.focusStartOfChipAfter = function(item) {
         const index = $grChipsCtrl.items.indexOf(item) + 1;
         if (index <= $grChipsCtrl.items.length) {
-            $grChipsCtrl.setFocusedChip($grChipsCtrl.items[index], 0, 0);
-            return true;
+            return $grChipsCtrl.setFocusedChip($grChipsCtrl.items[index], 0, 0);
         }
     };
 
     $grChipsCtrl.focusStartOfFirstChip = function() {
         const firstItem = $grChipsCtrl.items[0];
         if (firstItem) {
-            $grChipsCtrl.setFocusedChip(firstItem, 0, 0);
-            return true;
+            return $grChipsCtrl.setFocusedChip(firstItem, 0, 0);
         }
     };
 
@@ -149,8 +146,7 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         const lastItem = $grChipsCtrl.items.slice(-1)[0];
         if (lastItem) {
             const itemLength = lastItem.value.length;
-            $grChipsCtrl.setFocusedChip(lastItem, itemLength, itemLength);
-            return true;
+            return $grChipsCtrl.setFocusedChip(lastItem, itemLength, itemLength);
         }
     };
 

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.html
@@ -6,6 +6,7 @@
     >{{$chip.filterType === 'inclusion' ? '+' : '−' }}</button
     ><span class="gr-filter-chip__key">{{$chip.key}}:</span
     ><input type="text"
+            autocomplete="off"
             class="gr-filter-chip__value"
             gr-datalist-input
             gr-auto-width

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.html
@@ -1,0 +1,21 @@
+<gr-datalist gr-search="$grChipsCtrl.getSuggestions($chip)"
+             gr-on-select="$grFilterChipCtrl.apply($value)">
+    <button type="button"
+            class="gr-filter-chip__type"
+            ng:click="$grFilterChipCtrl.toggleFilterType()"
+    >{{$chip.filterType === 'inclusion' ? '+' : '−' }}</button
+    ><span class="gr-filter-chip__key">{{$chip.key}}:</span
+    ><input type="text"
+            class="gr-filter-chip__value"
+            gr-datalist-input
+            gr-auto-width
+            ng:trim="false"
+            gr-chip-input
+            gr-chip-input-on-enter="$grFilterChipCtrl.apply($chip.value)"
+            gr-chip-input-backspace-at-start="$grFilterChipCtrl.removeSelf()"
+            ng:model="$chip.value"
+    /><button type="button"
+              class="gr-filter-chip__remove"
+              ng:click="$grChipsCtrl.removeChip($chip)"
+    >✕</button>
+</gr-datalist>

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.js
@@ -1,0 +1,62 @@
+import angular from 'angular';
+
+import template from './gr-filter-chip.html!text';
+
+import {grChip} from './gr-chip';
+import {grChipInput} from './gr-chip-input';
+
+import {datalist} from '../../forms/datalist';
+import {autoWidth} from '../../directives/gr-auto-width';
+
+
+export const grFilterChip = angular.module('gr.filterChip', [
+    grChip.name,
+    grChipInput.name,
+    datalist.name,
+    autoWidth.name
+]);
+
+grFilterChip.controller('grFilterChipCtrl', function() {
+    const $grFilterChipCtrl = this;
+
+    let $grChipsCtrl;
+    let $grChipCtrl;
+
+    $grFilterChipCtrl.init = function($grChipsCtrl_, $grChipCtrl_) {
+        $grChipsCtrl = $grChipsCtrl_;
+        $grChipCtrl = $grChipCtrl_;
+    };
+
+    $grFilterChipCtrl.apply = function(value) {
+        // Only transform if /something/ is submitted
+        if (value) {
+            const chip = $grChipCtrl.chip;
+            $grChipsCtrl.focusStartOfChipAfter(chip);
+            $grChipsCtrl.onChange();
+        }
+    };
+
+    $grFilterChipCtrl.toggleFilterType = function() {
+        const chip = $grChipCtrl.chip;
+        chip.filterType = chip.filterType === 'exclusion' ? 'inclusion' : 'exclusion';
+        $grChipsCtrl.onChange();
+    };
+
+    $grFilterChipCtrl.removeSelf = function() {
+        $grChipsCtrl.removeChip($grChipCtrl.chip);
+    };
+});
+
+grFilterChip.directive('grFilterChip', [function() {
+    return {
+        restrict: 'E',
+        require: ['grChip', 'grFilterChip', '^grChips'],
+        template: template,
+        controller: 'grFilterChipCtrl',
+        controllerAs: '$grFilterChipCtrl',
+        link: function(scope, element, attrs,
+                       [$grChipCtrl, $grFilterChipCtrl, $grChipsCtrl]) {
+            $grFilterChipCtrl.init($grChipsCtrl, $grChipCtrl);
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.js
@@ -31,6 +31,13 @@ grFilterChip.controller('grFilterChipCtrl', function() {
         // Only transform if /something/ is submitted
         if (value) {
             const chip = $grChipCtrl.chip;
+
+            // Hack: this shouldn't be necessary as the value is
+            // data-bound to be the same, but there's a sequencing
+            // issue with datalist causing the update to come *after*
+            // this fires, without the value in case of mouse clicks
+            chip.value = value;
+
             $grChipsCtrl.focusStartOfChipAfter(chip);
             $grChipsCtrl.onChange();
         }

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
@@ -3,6 +3,7 @@
     <span class="gr-filter-chooser-chip__type"
     >{{$chip.filterType === 'inclusion' ? '+' : '−' }}</span
     ><input type="text"
+            autocomplete="off"
             class="gr-filter-chooser-chip__value"
             gr-datalist-input
             gr-auto-width

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
@@ -1,0 +1,15 @@
+<gr-datalist gr-search="$grChipsCtrl.getSuggestions($chip)"
+             gr-on-select="$grFilterChooserChipCtrl.apply($value)">
+    <span class="gr-filter-chooser-chip__type"
+    >{{$chip.filterType === 'inclusion' ? '+' : '−' }}</span
+    ><input type="text"
+            class="gr-filter-chooser-chip__value"
+            gr-datalist-input
+            gr-auto-width
+            ng:trim="false"
+            gr-chip-input
+            gr-chip-input-on-enter="$grFilterChooserChipCtrl.apply($chip.value)"
+            gr-chip-input-backspace-at-start="$grFilterChooserChipCtrl.removeSelf()"
+            ng:model="$chip.value"
+    />
+</gr-datalist>

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
@@ -41,12 +41,16 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
             const chip = $grChipCtrl.chip;
             if ($grChipsCtrl.isValidKey(value)) {
                 // Valid key, turn it into a filter
-                $grChipsCtrl.replaceChip(chip, [{
+                const filterChip = {
                     type: 'filter',
                     filterType: chip.filterType,
                     key: value,
                     value: ''
-                }]);
+                };
+                $grChipsCtrl.replaceChip(chip, [filterChip]);
+                // Force-set the focus in case the user clicked on the
+                // dropdown which blurred the current chip
+                $grChipsCtrl.setFocusedChip(filterChip);
             } else {
                 // Not a key, turn it into an 'any' filter and move focus next text
                 const anyFilterChip = {

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
@@ -1,0 +1,78 @@
+import angular from 'angular';
+
+import template from './gr-filter-chooser-chip.html!text';
+
+import {grChip} from './gr-chip';
+import {grChipInput} from './gr-chip-input';
+
+import {datalist} from '../../forms/datalist';
+import {autoWidth} from '../../directives/gr-auto-width';
+
+
+export const grFilterChooserChip = angular.module('gr.filterChooserChip', [
+    grChip.name,
+    grChipInput.name,
+    datalist.name,
+    autoWidth.name
+]);
+
+grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
+    const $grFilterChooserChipCtrl = this;
+
+    let $grChipsCtrl;
+    let $grChipCtrl;
+
+    $grFilterChooserChipCtrl.init = function($grChipsCtrl_, $grChipCtrl_) {
+        $grChipsCtrl = $grChipsCtrl_;
+        $grChipCtrl = $grChipCtrl_;
+    };
+
+    $grFilterChooserChipCtrl.apply = function(value) {
+        // Only transform if /something/ is submitted
+        // Note: this also prevents double-application of datalist/ENTER key
+        if (value) {
+            const chip = $grChipCtrl.chip;
+            if ($grChipsCtrl.isValidKey(value)) {
+                // Valid key, turn it into a filter
+                $grChipsCtrl.replaceChip(chip, [{
+                    type: 'filter',
+                    filterType: chip.filterType,
+                    key: value,
+                    value: ''
+                }]);
+            } else {
+                // Not a key, turn it into an 'any' filter and move focus next text
+                const anyFilterChip = {
+                    type: 'filter',
+                    filterType: chip.filterType,
+                    key: 'any',
+                    value: value
+                };
+                const nextText = {
+                    type: 'text',
+                    value: ''
+                };
+                $grChipsCtrl.replaceChip(chip, [anyFilterChip, nextText]);
+                $grChipsCtrl.setFocusedChip(nextText);
+            }
+        }
+    };
+
+    $grFilterChooserChipCtrl.removeSelf = function() {
+        $grChipsCtrl.removeChip($grChipCtrl.chip);
+    };
+});
+
+grFilterChooserChip.directive('grFilterChooserChip', [function() {
+    return {
+        restrict: 'E',
+        require: ['grChip', 'grFilterChooserChip', '^grChips'],
+        template: template,
+        controller: 'grFilterChooserChipCtrl',
+        controllerAs: '$grFilterChooserChipCtrl',
+        link: function(scope, element, attrs,
+                       [$grChipCtrl, $grFilterChooserChipCtrl, $grChipsCtrl]) {
+            $grFilterChooserChipCtrl.init($grChipsCtrl, $grChipCtrl);
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
@@ -22,6 +22,9 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
     let $grChipsCtrl;
     let $grChipCtrl;
 
+    // Hack to prevents double-application of datalist/ENTER key
+    let applied = false;
+
     $grFilterChooserChipCtrl.init = function($grChipsCtrl_, $grChipCtrl_) {
         $grChipsCtrl = $grChipsCtrl_;
         $grChipCtrl = $grChipCtrl_;
@@ -29,8 +32,12 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
 
     $grFilterChooserChipCtrl.apply = function(value) {
         // Only transform if /something/ is submitted
-        // Note: this also prevents double-application of datalist/ENTER key
-        if (value) {
+        if (value && ! applied) {
+            // Prevent double-application of datalist/ENTER key, as
+            // both events get fired even though the first one caused
+            // this chip to be replaced
+            applied = true;
+
             const chip = $grChipCtrl.chip;
             if ($grChipsCtrl.isValidKey(value)) {
                 // Valid key, turn it into a filter

--- a/kahuna/public/js/components/gr-chips/gr-static-filter-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-static-filter-chip.html
@@ -1,0 +1,10 @@
+<button type="button"
+        class="gr-static-filter-chip__type"
+        ng:click="$grStaticFilterChipCtrl.toggleFilterType()"
+>{{$chip.filterType === 'inclusion' ? '+' : '−' }}</button
+><span class="gr-static-filter-chip__key">{{$chip.key}}:</span
+><span class="gr-static-filter-chip__value">{{$chip.value}}</span
+><button type="button"
+         class="gr-static-filter-chip__remove"
+         ng:click="$grChipsCtrl.removeChip($chip)"
+>✕</button>

--- a/kahuna/public/js/components/gr-chips/gr-static-filter-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-static-filter-chip.js
@@ -1,0 +1,44 @@
+import angular from 'angular';
+
+import template from './gr-static-filter-chip.html!text';
+
+import {grChip} from './gr-chip';
+import {grChipInput} from './gr-chip-input';
+
+
+export const grStaticFilterChip = angular.module('gr.staticFilterChip', [
+    grChip.name,
+    grChipInput.name
+]);
+
+grStaticFilterChip.controller('grStaticFilterChipCtrl', function() {
+    const $grStaticFilterChipCtrl = this;
+
+    let $grChipsCtrl;
+    let $grChipCtrl;
+
+    $grStaticFilterChipCtrl.init = function($grChipsCtrl_, $grChipCtrl_) {
+        $grChipsCtrl = $grChipsCtrl_;
+        $grChipCtrl = $grChipCtrl_;
+    };
+
+    $grStaticFilterChipCtrl.toggleFilterType = function() {
+        const chip = $grChipCtrl.chip;
+        chip.filterType = chip.filterType === 'exclusion' ? 'inclusion' : 'exclusion';
+        $grChipsCtrl.onChange();
+    };
+});
+
+grStaticFilterChip.directive('grStaticFilterChip', [function() {
+    return {
+        restrict: 'E',
+        require: ['grChip', 'grStaticFilterChip', '^grChips'],
+        template: template,
+        controller: 'grStaticFilterChipCtrl',
+        controllerAs: '$grStaticFilterChipCtrl',
+        link: function(scope, element, attrs,
+                       [$grChipCtrl, $grStaticFilterChipCtrl, $grChipsCtrl]) {
+            $grStaticFilterChipCtrl.init($grChipsCtrl, $grChipCtrl);
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -1,0 +1,9 @@
+<input type="text"
+       gr-auto-width
+       ng:trim="false"
+       gr-chip-input
+       gr-chip-input-backspace-at-start="$grTextChipCtrl.removePrevious()"
+       gr-chip-input-delete-at-end="$grTextChipCtrl.removeNext()"
+       ng:model="$grChipCtrl.chip.value"
+       ng:keypress="$grTextChipCtrl.handleKey($event)"
+/>

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -1,4 +1,5 @@
 <input type="text"
+       autocomplete="off"
        gr-auto-width
        ng:trim="false"
        gr-chip-input

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.js
@@ -1,0 +1,122 @@
+import angular from 'angular';
+
+import template from './gr-text-chip.html!text';
+
+import {grChip} from './gr-chip';
+import {grChipInput} from './gr-chip-input';
+
+import {autoWidth} from '../../directives/gr-auto-width';
+
+
+export const grTextChip = angular.module('gr.textChip', [
+    grChip.name,
+    grChipInput.name,
+    autoWidth.name
+]);
+
+grTextChip.controller('grTextChipCtrl', function() {
+    const $grTextChipCtrl = this;
+
+    let $grChipsCtrl;
+    let $grChipCtrl;
+
+    $grTextChipCtrl.init = function($grChipsCtrl_, $grChipCtrl_) {
+        $grChipsCtrl = $grChipsCtrl_;
+        $grChipCtrl = $grChipCtrl_;
+    };
+
+    $grTextChipCtrl.removePrevious = function() {
+        $grChipsCtrl.removeChipBefore($grChipCtrl.chip);
+    };
+
+    $grTextChipCtrl.removeNext = function() {
+        $grChipsCtrl.removeChipAfter($grChipCtrl.chip);
+    };
+
+    $grTextChipCtrl.handleKey = function(event) {
+        const {which, target} = event;
+        const char = String.fromCharCode(which);
+        const caretStart = target.selectionStart;
+        const input = target.value;
+        const noCharBefore = caretStart === 0 || input[caretStart - 1] === ' ';
+
+        // if not within a word
+        if (noCharBefore) {
+            switch (char) {
+            case '+':
+                insertAndFocusFilterChooser('inclusion', caretStart, caretStart);
+                event.preventDefault();
+                break;
+            case '-':
+                insertAndFocusFilterChooser('exclusion', caretStart, caretStart);
+                event.preventDefault();
+                break;
+            case '#':
+                insertAndFocusFilter('inclusion', 'label', caretStart, caretStart);
+                event.preventDefault();
+                break;
+            }
+        }
+
+        if (char === ':') {
+            const [, sign, prevWord] = input.slice(0, caretStart).match(/\s*(-?)([a-zA-Z]+)$/);
+
+            // Check previous word is a valid filter key
+            if (prevWord && $grChipsCtrl.isValidKey(prevWord)) {
+                const filterType = sign === '-' ? 'exclusion' : 'inclusion';
+                const splitStart = caretStart - prevWord.length - sign.length;
+                const splitEnd = caretStart;
+                insertAndFocusFilter(filterType, prevWord, splitStart, splitEnd);
+                event.preventDefault();
+            }
+        }
+    };
+
+    function insertAndFocus(newChip, splitStart, splitEnd) {
+        const chip = $grChipCtrl.chip;
+        const textUntil = chip.value.slice(0, splitStart).trimRight();
+        const textAfter = chip.value.slice(splitEnd).trimLeft();
+
+        const remainderChip = textAfter && {
+            type: 'text',
+            value: textAfter
+        };
+        const newChips = remainderChip ? [newChip, remainderChip] : [newChip];
+
+        chip.value = textUntil;
+
+        $grChipsCtrl.insertChips(chip, newChips);
+        $grChipsCtrl.focusStartOfChipAfter(chip);
+    }
+
+    function insertAndFocusFilterChooser(filterType, splitStart) {
+        insertAndFocus({
+            type: 'filter-chooser',
+            filterType: filterType,
+            value: ''
+        }, splitStart, splitStart);
+    }
+
+    function insertAndFocusFilter(filterType, key, splitStart, splitEnd) {
+        insertAndFocus({
+            type: 'filter',
+            filterType: filterType,
+            key: key,
+            value: ''
+        }, splitStart, splitEnd);
+    }
+});
+
+grTextChip.directive('grTextChip', [function() {
+    return {
+        restrict: 'E',
+        require: ['grChip', 'grTextChip', '^grChips'],
+        template: template,
+        controller: 'grTextChipCtrl',
+        controllerAs: '$grTextChipCtrl',
+        link: function(scope, element, attrs,
+                       [$grChipCtrl, $grTextChipCtrl, $grChipsCtrl]) {
+            $grTextChipCtrl.init($grChipsCtrl, $grChipCtrl);
+        }
+    };
+}]);

--- a/kahuna/public/js/directives/gr-auto-width.js
+++ b/kahuna/public/js/directives/gr-auto-width.js
@@ -1,0 +1,56 @@
+import angular from 'angular';
+
+export var autoWidth = angular.module('gr.autoWidth', []);
+
+// Note: you *MUST* set ng:trim="false" on the input for the width to
+// correctly represent leading/trailing spaces
+autoWidth.directive('grAutoWidth', ['$document', function ($document) {
+    return {
+        require: 'ngModel',
+        restrict: 'A',
+        link: function(scope, element, attrs, ctrl) {
+            function computedStyle(property) {
+                var el = element[0];
+                if (el.currentStyle) {
+                    return el.currentStyle[property];
+                } else if (window.getComputedStyle) {
+                    var styles = document.defaultView.getComputedStyle(el, null);
+                    return styles.getPropertyValue(property);
+                }
+            }
+
+            var docBody = $document.find('body');
+
+            // Clone element and apply identical styling
+            var doppelganger = angular.element('<div></div>');
+            ['padding', 'letter-spacing', 'font-family',
+             'font-size', 'font-weight'].forEach(function(prop) {
+                 doppelganger.css(prop, computedStyle(prop));
+             });
+
+            // Out of sight, out of mind
+            doppelganger.css('position', 'absolute');
+            doppelganger.css('left', '-9999px');
+            doppelganger.css('top', '-9999px');
+            doppelganger.css('whiteSpace', 'nowrap');
+
+            docBody.append(doppelganger);
+
+            // Update doppelganger with model content, apply resulting width
+            scope.$watchCollection(function() {
+                return [scope.$eval(attrs.ngModel), element.attr('placeholder')];
+            }, function() {
+                var width;
+                var text = ctrl.$viewValue || element.attr('placeholder') || '';
+                doppelganger.html(text.replace(/ /g, '&nbsp;'));
+                width = doppelganger.prop('offsetWidth') + 1; // conservative padding
+                element.css('width', width + 'px');
+            });
+
+            // Garbage collect helper fragment
+            scope.$on('$destroy', function() {
+                doppelganger.remove();
+            });
+        }
+    };
+}]);

--- a/kahuna/public/js/forms/datalist.html
+++ b/kahuna/public/js/forms/datalist.html
@@ -1,6 +1,6 @@
 <div class="datalist">
     <ng:transclude></ng:transclude>
-    <div class="datalist__options" ng:if="ctrl.active">
+    <div class="datalist__options" ng:if="ctrl.active && ctrl.results.length > 0">
         <div class="datalist__option"
              ng:repeat="(key, result) in ctrl.results"
              ng:click="ctrl.setValueTo(result)"

--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -16,7 +16,7 @@ datalist.directive('grDatalist', ['$q', function($q) {
         },
         template: template,
         controllerAs: 'ctrl',
-        controller: ['$scope', function($scope) {
+        controller: [function() {
             var ctrl = this;
             var selectedIndex = 0;
 
@@ -30,8 +30,11 @@ datalist.directive('grDatalist', ['$q', function($q) {
 
             ctrl.isSelected = key => key === selectedIndex;
 
-            ctrl.searchFor = q =>
-                $q.when(ctrl.search({ q })).then(results => ctrl.results = results).then(selectedIndex = 0);
+            ctrl.searchFor = (q) => {
+                return $q.when(ctrl.search({ q })).
+                    then(results => ctrl.results = results).
+                    then(() => selectedIndex = 0);
+            };
 
             ctrl.setValueTo = value => {
                 ctrl.value = value;

--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -6,16 +6,17 @@ import '../util/eq';
 export var datalist = angular.module('kahuna.forms.datalist', ['util.eq']);
 
 
-datalist.directive('grDatalist', [function() {
+datalist.directive('grDatalist', ['$q', function($q) {
     return {
         restrict: 'E',
         transclude: true,
         scope: {
-            search: '&grSearch'
+            search:   '&grSearch',
+            onSelect: '&grOnSelect'
         },
         template: template,
         controllerAs: 'ctrl',
-        controller: [function() {
+        controller: ['$scope', function($scope) {
             var ctrl = this;
             var selectedIndex = 0;
 
@@ -30,12 +31,17 @@ datalist.directive('grDatalist', [function() {
             ctrl.isSelected = key => key === selectedIndex;
 
             ctrl.searchFor = q =>
-                ctrl.search({ q }).then(results => ctrl.results = results).then(selectedIndex = 0);
+                $q.when(ctrl.search({ q })).then(results => ctrl.results = results).then(selectedIndex = 0);
 
-            ctrl.setValueTo = value => ctrl.value = value;
+            ctrl.setValueTo = value => {
+                ctrl.value = value;
+                if (ctrl.onSelect) {
+                    $scope.$eval(ctrl.onSelect, {$value: value});
+                }
+            };
 
             ctrl.setValueFromSelectedIndex = () => {
-                ctrl.value = ctrl.results[selectedIndex];
+                ctrl.setValueTo(ctrl.results[selectedIndex]);
             };
 
             ctrl.reset = () => {
@@ -100,6 +106,7 @@ datalist.directive('grDatalistInput',
                 if (parentCtrl.active &&
                     ( keys[event.which] === 'up' || keys[event.which] === 'down' ) ) {
                     event.preventDefault();
+                    event.stopPropagation();
                 }
             });
 
@@ -116,6 +123,7 @@ datalist.directive('grDatalistInput',
                 }
             });
 
+            input.on('focus', searchAndActivate);
             input.on('click', searchAndActivate);
 
             // This is done to make the results disappear when you select

--- a/kahuna/public/js/forms/datalist.js
+++ b/kahuna/public/js/forms/datalist.js
@@ -12,7 +12,7 @@ datalist.directive('grDatalist', ['$q', function($q) {
         transclude: true,
         scope: {
             search:   '&grSearch',
-            onSelect: '&grOnSelect'
+            onSelect: '&?grOnSelect'
         },
         template: template,
         controllerAs: 'ctrl',
@@ -36,7 +36,7 @@ datalist.directive('grDatalist', ['$q', function($q) {
             ctrl.setValueTo = value => {
                 ctrl.value = value;
                 if (ctrl.onSelect) {
-                    $scope.$eval(ctrl.onSelect, {$value: value});
+                    ctrl.onSelect({$value: value});
                 }
             };
 

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -23,6 +23,10 @@ export function removeLabels(q, labels) {
     return labels.reduce((q, curr) => removeLabel(q, curr.name), q);
 }
 
+export function getLabel(name) {
+    return createLabel(name);
+}
+
 export function getCollection(path) {
     return createCollection(path);
 }

--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -7,13 +7,18 @@ export var queryFilters = angular.module('kahuna.search.filters.query', []);
 var containsSpace = s => / /.test(s);
 var stripDoubleQuotes = s => s.replace(/"/g, '');
 
+export function maybeQuoted(value) {
+    if (containsSpace(value)) {
+        return `"${value}"`;
+    } else {
+        return value;
+    }
+}
+
 export function fieldFilter(field, value) {
     const cleanValue = stripDoubleQuotes(value);
-    if (containsSpace(cleanValue)) {
-        return `${field}:"${cleanValue}"`;
-    } else {
-        return `${field}:${cleanValue}`;
-    }
+    const valueMaybeQuoted = maybeQuoted(cleanValue);
+    return `${field}:"${valueMaybeQuoted}"`;
 }
 
 queryFilters.filter('queryFilter', function() {

--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -18,7 +18,7 @@ export function maybeQuoted(value) {
 export function fieldFilter(field, value) {
     const cleanValue = stripDoubleQuotes(value);
     const valueMaybeQuoted = maybeQuoted(cleanValue);
-    return `${field}:"${valueMaybeQuoted}"`;
+    return `${field}:${valueMaybeQuoted}`;
 }
 
 queryFilters.filter('queryFilter', function() {

--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -14,7 +14,7 @@ export function fieldFilter(field, value) {
     } else {
         return `${field}:${cleanValue}`;
     }
-};
+}
 
 queryFilters.filter('queryFilter', function() {
     return (value, field) => fieldFilter(field, value);

--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -7,15 +7,17 @@ export var queryFilters = angular.module('kahuna.search.filters.query', []);
 var containsSpace = s => / /.test(s);
 var stripDoubleQuotes = s => s.replace(/"/g, '');
 
+export function fieldFilter(field, value) {
+    const cleanValue = stripDoubleQuotes(value);
+    if (containsSpace(cleanValue)) {
+        return `${field}:"${cleanValue}"`;
+    } else {
+        return `${field}:${cleanValue}`;
+    }
+};
+
 queryFilters.filter('queryFilter', function() {
-    return (value, field) => {
-        const cleanValue = stripDoubleQuotes(value);
-        if (containsSpace(cleanValue)) {
-            return `${field}:"${cleanValue}"`;
-        } else {
-            return `${field}:${cleanValue}`;
-        }
-    };
+    return (value, field) => fieldFilter(field, value);
 });
 
 queryFilters.filter('queryLabelFilter', function() {

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -1,19 +1,14 @@
 <form class="search">
     <span class="search-query">
-        <gr-icon class="search-query__icon">search</gr-icon>
-        <input type="text"
-               placeholder="Search for images…"
-               class="text-input search__query search-query__input"
-               autofocus="autofocus"
-               ng:model="searchQuery.filter.query"
-               ng:model-options="{ debounce: 400 }"
-               grid:focus-on="search:focus-query"
-        />
+        <gr-icon class="search-query__magnifier search-query__icon">search</gr-icon>
+        <gr-structured-query class="search-query__query"
+                             ng:model="searchQuery.filter.query">
+        </gr-structured-query>
         <button class="search-query__icon search-query__clear clear-button"
                 type="button"
                 title="Clear query"
                 ng:show="searchQuery.filter.query"
-                ng:click="searchQuery.resetQueryAndFocus()">
+                ng:click="searchQuery.resetQuery()">
             <gr-icon>cancel</gr-icon>
         </button>
     </span>

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -9,6 +9,7 @@ import {eq} from '../util/eq';
 import {guDateRange} from '../components/gu-date-range/gu-date-range';
 import template from './query.html!text';
 import {syntax} from './syntax/syntax';
+import {grStructuredQuery} from './structured-query/structured-query';
 
 import {track} from '../analytics/track';
 
@@ -18,6 +19,7 @@ export var query = angular.module('kahuna.search.query', [
     eq.name,
     guDateRange.name,
     syntax.name,
+    grStructuredQuery.name,
     track.name
 ]);
 
@@ -39,7 +41,7 @@ query.controller('SearchQueryCtrl',
         // filled in by the watcher below
     };
 
-    ctrl.resetQueryAndFocus = resetQueryAndFocus;
+    ctrl.resetQuery = resetQuery;
 
     // Note that this correctly uses local datetime and returns
     // midnight for the local user
@@ -152,9 +154,8 @@ query.controller('SearchQueryCtrl',
         ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
     });
 
-    function resetQueryAndFocus() {
+    function resetQuery() {
         ctrl.filter.query = '';
-        $scope.$broadcast('search:focus-query');
     }
 }]);
 
@@ -165,11 +166,3 @@ query.directive('searchQuery', [function() {
         template: template
     };
 }]);
-
-query.directive('gridFocusOn', function() {
-   return function(scope, elem, attr) {
-      scope.$on(attr.gridFocusOn, () => {
-          elem[0].focus();
-      });
-   };
-});

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -5,20 +5,20 @@ import angular from 'angular';
 // animations locally, we should turn it back on here.
 // import 'angular-animate';
 import moment from 'moment';
-import '../util/eq';
-import '../components/gu-date-range/gu-date-range';
+import {eq} from '../util/eq';
+import {guDateRange} from '../components/gu-date-range/gu-date-range';
 import template from './query.html!text';
-import './syntax/syntax';
+import {syntax} from './syntax/syntax';
 
-import '../analytics/track';
+import {track} from '../analytics/track';
 
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
     // 'ngAnimate',
-    'util.eq',
-    'gu-dateRange',
-    'grSyntax',
-    'analytics.track'
+    eq.name,
+    guDateRange.name,
+    syntax.name,
+    track.name
 ]);
 
 query.controller('SearchQueryCtrl',

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -18,6 +18,7 @@ export const filterFields = [
     'country',
     'credit',
     'description',
+    'illustrator',
     'in',
     'keyword',
     'label',
@@ -94,6 +95,18 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
             });
     }
 
+    function listIllustrators() {
+        return editsApi.getUsageRightsCategories().
+            then(results => {
+                return List(results).
+                    filter(res => res.value === 'contract-illustrator').
+                    flatMap(res => res.properties).
+                    filter(prop => prop.name === 'creator').
+                    flatMap(prop => prop.options).
+                    toJS();
+            });
+    }
+
     function suggestCredit(prefix) {
         return mediaApi.metadataSearch('credit', {q: prefix}).
             then(results => results.data.map(res => res.key));
@@ -113,6 +126,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'agency':   return listAgencies().then(prefixFilter(value));
         // TODO: list all known bylines, not just our photographers
         case 'by':       return listPhotographers().then(prefixFilter(value));
+        case 'illustrator': return listIllustrators().then(prefixFilter(value));
         case 'category': return listCategories().then(prefixFilter(value));
 
         // No suggestions

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -50,18 +50,6 @@ const subjects = [
 
 querySuggestions.factory('querySuggestions', ['mediaApi', function(mediaApi) {
 
-    const allCompletions = (chip) => {
-        switch (chip.type) {
-        case 'filter-chooser': return filterFields;
-        case 'filter':
-            return {
-                by: ['Tom Jenkins', 'Thomas Bool'],
-                    in: ['Switzerland', 'Sweden', 'Swaziland'],
-                subject: subjects
-            }[chip.key] || [];
-        }
-    };
-
     function getFilterSuggestions(field, value) {
         switch (field) {
         case 'subject':

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -1,0 +1,97 @@
+import angular from 'angular';
+
+import {mediaApi} from '../../services/api/media-api';
+
+export const querySuggestions = angular.module('querySuggestions', [
+    mediaApi.name
+]);
+
+// FIXME: get fields and subjects from API
+export const filterFields = [
+    'any',
+    'by',
+    'category',
+    'city',
+    'copyright',
+    'country',
+    'credit',
+    'description',
+    'in',
+    'keyword',
+    'label',
+    'location',
+    'state',
+    'subject',
+    'supplier',
+    'uploader'
+];
+// TODO: add date fields
+
+const subjects = [
+    "arts",
+    "crime",
+    "disaster",
+    "finance",
+    "education",
+    "environment",
+    "health",
+    "human",
+    "labour",
+    "lifestyle",
+    "nature",
+    "politics",
+    "religion",
+    "science",
+    "social",
+    "sport",
+    "war",
+    "weather"
+];
+
+querySuggestions.factory('querySuggestions', ['mediaApi', function(mediaApi) {
+
+    const allCompletions = (chip) => {
+        switch (chip.type) {
+        case 'filter-chooser': return filterFields;
+        case 'filter':
+            return {
+                by: ['Tom Jenkins', 'Thomas Bool'],
+                    in: ['Switzerland', 'Sweden', 'Swaziland'],
+                subject: subjects
+            }[chip.key] || [];
+        }
+    };
+
+    function getFilterSuggestions(field, value) {
+        switch (field) {
+        case 'subject':
+            return subjects;
+
+        case 'label':
+            return mediaApi.labelsSuggest({q: value}).
+                then(labels => labels.data);
+
+        case 'credit':
+            return mediaApi.metadataSearch('credit', {q: value}).
+                then(results => results.data.map(res => res.key));
+
+        default:
+            // No suggestions
+            return [];
+        }
+    }
+
+    function getChipSuggestions(chip) {
+        if (chip.type === 'filter-chooser') {
+            return filterFields.filter(f => f.startsWith(chip.value));
+        } else if (chip.type === 'filter') {
+            return getFilterSuggestions(chip.key, chip.value);
+        } else {
+            return [];
+        }
+    };
+
+    return {
+        getChipSuggestions
+    };
+}]);

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -31,24 +31,24 @@ export const filterFields = [
 // TODO: add date fields
 
 const subjects = [
-    "arts",
-    "crime",
-    "disaster",
-    "finance",
-    "education",
-    "environment",
-    "health",
-    "human",
-    "labour",
-    "lifestyle",
-    "nature",
-    "politics",
-    "religion",
-    "science",
-    "social",
-    "sport",
-    "war",
-    "weather"
+    'arts',
+    'crime',
+    'disaster',
+    'finance',
+    'education',
+    'environment',
+    'health',
+    'human',
+    'labour',
+    'lifestyle',
+    'nature',
+    'politics',
+    'religion',
+    'science',
+    'social',
+    'sport',
+    'war',
+    'weather'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {
@@ -61,7 +61,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
     function listAgencies() {
         return editsApi.getUsageRightsCategories().
             then(results => {
-                return List(results).
+                return new List(results).
                     filter(res => res.value === 'agency').
                     flatMap(res => res.properties).
                     filter(prop => prop.name === 'supplier').
@@ -77,18 +77,22 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
             then(results => {
                 return results.
                     map(res => res.value).
-                    filter(key => key != ''); // no empty category
+                    filter(key => key !== ''); // no empty category
             });
     }
 
+    const photographerCategories = List.of(
+        'staff-photographer',
+        'contract-photographer'
+    );
     function listPhotographers() {
         return editsApi.getUsageRightsCategories().
             then(results => {
-                return List(results).
-                    filter(res => ['staff-photographer', 'contract-photographer'].indexOf(res.value) !== -1).
+                return new List(results).
+                    filter(res => photographerCategories.includes(res.value)).
                     flatMap(res => res.properties).
                     filter(prop => prop.name === 'photographer').
-                    flatMap(prop => Map(prop.optionsMap).valueSeq()).
+                    flatMap(prop => new Map(prop.optionsMap).valueSeq()).
                     flatMap(list => list).
                     sort().
                     toJS();
@@ -98,7 +102,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
     function listIllustrators() {
         return editsApi.getUsageRightsCategories().
             then(results => {
-                return List(results).
+                return new List(results).
                     filter(res => res.value === 'contract-illustrator').
                     flatMap(res => res.properties).
                     filter(prop => prop.name === 'creator').
@@ -142,7 +146,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         } else {
             return [];
         }
-    };
+    }
 
     return {
         getChipSuggestions

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -10,7 +10,6 @@ export const querySuggestions = angular.module('querySuggestions', [
 // FIXME: get fields and subjects from API
 export const filterFields = [
     'any', // first on purpose in spite of alphabet
-    'agency',
     'by',
     'category',
     'city',
@@ -58,7 +57,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         return (values) => values.filter(val => val.toLowerCase().startsWith(lowerPrefix));
     }
 
-    function listAgencies() {
+    function listSuppliers() {
         return editsApi.getUsageRightsCategories().
             then(results => {
                 return new List(results).
@@ -127,7 +126,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'subject':  return prefixFilter(value)(subjects);
         case 'label':    return suggestLabels(value);
         case 'credit':   return suggestCredit(value);
-        case 'agency':   return listAgencies().then(prefixFilter(value));
+        case 'supplier': return listSuppliers().then(prefixFilter(value));
         // TODO: list all known bylines, not just our photographers
         case 'by':       return listPhotographers().then(prefixFilter(value));
         case 'illustrator': return listIllustrators().then(prefixFilter(value));

--- a/kahuna/public/js/search/structured-query/structured-query.css
+++ b/kahuna/public/js/search/structured-query/structured-query.css
@@ -2,6 +2,12 @@
 gr-chips input[type="text"] {
     color: #ccc;
 }
+gr-chips input[type="text"][autocomplete="off"] {
+    /* awful hack to hide LastPass widget which should not be here in the
+       first place.
+       See: http://stackoverflow.com/a/29473242 */
+    background-position: 150% 50% !important;
+}
 
 gr-chips .datalist {
     position: static;

--- a/kahuna/public/js/search/structured-query/structured-query.css
+++ b/kahuna/public/js/search/structured-query/structured-query.css
@@ -15,7 +15,6 @@ gr-chips .datalist {
 }
 gr-chips .datalist__options {
     width: auto;
-    overflow-y: auto; /* FIXME: always? */
 }
 
 

--- a/kahuna/public/js/search/structured-query/structured-query.css
+++ b/kahuna/public/js/search/structured-query/structured-query.css
@@ -32,9 +32,11 @@ gr-chips .datalist__options {
 .gr-filter-chip__type,
 .gr-static-filter-chip__type,
 .gr-filter-chooser-chip__type {
-    padding: 3px;
+    padding: 0 3px;
+    vertical-align: middle;
     border-right: 1px solid #444;
     margin-right: 3px;
+    font-size: 150%;
     font-weight: bold;
     color: #888;
 }

--- a/kahuna/public/js/search/structured-query/structured-query.css
+++ b/kahuna/public/js/search/structured-query/structured-query.css
@@ -20,7 +20,7 @@ gr-chips .datalist__options {
 
 .gr-filter-chip__key,
 .gr-static-filter-chip__key {
-    font-family: sans-serif;
+    font-family: "Guardian Agate Sans Web", Helvetica, Arial;
     color: #888;
 }
 

--- a/kahuna/public/js/search/structured-query/structured-query.css
+++ b/kahuna/public/js/search/structured-query/structured-query.css
@@ -1,0 +1,48 @@
+/* Override some global styling */
+gr-chips input[type="text"] {
+    color: #ccc;
+}
+
+gr-chips .datalist {
+    position: static;
+    width: auto;
+}
+gr-chips .datalist__options {
+    width: auto;
+    overflow-y: auto; /* FIXME: always? */
+}
+
+
+.gr-chips__placeholder {
+    /* Better vertical alignment */
+    line-height: 16px;
+}
+
+.gr-filter-chip__key,
+.gr-static-filter-chip__key {
+    font-family: sans-serif;
+    color: #888;
+}
+
+.gr-filter-chip__type,
+.gr-static-filter-chip__type,
+.gr-filter-chooser-chip__type {
+    padding: 3px;
+    border-right: 1px solid #444;
+    margin-right: 3px;
+    font-weight: bold;
+    color: #888;
+}
+.gr-filter-chip__remove,
+.gr-static-filter-chip__remove {
+    border-left: 1px solid #444;
+    padding: 3px;
+    color: #888;
+}
+
+gr-filter-chip,
+gr-static-filter-chip,
+gr-filter-chooser-chip {
+    background-color: #333;
+    border-radius: 8px;
+}

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -1,0 +1,75 @@
+import angular from 'angular';
+import Rx from 'rx';
+
+import './structured-query.css!';
+
+import {grChips} from '../../components/gr-chips/gr-chips';
+
+import {rxUtil} from '../../util/rx';
+
+import {querySuggestions, filterFields} from './query-suggestions';
+import {renderQuery, structureQuery} from './syntax';
+
+
+export const grStructuredQuery = angular.module('gr.structuredQuery', [
+    rxUtil.name,
+    grChips.name,
+    querySuggestions.name
+]);
+
+
+grStructuredQuery.controller('grStructuredQueryCtrl',
+                             ['querySuggestions',
+                              function(querySuggestions) {
+    const ctrl = this;
+
+    const structuredQueryUpdates$ = Rx.Observable.create(observer => {
+        ctrl.structuredQueryChanged = function(structuredQuery) {
+            observer.onNext(structuredQuery);
+        };
+    });
+
+    ctrl.newQuery$ = structuredQueryUpdates$.
+        map(renderQuery).
+        map(valOrUndefined).
+        distinctUntilChanged().
+        debounce(500);
+
+    ctrl.getSuggestions = querySuggestions.getChipSuggestions;
+
+    ctrl.filterFields = filterFields;
+
+
+    function valOrUndefined(x) {
+        return angular.isDefined(x) ? x : undefined;
+    }
+}]);
+
+
+grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscribe$) {
+    return {
+        restrict: 'E',
+        require: ['grStructuredQuery', 'ngModel'],
+        template: `
+<gr-chips placeholder="Search for images…"
+          autofocus="autofocus"
+          ng:model="ctrl.structuredQuery"
+          gr:valid-keys="ctrl.filterFields"
+          gr:on-change="ctrl.structuredQueryChanged($chips)"
+          gr:autocomplete="ctrl.getSuggestions($chip)">
+</gr-chips>
+`,
+        controller: 'grStructuredQueryCtrl',
+        controllerAs: 'ctrl',
+        link: function(scope, element, attrs, [ctrl, ngModelCtrl]) {
+            ngModelCtrl.$render = function() {
+                const queryString = ngModelCtrl.$viewValue || '';
+                ctrl.structuredQuery = structureQuery(queryString);
+            };
+
+            subscribe$(scope, ctrl.newQuery$, query => {
+                ngModelCtrl.$setViewValue(query);
+            });
+        }
+    };
+}]);

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -40,8 +40,9 @@ grStructuredQuery.controller('grStructuredQueryCtrl',
     ctrl.filterFields = filterFields;
 
 
-    function valOrUndefined(x) {
-        return angular.isDefined(x) ? x : undefined;
+    function valOrUndefined(str) {
+        // Watch out for `false`, but we know it's a string here..
+        return str ? str : undefined;
     }
 }]);
 

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -1,4 +1,5 @@
 import {fieldFilter} from '../query-filter';
+import {getLabel, getCollection} from '../../search-query/query-syntax';
 
 const parserRe = /(-?)(?:(?:([a-zA-Z]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^']+)')|([a-zA-Z0-9]+)|"([^"]*)"|'([^']*)')/g;
 
@@ -38,6 +39,14 @@ export function structureQuery(query) {
     return struct;
 }
 
+function renderFilter(field, value) {
+    switch (field) {
+    case 'label':      return getLabel(value);
+    case 'collection': return getCollection(value);
+    default:           return fieldFilter(field, value);
+    }
+}
+
 // Serialise a structured query into a plain string query
 export function renderQuery(structuredQuery) {
     return structuredQuery.filter(item => item.value).map(item => {
@@ -45,8 +54,8 @@ export function renderQuery(structuredQuery) {
         // Match both filters
         case 'static-filter':
         case 'filter':
-            const filterExpr = fieldFilter(item.key, item.value);
             const prefix = (item.filterType === 'exclusion') ? '-' : '';
+            const filterExpr = renderFilter(item.key, item.value);
             return prefix + filterExpr;
 
         case 'text':

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -1,7 +1,10 @@
 import {fieldFilter} from '../query-filter';
 import {getLabel, getCollection} from '../../search-query/query-syntax';
 
+// Line too long for jshint, but can't break it down..
+/*jshint -W101 */
 const parserRe = /(-?)(?:(?:([a-zA-Z]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^']+)')|([a-zA-Z0-9]+)|"([^"]*)"|'([^']*)')/g;
+/*jshint +W101 */
 
 // TODO: expose the server-side query parser via an API instead of
 // replicating it poorly here

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -1,4 +1,4 @@
-import {fieldFilter} from '../query-filter';
+import {fieldFilter, maybeQuoted} from '../query-filter';
 import {getLabel, getCollection} from '../../search-query/query-syntax';
 
 // Line too long for jshint, but can't break it down..
@@ -46,6 +46,7 @@ function renderFilter(field, value) {
     switch (field) {
     case 'label':      return getLabel(value);
     case 'collection': return getCollection(value);
+    case 'any':        return maybeQuoted(value);
     default:           return fieldFilter(field, value);
     }
 }

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -1,0 +1,59 @@
+import {fieldFilter} from '../query-filter';
+
+const parserRe = /(-?)(?:(?:([a-zA-Z]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^']+)')|([a-zA-Z0-9]+)|"([^"]*)"|'([^']*)')/g;
+
+// TODO: expose the server-side query parser via an API instead of
+// replicating it poorly here
+export function structureQuery(query) {
+    const struct = [];
+    let m;
+    while ((m = parserRe.exec(query)) !== null) {
+        const sign  = m[1];
+        const field = m[2];
+        const symbol  = m[3] || m[4];
+        const value = m[5] || m[6] || m[7];
+        const text  = m[8] || m[9] || m[10];
+
+        const key = {
+            '#': 'label',
+            '~': 'collection'
+        }[symbol] || field;
+        if (key) {
+            // We don't want editable collection filters
+            const type = key === 'collection' ? 'static-filter' : 'filter';
+            const filterType = sign === '-' ? 'exclusion' : 'inclusion';
+            struct.push({
+                type: type,
+                filterType: filterType,
+                key: key,
+                value: value
+            });
+        } else {
+            struct.push({
+                type: 'text',
+                value: text
+            });
+        }
+    }
+    return struct;
+}
+
+// Serialise a structured query into a plain string query
+export function renderQuery(structuredQuery) {
+    return structuredQuery.filter(item => item.value).map(item => {
+        switch (item.type) {
+        // Match both filters
+        case 'static-filter':
+        case 'filter':
+            const filterExpr = fieldFilter(item.key, item.value);
+            const prefix = (item.filterType === 'exclusion') ? '-' : '';
+            return prefix + filterExpr;
+
+        case 'text':
+            return item.value;
+
+        default:
+            return '';
+        }
+    }).filter(token => token).join(' ').trim();
+}

--- a/kahuna/public/js/search/syntax/syntax.js
+++ b/kahuna/public/js/search/syntax/syntax.js
@@ -2,9 +2,9 @@ import angular from 'angular';
 
 import template from './syntax.html!text';
 
-export const module = angular.module('grSyntax', []);
+export const syntax = angular.module('grSyntax', []);
 
-module.directive('grSyntax', [function () {
+syntax.directive('grSyntax', [function () {
     return {
         restrict: 'E',
         template: template,

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -461,7 +461,7 @@ textarea.ng-invalid {
     padding: 10px;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 950px) {
     .top-bar-item .gr-confirm-delete {
         min-width: inherit;
     }
@@ -568,7 +568,8 @@ textarea.ng-invalid {
 .search {
     margin-top: 10px;
     display: flex;
-    line-height:12px;
+    height: 30px;
+    line-height: 12px;
 }
 
 .search-query__magnifier {
@@ -608,25 +609,20 @@ textarea.ng-invalid {
     display: none;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 850px) {
     .search__advanced-toggle {
         display: none;
     }
 }
 
 /* Note: order matters for cascade ;_; */
-@media screen and (max-width: 600px) {
-    /* fill width */
-    input.search-query__input {
-        width: 100%;
-    }
-
+@media screen and (max-width: 750px) {
     .search__modifier-toggle__text {
         display: none;
     }
 }
 
-@media screen and (max-width: 1200px) {
+@media screen and (max-width: 1350px) {
     .search__modifier-toggle {
         display: inherit;
         margin-left: 15px
@@ -661,12 +657,6 @@ textarea.ng-invalid {
     .search .search__filter {
         margin-left: 0;
     }
-}
-
-/* input to win specificity war with 'input' rule ;_; */
-input.search-query__input {
-    padding-right: 25px;
-    padding-left: 25px;
 }
 
 .search-query__icon {
@@ -2079,10 +2069,12 @@ FIXME: what to do with touch devices
     border: 1px solid #999;
     background: #444;
     color: #ccc;
-    padding: 10px;
+    padding: 5px;
+    padding-right: 15px; /* hack to reserve some space for the scrollbar */
     font-size: 1.2rem;
     box-sizing: border-box;
     max-height: 400px;
+    overflow-y: auto;
 }
 
 .datalist__input {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -552,16 +552,35 @@ textarea.ng-invalid {
    Search
    ========================================================================== */
 
-.search {
-    margin-top: 12px;
+.search-query {
     display: flex;
-    max-height: 26px;
-    line-height:12px}
+    /* Fill the container for larger clickable area */
+    align-items: stretch;
 
-.search__query {
-    padding: 5px 10px;
-    max-width: 250px;
-    width: 100%;
+    background-color: #444;
+    color: #ccc;
+    border: 1px solid #999;
+    box-sizing: border-box;
+
+    width: 300px
+}
+
+.search {
+    margin-top: 10px;
+    display: flex;
+    line-height:12px;
+}
+
+.search-query__magnifier {
+    /* Better vertical centering */
+    align-self: center;
+}
+
+.search-query__query {
+    flex: 1;
+    /* Better vertical centering */
+    align-self: center;
+    overflow: hidden;
 }
 
 .search__modifier {
@@ -569,6 +588,7 @@ textarea.ng-invalid {
     flex-direction: row;
     justify-content: flex-start;
     margin-left: 25px;
+    align-items: baseline; /* vertical align all filters */
 }
 
 .search__modifier-item {
@@ -643,10 +663,6 @@ textarea.ng-invalid {
     }
 }
 
-.search-query {
-    position: relative;
-}
-
 /* input to win specificity war with 'input' rule ;_; */
 input.search-query__input {
     padding-right: 25px;
@@ -654,16 +670,11 @@ input.search-query__input {
 }
 
 .search-query__icon {
-    position: absolute;
-    top: 0;
-    /* Make it fill the container for larger clickable area */
-    height: 100%;
-    padding: 5px;
-    outline: none;
+    padding: 0 5px;
 }
 
 .search-query__clear {
-    right: 0;
+    outline: none;
 }
 
 /* fade in/out */

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2076,13 +2076,13 @@ FIXME: what to do with touch devices
     position: absolute;
     width: 100%;
     z-index: 1;
+    border: 1px solid #999;
     background: #444;
     color: #ccc;
     padding: 10px;
     font-size: 1.2rem;
     box-sizing: border-box;
     max-height: 400px;
-    overflow-y: scroll;
 }
 
 .datalist__input {


### PR DESCRIPTION
Use visual "chips" as part of the search to help users rely on faceted searches.

So far, only the facet fields, labels and credits are auto-completed. We could easily add more ES suggesters to do the same on things like `by`, `uploader` (!), etc.

Sample use:

![recorded](https://cloud.githubusercontent.com/assets/36964/13226117/c5b25454-d987-11e5-8c42-d6ab0bd7fb78.gif)
![recorded](https://cloud.githubusercontent.com/assets/36964/13226150/f111f974-d987-11e5-9b19-afdd2d11e8ad.gif)

Sorry, the code dump is little epic. I blame Angular :cry: 

## Minor bugs left

- [ ] Datalist dropdown offset to the right when the query is wider than the input field (horizontal scroll). Due to some tricky positioning of the dropdown I haven't managed to solve yet.
- [ ] Collections are static filters (can't be edited), which is OK, but they also can't be focused, which breaks keyboard navigation (Left/Right) to jump over these chips.
- [ ] Scroll datalist vertical position when up/down moves the active item out of view (existing issue with datalist)

## Next

- [ ] Update Advanced panel to document the feature and guide the user through using it
- [ ] Announce the feature more widely via comms to all picture editors
- [ ] In-tool tooltip to advertise feature for those who don't read comms
- [ ] Add ES suggesters for all fields we care about (e.g. `by`, `uploader` (!!), `country`, etc) to add auto-suggestion
- [ ] Separate `by` from `photographer`/`illustrator` (currently cheating by using `photographer` list instead of existing `byline`s), talk to @paperboyo if needed
