### PR TITLE
Aggregate empties

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -172,6 +172,7 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
       .dateHistogram(params.field)
       .field(params.field)
       .interval(DateHistogram.Interval.MONTH)
+      .minDocCount(0)
     aggregateSearch(params.field, params, aggregate)
   }
 


### PR DESCRIPTION
Allows you to get all elements in an interval, e.g. I want all the usages in a time period, but ES will exclude months with no data, which makes it bad for graphing. This way all months will be returned whether or not there was a usage

i thought about making this parameterizable but figured right now I'm the only one with a use case so we can leave that for later 