### PR TITLE
Make /management/manifest return JSON 

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
@@ -1,21 +1,39 @@
 package com.gu.mediaservice.lib.management
 
 import scala.io.Source
+
+import play.api.libs.json._
+import com.gu.mediaservice.lib.argo._
+import com.gu.mediaservice.lib.argo.model._
+
 import play.api.mvc.{Action, Controller}
 
 
-object Management extends Controller {
+object Management extends Controller with ArgoHelpers {
 
   def healthCheck = Action {
     Ok("OK")
   }
 
-  lazy val manifest_ : Option[String] =
+  def manifestFromFile: Option[String] =
     for (stream <- Option(getClass.getResourceAsStream("/version.txt")))
     yield Source.fromInputStream(stream, "UTF-8").getLines.mkString("\n")
 
+
+  lazy val manifest_ : Option[JsValue] = manifestFromFile.map(manifestString => {
+    Json.toJson(
+      manifestString.split("\n")
+        .flatMap(pair => pair.split(":", 2))
+        .toList.map(_.trim)
+        .grouped(2).collect { case List(k,v) => k -> v }
+        .toMap[String, String]
+    )
+  })
+
   def manifest = Action {
-    manifest_.fold(NotFound("Manifest missing."))(Ok(_))
+    manifest_.fold(
+      respondError(NotFound, "manifest-missing", "Manifest missing.")
+    )(respond(_))
   }
 
 }


### PR DESCRIPTION
In order to allow the UI client to understand when the API has changed
this makes the manifest endpoint (more) machine readable.

Ultimately the intention is allow the kahuna client to refresh itself if
it's out of sync with the server version.

`GET /management/manifest` with `Accept: application/json`

```json
{
  "data": {
    "Build": "DEV",
    "Built-On": "derpbox",
    "Built-By": "rkenny",
    "Revision": "DEV",
    "Branch": "DEV",
    "Date": "Tue Mar 29 10:30:43 BST 2016"
  }
}
```