### PR TITLE
Use perms to hide pay view

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Store.scala
@@ -68,9 +68,20 @@ object PermissionType extends Enumeration {
   val EditMetadata = Value("editMetadata")
   val DeleteImage  = Value("deleteImage")
   val DeleteCrops  = Value("deleteCrops")
+  val BigSpender   = Value("bigSpender")
 }
-
 class PermissionStore(bucket: String, credentials: AWSCredentials) extends BaseStore[PermissionType, List[String]](bucket, credentials) {
+
+  type FuturePerms = Future[Set[PermissionType.PermissionType]]
+
+  def getUserPermissions(
+    user: PandaUser
+  ): FuturePerms = store.future.map {
+    _.filter {
+      case (_, list) => list.contains(user.email.toLowerCase)
+    }.keys
+  }.map(_.toSet)
+
   def hasPermission(permission: PermissionType, userEmail: String) = {
     store.future().map {
       list => {

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -6,10 +6,11 @@ import {heal} from 'pandular';
 
 import uriTemplates from 'uri-templates';
 
-import {cropperApi} from './services/api/media-cropper';
-import {editsApi}   from './services/api/edits-api';
-import {loaderApi}  from './services/api/loader';
-import {mediaApi}   from './services/api/media-api';
+import {cropperApi}     from './services/api/media-cropper';
+import {editsApi}       from './services/api/edits-api';
+import {loaderApi}      from './services/api/loader';
+import {mediaApi}       from './services/api/media-api';
+import {permissionsApi} from './services/api/permissions-api';
 
 import {imageFade} from './directives/gr-image-fade-on-load';
 
@@ -41,8 +42,12 @@ var reauthLink = document.querySelector('link[rel="reauth-uri"]');
 var sentryDsnLink = document.querySelector('link[rel="sentry-dsn"]');
 var assetsRootLink = document.querySelector('link[rel="assets"]');
 
+const mediaApiUri = apiLink.getAttribute('href');
+const permissionsApiUri = mediaApiUri + '/permissions';
+
 var config = {
-    mediaApiUri: apiLink.getAttribute('href'),
+    mediaApiUri,
+    permissionsApiUri,
     sentryDsn: sentryDsnLink && sentryDsnLink.getAttribute('href'),
     assetsRoot: assetsRootLink && assetsRootLink.getAttribute('href'),
 

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -30,7 +30,7 @@
         </button>
 
         <ul class="search__modifier search__filter" ng:class="filtersShown ? 'search__filter--show' : 'search__filter--hide'">
-            <li class="search__modifier-item">
+            <li class="search__modifier-item" ng:if="searchQuery.canSearchPaidImages">
             <label>
                 <!-- minor mindfuck logic as we want an optional flag
                             when the option is off -->

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -12,10 +12,12 @@ import {syntax} from './syntax/syntax';
 import {grStructuredQuery} from './structured-query/structured-query';
 
 import {track} from '../analytics/track';
+import '../services/api/permissions-api';
 
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
     // 'ngAnimate',
+    'kahuna.services.api.permissions',
     eq.name,
     guDateRange.name,
     syntax.name,
@@ -24,10 +26,14 @@ export var query = angular.module('kahuna.search.query', [
 ]);
 
 query.controller('SearchQueryCtrl',
-                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track',
-                 function($scope, $state, $stateParams, onValChange , mediaApi, track) {
+                 ['$scope', '$state', '$stateParams', 'onValChange', 'mediaApi', 'track', 'permissionsApi',
+                 function($scope, $state, $stateParams, onValChange , mediaApi, track, permissionsApi) {
 
     const ctrl = this;
+
+    permissionsApi.get().then(userPerms => {
+        ctrl.canSearchPaidImages = Boolean(userPerms.permissions.find((perm) => perm == "bigSpender"));
+    })
 
     ctrl.ordering = {
         orderBy: $stateParams.orderBy

--- a/kahuna/public/js/services/api/permissions-api.js
+++ b/kahuna/public/js/services/api/permissions-api.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+
+import 'theseus-angular';
+
+export var permissionsApi = angular.module('kahuna.services.api.permissions', [
+    'theseus'
+]);
+
+permissionsApi.factory('permissionsApi',
+                 ['permissionsApiUri', 'theseus.client',
+                  function(permissionsApiUri, client) {
+
+    var root = client.resource(permissionsApiUri);
+
+    function get() {
+        return root.getData();
+    }
+
+    return {
+        get
+    };
+}]);

--- a/media-api/app/controllers/PermissionsController.scala
+++ b/media-api/app/controllers/PermissionsController.scala
@@ -1,0 +1,49 @@
+package controllers
+
+import scala.concurrent.Future
+
+import play.api.mvc._
+import play.api.libs.concurrent.Execution.Implicits._
+
+import play.api.libs.json._
+
+import com.gu.mediaservice.lib.auth
+import com.gu.mediaservice.lib.auth._
+import com.gu.mediaservice.lib.argo._
+import com.gu.mediaservice.lib.argo.model._
+
+import com.gu.mediaservice.lib.auth.PermissionType
+
+import lib.Config
+
+
+object PermissionsController extends Controller with ArgoHelpers {
+
+  val Authenticated = Authed.action
+  val permissionStore = Authed.permissionStore
+
+  def permissionsResponse(permissions: Set[PermissionType.PermissionType]) = {
+    val perms = Json.toJson(permissions.map(_.toString))
+
+    val permsData = Json.obj(
+      "description" -> "Available permissions for current user (you)",
+      "permissions" -> perms
+    )
+
+    respond(permsData)
+  }
+
+  def getUserPermissions = Authenticated.async { request =>
+    request.user match {
+      case user: PandaUser =>
+        permissionStore
+          .getUserPermissions(user)
+          .map(permissionsResponse)
+
+      case _: AuthenticatedService => Future(NotFound)
+      case _ => Future(BadRequest)
+    }
+
+
+  }
+}

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -30,6 +30,9 @@ GET     /suggest/edits/labels                         controllers.SuggestionCont
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
 
+# Permissions
+GET     /permissions                                  controllers.PermissionsController.getUserPermissions
+
 # Enable CORS
 OPTIONS /                                             controllers.CorsPreflight.options(ignoredUrl = "")
 OPTIONS /*ignoredUrl                                  controllers.CorsPreflight.options(ignoredUrl)


### PR DESCRIPTION
These changes cause your perms to be checked before showing the "Free to use" toggle in the UI.

This is intended to restrict the browsing of pay-for images.

![screenshot from 2016-03-10 12 56 52](https://cloud.githubusercontent.com/assets/953792/13670079/93c42c84-e6bf-11e5-85e9-cf8ef2dd3198.png)

Depends on https://github.com/guardian/grid/pull/1806