### PR TITLE
corrects square shortcut and makes all lowercase

### DIFF
--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -9,12 +9,12 @@
     <gr-top-bar-actions>
         <div class="top-bar-item side-padded">{{ ctrl.cropWidth() }} &times; {{ ctrl.cropHeight() }}</div>
 
-        <label class="top-bar-item clickable side-padded" gr-tooltip="landscape [L]">
+        <label class="top-bar-item clickable side-padded" gr-tooltip="landscape [l]">
             <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.landscapeRatio}}"/>
             <gr-icon>crop_landscape</gr-icon><span class="top-bar-item__label">Landscape</span> ({{::ctrl.getRatioString(ctrl.landscapeRatio)}})
         </label>
 
-        <label class="top-bar-item clickable side-padded" gr-tooltip="portrait [P]">
+        <label class="top-bar-item clickable side-padded" gr-tooltip="portrait [p]">
             <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.portraitRatio}}" />
             <gr-icon>crop_portrait</gr-icon><span class="top-bar-item__label">Portrait</span> ({{::ctrl.getRatioString(ctrl.portraitRatio)}})
         </label>
@@ -24,7 +24,7 @@
             <gr-icon>crop_16_9</gr-icon><span class="top-bar-item__label">Video</span> ({{::ctrl.getRatioString(ctrl.videoRatio)}})
         </label>
 
-        <label class="top-bar-item clickable side-padded" gr-tooltip="square [v]">
+        <label class="top-bar-item clickable side-padded" gr-tooltip="square [s]">
             <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.squareRatio}}" />
             <gr-icon>crop_square</gr-icon><span class="top-bar-item__label">Square</span> ({{::ctrl.getRatioString(ctrl.squareRatio)}})
         </label>


### PR DESCRIPTION
Makes all keyboard shortcuts lowercase - upper case letters do not work as shortcut. 
Corrects letter for square crop to 'v' -> 's'. 

Fixes: 
![screen shot 2016-03-22 at 17 44 32](https://cloud.githubusercontent.com/assets/8484757/13961736/c220edfc-f055-11e5-833e-b8c8ee93b4f6.jpg)
