### PR TITLE
Removes related lables

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -31,51 +31,6 @@
                 </button>
             </div>
 
-            <div class="results-toolbar-item results-toolbar-item--static results-toolbar-item--left
-                        results__related-labels related-labels flex-container text-small"
-                        ng:class="{'related-labels--with-labels': ctrl.relatedLabels.length !== 0}">
-                <div class="related-labels__title">
-                    Related to
-                    <span ng:switch="ctrl.relatedLabels.length === 0">
-                        <form class="inline-block" ng:switch-when="true" ng:submit="ctrl.setParentLabel()">
-                            <gr-datalist
-                                    class="related-labels__datalist"
-                                gr:search="ctrl.suggestedLabelSearch(q)">
-                                <!-- TODO: autogrow this element -->
-                                <input type="text"
-                                       class="text-input related-labels__parent"
-                                       placeholder="e.g. observer"
-                                       ng:model="ctrl.parentLabel"
-                                       ng:model-options="{ updateOn: 'gr:datalist:update' }"
-                                       ng:change="ctrl.setParentLabel()"
-                                       gr:datalist-input />
-                            </gr-datalist>
-                        </form>
-                        <span ng:switch-default>{{ctrl.parentLabel}}:</span>
-                    </span>
-                </div>
-                <ul class="flex-container related-labels__labels">
-                    <li class="related-labels__label" ng:repeat="relatedLabel in ctrl.relatedLabels">
-                        <div ng:switch="relatedLabel.selected">
-                            <button class="related-labels__label-text related-labels__label-text--selected"
-                                    ng:switch-when="true"
-                                    ng:click="ctrl.removeSuggestedLabel(relatedLabel)"
-                                    gr:track-click="Related label remove"
-                                    gr:track-click-data="{'Label': relatedLabel.name}">
-                                    {{relatedLabel.name}}
-                            </button>
-                            <button class="related-labels__label-text"
-                                    ng:switch-when="false"
-                                    ng:click="ctrl.switchSuggestedLabelTo(relatedLabel)"
-                                    gr:track-click="Related label select"
-                                    gr:track-click-data="{'Label': relatedLabel.name}">
-                                    {{relatedLabel.name}}
-                            </button>
-                        </div>
-                    </li>
-                </ul>
-            </div>
-
             <div class="results-toolbar__right flex-container">
                 <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static"
                      ng:if="ctrl.selectionCount > 0">

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import Rx from 'rx';
-import * as querySyntax from '../search-query/query-syntax';
 import moment from 'moment';
 
 import '../services/scroll-position';
@@ -165,66 +164,6 @@ results.controller('SearchResultsCtrl', [
         }).finally(() => {
             ctrl.loading = false;
         });
-
-        // related labels
-        const relatedLabelsPromise$ = Rx.Observable.fromPromise(ctrl.searched).flatMap(images =>
-            Rx.Observable
-                .fromPromise(images.follow('related-labels').get())
-                .catch(err => err.message === 'No link found for rel: related-labels' ?
-                    Rx.Observable.empty() : Rx.Observable.throw(err)
-                )
-        );
-
-        const relatedLabels$ = relatedLabelsPromise$.map(labels =>
-            labels.data.siblings).startWith([]);
-
-        const parentLabel$ = relatedLabelsPromise$.map(labels => labels.data.label);
-
-        inject$($scope, relatedLabels$, ctrl, 'relatedLabels');
-        inject$($scope, parentLabel$, ctrl, 'parentLabel');
-
-        ctrl.switchSuggestedLabelTo = label => {
-            const q = $stateParams.query;
-            const removedLabelsQ = querySyntax.removeLabels(q, ctrl.relatedLabels);
-            const query = querySyntax.addLabel(removedLabelsQ, label.name);
-            setQuery(query);
-        };
-
-        ctrl.removeSuggestedLabel = label => {
-            const query = querySyntax.removeLabel($stateParams.query, label.name);
-            setQuery(query);
-        };
-
-        ctrl.setParentLabel = () => {
-            if (ctrl.parentLabel) {
-                const query = querySyntax.addLabel($stateParams.query || '', ctrl.parentLabel);
-                setQuery(query);
-            }
-        };
-
-        function setQuery(query) {
-            const newStateParams = angular.extend({}, $stateParams, { query });
-            $state.transitionTo($state.current, newStateParams, {
-                reload: true, inherit: false, notify: true
-            });
-        }
-
-        ctrl.suggestedLabelSearch = q =>
-            ctrl.searched.then(images =>
-                images.follow('suggested-labels').get({q}).then(labels => labels.data)
-            ).catch(() => []);
-
-        ctrl.setParentLabel = () => {
-            if (ctrl.parentLabel) {
-                $state.transitionTo($state.current, { query: `#${ctrl.parentLabel}` }, {
-                    reload: true, inherit: false, notify: true
-                });
-            }
-        };
-        ctrl.suggestedLabelSearch = q =>
-            ctrl.searched.then(images =>
-                images.follow('suggested-labels').get({q}).then(labels => labels.data)
-            ).catch(() => []);
 
         ctrl.loadRange = function(start, end) {
             const length = end - start + 1;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -987,62 +987,6 @@ input.search-query__input {
     padding: 0px;
 }
 
-.related-labels--with-labels {
-    /* This is to allow scrolling of labels, but show the
-    autocomplete dropdown */
-    overflow-x: auto;
-}
-
-.related-labels__datalist {
-    line-height: 1;
-}
-
-input.related-labels__parent {
-    border: 0;
-    background: transparent;
-    border-bottom: 1px solid #999;
-    box-sizing: border-box;
-    padding: 2px 5px;
-    width: 150px;
-}
-
-.related-labels__labels {
-    overflow-x: auto;
-    overflow-y: hidden;
-    /* space below scrollbar */
-    margin-bottom: 3px;
-}
-
-/* style scrollbar to take less space */
-.related-labels__labels::-webkit-scrollbar-track {
-	border-radius: 10px;
-	background-color: #555;
-}
-
-.related-labels__labels::-webkit-scrollbar {
-    height: 5px;
-	background-color: #555;
-}
-
-.related-labels__labels::-webkit-scrollbar-thumb {
-	border-radius: 10px;
-	background-color: #888;
-}
-
-
-.related-labels__label {
-    margin-left: 2px;
-}
-
-.related-labels__label-text {
-    padding: 2px 5px 4px;
-    box-sizing: border-box;
-}
-.related-labels__label-text--selected {
-    border-top: 2px solid #00adee;
-    background-color: #444;
-}
-
 .image-results-count__new {
     font-family: inherit;
     background-color: #00adee;
@@ -2212,7 +2156,6 @@ FIXME: what to do with touch devices
     gr-add-label,
     .image-details--crop,
     .image-info__group--full-metadata,
-    .related-labels__title,
     .radio-list {
         display: none !important;
     }

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -39,7 +39,7 @@ import com.gu.mediaservice.model._
 
 object MediaApi extends Controller with ArgoHelpers {
 
-  import Config.{rootUri, cropperUri, loaderUri, metadataUri, authUri, loginUriTemplate, collectionsUri}
+  import Config.{rootUri, cropperUri, loaderUri, metadataUri, authUri, collectionsUri}
 
   val Authenticated = Authed.action
   val permissionStore = Authed.permissionStore
@@ -51,9 +51,6 @@ object MediaApi extends Controller with ArgoHelpers {
     "persisted", "usageStatus", "usagePlatform").mkString(",")
 
   val searchLinkHref = s"$rootUri/images{?$searchParamList}"
-
-  private val suggestedLabelsLink =
-    Link("suggested-labels", s"$rootUri/suggest/edits/labels{?q}")
 
   private val searchLink = Link("search", searchLinkHref)
 
@@ -77,8 +74,7 @@ object MediaApi extends Controller with ArgoHelpers {
       Link("edits",           metadataUri),
       Link("session",         s"$authUri/session"),
       Link("witness-report",  s"https://n0ticeapis.com/2/report/{id}"),
-      Link("collections",     collectionsUri),
-      suggestedLabelsLink
+      Link("collections",     collectionsUri)
     )
     respond(indexData, indexLinks)
   }
@@ -241,8 +237,7 @@ object MediaApi extends Controller with ArgoHelpers {
       imageEntities <- Future.sequence(hits map (hitToImageEntity _).tupled)
       prevLink = getPrevLink(searchParams)
       nextLink = getNextLink(searchParams, totalCount)
-      relatedLabelsLink = getRelatedLabelsLink(searchParams)
-      links = suggestedLabelsLink :: List(prevLink, nextLink, relatedLabelsLink).flatten
+      links = List(prevLink, nextLink).flatten
     } yield respondCollection(imageEntities, Some(searchParams.offset), Some(totalCount), links)
 
     val searchParams = SearchParams(request)
@@ -297,35 +292,6 @@ object MediaApi extends Controller with ArgoHelpers {
     }
   }
 
-  private def getRelatedLabelsLink(searchParams: SearchParams) = {
-    // We search if we have a label in the search, take the first one and then look up it's
-    // siblings so that we can return them as "related labels"
-    val labels = searchParams.structuredQuery.flatMap {
-      // TODO: Use ImageFields for guard
-      case Match(field: SingleField, value:Words) if field.name == "userMetadata.labels" => Some(value.string)
-      case Match(field: SingleField, value:Phrase) if field.name == "userMetadata.labels" => Some(value.string)
-      case _ => None
-    }
-
-    val (mainLabel, selectedLabels) = labels match {
-      case Nil => (None, Nil)
-      case label :: Nil => (Some(label), Nil)
-      case label :: extraLabels => (Some(label), extraLabels)
-    }
-
-    mainLabel.map { label =>
-      // FIXME: This is to stop a search for plain `"` breaking the whole lot.
-      val encodedLabel = UriEncoding.encodePathSegment(label, "UTF-8")
-      val uriTemplate = URITemplate(s"$rootUri/suggest/edits/labels/${encodedLabel}/sibling-labels{?selectedLabels,q}")
-      val paramMap = Map(
-        "selectedLabels" -> Some(selectedLabels.mkString(",")).filter(_.trim.nonEmpty),
-        "q" -> searchParams.query
-      )
-      val paramVars = paramMap.map { case (key, value) => key := value }.toSeq
-      val uri = uriTemplate expand (paramVars: _*)
-      Link("related-labels", uri)
-    }
-  }
 }
 
 

--- a/media-api/app/controllers/SuggestionController.scala
+++ b/media-api/app/controllers/SuggestionController.scala
@@ -21,43 +21,6 @@ object SuggestionController extends Controller with ArgoHelpers {
       .map(c => respondCollection(c.results))
   }
 
-  def suggestLabels(q: Option[String]) = Authenticated {
-
-    val pseudoFamousLabels = List(
-      "cities", "family", "filmandmusic", "longread", "money", "pp", "satrev", "trv",
-
-      "culturearts", "culturebooks", "culturefilm", "culturestage", "culturemusic",
-
-      "g2arts", "g2columns", "g2coverfeatures", "g2fashion", "g2features", "g2food", "g2health",
-      "g2lifestyle", "g2shortcuts", "g2tv", "g2women",
-
-      "obsbizcash", "obscomment", "obsfocus", "obsfoodfeat", "obsfoodother", "obsfoodrecipes",
-      "obsfoodsupp", "obsforeign", "obshome", "obsmagfash", "obsmagfeat", "obsmaglife",
-      "obsrevagenda", "obsrevbooks", "obsrevcritics", "obsrevdiscover", "obsrevfeat",
-      "obsrevmusic", "obsrevtv", "obssports", "obssupps", "obstechbright", "obstechfeat",
-      "obstechplay"
-    )
-
-    val labels = q.map { q =>
-      pseudoFamousLabels.filter(_.startsWith(q))
-    }.getOrElse(pseudoFamousLabels)
-
-    respondCollection(labels)
-  }
-
-  def suggestLabelSiblings(label: String, q: Option[String], selectedLabels: Option[String]) = Authenticated.async { request =>
-    val selectedLabels_ = selectedLabels.map(_.split(",").toList.map(_.trim)).getOrElse(Nil)
-    val structuredQuery = q.map(Parser.run) getOrElse List()
-
-    ElasticSearch.labelSiblingsSearch(structuredQuery, excludeLabels = List(label)) map { agg =>
-      val labels = agg.results.map { label =>
-        val selected = selectedLabels_.contains(label.key)
-        LabelSibling(label.key, selected)
-      }
-      respond(LabelSiblingsResponse(label, labels.toList))
-    }
-  }
-
   // TODO: work with analysed fields
   // TODO: recover with HTTP error if invalid field
   // TODO: Add validation, especially if you use length
@@ -73,18 +36,6 @@ object SuggestionController extends Controller with ArgoHelpers {
   def aggregateResponse(agg: AggregateSearchResults) =
     respondCollection(agg.results, Some(0), Some(agg.total))
 
-}
-
-case class LabelSibling(name: String, selected: Boolean)
-object LabelSibling {
-  implicit def jsonWrites: Writes[LabelSibling] = Json.writes[LabelSibling]
-  implicit def jsonReads: Reads[LabelSibling] =  Json.reads[LabelSibling]
-}
-
-case class LabelSiblingsResponse(label: String, siblings: List[LabelSibling])
-object LabelSiblingsResponse {
-  implicit def jsonWrites: Writes[LabelSiblingsResponse] = Json.writes[LabelSiblingsResponse]
-  implicit def jsonReads: Reads[LabelSiblingsResponse] =  Json.reads[LabelSiblingsResponse]
 }
 
 case class AggregateSearchParams(field: String, q: Option[String])

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -129,41 +129,6 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
       }
   }
 
-  def labelSiblingsSearch(structuredQuery: List[Condition], excludeLabels: List[String] = Nil, size: Int = 30)
-                         (implicit ex: ExecutionContext): Future[AggregateSearchResults] = {
-    val name = "labelSiblings"
-    val lastModifiedField = "lastModified"
-    val labelsField = editsField("labels")
-    val query = queryBuilder.makeQuery(structuredQuery)
-
-    // We sort by the maximum lastModified
-    // TODO: We could add a lastModified to the labels resource and then sort by that
-    val sortByDateAggr =
-      AggregationBuilders.
-        max(lastModifiedField).
-        field(lastModifiedField)
-
-    val aggregate =
-      AggregationBuilders
-        .terms(name)
-        .field(labelsField)
-        .excludeList(excludeLabels)
-        .order(Terms.Order.aggregation(lastModifiedField, false))
-        .size(size)
-        .subAggregation(sortByDateAggr)
-
-    val search =
-      prepareImagesSearch
-        .setQuery(query)
-        .addAggregation(aggregate)
-
-    search
-      .setSearchType(SearchType.COUNT)
-      .executeAndLog("sibling labels aggregate search")
-      .toMetric(searchQueries, List(searchTypeDimension("aggregate")))(_.getTookInMillis)
-      .map(searchResultToAggregateResponse(_, name))
-  }
-
   def metadataSearch(params: AggregateSearchParams)(implicit ex: ExecutionContext): Future[AggregateSearchResults] =
     aggregateSearch("metadata", metadataField(params.field), params)
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -19,8 +19,6 @@ GET     /images                                       controllers.MediaApi.image
 
 # completion
 GET     /suggest/metadata/credit                      controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
-GET     /suggest/edits/labels/:label/sibling-labels   controllers.SuggestionController.suggestLabelSiblings(label: String, q: Option[String], selectedLabels: Option[String])
-GET     /suggest/edits/labels                         controllers.SuggestionController.suggestLabels(q: Option[String])
 
 # Management
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck


### PR DESCRIPTION
As per email welcoming collections which said "Collections will replace the label based views accessed from the 'Related to' menu in The Grid."

@jamesgorrie please let me know what you think. 