### PR TITLE
reverting https://github.com/guardian/grid/pull/1786

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
@@ -60,14 +60,4 @@ gr-nodes, gr-node,
 .collections-panel-heading {
     padding: 5px 10px;
     border-bottom: 1px solid #565656;
-    position: fixed;
-    width: 270px;
-    background-color: #444;
-    margin-top: -35px;
-    z-index: 10;
-}
-
-gr-collection-tree > :first-child {
-    /*to sit below the fixed heading */
-    margin-top: 35px;
 }


### PR DESCRIPTION
collections header was fixed when panel was collapsed. reverting for now.