### PR TITLE
Expose user permissions

### DIFF
--- a/cloud-formation/scripts/permissions.properties
+++ b/cloud-formation/scripts/permissions.properties
@@ -1,3 +1,4 @@
 editMetadata=
 deleteImage=
 deleteCrops=
+bigSpender=

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
@@ -68,9 +68,20 @@ object PermissionType extends Enumeration {
   val EditMetadata = Value("editMetadata")
   val DeleteImage  = Value("deleteImage")
   val DeleteCrops  = Value("deleteCrops")
+  val BigSpender   = Value("bigSpender")
 }
-
 class PermissionStore(bucket: String, credentials: AWSCredentials) extends BaseStore[PermissionType, List[String]](bucket, credentials) {
+
+  type FuturePerms = Future[Set[PermissionType.PermissionType]]
+
+  def getUserPermissions(
+    user: PandaUser
+  ): FuturePerms = store.future.map {
+    _.filter {
+      case (_, list) => list.contains(user.email.toLowerCase)
+    }.keys
+  }.map(_.toSet)
+
   def hasPermission(permission: PermissionType, userEmail: String) = {
     store.future().map {
       list => {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
@@ -18,12 +18,18 @@ import com.amazonaws.auth.AWSCredentials
 import org.apache.commons.io.IOUtils
 import com.amazonaws.AmazonServiceException
 
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+import org.joda.time.DateTime
+
 abstract class BaseStore[TStoreKey, TStoreVal](bucket: String, credentials: AWSCredentials) {
   val s3 = new S3(credentials)
 
   private val log = LoggerFactory.getLogger(getClass)
 
   protected val store: Agent[Map[TStoreKey, TStoreVal]] = Agent(Map.empty)
+  protected val lastUpdated: Agent[DateTime] = Agent(DateTime.now())
 
   protected def getS3Object(key: String): Option[String] = {
     val content = s3.client.getObject(bucket, key)
@@ -54,6 +60,7 @@ class KeyStore(bucket: String, credentials: AWSCredentials) extends BaseStore[St
   def findKey(prefix: String): Option[String] = s3.syncFindKey(bucket, prefix)
 
   def update() {
+    lastUpdated.sendOff(_ => DateTime.now())
     store.sendOff(_ => fetchAll)
   }
 
@@ -70,17 +77,46 @@ object PermissionType extends Enumeration {
   val DeleteCrops  = Value("deleteCrops")
   val BigSpender   = Value("bigSpender")
 }
+
+case class PermissionSet(
+  user: PandaUser,
+  permissions: Set[PermissionType.PermissionType],
+  lastUpdated: DateTime
+)
+object PermissionSet {
+  implicit val pandaUserWrites: Writes[PandaUser] = (
+    (__ \ "email").write[String] ~
+    (__ \ "firstName").write[String] ~
+    (__ \ "lastName").write[String] ~
+    (__ \ "avatarUrl").writeNullable[String]
+  )(unlift(PandaUser.unapply))
+  implicit def permissionTypeWrites: Writes[PermissionType] = new Writes[PermissionType] {
+    def writes(permissionType: PermissionType.PermissionType): JsValue = JsString(permissionType.toString)
+  }
+  implicit val permissionSetWrites: Writes[PermissionSet] = Json.writes[PermissionSet]
+}
 class PermissionStore(bucket: String, credentials: AWSCredentials) extends BaseStore[PermissionType, List[String]](bucket, credentials) {
 
   type FuturePerms = Future[Set[PermissionType.PermissionType]]
+  case class StoreAccess(store: Map[PermissionType, List[String]], lastUpdated: DateTime)
 
   def getUserPermissions(
     user: PandaUser
-  ): FuturePerms = store.future.map {
-    _.filter {
-      case (_, list) => list.contains(user.email.toLowerCase)
-    }.keys
-  }.map(_.toSet)
+  ): Future[PermissionSet] = {
+    val storeAccess = for {
+      s <- store.future
+      l <- lastUpdated.future
+    } yield StoreAccess(s,l)
+
+    storeAccess.map(s => {
+      (s.store.filter {
+        case (_, list) => list.contains(user.email.toLowerCase)
+        case _ => false
+      }.keys.toSet, s.lastUpdated)
+    }).map {
+      case (keys, lastUpdated) => PermissionSet(user, keys, lastUpdated)
+    }
+  }
 
   def hasPermission(permission: PermissionType, userEmail: String) = {
     store.future().map {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -74,7 +74,8 @@ object MediaApi extends Controller with ArgoHelpers {
       Link("edits",           metadataUri),
       Link("session",         s"$authUri/session"),
       Link("witness-report",  s"https://n0ticeapis.com/2/report/{id}"),
-      Link("collections",     collectionsUri)
+      Link("collections",     collectionsUri),
+      Link("permissions",     s"$rootUri/permissions")
     )
     respond(indexData, indexLinks)
   }

--- a/media-api/app/controllers/PermissionsController.scala
+++ b/media-api/app/controllers/PermissionsController.scala
@@ -1,0 +1,49 @@
+package controllers
+
+import scala.concurrent.Future
+
+import play.api.mvc._
+import play.api.libs.concurrent.Execution.Implicits._
+
+import play.api.libs.json._
+
+import com.gu.mediaservice.lib.auth
+import com.gu.mediaservice.lib.auth._
+import com.gu.mediaservice.lib.argo._
+import com.gu.mediaservice.lib.argo.model._
+
+import com.gu.mediaservice.lib.auth.PermissionType
+
+import lib.Config
+
+
+object PermissionsController extends Controller with ArgoHelpers {
+
+  val Authenticated = Authed.action
+  val permissionStore = Authed.permissionStore
+
+  def permissionsResponse(permissions: Set[PermissionType.PermissionType]) = {
+    val perms = Json.toJson(permissions.map(_.toString))
+
+    val permsData = Json.obj(
+      "description" -> "Available permissions for current user (you)",
+      "permissions" -> perms
+    )
+
+    respond(permsData)
+  }
+
+  def getUserPermissions = Authenticated.async { request =>
+    request.user match {
+      case user: PandaUser =>
+        permissionStore
+          .getUserPermissions(user)
+          .map(permissionsResponse)
+
+      case _: AuthenticatedService => Future(NotFound)
+      case _ => Future(BadRequest)
+    }
+
+
+  }
+}

--- a/media-api/app/controllers/PermissionsController.scala
+++ b/media-api/app/controllers/PermissionsController.scala
@@ -12,7 +12,7 @@ import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model._
 
-import com.gu.mediaservice.lib.auth.PermissionType
+import com.gu.mediaservice.lib.auth.{PermissionSet, PermissionType}
 
 import lib.Config
 
@@ -22,12 +22,10 @@ object PermissionsController extends Controller with ArgoHelpers {
   val Authenticated = Authed.action
   val permissionStore = Authed.permissionStore
 
-  def permissionsResponse(permissions: Set[PermissionType.PermissionType]) = {
-    val perms = Json.toJson(permissions.map(_.toString))
-
+  def permissionsResponse(permissionSet: PermissionSet, user: PandaUser) = {
     val permsData = Json.obj(
       "description" -> "Available permissions for current user (you)",
-      "permissions" -> perms
+      "permissionsSet" -> Json.toJson(permissionSet)
     )
 
     respond(permsData)
@@ -38,7 +36,7 @@ object PermissionsController extends Controller with ArgoHelpers {
       case user: PandaUser =>
         permissionStore
           .getUserPermissions(user)
-          .map(permissionsResponse)
+          .map(perms => permissionsResponse(perms, user))
 
       case _: AuthenticatedService => Future(NotFound)
       case _ => Future(BadRequest)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -28,6 +28,9 @@ GET     /suggest/metadata/credit                      controllers.SuggestionCont
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
 
+# Permissions
+GET     /permissions                                  controllers.PermissionsController.getUserPermissions
+
 # Enable CORS
 OPTIONS /                                             controllers.CorsPreflight.options(ignoredUrl = "")
 OPTIONS /*ignoredUrl                                  controllers.CorsPreflight.options(ignoredUrl)


### PR DESCRIPTION
Expose permissions for current user in order to provide this info to the UI client so controls can be varied according to permissions.

This is specifically to add controls around paid imagery.

Example response:

`GET /permissions`

```json
{
  "data": {
    "description": "Available permissions for current user (you)",
    "permissionsSet": {
      "user": {
        "email": "nope@guardian.co.uk",
        "firstName": "Robert",
        "lastName": "Kenny",
        "avatarUrl": "https://lh3.googleusercontent.com/nope/photo.jpg"
      },
      "permissions": [
        "editMetadata",
        "deleteImage",
        "deleteCrops",
        "bigSpender"
      ],
      "lastUpdated": 1458298190366
    }
  }
}
```