### PR TITLE
add to collections on upload

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -19,9 +19,10 @@
             <gr-icon ng:hide="ctrl.showChildren">chevron_right</gr-icon>
         </button>
 
-        <button ng:if="ctrl.hasCustomSelect"
+        <button class="node__name flex-spacer"
+                ng:if="ctrl.hasCustomSelect"
                 ng:click="ctrl.select()">
-           <span class="node__name flex-spacer">{{:: node.data.data.description}}</span>
+            {{:: node.data.data.description}}
         </button>
 
         <a ng:if="! ctrl.hasCustomSelect"

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
@@ -24,6 +24,7 @@ gr-nodes, gr-node,
     margin-left: -200px;
     box-sizing: border-box;
 }
+
 .node__info:hover,
 .collection-drop-drag-over {
     background-color: #666;
@@ -36,6 +37,8 @@ gr-nodes, gr-node,
 
 .node__name {
     padding: 5px;
+    text-align: left;
+    line-height: 1.5;
 }
 
 .node__toggler,

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -135,7 +135,8 @@
                     ng:click="ctrl.addCollection = false">
                     <gr-icon>close</gr-icon>
                 </button>
-                <div class="result-editor__collections">
+                <div class="result-editor__collections"
+                     gr:remember-scroll-top="true">
                     <div class="error" ng:if="ctrl.collectionError">
                         There was an error loading the collections.
                         Please try again later.
@@ -169,7 +170,7 @@
                     </li>
                 </ul>
             </div>
-            <button ng:click="ctrl.addCollection=true"
+            <button ng:click="ctrl.openCollectionTree()"
                     gr-tooltip="Click to add image to a collection">
                 <gr-icon>library_add</gr-icon>
             </button>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -130,6 +130,11 @@
             <span class="result-editor__field-label  flex-no-shrink text-small">
                 Collections
             </span>
+            <button ng:click="ctrl.openCollectionTree()"
+                    class="result-editor__field-container__add-button"
+                    gr-tooltip="Click to add image to a collection">
+                <gr-icon>add_box</gr-icon>
+            </button>
             <div ng:if="ctrl.addCollection" class="result-editor__overlay">
                 <button class="result-editor__overlay__cancel"
                     ng:click="ctrl.addCollection = false">
@@ -170,10 +175,6 @@
                     </li>
                 </ul>
             </div>
-            <button ng:click="ctrl.openCollectionTree()"
-                    gr-tooltip="Click to add image to a collection">
-                <gr-icon>library_add</gr-icon>
-            </button>
             <span class="preview__collections__collection__apply-all" ng:if="ctrl.withBatch">
                 <button ng:if="! ctrl.confirmDelete"
                         title="Apply these collections to all your current uploads"
@@ -193,7 +194,10 @@
                 Labels
             </span>
             <div class="result-editor__field-container__labels" ng:class="{'result-editor__field-container__labels--hidden' : ctrl.inputtingLabel}">
-                <gr-add-label images="[ctrl.image]" active="ctrl.inputtingLabel"></gr-add-label>
+                <gr-add-label images="[ctrl.image]"
+                              active="ctrl.inputtingLabel"
+                              class="result-editor__field-container__add-button"
+                ></gr-add-label>
                 <ui-labeller
                     image="ctrl.image"
                     with-batch="ctrl.withBatch"

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -128,6 +128,67 @@
 
         <div class="result-editor__field-container flex-container flex-center">
             <span class="result-editor__field-label  flex-no-shrink text-small">
+                Collections
+            </span>
+            <div ng:if="ctrl.addCollection" class="result-editor__overlay">
+                <button class="result-editor__overlay__cancel"
+                    ng:click="ctrl.addCollection = false">
+                    <gr-icon>close</gr-icon>
+                </button>
+                <div class="result-editor__collections">
+                    <div class="error" ng:if="ctrl.collectionError">
+                        There was an error loading the collections.
+                        Please try again later.
+                    </div>
+                    <div class="result-editor__collections__heading">Select a collection to add image to</div>
+                    <gr-collection-tree
+                        gr:nodes="ctrl.collections"
+                        gr:selection-mode="true"
+                        gr:on-select="ctrl.addToCollection($collection)"
+                    ></gr-collection-tree>
+                </div>
+            </div>
+            <div class="result-editor__field-container__collections">
+                <ul class="preview__collections">
+                    <li class="preview__collections__collection"
+                        ng:repeat="collection in ctrl.image.data.collections track by collection.data.pathId">
+                        <a gr-tooltip="Click to open collection: {{::collection.data.path.join(' ▸ ')}}"
+                           gr-tooltip-position="top"
+                           ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                           ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
+                           class="preview__collections__collection__value">
+                            {{::collection.data.description}}
+                        </a>
+                        <button gr-tooltip="Click to remove image from this collection"
+                                gr-tooltip-position="top"
+                                class="preview__collections__collection__remove"
+                                ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
+                                ng:click="ctrl.removeImageFromCollection(collection)">
+                            <gr-icon>close</gr-icon>
+                        </button>
+                    </li>
+                </ul>
+            </div>
+            <button ng:click="ctrl.addCollection=true"
+                    gr-tooltip="Click to add image to a collection">
+                <gr-icon>library_add</gr-icon>
+            </button>
+            <span class="preview__collections__collection__apply-all" ng:if="ctrl.withBatch">
+                <button ng:if="! ctrl.confirmDelete"
+                        title="Apply these collections to all your current uploads"
+                        ng:click="ctrl.batchApplyCollections()"
+                >⇔</button>
+                <button title="Remove ALL collections"
+                        class="button button--confirm-delete"
+                        ng:if="ctrl.confirmDelete"
+                        ng:click="ctrl.batchRemoveCollections()">
+                    <gr-icon>warning</gr-icon>Remove ALL collections in job?
+                </button>
+            </span>
+        </div>
+
+        <div class="result-editor__field-container flex-container flex-center">
+            <span class="result-editor__field-label  flex-no-shrink text-small">
                 Labels
             </span>
             <div class="result-editor__field-container__labels" ng:class="{'result-editor__field-container__labels--hidden' : ctrl.inputtingLabel}">

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -187,7 +187,7 @@ imageEditor.controller('ImageEditorCtrl', [
         $scope.$on(batchRemoveCollectionsEvent, () => {
             const collectionsOnImage = ctrl.image.data.collections;
             collectionsOnImage.forEach( ctrl.removeImageFromCollection );
-        })
+        });
     }
 }]);
 

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -150,21 +150,20 @@ imageEditor.controller('ImageEditorCtrl', [
     function openCollectionTree() {
         ctrl.addCollection = true;
 
-        if (!ctrl.collections) {
-            collections.getCollections().then(collections => {
-                ctrl.collections = collections.data.children;
-                // this will trigger the remember-scroll-top directive to return
-                // users to their previous position on the collections panel
-                // once the tree has been rendered
-                $timeout(() => {
-                    $scope.$broadcast('gr:remember-scroll-top:apply');
-                });
-            }, () => {
-                // TODO: More informative error handling
-                // TODO: Stop error propagating to global error handler
-                ctrl.error = true;
-            }).catch(() => ctrl.collectionError = true);
-        }
+        collections.getCollections().then(collections => {
+            ctrl.collections = collections.data.children;
+            // this will trigger the remember-scroll-top directive to return
+            // users to their previous position on the collections panel
+            // once the tree has been rendered
+            $timeout(() => {
+                $scope.$broadcast('gr:remember-scroll-top:apply');
+            });
+        }, () => {
+            // TODO: More informative error handling
+            // TODO: Stop error propagating to global error handler
+            ctrl.error = true;
+        }).catch(() => ctrl.collectionError = true);
+
     }
 
     function addToCollection(collection) {

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -6,6 +6,7 @@ import '../image/service';
 import '../usage-rights/usage-rights-editor';
 import '../components/gr-archiver-status/gr-archiver-status';
 import {collectionsApi} from '../services/api/collections-api';
+import {rememberScrollTop} from '../directives/gr-remember-scroll-top';
 
 
 export var imageEditor = angular.module('kahuna.edits.imageEditor', [
@@ -13,7 +14,8 @@ export var imageEditor = angular.module('kahuna.edits.imageEditor', [
     'gr.image.service',
     'kahuna.edits.usageRightsEditor',
     'gr.archiverStatus',
-    collectionsApi.name
+    collectionsApi.name,
+    rememberScrollTop.name
 ]);
 
 imageEditor.controller('ImageEditorCtrl', [
@@ -122,21 +124,27 @@ imageEditor.controller('ImageEditorCtrl', [
 
     ctrl.collectionError = false;
 
-    collections.getCollections().then(collections => {
-        ctrl.collections = collections.data.children;
-        // this will trigger the remember-scroll-top directive to return
-        // users to their previous position on the collections panel
-        // once the tree has been rendered
-        $timeout(() => {
-            $scope.$emit('gr:remember-scroll-top:apply');
-        });
-    }, () => {
-        // TODO: More informative error handling
-        // TODO: Stop error propagating to global error handler
-        ctrl.error = true;
-    }).catch(() => ctrl.collectionError = true);
-
     ctrl.selectionMode = true;
+
+    ctrl.openCollectionTree = () => {
+        ctrl.addCollection = true;
+
+        if (!ctrl.collections) {
+            collections.getCollections().then(collections => {
+                ctrl.collections = collections.data.children;
+                // this will trigger the remember-scroll-top directive to return
+                // users to their previous position on the collections panel
+                // once the tree has been rendered
+                $timeout(() => {
+                    $scope.$broadcast('gr:remember-scroll-top:apply');
+                });
+            }, () => {
+                // TODO: More informative error handling
+                // TODO: Stop error propagating to global error handler
+                ctrl.error = true;
+            }).catch(() => ctrl.collectionError = true);
+        }
+    };
 
     ctrl.addToCollection = (collection) => {
         collections.addCollectionToImage(ctrl.image, collection);

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -1,19 +1,19 @@
 import angular from 'angular';
 import template from './image-editor.html!text';
 
-import './service';
-import '../image/service';
-import '../usage-rights/usage-rights-editor';
-import '../components/gr-archiver-status/gr-archiver-status';
+import {service} from './service';
+import {imageService} from '../image/service';
+import {usageRightsEditor} from '../usage-rights/usage-rights-editor';
+import {archiver} from '../components/gr-archiver-status/gr-archiver-status';
 import {collectionsApi} from '../services/api/collections-api';
 import {rememberScrollTop} from '../directives/gr-remember-scroll-top';
 
 
 export var imageEditor = angular.module('kahuna.edits.imageEditor', [
-    'kahuna.edits.service',
-    'gr.image.service',
-    'kahuna.edits.usageRightsEditor',
-    'gr.archiverStatus',
+    service.name,
+    imageService.name,
+    usageRightsEditor.name,
+    archiver.name,
     collectionsApi.name,
     rememberScrollTop.name
 ]);

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -37,26 +37,24 @@ imageEditor.controller('ImageEditorCtrl', [
 
     var ctrl = this;
 
-    ctrl.batchApplyCollections = batchApplyCollections;
     ctrl.batchApplyUsageRights = batchApplyUsageRights;
-    ctrl.categories;
+    editsApi.getUsageRightsCategories()
+        .then(cats => ctrl.categories = cats)
+        .finally(() => updateUsageRightsCategory());
     ctrl.error = false;
-    ctrl.image;
     ctrl.saved = false;
     ctrl.saving = false;
-    ctrl.showUsageRights;
+    ctrl.showUsageRights = false;
     ctrl.status = ctrl.image.data.valid ? 'ready' : 'invalid';
     ctrl.usageRights = imageService(ctrl.image).usageRights;
-    ctrl.usageRightsCategory;
-
 
     //TODO put collections in their own directive
-    ctrl.addCollection;
+    ctrl.addCollection = false;
     ctrl.addToCollection = addToCollection;
-    ctrl.batchRemoveCollections;
+    ctrl.batchApplyCollections = batchApplyCollections;
     ctrl.collectionError = false;
-    ctrl.collections;
-    ctrl.confirmDelete;
+    ctrl.confirmDelete = false;
+    ctrl.getCollectionStyle = getCollectionStyle;
     ctrl.openCollectionTree = openCollectionTree;
     ctrl.removeImageFromCollection = removeImageFromCollection;
     ctrl.selectionMode = true;
@@ -86,10 +84,6 @@ imageEditor.controller('ImageEditorCtrl', [
 
     const offUsageRightsUpdateError =
         editsService.on(usageRights, 'update-error', onError);
-
-    editsApi.getUsageRightsCategories()
-        .then(cats => ctrl.categories = cats)
-        .finally(() => updateUsageRightsCategory());
 
     $scope.$on('$destroy', () => {
         offMetadataUpdateStart();
@@ -201,6 +195,10 @@ imageEditor.controller('ImageEditorCtrl', [
             $rootScope.$broadcast(batchRemoveCollectionsEvent);
         };
 
+    }
+
+    function getCollectionStyle(collection) {
+        return collection.data.cssColour && `background-color: ${collection.data.cssColour}`;
     }
 }]);
 

--- a/kahuna/public/js/services/api/collections-api.js
+++ b/kahuna/public/js/services/api/collections-api.js
@@ -168,6 +168,7 @@ collectionsApi.factory('collections',
         removeFromList,
         addToCollectionUsingImageIds,
         addToCollectionUsingImageResources,
+        addCollectionToImage,
         removeImageFromCollection,
         batchRemove
     };

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1354,10 +1354,14 @@ FIXME: what to do with touch devices
     display: inline;
 }
 
-.result-editor__field-container gr-add-label {
+.result-editor__field-container__add-button {
     font-size: 1.3rem;
     padding-right: 10px;
     padding-bottom: 5px;
+}
+
+.result-editor__field-container__add-button:hover {
+    color: white;
 }
 
 .result-editor__field-label {
@@ -1382,7 +1386,6 @@ FIXME: what to do with touch devices
 
 .result-editor__overlay__cancel {
     float: right;
-    padding: 20px;
 }
 
 .result-editor__overlay__cancel gr-icon {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1404,6 +1404,14 @@ FIXME: what to do with touch devices
 .result-editor__collections__heading {
     padding: 5px 10px;
     border-bottom: 1px solid #565656;
+    position: fixed;
+    width: 100%;
+    background: #444;
+}
+
+.result-editor__collections gr-collection-tree > :first-child {
+    /*to sit below the fixed heading */
+    margin-top: 35px;
 }
 
 .result-editor__usage-rights-container {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1157,7 +1157,8 @@ FIXME: what to do with touch devices
     margin: 0 5px 5px 0;
 }
 
-.preview__collections__collection__value {
+.preview__collections__collection__value,
+.preview__collections__collection__remove {
     color: #fff;
     padding: 0 5px;
     margin-left: 2px;
@@ -1166,10 +1167,23 @@ FIXME: what to do with touch devices
     background-color: #555;
 }
 
-.preview__collections__collection__value:hover {
+.preview__collections__collection__remove {
+    margin-left: -1px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.preview__collections__collection__value:hover,
+.preview__collections__collection__remove:hover {
     /*need important to overwrite the inline style*/
     background-color: #fff !important;
     color: black;
+}
+
+.preview__collections__collection__apply-all {
+    margin-left: 10px;
+    line-height: 20px;
+    font-size: 1.6rem;
 }
 
 .preview__cost {
@@ -1330,8 +1344,10 @@ FIXME: what to do with touch devices
     margin-bottom: 5px;
 }
 
-.result-editor__field-container__labels {
+.result-editor__field-container__labels,
+.result-editor__field-container__collections {
     display: flex;
+    font-size: 1.4rem;
 }
 
 .result-editor__field-container__labels--hidden {
@@ -1352,6 +1368,42 @@ FIXME: what to do with touch devices
 .result-editor__field-value {
     font-size: 1.4rem;
     line-height: 24px;
+}
+
+.result-editor__overlay {
+    background: rgba(20, 20, 20, .75);
+    width: calc(100vw);
+    height: calc(100vh);
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 40;
+}
+
+.result-editor__overlay__cancel {
+    float: right;
+    padding: 20px;
+}
+
+.result-editor__overlay__cancel gr-icon {
+    font-size: 30px;
+}
+
+.result-editor__collections {
+    background: rgba(68, 68, 68, 1);
+    height: calc(100vh);
+    position: fixed;
+    top: 30px;
+    left: 50%;
+    z-index: 40;
+    overflow: auto;
+    width: 400px;
+    margin-left: -200px;
+}
+
+.result-editor__collections__heading {
+    padding: 5px 10px;
+    border-bottom: 1px solid #565656;
 }
 
 .result-editor__usage-rights-container {


### PR DESCRIPTION
#1590 Adds ability to add/remove images to/from collections on upload page.

Remembers open/closed nodes and position on collections tree. 

Can batch add collections on one image to all recent uploads. 
Can remove all collections by 'adding' no collections (as per labels). 

! If the same image is upload again and it was previously added to collections, it will only display the collections once it is added to a collection. So, the collection is present in the media-collection api but not on the image's collections data in the media api and it only fetches the collections list when collections are edited.

![collections on uploads](https://cloud.githubusercontent.com/assets/8484757/13252476/c8facbe4-da2e-11e5-8a6e-c3ab56b8558e.gif)
