### PR TITLE
adds Janus support for cf actions

### DIFF
--- a/cloud-formation/scripts/stack-name.sh
+++ b/cloud-formation/scripts/stack-name.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
-if [ -z "$ENV" ];
+if [ -z "$GRID_STACK_NAME" ];
 then
-    export STACK_NAME="media-service-DEV-`aws iam get-user | jq '.User.UserName' | tr -d '"' | tr [A-Z] [a-z]`"
+    USER_NAME=`aws iam get-user`
+
+    if [ $? != "0" ]; then
+        echo -e "\033[1;41m    FAILED!    \033[m"
+        echo '`iam get-user` failed. Are you using temporary credentials?'
+        echo 'If you are using temporary credentials please set the GRID_STACK_NAME environment variable and try again:'
+        echo ''
+        echo "  export GRID_STACK_NAME=DEV-foo && $0"
+        echo ''
+        exit 1
+    else
+        export STACK_NAME="media-service-DEV-`$USER_NAME | jq '.User.UserName' | tr -d '"' | tr [A-Z] [a-z]`"
+    fi
 else
-    export STACK_NAME="media-service-$ENV"
+    export STACK_NAME="media-service-$GRID_STACK_NAME"
 fi


### PR DESCRIPTION
If you're using temporary credentials, `aws iam get-user` fails so `STACK_NAME` is not set correctly.

Fail gracefully and suggest setting the envvar which, if set,  will be preferred over the result of `aws iam get-user`.