### PR TITLE
Add `invalidReasons` to ImageResponse

### DIFF
--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,9 +1,8 @@
-<div ng:if="image.data.source.mimeType === 'image/png'"
-    class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
-    <strong>Png images cannot be cropped</strong>
-</div>
-<div ng:if="image.data.source.mimeType === 'image/jpeg' && ! image.data.valid"
-    class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
-    <strong>Incomplete metadata</strong>
-    Fill in description and credit before use
+<div ng:if="!image.data.valid" class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
+    <strong>Invalid Image</strong>
+    <ul>
+        <li ng:repeat="(key, reason) in image.data.invalidReasons">
+            {{reason}}
+        </li>
+    </ul>
 </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -66,8 +66,8 @@
 
                 <span class="result-editor__status status status--invalid"
                       ng:switch-when="invalid">
-                        Info missing
-                    <gr-icon title="You need to add both a credit and description">help</gr-icon>
+                        Invalid
+                    <gr-icon title="You need to add both a credit and description, (PNGs are also invalid).">help</gr-icon>
                 </span>
             </div>
 

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -69,6 +69,9 @@
                         Invalid
                     <gr-icon title="You need to add both a credit and description, (PNGs are also invalid).">help</gr-icon>
                 </span>
+                <div class="result-editor__info-item--png-warning"ng:if="ctrl.invalidReasons['is_png']">
+                    <strong>PNG</strong>: Currently not supported!
+                </div>
             </div>
 
             <gr-archiver-status class="result-editor__archiver"

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -47,6 +47,7 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.showUsageRights = false;
     ctrl.status = ctrl.image.data.valid ? 'ready' : 'invalid';
     ctrl.usageRights = imageService(ctrl.image).usageRights;
+    ctrl.invalidReasons = ctrl.image.data.invalidReasons;
 
     //TODO put collections in their own directive
     ctrl.addCollection = false;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1319,6 +1319,15 @@ FIXME: what to do with touch devices
     font-size: 1.4rem;
 }
 
+.result-editor__info-item--png-warning {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background-color: rgba(256, 0, 0, .7);
+    text-align: center;
+}
+
 .result-editor__info-item--first {
     margin-left: 0;
 }

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -10,7 +10,8 @@ object ImageExtras {
 
   val validityDescription = Map(
     "has_credit" -> "No credit information",
-    "has_description" -> "No description"
+    "has_description" -> "No description",
+    "is_png" -> "PNG images cannot be exported"
   )
 
   private def optToBool[T](o: Option[T]): Boolean =
@@ -18,14 +19,16 @@ object ImageExtras {
 
   def hasCredit(meta: ImageMetadata) = optToBool(meta.credit)
   def hasDescription(meta: ImageMetadata) = optToBool(meta.description)
+  def isPng(asset: Asset) = asset.mimeType == Some("image/png")
 
   def validityMap(image: Image): Map[String, Boolean] = Map(
     "has_credit" -> hasCredit(image.metadata),
-    "has_description" -> hasDescription(image.metadata)
+    "has_description" -> hasDescription(image.metadata),
+    "is_png" -> !isPng(image.source)
   )
 
   def invalidReasons(validityMap: Map[String, Boolean]) = validityMap
-    .find(_._2 == false)
+    .filter(_._2 == false)
     .map { case (id, _) => id -> validityDescription.get(id) }
     .map {
       case (id, Some(reason)) => id -> reason

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -7,6 +7,31 @@ import com.gu.mediaservice.model._
 
 
 object ImageExtras {
-  def isValid(metadata: JsValue): Boolean =
-    Config.requiredMetadata.forall(field => (metadata \ field).asOpt[String].isDefined)
+
+  val validityDescription = Map(
+    "has_credit" -> "No credit information",
+    "has_description" -> "No description"
+  )
+
+  private def optToBool[T](o: Option[T]): Boolean =
+    o.map(_ => true).getOrElse(false)
+
+  def hasCredit(meta: ImageMetadata) = optToBool(meta.credit)
+  def hasDescription(meta: ImageMetadata) = optToBool(meta.description)
+
+  def validityMap(image: Image): Map[String, Boolean] = Map(
+    "has_credit" -> hasCredit(image.metadata),
+    "has_description" -> hasDescription(image.metadata)
+  )
+
+  def invalidReasons(validityMap: Map[String, Boolean]) = validityMap
+    .find(_._2 == false)
+    .map { case (id, _) => id -> validityDescription.get(id) }
+    .map {
+      case (id, Some(reason)) => id -> reason
+      case (id, None) => id -> s"Validity error: ${id}"
+    }.toMap
+
+  def isValid(validityMap: Map[String, Boolean]): Boolean =
+    !optToBool(validityMap.find(_._2 == false))
 }

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -9,9 +9,9 @@ import com.gu.mediaservice.model._
 object ImageExtras {
 
   val validityDescription = Map(
-    "has_credit" -> "Missing credit information",
-    "has_description" -> "Missing description",
-    "is_png" -> "PNG images cannot be cropped"
+    "missing_credit"      -> "Missing credit information",
+    "missing_description" -> "Missing description",
+    "is_png"              -> "PNG images cannot be cropped"
   )
 
   private def optToBool[T](o: Option[T]): Boolean =
@@ -22,13 +22,13 @@ object ImageExtras {
   def isPng(asset: Asset) = asset.mimeType == Some("image/png")
 
   def validityMap(image: Image): Map[String, Boolean] = Map(
-    "has_credit" -> hasCredit(image.metadata),
-    "has_description" -> hasDescription(image.metadata),
-    "is_png" -> !isPng(image.source)
+    "missing_credit"      -> !hasCredit(image.metadata),
+    "missing_description" -> !hasDescription(image.metadata),
+    "is_png"              -> isPng(image.source)
   )
 
   def invalidReasons(validityMap: Map[String, Boolean]) = validityMap
-    .filter(_._2 == false)
+    .filter(_._2 == true)
     .map { case (id, _) => id -> validityDescription.get(id) }
     .map {
       case (id, Some(reason)) => id -> reason

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -9,8 +9,8 @@ import com.gu.mediaservice.model._
 object ImageExtras {
 
   val validityDescription = Map(
-    "has_credit" -> "No credit information",
-    "has_description" -> "No description",
+    "has_credit" -> "Missing credit information",
+    "has_description" -> "Missing description",
     "is_png" -> "PNG images cannot be exported"
   )
 

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -11,7 +11,7 @@ object ImageExtras {
   val validityDescription = Map(
     "has_credit" -> "Missing credit information",
     "has_description" -> "Missing description",
-    "is_png" -> "PNG images cannot be exported"
+    "is_png" -> "PNG images cannot be cropped"
   )
 
   private def optToBool[T](o: Option[T]): Boolean =

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -15,6 +15,8 @@ trait SearchFilters extends ImageFields {
 
   import UsageRightsConfig.{ suppliersCollectionExcl, freeSuppliers }
 
+  // Warning: The current media-api definition of invalid includes other requirements
+  // so does not match this filter exactly!
   val validFilter   = Config.requiredMetadata.map(metadataField).toNel.map(filters.exists)
   val invalidFilter = Config.requiredMetadata.map(metadataField).toNel.map(filters.anyMissing)
 

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -13,11 +13,10 @@ import lib.Config
 
 trait SearchFilters extends ImageFields {
 
+  import UsageRightsConfig.{ suppliersCollectionExcl, freeSuppliers }
+
   val validFilter   = Config.requiredMetadata.map(metadataField).toNel.map(filters.exists)
   val invalidFilter = Config.requiredMetadata.map(metadataField).toNel.map(filters.anyMissing)
-
-  // New Cost Model
-  import UsageRightsConfig.{ suppliersCollectionExcl, freeSuppliers }
 
   val (suppliersWithExclusions, suppliersNoExclusions) = freeSuppliers.partition(suppliersCollectionExcl.contains)
   val suppliersWithExclusionsFilters = for {


### PR DESCRIPTION
In order that the UI can provide a more granular indicator of validity.

![screenshot from 2016-04-19 15 41 50](https://cloud.githubusercontent.com/assets/953792/14643391/20839ace-0646-11e6-9252-413a102bb116.png)

Upload screen changes:
![screenshot from 2016-04-19 16 27 04](https://cloud.githubusercontent.com/assets/953792/14644916/975c7526-064b-11e6-9b89-c5a0b08005c3.png)
