### PR TITLE
Add Staff Illustrator option

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -121,6 +121,11 @@ object MetadataConfig {
     "Suki Dhanda"         -> "The Observer"
   )
 
+  val staffIllustrators = List(
+    "Mona Chalabi",
+    "Jan Diehm"
+  )
+
   val contractIllustrators = List(
     "Ben Lamb",
     "Andrzej Krauze",

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -27,7 +27,8 @@ object UsageRights {
     Agency, CommissionedAgency, Chargeable,
     StaffPhotographer, ContractPhotographer, CommissionedPhotographer,
     CreativeCommons, GuardianWitness, Pool, CrownCopyright, Obituary,
-    ContractIllustrator, CommissionedIllustrator, Composite, PublicDomain
+    ContractIllustrator, CommissionedIllustrator, StaffIllustrator,
+    Composite, PublicDomain
   )
 
   // this is a convenience method so that we use the same formatting for all subtypes
@@ -66,6 +67,7 @@ object UsageRights {
     case o: Pool => Pool.formats.writes(o)
     case o: CrownCopyright => CrownCopyright.formats.writes(o)
     case o: ContractIllustrator => ContractIllustrator.formats.writes(o)
+    case o: StaffIllustrator => StaffIllustrator.formats.writes(o)
     case o: CommissionedIllustrator => CommissionedIllustrator.formats.writes(o)
     case o: CreativeCommons => CreativeCommons.formats.writes(o)
     case o: Composite => Composite.formats.writes(o)
@@ -97,6 +99,7 @@ object UsageRights {
         case Pool.category => json.asOpt[Pool]
         case CrownCopyright.category => json.asOpt[CrownCopyright]
         case ContractIllustrator.category => json.asOpt[ContractIllustrator]
+        case StaffIllustrator.category => json.asOpt[StaffIllustrator]
         case CommissionedIllustrator.category => json.asOpt[CommissionedIllustrator]
         case CreativeCommons.category => json.asOpt[CreativeCommons]
         case Composite.category => json.asOpt[Composite]
@@ -363,6 +366,20 @@ object CrownCopyright extends UsageRightsSpec {
     UsageRights.subtypeFormat(CrownCopyright.category)(Json.format[CrownCopyright])
 }
 
+final case class StaffIllustrator(creator: String, restrictions: Option[String] = None)
+  extends Illustrator {
+  val defaultCost = StaffIllustrator.defaultCost
+}
+object StaffIllustrator extends UsageRightsSpec {
+  val category = "staff-illustrator"
+  val defaultCost = Some(Free)
+  val name = "Illustrator - staff"
+  val description =
+    "Images from illustrators who are or were members of staff."
+
+  implicit val formats: Format[StaffIllustrator] =
+    UsageRights.subtypeFormat(StaffIllustrator.category)(Json.format[StaffIllustrator])
+}
 
 final case class ContractIllustrator(creator: String, restrictions: Option[String] = None)
   extends Illustrator {

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -56,6 +56,7 @@ trait SearchFilters extends ImageFields {
     ContractPhotographer.category,
     CommissionedPhotographer.category,
     ContractIllustrator.category,
+    StaffIllustrator.category,
     CommissionedIllustrator.category,
     CommissionedAgency.category
   )

--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -10,6 +10,7 @@ object UsageRightsMetadataMapper {
       case u: ContractPhotographer     => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: ContractIllustrator      => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
+      case u: StaffIllustrator         => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: CommissionedIllustrator  => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: Composite                => ImageMetadata(credit = Some(u.suppliers))
       case u: Screengrab               => ImageMetadata(credit = u.source)

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -24,7 +24,7 @@ object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import MetadataConfig.{contractPhotographersMap, staffPhotographersMap, contractIllustrators, creativeCommonsLicense}
+  import MetadataConfig.{contractPhotographersMap, staffPhotographersMap, contractIllustrators, staffIllustrators, creativeCommonsLicense}
   import UsageRightsConfig.freeSuppliers
 
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
@@ -69,16 +69,19 @@ object UsageRightsProperty {
         "suppliersCollection", "Collection", "string", required = false,
         examples = Some("AFP, FilmMagic, WireImage"))
     )
+
     case CommissionedAgency => List(requiredStringField("supplier", "Supplier", examples = Some("Demotix")))
 
     case StaffPhotographer => List(
       publicationField(true),
       photographerField(staffPhotographersMap, "publication")
     )
+
     case ContractPhotographer => List(
       publicationField(true),
       photographerField(contractPhotographersMap, "publication")
     )
+
     case CommissionedPhotographer => List(
       publicationField(false),
       photographerField("Sophia Evans, Murdo Macleod")
@@ -86,6 +89,9 @@ object UsageRightsProperty {
 
     case ContractIllustrator => List(
       requiredStringField("creator", "Illustrator", Some(sortList(contractIllustrators))))
+
+    case StaffIllustrator => List(
+      requiredStringField("creator", "Illustrator", Some(sortList(staffIllustrators))))
 
     case CommissionedIllustrator => List(
       requiredStringField("creator", "Illustrator", examples = Some("Ellie Foreman Peck, Matt Bors")))


### PR DESCRIPTION
In order that rights & restrictions can be correctly chosen by users
this changeset adds a "Staff Illustrator" option to `metadata-editor`.

![foop](https://cloud.githubusercontent.com/assets/953792/14707560/4aacdd2e-07bd-11e6-8d54-69c3d75134f8.png)

Requires deployment of:

- `media-api`
- `metadata-editor`