### PR TITLE
Simplify imgops setup, use system nginx instead

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -15,7 +15,6 @@ From the **project root**:
 - metadata-editor `sbt "project metadata-editor" "run 9007"`
 - collections `sbt "project collections" "run 9010"`
 - auth `sbt "project auth" "run 9011"`
-- [imgops](../imgops/README.md)
 
 ## [run.sh](../run.sh)
 `run.sh` is a single script to start all the services.

--- a/imgops/README.md
+++ b/imgops/README.md
@@ -3,7 +3,7 @@ Local version of the imgops service
 
 ## Requirements
 * [Nginx with with image filter module](http://nginx.org/en/docs/http/ngx_http_image_filter_module.html)
-  * Linux: `sudo apt-get install nginx`
+  * Linux: `sudo apt-get install nginx nginx-extras`
   * Mac: `brew install nginx-full --with-image-filter`
 * [GD](http://libgd.github.io/)
   * Linux: `sudo apt-get install libgd-dev`

--- a/imgops/README.md
+++ b/imgops/README.md
@@ -2,6 +2,9 @@
 Local version of the imgops service
 
 ## Requirements
+* [Nginx with with image filter module](http://nginx.org/en/docs/http/ngx_http_image_filter_module.html)
+  * Linux: `sudo apt-get install nginx`
+  * Mac: `brew install nginx-full --with-image-filter`
 * [GD](http://libgd.github.io/)
   * Linux: `sudo apt-get install libgd-dev`
   * Mac:  `brew install gd`
@@ -9,7 +12,13 @@ Local version of the imgops service
 ## Installation
 ``` Bash
 ./dev-setup.sh YOUR_IMAGE_BUCKET
-./dev-start.sh
+```
+
+## Running
+You should have the [dev-nginx](https://github.com/guardian/dev-nginx) repo checked out and set up.
+``` Bash
+cd PATH_TO/dev-nginx
+sudo ./restart-nginx.sh
 ```
 
 ## Is it running

--- a/imgops/dev-setup.sh
+++ b/imgops/dev-setup.sh
@@ -11,47 +11,10 @@ then
     exit 1
 fi
 
-NGINX_VERSION=1.7.10
-NGINX_LOCATION=$PWD/nginx
+NGINX_LOCATION=$(nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g')
 
-# preclean
-rm -rf ./nginx-${NGINX_VERSION}
-rm -rf $NGINX_LOCATION
-
-# unpack
-wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
-tar -xvzf nginx-${NGINX_VERSION}.tar.gz
-
-# link up
-ln -s ./nginx-${NGINX_VERSION} $NGINX_LOCATION
-
-# compile
-pushd $NGINX_LOCATION
-./configure \
-  --prefix=$NGINX_LOCATION \
-  --with-http_ssl_module \
-  --with-http_image_filter_module
-
-make
-
-# logs
-mkdir logs
-chmod +w logs
-touch logs/access.log
-touch logs/error.log
-
-popd
+echo $NGINX_LOCATION
 
 # replace the {{BUCKET}} variable with the supplied bucket name
-rm -f imgops.conf
-sed -e 's/{{BUCKET}}/'$1'/g' imgops.template.conf > imgops.conf
-
-# let our own conf usurp the default
-rm -f $NGINX_LOCATION/conf/nginx.conf
-
-ln -s $PWD/nginx.conf $NGINX_LOCATION/conf/nginx.conf
-ln -s $PWD/imgops.conf $NGINX_LOCATION/conf/imgops.conf
-
-# postclean
-rm -f nginx-${NGINX_VERSION}.tar.gz*
-
+rm -f $NGINX_LOCATION/sites-enabled/media-service-imgops.conf
+sed -e 's/{{BUCKET}}/'$1'/g' imgops.template.conf > $NGINX_LOCATION/sites-enabled/media-service-imgops.conf

--- a/imgops/dev-start.sh
+++ b/imgops/dev-start.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-if [ -f ./nginx/logs/nginx.pid ]; then
-    $SCRIPT_DIR/nginx/objs/nginx -s stop
-fi
-$SCRIPT_DIR/nginx/objs/nginx

--- a/run.sh
+++ b/run.sh
@@ -11,4 +11,3 @@ x-terminal-emulator -T metadata-editor -e "sbt 'project metadata-editor' 'run 90
 x-terminal-emulator -T usage         -e "sbt 'project usage'        'run 9009'" &
 x-terminal-emulator -T collections   -e "sbt 'project collections'  'run 9010'" &
 x-terminal-emulator -T auth          -e "sbt 'project auth'         'run 9011'" &
-x-terminal-emulator -T imgops        -e '/bin/bash -c "cd imgops; ./dev-start.sh"' &

--- a/run_tmux.sh
+++ b/run_tmux.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-/bin/bash -c "cd imgops; ./dev-start.sh"
-
 tmux split-window "sbt 'project media-api'    'run 9001'"
 tmux select-layout even-horizontal
 tmux split-window "sbt 'project thrall'       'run 9002'"


### PR DESCRIPTION
After having a hell of a time installing everything on El Capitan, @akash1810 and I simplified the setup a bit. It means the imgops is running on the system nginx, but also means there's no compilation issues due to El Capitan not playing nice with openssl.