### PR TITLE
Adds endpoints to list exports or export

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -91,8 +91,7 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
     val hasIdentifier     = params.hasIdentifier.map(idName => filters.exists(NonEmptyList(identifierField(idName))))
     val missingIdentifier = params.missingIdentifier.map(idName => filters.missing(NonEmptyList(identifierField(idName))))
     val uploadedByFilter  = params.uploadedBy.map(uploadedBy => filters.terms("uploadedBy", NonEmptyList(uploadedBy)))
-
-    val costFilter        =  params.free.flatMap(free => if (free) freeFilter else nonFreeFilter)
+    val costFilter        = params.free.flatMap(free => if (free) freeFilter else nonFreeFilter)
 
     val validityFilter: Option[FilterBuilder] = params.valid.flatMap(valid => if(valid) validFilter else invalidFilter)
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -12,6 +12,8 @@ GET     /images/edits/:field                          controllers.SuggestionCont
 # Images
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
+GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
+GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
 POST    /images/:id/reindex                           controllers.MediaApi.reindexImage(id: String)
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
 


### PR DESCRIPTION
Adds:
- `/images/:image_id/export/:crop_id`
- `/images/:image_id/export`

Values are argofied (i.e. inside data blocks), and simply cut from the parent image element.

