### PR TITLE
makes header sticky on collections panel

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
@@ -60,4 +60,13 @@ gr-nodes, gr-node,
 .collections-panel-heading {
     padding: 5px 10px;
     border-bottom: 1px solid #565656;
+    position: fixed;
+    width: 270px;
+    background-color: #444;
+    margin-top: -35px;
+}
+
+gr-collection-tree > :first-child {
+    /*to sit below the fixed heading */
+    margin-top: 35px;
 }


### PR DESCRIPTION
Makes edit bar sticky. As we now remember scroll position you cannot see if you are in edit mode - will be unable to add images to collections. Also prevents repetitive scrolling when adding subcollections. 

![sticky collections header](https://cloud.githubusercontent.com/assets/8484757/13326150/9ebd3b3c-dbdc-11e5-9f5b-249ec13ffacf.gif)