### PR TITLE
delete stack script

### DIFF
--- a/cloud-formation/scripts/delete-dev-stack.sh
+++ b/cloud-formation/scripts/delete-dev-stack.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source ./stack-name.sh
+
+# empty all S3 buckets first
+aws cloudformation list-stack-resources \
+	--stack-name $STACK_NAME \
+	| jq '.StackResourceSummaries[] | select(.ResourceType == "AWS::S3::Bucket").PhysicalResourceId' \
+	| tr -d '"' \
+	| while read BUCKET
+do
+	echo "Deleting contents of $BUCKET"
+	aws s3 rm s3://$BUCKET --recursive
+done
+
+aws cloudformation delete-stack \
+	--stack-name $STACK_NAME
+
+echo 'Done'


### PR DESCRIPTION
Following @philmcmahon's recent email about inactive workflow stacks, I'll be deleting my DEV stacks from the media-service account soon.

Buckets have to be empty for a `delete-stack` call to work.

As the Grid stack has many buckets, a script makes life easier :smile:.