### PR TITLE
Add POST and DELETE Action for Leases to Media API

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -156,15 +156,22 @@ object ImageResponse extends EditsResponse {
     val imageUri = URI.create(s"${Config.rootUri}/images/$id")
     val reindexUri = URI.create(s"${Config.rootUri}/images/$id/reindex")
     val addCollectionUri = URI.create(s"${Config.collectionsUri}/images/$id")
+    val addLeasesUri = URI.create(s"${Config.leaseUri}/leases")
+    val deleteLeasesUri = URI.create(s"${Config.leaseUri}/leases/media/$id")
 
     val deleteAction = Action("delete", imageUri, "DELETE")
     val reindexAction = Action("reindex", reindexUri, "POST")
 
     val addCollectionAction = Action("add-collection", addCollectionUri, "POST")
 
+    val addLeasesAction = Action("add-lease", addLeasesUri, "POST")
+    val deleteLeasesAction = Action("delete-leases", deleteLeasesUri, "DELETE")
+
     List(
       deleteAction        -> isDeletable,
       reindexAction       -> withWritePermission,
+      addLeasesAction     -> withWritePermission,
+      deleteLeasesAction  -> withWritePermission,
       addCollectionAction -> true
     )
     .filter{ case (action, active) => active }


### PR DESCRIPTION
On an `ImageResponse`:

```json
{
 "actions": [
    {
      "name": "add-lease",
      "href": "https://example.com/leases",
      "method": "POST"
    },
    {
      "name": "delete-leases",
      "href": "https://example.com/leases/media/48bf45fee9fb361acfa093996f8a6e8c145c8189",
      "method": "DELETE"
    },
    "...": "..."
  ],
  "...": "..."
}
```