### PR TITLE
Display search chips to the left, to the left

### DIFF
--- a/kahuna/public/js/components/gr-chips/gr-chips.css
+++ b/kahuna/public/js/components/gr-chips/gr-chips.css
@@ -4,9 +4,8 @@ gr-chips {
     cursor: text; /* pretend the whole thing is a text input */
 }
 
-/* Make sure the last text token is wide enough */
-gr-chips .gr-chips__chip-wrapper:last-child gr-text-chip input {
-    min-width: 2em;
+.gr-chips__wrapper {
+    display: flex;
 }
 
 .gr-chips__placeholder {
@@ -17,6 +16,19 @@ gr-chips .gr-chips__chip-wrapper:last-child gr-text-chip input {
             user-select: none;
 }
 
+.gr-chips__chip-wrapper {
+    display: inline-flex;
+}
+
+.gr-chips__chip-wrapper.text-chip {
+    flex-grow: 3;
+    order: -1; /*always have the text chip first*/
+}
+
+gr-text-chip, gr-text-chip input {
+    width: 100%;
+}
+
 gr-text-chip,
 gr-filter-chip,
 gr-static-filter-chip,
@@ -24,6 +36,10 @@ gr-filter-chooser-chip,
 gr-filter-chip,
 gr-datalist {
     display: inline-block;
+}
+
+gr-text-chip {
+    line-height: 22px;
 }
 
 gr-filter-chip button,
@@ -62,4 +78,9 @@ gr-filter-chip input:focus,
 gr-static-filter-chip input:focus,
 gr-filter-chooser-chip input:focus {
     outline: none;
+}
+
+gr-static-filter-chip,
+gr-filter-chip {
+    margin-left: 5px;
 }

--- a/kahuna/public/js/components/gr-chips/gr-chips.css
+++ b/kahuna/public/js/components/gr-chips/gr-chips.css
@@ -22,7 +22,7 @@ gr-chips {
 
 .gr-chips__chip-wrapper.text-chip {
     flex-grow: 3;
-    order: -1; /*always have the text chip first*/
+    order: 999; /*always have the text chip after filter chips*/
 }
 
 gr-text-chip, gr-text-chip input {
@@ -82,5 +82,5 @@ gr-filter-chooser-chip input:focus {
 
 gr-static-filter-chip,
 gr-filter-chip {
-    margin-left: 5px;
+    margin-right: 5px;
 }

--- a/kahuna/public/js/components/gr-chips/gr-chips.html
+++ b/kahuna/public/js/components/gr-chips/gr-chips.html
@@ -1,11 +1,9 @@
 <div class="gr-chips__wrapper"
      ng:click="$grChipsCtrl.wrapperClicked($event)">
-    <span ng:if="$grChipsCtrl.placeholder && $grChipsCtrl.isEmpty()"
-          class="gr-chips__placeholder"
-    >{{$grChipsCtrl.placeholder}}</span>
     <span ng:repeat="$chip in $grChipsCtrl.items"
           ng:switch="$chip.type"
-          class="gr-chips__chip-wrapper">
+          class="gr-chips__chip-wrapper"
+          ng:class="$chip.type === 'text' ? 'text-chip' : 'filter-chip'">
        <gr-text-chip ng:switch-when="text"
                      gr-chip="$chip"></gr-text-chip>
        <gr-filter-chip ng:switch-when="filter"

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -42,7 +42,6 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
 
         ngModelCtrl.$render = function() {
             $grChipsCtrl.items = ngModelCtrl.$viewValue;
-            normalizeChips();
 
             if (autofocus) {
                 $grChipsCtrl.focusEndOfFirstChip();
@@ -163,26 +162,6 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         $grChipsCtrl.items.splice(index, 1);
     }
 
-    function normalizeChips() {
-        // merge consecutive text chips
-        for (let i = 1; i < $grChipsCtrl.items.length; i++) {
-            if ($grChipsCtrl.items[i].type === 'text' &&
-                $grChipsCtrl.items[i - 1].type === 'text') {
-                // TODO: need to force chip to re-set the caret
-                // position else it gets moved to the end of the field
-                const prevValue = $grChipsCtrl.items[i - 1].value;
-                const currValue = $grChipsCtrl.items[i].value;
-                $grChipsCtrl.items[i - 1].value = `${prevValue} ${currValue}`.trim();
-                removeChipAt(i);
-                i--;
-            }
-        }
-        // ensure leading empty text chip
-        const firstChip = $grChipsCtrl.items[0];
-        if (! firstChip || firstChip.type !== 'text') {
-            $grChipsCtrl.items.unshift({type: 'text', value: ''});
-        }
-    }
 }]);
 
 grChips.directive('grChips', ['$parse', function($parse) {

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -45,7 +45,7 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
             normalizeChips();
 
             if (autofocus) {
-                $grChipsCtrl.focusStartOfFirstChip();
+                $grChipsCtrl.focusEndOfFirstChip();
             }
         };
     };
@@ -60,17 +60,6 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         }
     });
 
-
-    // If clicking on the inner wrapper or the placeholder
-    // (and not in between chips), focus the end of the
-    // component
-    $grChipsCtrl.wrapperClicked = function($event) {
-        if ($event.target.classList.contains('gr-chips__wrapper') ||
-            $event.target.classList.contains('gr-chips__placeholder')) {
-            $grChipsCtrl.focusEndOfFirstChip();
-        }
-    };
-
     $grChipsCtrl.isEmpty = function() {
         return $grChipsCtrl.items.length === 1 &&
             $grChipsCtrl.items[0].value === '';
@@ -80,23 +69,13 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         const index = $grChipsCtrl.items.indexOf(item);
         if (index !== -1) {
             removeChipAt(index);
-            normalizeChips();
         }
     };
 
-    $grChipsCtrl.removeChipBefore = function(item) {
-        const index = $grChipsCtrl.items.indexOf(item) - 1;
-        if (index >= 0) {
-            removeChipAt(index);
-            normalizeChips();
-        }
-    };
-
-    $grChipsCtrl.removeChipAfter = function(item) {
-        const index = $grChipsCtrl.items.indexOf(item) + 1;
-        if (index <= $grChipsCtrl.items.length) {
-            removeChipAt(index);
-            normalizeChips();
+    $grChipsCtrl.removeLastChip = function() {
+        //do not remove text chip
+        if($grChipsCtrl.items.length > 1) {
+            removeChipAt($grChipsCtrl.items.length - 1);
         }
     };
 
@@ -159,9 +138,10 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
     };
 
     $grChipsCtrl.insertChips = function(previousItem, newItems) {
-        const index = $grChipsCtrl.items.indexOf(previousItem) + 1;
-        $grChipsCtrl.items.splice(index, 0, ...newItems);
-        normalizeChips();
+        //always insert chips to the end of items list
+        //NB text chip is styled to appear last but is first in the items list
+        const end = $grChipsCtrl.items.length;
+        $grChipsCtrl.items.splice(end, 0, ...newItems);
     };
 
     $grChipsCtrl.replaceChip = function(existingItem, newItems) {
@@ -170,7 +150,6 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         if ($grChipsCtrl.focusedItem === existingItem) {
             $grChipsCtrl.setFocusedChip(newItems[0]);
         }
-        normalizeChips();
     };
 
     function removeChipAt(index) {
@@ -198,7 +177,6 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
                 i--;
             }
         }
-
         // ensure leading empty text chip
         const firstChip = $grChipsCtrl.items[0];
         if (! firstChip || firstChip.type !== 'text') {
@@ -240,5 +218,4 @@ grChips.directive('grChips', ['$parse', function($parse) {
 /* TODO
   * cannot focus static filter, breaks navigation
   - auto-completion: key descriptions
-  - keep caret position as chips are merged
  */

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -74,7 +74,7 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
 
     $grChipsCtrl.removeLastChip = function() {
         //do not remove text chip
-        if($grChipsCtrl.items.length > 1) {
+        if ($grChipsCtrl.items.length > 1) {
             removeChipAt($grChipsCtrl.items.length - 1);
         }
     };

--- a/kahuna/public/js/components/gr-chips/gr-chips.js
+++ b/kahuna/public/js/components/gr-chips/gr-chips.js
@@ -67,7 +67,7 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
     $grChipsCtrl.wrapperClicked = function($event) {
         if ($event.target.classList.contains('gr-chips__wrapper') ||
             $event.target.classList.contains('gr-chips__placeholder')) {
-            $grChipsCtrl.focusEndOfLastChip();
+            $grChipsCtrl.focusEndOfFirstChip();
         }
     };
 
@@ -142,6 +142,14 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         }
     };
 
+    $grChipsCtrl.focusEndOfFirstChip = function() {
+        const firstItem = $grChipsCtrl.items[0];
+        if (firstItem) {
+            const itemLength = firstItem.value.length;
+            return $grChipsCtrl.setFocusedChip(firstItem, itemLength, itemLength);
+        }
+    };
+
     $grChipsCtrl.focusEndOfLastChip = function() {
         const lastItem = $grChipsCtrl.items.slice(-1)[0];
         if (lastItem) {
@@ -195,12 +203,6 @@ grChips.controller('grChipsCtrl', ['$scope', function($scope) {
         const firstChip = $grChipsCtrl.items[0];
         if (! firstChip || firstChip.type !== 'text') {
             $grChipsCtrl.items.unshift({type: 'text', value: ''});
-        }
-
-        // ensure trailing empty text chip
-        const lastChip = $grChipsCtrl.items.slice(-1)[0];
-        if (! lastChip || lastChip.type !== 'text') {
-            $grChipsCtrl.items.push({type: 'text', value: ''});
         }
     }
 }]);

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.js
@@ -38,7 +38,7 @@ grFilterChip.controller('grFilterChipCtrl', function() {
             // this fires, without the value in case of mouse clicks
             chip.value = value;
 
-            $grChipsCtrl.focusEndOfFirstChip(chip);  //return focus to the text chip
+            $grChipsCtrl.focusEndOfFirstChip();  //return focus to the text chip
             $grChipsCtrl.onChange();
         }
     };

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.js
@@ -38,7 +38,7 @@ grFilterChip.controller('grFilterChipCtrl', function() {
             // this fires, without the value in case of mouse clicks
             chip.value = value;
 
-            $grChipsCtrl.focusStartOfChipAfter(chip);
+            $grChipsCtrl.focusEndOfFirstChip(chip);  //return focus to the text chip
             $grChipsCtrl.onChange();
         }
     };

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
@@ -12,5 +12,6 @@
             gr-chip-input-on-enter="$grFilterChooserChipCtrl.apply($chip.value)"
             gr-chip-input-backspace-at-start="$grFilterChooserChipCtrl.removeSelf()"
             ng:model="$chip.value"
+            ng:class="{'gr-filter-chooser-chip__value--not-valid' : $grFilterChooserChipCtrl.notValid}"
     />
 </gr-datalist>

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
@@ -12,6 +12,5 @@
             gr-chip-input-on-enter="$grFilterChooserChipCtrl.apply($chip.value)"
             gr-chip-input-backspace-at-start="$grFilterChooserChipCtrl.removeSelf()"
             ng:model="$chip.value"
-            ng:class="{'gr-filter-chooser-chip__value--not-valid' : $grFilterChooserChipCtrl.notValid}"
     />
 </gr-datalist>

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
@@ -54,12 +54,12 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', ['$timeout', function(
             } else {
                 // Not a key, turn it back to text search
                 $grChipsCtrl.focusEndOfFirstChip();
-                chip.value = "FIELD NOT FOUND";
+                chip.value = 'FIELD NOT FOUND';
                 $grFilterChooserChipCtrl.notValid = true;
 
                 $timeout(() => {
                     $grFilterChooserChipCtrl.removeSelf();
-                    $grChipsCtrl.items[0].value += (" " + value);
+                    $grChipsCtrl.items[0].value += (' ' + value);
                 }, 800);
 
             }

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
@@ -16,7 +16,7 @@ export const grFilterChooserChip = angular.module('gr.filterChooserChip', [
     autoWidth.name
 ]);
 
-grFilterChooserChip.controller('grFilterChooserChipCtrl', ['$timeout', function($timeout) {
+grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
     const $grFilterChooserChipCtrl = this;
 
     let $grChipsCtrl;
@@ -53,15 +53,9 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', ['$timeout', function(
                 $grChipsCtrl.setFocusedChip(filterChip);
             } else {
                 // Not a key, turn it back to text search
+                $grFilterChooserChipCtrl.removeSelf();
+                $grChipsCtrl.items[0].value += (' ' + value);
                 $grChipsCtrl.focusEndOfFirstChip();
-                chip.value = 'FIELD NOT FOUND';
-                $grFilterChooserChipCtrl.notValid = true;
-
-                $timeout(() => {
-                    $grFilterChooserChipCtrl.removeSelf();
-                    $grChipsCtrl.items[0].value += (' ' + value);
-                }, 800);
-
             }
         }
     };
@@ -69,7 +63,7 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', ['$timeout', function(
     $grFilterChooserChipCtrl.removeSelf = function() {
         $grChipsCtrl.removeChip($grChipCtrl.chip);
     };
-}]);
+});
 
 grFilterChooserChip.directive('grFilterChooserChip', [function() {
     return {

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.js
@@ -16,7 +16,7 @@ export const grFilterChooserChip = angular.module('gr.filterChooserChip', [
     autoWidth.name
 ]);
 
-grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
+grFilterChooserChip.controller('grFilterChooserChipCtrl', ['$timeout', function($timeout) {
     const $grFilterChooserChipCtrl = this;
 
     let $grChipsCtrl;
@@ -52,19 +52,16 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
                 // dropdown which blurred the current chip
                 $grChipsCtrl.setFocusedChip(filterChip);
             } else {
-                // Not a key, turn it into an 'any' filter and move focus next text
-                const anyFilterChip = {
-                    type: 'filter',
-                    filterType: chip.filterType,
-                    key: 'any',
-                    value: value
-                };
-                const nextText = {
-                    type: 'text',
-                    value: ''
-                };
-                $grChipsCtrl.replaceChip(chip, [anyFilterChip, nextText]);
-                $grChipsCtrl.setFocusedChip(nextText);
+                // Not a key, turn it back to text search
+                $grChipsCtrl.focusEndOfFirstChip();
+                chip.value = "FIELD NOT FOUND";
+                $grFilterChooserChipCtrl.notValid = true;
+
+                $timeout(() => {
+                    $grFilterChooserChipCtrl.removeSelf();
+                    $grChipsCtrl.items[0].value += (" " + value);
+                }, 800);
+
             }
         }
     };
@@ -72,7 +69,7 @@ grFilterChooserChip.controller('grFilterChooserChipCtrl', function() {
     $grFilterChooserChipCtrl.removeSelf = function() {
         $grChipsCtrl.removeChip($grChipCtrl.chip);
     };
-});
+}]);
 
 grFilterChooserChip.directive('grFilterChooserChip', [function() {
     return {

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -4,7 +4,6 @@
        ng:trim="false"
        gr-chip-input
        gr-chip-input-backspace-at-start="$grTextChipCtrl.removePrevious()"
-       gr-chip-input-delete-at-end="$grTextChipCtrl.removeNext()"
        ng:model="$grChipCtrl.chip.value"
        ng:keypress="$grTextChipCtrl.handleKey($event)"
 />

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -1,6 +1,6 @@
 <input type="text"
        autocomplete="off"
-       gr-auto-width
+       placeholder="Search for images..."
        ng:trim="false"
        gr-chip-input
        gr-chip-input-backspace-at-start="$grTextChipCtrl.removePrevious()"

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.js
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.js
@@ -26,7 +26,7 @@ grTextChip.controller('grTextChipCtrl', function() {
     };
 
     $grTextChipCtrl.removePrevious = function() {
-        $grChipsCtrl.removeChipBefore($grChipCtrl.chip);
+        $grChipsCtrl.removeLastChip();
     };
 
     $grTextChipCtrl.removeNext = function() {
@@ -86,7 +86,7 @@ grTextChip.controller('grTextChipCtrl', function() {
         chip.value = textUntil;
 
         $grChipsCtrl.insertChips(chip, newChips);
-        $grChipsCtrl.focusStartOfChipAfter(chip);
+        $grChipsCtrl.focusEndOfLastChip(chip); //newly created chip will be last
     }
 
     function insertAndFocusFilterChooser(filterType, splitStart) {

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -9,7 +9,6 @@ export const querySuggestions = angular.module('querySuggestions', [
 
 // FIXME: get fields and subjects from API
 export const filterFields = [
-    'any', // first on purpose in spite of alphabet
     'by',
     'category',
     'city',

--- a/kahuna/public/js/search/structured-query/structured-query.css
+++ b/kahuna/public/js/search/structured-query/structured-query.css
@@ -9,6 +9,11 @@ gr-chips input[type="text"][autocomplete="off"] {
     background-position: 150% 50% !important;
 }
 
+gr-chips input.gr-filter-chooser-chip__value--not-valid {
+    background: #ffbc01;
+    color: black;
+}
+
 gr-chips .datalist {
     position: static;
     width: auto;

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -52,8 +52,7 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
         restrict: 'E',
         require: ['grStructuredQuery', 'ngModel'],
         template: `
-<gr-chips placeholder="Search for images…"
-          autofocus="autofocus"
+<gr-chips autofocus="autofocus"
           ng:model="ctrl.structuredQuery"
           gr:valid-keys="ctrl.filterFields"
           gr:on-change="ctrl.structuredQueryChanged($chips)"

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -3,7 +3,7 @@ import {getLabel, getCollection} from '../../search-query/query-syntax';
 
 // Line too long for jshint, but can't break it down..
 /*jshint -W101 */
-const parserRe = /(-?)(?:(?:([a-zA-Z]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^']+)')|([a-zA-Z0-9]+)|"([^"]*)"|'([^']*)')/g;
+const parserRe = /(-?)(?:(?:([a-zA-Z@><]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^']+)')|([a-zA-Z0-9]+)|"([^"]*)"|'([^']*)')/g;
 /*jshint +W101 */
 
 // TODO: expose the server-side query parser via an API instead of

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -39,7 +39,27 @@ export function structureQuery(query) {
             });
         }
     }
-    return struct;
+
+    return orderChips(struct);
+}
+
+function orderChips(structuredQuery){
+    const filterChips = structuredQuery.filter(e => e.type !== 'text');
+    const textChipsValues = mergeTextValues(structuredQuery);
+    const textChip = {
+        type: 'text',
+        value: textChipsValues
+    };
+
+    const cleanStruct = [textChip].concat(filterChips);
+
+    function mergeTextValues(chips){
+        return chips.filter(e => e.type === 'text')
+            .map(e => e.value)
+            .join(' ');
+    }
+
+    return cleanStruct;
 }
 
 function renderFilter(field, value) {


### PR DESCRIPTION
![chips](https://cloud.githubusercontent.com/assets/8484757/13778612/ccaa5c24-eaae-11e5-86bc-b79aed1bae1f.gif)

Once created, pushes chips to the right of the search box.
Only  has ONE text chip which stays on the left. 

#1801