### PR TITLE
Aggregates query

### DIFF
--- a/media-api/app/controllers/AggregationController.scala
+++ b/media-api/app/controllers/AggregationController.scala
@@ -7,9 +7,6 @@ import play.api.mvc.{AnyContent, Request, Controller}
 
 import scala.util.Try
 
-/**
-  * Created by npapacostas on 01/03/2016.
-  */
 object AggregationController extends Controller {
   val Authenticated = Authed.action
 

--- a/media-api/app/controllers/AggregationController.scala
+++ b/media-api/app/controllers/AggregationController.scala
@@ -1,0 +1,40 @@
+package controllers
+
+import play.api.libs.concurrent.Execution.Implicits._
+import lib.elasticsearch.ElasticSearch
+import lib.querysyntax.{Parser, Condition}
+import play.api.mvc.{AnyContent, Request, Controller}
+
+import scala.util.Try
+
+/**
+  * Created by npapacostas on 01/03/2016.
+  */
+object AggregationController extends Controller {
+  val Authenticated = Authed.action
+
+  def dateHistogram(field: String, q: Option[String]) = Authenticated.async { request =>
+    ElasticSearch.dateHistogramAggregate(AggregateSearchParams(field, request))
+      .map(ElasticSearch.aggregateResponse(_))
+  }
+
+}
+
+case class AggregateSearchParams(
+                                  field: String,
+                                  q: Option[String],
+                                  structuredQuery: List[Condition])
+
+object AggregateSearchParams {
+  def parseIntFromQuery(s: String): Option[Int] = Try(s.toInt).toOption
+
+  def apply(field: String, request: Request[AnyContent]): AggregateSearchParams = {
+    val query = request.getQueryString("q")
+    val structuredQuery = query.map(Parser.run) getOrElse List[Condition]()
+    new AggregateSearchParams(
+      field,
+      query,
+      structuredQuery
+    )
+  }
+}

--- a/media-api/app/controllers/SuggestionController.scala
+++ b/media-api/app/controllers/SuggestionController.scala
@@ -2,12 +2,12 @@ package controllers
 
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{Reads, Json, Writes}
-import play.api.mvc.{AnyContent, Request, Controller}
+import play.api.mvc.Controller
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 
-import lib.elasticsearch.{QueryBuilder, AggregateSearchResults, ElasticSearch}
-import lib.querysyntax.{Condition, Parser}
+import lib.elasticsearch.ElasticSearch
+import lib.querysyntax.Parser
 
 import scala.util.Try
 

--- a/media-api/app/controllers/SuggestionController.scala
+++ b/media-api/app/controllers/SuggestionController.scala
@@ -62,17 +62,12 @@ object SuggestionController extends Controller with ArgoHelpers {
   // TODO: recover with HTTP error if invalid field
   // TODO: Add validation, especially if you use length
   def metadataSearch(field: String, q: Option[String]) = Authenticated.async { request =>
-    ElasticSearch.metadataSearch(AggregateSearchParams(field, request)) map aggregateResponse
+    ElasticSearch.metadataSearch(AggregateSearchParams(field, request)) map ElasticSearch.aggregateResponse
   }
 
   def editsSearch(field: String, q: Option[String]) = Authenticated.async { request =>
-    ElasticSearch.editsSearch(AggregateSearchParams(field, request)) map aggregateResponse
+    ElasticSearch.editsSearch(AggregateSearchParams(field, request)) map ElasticSearch.aggregateResponse
   }
-
-  // TODO: Add some useful links
-  def aggregateResponse(agg: AggregateSearchResults) =
-    respondCollection(agg.results, Some(0), Some(agg.total))
-
 }
 
 case class LabelSibling(name: String, selected: Boolean)
@@ -85,22 +80,4 @@ case class LabelSiblingsResponse(label: String, siblings: List[LabelSibling])
 object LabelSiblingsResponse {
   implicit def jsonWrites: Writes[LabelSiblingsResponse] = Json.writes[LabelSiblingsResponse]
   implicit def jsonReads: Reads[LabelSiblingsResponse] =  Json.reads[LabelSiblingsResponse]
-}
-
-case class AggregateSearchParams(
-                                  field: String,
-                                  q: Option[String],
-                                  structuredQuery: List[Condition])
-object AggregateSearchParams {
-  def parseIntFromQuery(s: String): Option[Int] = Try(s.toInt).toOption
-
-  def apply(field: String, request: Request[AnyContent]): AggregateSearchParams = {
-    val query = request.getQueryString("q")
-    val structuredQuery = query.map(Parser.run) getOrElse List[Condition]()
-    new AggregateSearchParams(
-      field,
-      query,
-      structuredQuery
-    )
-  }
 }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -169,10 +169,10 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
 
   def dateHistogramAggregate(params: AggregateSearchParams)(implicit ex: ExecutionContext): Future[AggregateSearchResults] = {
     val aggregate = AggregationBuilders
-      .dateHistogram("date_added")
-      .field("usages.dateAdded")
+      .dateHistogram(params.field)
+      .field(params.field)
       .interval(DateHistogram.Interval.MONTH)
-    aggregateSearch("date_added", params, aggregate)
+    aggregateSearch(params.field, params, aggregate)
   }
 
   def metadataSearch(params: AggregateSearchParams)(implicit ex: ExecutionContext): Future[AggregateSearchResults] = {

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -172,12 +172,15 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
 
   def aggregateSearch(name: String, field: String, params: AggregateSearchParams)
                      (implicit ex: ExecutionContext): Future[AggregateSearchResults] = {
+
     val aggregate = AggregationBuilders
       .terms(name)
       .field(field)
-      .include(Pattern.quote(params.q.getOrElse("")) + ".*", Pattern.CASE_INSENSITIVE)
 
-    val search = prepareImagesSearch.addAggregation(aggregate)
+    val query = queryBuilder.makeQuery(params.structuredQuery)
+    val search = prepareImagesSearch
+      .setQuery(query)
+      .addAggregation(aggregate)
 
     search
       .setSearchType(SearchType.COUNT)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -9,6 +9,8 @@ GET     /                                             controllers.MediaApi.index
 GET     /images/metadata/:field                       controllers.SuggestionController.metadataSearch(field: String, q: Option[String])
 GET     /images/edits/:field                          controllers.SuggestionController.editsSearch(field: String, q: Option[String])
 
+GET     /images/aggregations/date/:field                 controllers.AggregationController.dateHistogram(field: String, q: Option[String])
+
 # Images
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -9,7 +9,7 @@ GET     /                                             controllers.MediaApi.index
 GET     /images/metadata/:field                       controllers.SuggestionController.metadataSearch(field: String, q: Option[String])
 GET     /images/edits/:field                          controllers.SuggestionController.editsSearch(field: String, q: Option[String])
 
-GET     /images/aggregations/date/:field                 controllers.AggregationController.dateHistogram(field: String, q: Option[String])
+GET     /images/aggregations/date/:field              controllers.AggregationController.dateHistogram(field: String, q: Option[String])
 
 # Images
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)


### PR DESCRIPTION
adding new aggregations namespace in routes and functionality for structured queries along with aggregations, also added general DateHistogram aggregation endpoint to be used for usage analysis

* the reason i made the new controller and namespace is that previously suggestions was the only thing using aggregation and thus had that functionality under it, but now we have a reason to pull it out. there are probably more things that can be pulled out of suggestions but i think this is a good first pass.

No previous functionality should be effected. (which i've tested locally)


Examples!

Structured Queries with aggregates:

*before* 
https://api.media.local.dev-gutools.co.uk/images/metadata/credit

returned:
```json
[
   {
      key:"AFP/Getty Images",
      count:249
   },
   {
      key:"AP",
      count:167
   },
   {
      key:"Getty Images",
      count:162
   },
   {
      key:"Reuters",
      count:134
   }

....
```

*Now* you can add a query:
https://api.media.local.dev-gutools.co.uk/images/metadata/credit?q=usages@status:pending

and it will get parsed like it does for normal searches, and filter the aggregations accordingly


Aggregations example:

Right now the only thing under "aggregations" is the date histogram feature, which provides you with interval-based (right now just monthly) counts of date fields based on search queries (...confusing >.<)

example:
If I want monthly usages where status is pending and credit is "REX/Shutterstock" I could do:

https://api.media.local.dev-gutools.co.uk/images/aggregations/date/usages.dateAdded?q=usages@status:pending%20credit:REX/Shutterstock

and get something like this:

```json
data:[
   {
      key:"2014-07-01T00:00:00.000Z",
      count:1
   },
   {
      key:"2016-01-01T00:00:00.000Z",
      count:1
   }
]
}
```






