### PR TITLE
Adding leases root uri to media-api index response

### DIFF
--- a/leases/app/controllers/MediaLeaseController.scala
+++ b/leases/app/controllers/MediaLeaseController.scala
@@ -20,7 +20,11 @@ import com.gu.mediaservice.lib.argo.model._
 import lib.LeaseStore
 
 
-case class AppIndex(name: String, description: String, config: Map[String, String] = Map())
+case class AppIndex(
+                     name: String,
+                     description: String,
+                     config: Map[String, String] = Map(),
+                     links: List[Link] = Nil)
 object AppIndex {
   implicit def jsonWrites: Writes[AppIndex] = Json.writes[AppIndex]
 }
@@ -32,7 +36,12 @@ object MediaLeaseController extends Controller with ArgoHelpers {
 
   val notFound = respondNotFound("MediaLease not found")
 
-  val appIndex = AppIndex("media-leases", "Media leases service")
+  val appIndex = AppIndex(
+    "media-leases",
+    "Media leases service",
+    Map(),
+    List(Link("by-media-id", s"$rootUri/leases/media/{id}"))
+  )
   def index = Authenticated { _ => respond(appIndex) }
 
   def postLease = Authenticated.async(parse.json) { implicit request => Future {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -39,7 +39,7 @@ import com.gu.mediaservice.model._
 
 object MediaApi extends Controller with ArgoHelpers {
 
-  import Config.{rootUri, cropperUri, loaderUri, metadataUri, authUri, collectionsUri}
+  import Config.{rootUri, cropperUri, loaderUri, metadataUri, authUri, collectionsUri, leaseUri}
 
   val Authenticated = Authed.action
   val permissionStore = Authed.permissionStore
@@ -75,7 +75,8 @@ object MediaApi extends Controller with ArgoHelpers {
       Link("session",         s"$authUri/session"),
       Link("witness-report",  s"https://n0ticeapis.com/2/report/{id}"),
       Link("collections",     collectionsUri),
-      Link("permissions",     s"$rootUri/permissions")
+      Link("permissions",     s"$rootUri/permissions"),
+      Link("leases", leaseUri)
     )
     respond(indexData, indexLinks)
   }


### PR DESCRIPTION
So that we can build the right routes on the client. 