### PR TITLE
fixes problem with collections and quotes

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -130,7 +130,7 @@ object CollectionsController extends Controller with ArgoHelpers {
           case e: CollectionsStoreError => storeError(e.message)
         }
       } else {
-        Future.successful(respondError(BadRequest, "invalid-input", "You cannot have slashes in your path name"))
+        Future.successful(respondError(BadRequest, "invalid-input", "You cannot have slashes or double quotes in your path name"))
       }
     } getOrElse Future.successful(invalidJson(req.body))
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -6,6 +6,7 @@ import com.gu.mediaservice.model.Collection
 
 object CollectionsManager {
   val delimiter = "/"
+  val doublequotes = "\""
 
   def stringToPath(s: String) = s.split(delimiter).toList
   def pathToString(path: List[String]) = path.mkString(delimiter)
@@ -38,7 +39,7 @@ object CollectionsManager {
     }
 
   // We could use `ValidationNel`s here, but that's overkill
-  def isValidPathBit(s: String) = if (s.contains(delimiter)) false else true
+  def isValidPathBit(s: String) = if (s.contains(delimiter) || s.contains(doublequotes)) false else true
 
   val collectionColours = Map(
     "australia"    -> "#ffb93e",

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -1,7 +1,6 @@
 const hasSpace         = s     => /\s/g.test(s);
 const labelMatch       = label => new RegExp(`(label:|#)("|')?${label}(("|')|\\b)`, 'g');
 const createLabel      = label => hasSpace(label) ? `#"${label}"` : `#${label}`;
-const createCollection = path  => hasSpace(path) ? `~"${path}"` : `~${path}`;
 
 function hasLabel(q, label) {
     return labelMatch(label).test(q);
@@ -28,7 +27,7 @@ export function getLabel(name) {
 }
 
 export function getCollection(path) {
-    return createCollection(path);
+    return `~"${path}"`
 }
 
 export function getCollectionsFromQuery(q) {

--- a/kahuna/public/js/search-query/query-syntax.js
+++ b/kahuna/public/js/search-query/query-syntax.js
@@ -27,7 +27,7 @@ export function getLabel(name) {
 }
 
 export function getCollection(path) {
-    return `~"${path}"`
+    return `~"${path}"`;
 }
 
 export function getCollectionsFromQuery(q) {


### PR DESCRIPTION
Wraps all collections in double quotes, fixes navigating to a collection with no spaces and single quote mark i.e. apostrophes e.g. "jonny's"
![quotes](https://cloud.githubusercontent.com/assets/8484757/14207961/e2f85ada-f814-11e5-9fb3-81f0d9aa6aa8.gif)


Does not allow adding a collection with double quotes. Informs users. 
![screen shot 2016-04-01 at 14 18 34](https://cloud.githubusercontent.com/assets/8484757/14207908/aba407f0-f814-11e5-931c-0f70687b0022.jpg)
