### PR TITLE
prompt to alter search when no results

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -133,7 +133,7 @@
 
         <div ng:if="ctrl.totalResults == 0"
              class="image-no-results">
-            No matches, sorry!
+            No matches, sorry! Try altering your search.
         </div>
     </div>
 </div>


### PR DESCRIPTION
The embedded Grid defaults search for Video pages, setting a label search. However, its not guaranteed that any images will exist and its been (incorrectly) said that "the Grid doesn't work". This PR prompts to check your search if this is the case.

I've started creating a `clear-search` component that can be placed in next to this message, however need to share state between controllers, so need a factory and so refactoring :unamused:. I'll carry on with this on a branch, however I think this is a good first step to solving the problem.

/cc @jamesgorrie 