### PR TITLE
Fix crops width

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1409,7 +1409,6 @@ FIXME: what to do with touch devices
 .easel__image-container {
     /*style rules also affect the cropper preview*/
     display: inline-block;
-    height: 100%;
 }
 
 .easel__image {


### PR DESCRIPTION
remove height to stop unusually wide images spilling out of the crop container.

This does mean there will be a gap under any image thats smaller than the viewport height (for now).

Before:
![picture 42](https://cloud.githubusercontent.com/assets/2104095/14255646/ec5aaaea-fa8c-11e5-9f87-deef2ffb28e8.png)

After:
![picture 41](https://cloud.githubusercontent.com/assets/2104095/14255645/ec597300-fa8c-11e5-80cc-039d0bc0e797.png)