### PR TITLE
Adds original file metadata to image view

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -279,3 +279,24 @@
         </dd>
     </dl>
 </div>
+
+<div class="image-info">
+    <div class="image-info__group">
+        <button class="metadata-reveal"
+                ng:click="originalInfoExpanded = !originalInfoExpanded">
+            <span ng:hide="originalInfoExpanded">▸ Show</span>
+            <span ng:show="originalInfoExpanded">▾ Hide</span>
+            file info
+        </button>
+
+
+        <div ng:if="originalInfoExpanded" class="metadata metadata-line image-info__group--dl">
+            <dl ng:repeat="(key, value) in ctrl.source" class="metadata__body image-info__group--dl">
+                <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
+                <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
+            </dl>
+        </div>
+    </div>
+</div>
+
+

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -41,6 +41,37 @@ module.controller('grImageMetadataCtrl', [
 
         // Alias for convenience in view
         ctrl.metadata = ctrl.image.data.metadata;
+
+        function formatBytes(bytes) {
+            if(bytes == 0) return '0 Byte';
+
+            const k = 1000;
+            const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+            return parseFloat((bytes / Math.pow(k, i)).toFixed(3)) + ' ' + sizes[i];
+        }
+
+        function buildOriginalFileInfo() {
+            const defaultEmptyInfo = {};
+            var fileInfo;
+
+            try {
+                fileInfo = {
+                    filename: ctrl.image.data.uploadInfo.filename,
+                    mimeType: ctrl.image.data.source.mimeType,
+                    size: formatBytes(ctrl.image.data.source.size),
+                    width: ctrl.image.data.source.dimensions.width + "px",
+                    height: ctrl.image.data.source.dimensions.height + "px"
+                }
+            } catch(err) {
+                // Do nothing!
+            }
+
+            return fileInfo || defaultEmptyInfo;
+        }
+
+        ctrl.source = buildOriginalFileInfo();
         ctrl.identifiers = ctrl.image.data.identifiers;
 
         ctrl.isUsefulMetadata = isUsefulMetadata;


### PR DESCRIPTION
This is useful for commercial folks whose workflow is mainly downloading
images from the grid for 3rd parties.

![screenshot from 2016-04-13 12 11 06](https://cloud.githubusercontent.com/assets/953792/14491467/d223890e-0170-11e6-8b14-f0b816c8abc9.png)
