### PR TITLE
Allow for cropping transparent true color pngs

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -37,9 +37,16 @@ class S3(credentials: AWSCredentials) {
   }
 
   private def getContentDispositionFilename(image: Image, charset: CharSet): String = {
+
+    val extension = image.source.mimeType match {
+      case Some("image/jpeg") => "jpg"
+      case Some("image/png")  => "png"
+      case _ => throw new Exception("Unsupported mime type")
+    }
+
     val baseFilename: String = image.uploadInfo.filename match {
-      case Some(f)  => s"${removeExtension(f)} (${image.id}).jpg"
-      case _        => s"${image.id}.jpg"
+      case Some(f)  => s"${removeExtension(f)} (${image.id}).${extension}"
+      case _        => s"${image.id}.${extension}"
     }
 
     charset match {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -123,7 +123,7 @@ object ImageOperations {
         val split = fileName.split('.')
 
         val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
-        Seq("pngquant",  "--quality", "45-90", fileName, "--output", optimisedImageName).!
+        Seq("pngquant",  "--quality", "1-85", fileName, "--output", optimisedImageName).!
 
         val file = new File(optimisedImageName)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -10,6 +10,7 @@ import com.gu.mediaservice.model.{Asset, Bounds, Dimensions, ImageMetadata}
 import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
+import scala.sys.process._
 
 
 case class ExportResult(id: String, masterCrop: Asset, othersizings: List[Asset])
@@ -112,6 +113,24 @@ object ImageOperations {
       _           <- runConvertCmd(addOutput)
     }
     yield outputFile
+  }
+
+  def optimiseImage(resizedFile: File, mediaType: String): Future[File] = {
+
+    if (mediaType == "image/png") {
+      val fileName: String = resizedFile.getAbsolutePath()
+      val split = fileName.split('.')
+
+      val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
+      Seq("pngquant",  "--quality", "45-90", fileName, "--output", optimisedImageName).!
+
+      val file = new File(optimisedImageName)
+
+      Future(file)
+    }
+
+    else
+      Future(resizedFile)
   }
 
   val thumbUnsharpRadius = 0.5d

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -115,23 +115,23 @@ object ImageOperations {
     yield outputFile
   }
 
-  def optimiseImage(resizedFile: File, mediaType: String): Future[File] = {
+  def optimiseImage(resizedFile: File, mediaType: MimeType): File =
 
-    if (mediaType == "image/png") {
-      val fileName: String = resizedFile.getAbsolutePath()
-      val split = fileName.split('.')
+    mediaType.name match {
+      case "image/png" => {
+        val fileName: String = resizedFile.getAbsolutePath()
+        val split = fileName.split('.')
 
-      val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
-      Seq("pngquant",  "--quality", "45-90", fileName, "--output", optimisedImageName).!
+        val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
+        Seq("pngquant",  "--quality", "45-90", fileName, "--output", optimisedImageName).!
 
-      val file = new File(optimisedImageName)
+        val file = new File(optimisedImageName)
 
-      Future(file)
+        file
+
+      }
+      case "image/jpeg" => resizedFile
     }
-
-    else
-      Future(resizedFile)
-  }
 
   val thumbUnsharpRadius = 0.5d
   val thumbUnsharpSigma = 0.5d
@@ -151,4 +151,20 @@ object ImageOperations {
       _          <- runConvertCmd(addOutput)
     } yield outputFile
   }
+
+  sealed trait MimeType {
+    def name: String
+    def extension: String
+  }
+
+  case object Png extends MimeType {
+    val name  = "image/png"
+    val extension = "png"
+  }
+
+  case object Jpeg extends MimeType {
+    val name = "image/jpeg"
+    val extension = "jpg"
+  }
+
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -48,7 +48,7 @@ object ImageOperations {
         val source = addImage(sourceFile)
 
         val formatter = format(source)("%[JPEG-Colorspace-Name]")
-        
+
         for {
           output <- runIdentifyCmd(formatter)
           colourModel = output.headOption
@@ -78,9 +78,9 @@ object ImageOperations {
   }
 
   def cropImage(sourceFile: File, bounds: Bounds, qual: Double = 100d, tempDir: File,
-                iccColourSpace: Option[String], colourModel: Option[String]): Future[File] = {
+                iccColourSpace: Option[String], colourModel: Option[String], fileType: String): Future[File] = {
     for {
-      outputFile <- createTempFile(s"crop-", ".jpg", tempDir)
+      outputFile <- createTempFile(s"crop-", s".${fileType}", tempDir)
       cropSource  = addImage(sourceFile)
       qualified   = quality(cropSource)(qual)
       corrected   = correctColour(qualified)(iccColourSpace, colourModel)
@@ -101,9 +101,9 @@ object ImageOperations {
       ).map(_ => sourceFile)
   }
 
-  def resizeImage(sourceFile: File, dimensions: Dimensions, qual: Double = 100d, tempDir: File): Future[File] = {
+  def resizeImage(sourceFile: File, dimensions: Dimensions, qual: Double = 100d, tempDir: File, fileType: String): Future[File] = {
     for {
-      outputFile  <- createTempFile(s"resize-", ".jpg", tempDir)
+      outputFile  <- createTempFile(s"resize-", s".${fileType}", tempDir)
       resizeSource = addImage(sourceFile)
       qualified    = quality(resizeSource)(qual)
       resized      = scale(qualified)(dimensions)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -120,14 +120,11 @@ object ImageOperations {
     mediaType.name match {
       case "image/png" => {
         val fileName: String = resizedFile.getAbsolutePath()
-        val split = fileName.split('.')
 
         val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
         Seq("pngquant",  "--quality", "1-85", fileName, "--output", optimisedImageName).!
 
-        val file = new File(optimisedImageName)
-
-        file
+        new File(optimisedImageName)
 
       }
       case "image/jpeg" => resizedFile

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -81,15 +81,16 @@ object ImageOperations {
                 iccColourSpace: Option[String], colourModel: Option[String], fileType: String): Future[File] = {
     for {
       outputFile <- createTempFile(s"crop-", s".${fileType}", tempDir)
-      cropSource  = addImage(sourceFile)
-      qualified   = quality(cropSource)(qual)
-      corrected   = correctColour(qualified)(iccColourSpace, colourModel)
-      converted   = applyOutputProfile(corrected)
-      stripped    = stripMeta(converted)
-      profiled    = applyOutputProfile(stripped)
-      cropped     = crop(profiled)(bounds)
-      addOutput   = addDestImage(cropped)(outputFile)
-      _          <- runConvertCmd(addOutput)
+      cropSource    = addImage(sourceFile)
+      qualified     = quality(cropSource)(qual)
+      corrected     = correctColour(qualified)(iccColourSpace, colourModel)
+      converted     = applyOutputProfile(corrected)
+      stripped      = stripMeta(converted)
+      profiled      = applyOutputProfile(stripped)
+      cropped       = crop(profiled)(bounds)
+      depthAdjusted = depth(cropped)(8)
+      addOutput     = addDestImage(depthAdjusted)(outputFile)
+      _             <- runConvertCmd(addOutput)
     }
     yield outputFile
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -30,6 +30,7 @@ object ImageMagick {
   def resize(op: IMOperation)(maxSize: Int): IMOperation = op <| (_.resize(maxSize, maxSize))
   def scale(op: IMOperation)(dimensions: Dimensions): IMOperation = op <| (_.scale(dimensions.width, dimensions.height))
   def format(op: IMOperation)(definition: String): IMOperation = op <| (_.format(definition))
+  def depth(op: IMOperation)(depth: Int): IMOperation = op <| (_.depth(depth))
   val useGraphicsMagick = true
 
   def runConvertCmd(op: IMOperation): Future[Unit] = Future((new ConvertCmd(useGraphicsMagick)).run(op))

--- a/cropper/README.md
+++ b/cropper/README.md
@@ -1,0 +1,11 @@
+# cropper
+
+## Requirements
+
+You need to install
+* pngquant
+
+Pngquant should be available from /usr/bin/
+
+If installing pngquant with brew, create a symlink from /usr/local/bin/pngquant to /urs/bin/pngquant.
+

--- a/cropper/app/lib/Crops.scala
+++ b/cropper/app/lib/Crops.scala
@@ -46,7 +46,7 @@ object Crops {
   }
 
   def createCrops(sourceFile: File, dimensionList: List[Dimensions], apiImage: SourceImage, crop: Crop, mediaType: String): Future[List[Asset]] = {
-    
+
     val fileType = getFileExtension(mediaType)
 
     Future.sequence[Asset, List](dimensionList.map { dimensions =>

--- a/kahuna/public/js/components/gr-icon/gr-icon.js
+++ b/kahuna/public/js/components/gr-icon/gr-icon.js
@@ -28,11 +28,12 @@ icon.directive('grIconLabel', [function () {
     return {
         restrict: 'E',
         scope: {
-            grIcon: '@'
+            grIcon: '@',
+            grLoading: '@'
         },
         transclude: 'replace',
         template: `
-            <gr-icon>{{grIcon}}</gr-icon>
+            <gr-icon ng-class="{'spin': grLoading === 'true'}">{{grIcon}}</gr-icon>
             <span class="icon-label"><ng:transclude></ng:transclude></span>`
     };
 }]);

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -100,7 +100,7 @@
                     ng:click="ctrl.callCrop()"
                     ng:disabled="ctrl.cropping"
                     gr-tooltip="Crop [enter]">
-                <gr-icon-label gr-icon="crop">Crop<span ng:show="ctrl.cropping">ping…</span></gr-icon-label>
+                <gr-icon-label gr-icon="crop" gr-loading={{ctrl.cropping}}>Crop<span ng:show="ctrl.cropping">ping…</span></gr-icon-label>
             </button>
         </div>
     </gr-top-bar-actions>

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -100,7 +100,7 @@
                     ng:click="ctrl.callCrop()"
                     ng:disabled="ctrl.cropping"
                     gr-tooltip="Crop [enter]">
-                <gr-icon-label gr-icon="crop" gr-loading={{ctrl.cropping}}>Crop<span ng:show="ctrl.cropping">ping…</span></gr-icon-label>
+                <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}">Crop<span ng:show="ctrl.cropping">ping…</span></gr-icon-label>
             </button>
         </div>
     </gr-top-bar-actions>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -72,7 +72,7 @@
                 <div class="result-editor__info-item--png-warning"ng:if="ctrl.invalidReasons['is_invalid_png']">
                     <strong>PNG</strong>: This type currently not supported
                     <button
-                     gr-tooltip={{ctrl.invalidPngHelp}}
+                     gr-tooltip="{{ctrl.invalidPngHelp}}"
                         gr-tooltip-position="right">
                         <gr-icon>help</gr-icon></button>
                 </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -67,15 +67,8 @@
                 <span class="result-editor__status status status--invalid"
                       ng:switch-when="invalid">
                         Invalid
-                    <gr-icon title="You need to add both a credit and description, (Some PNGs are also invalid).">help</gr-icon>
+                    <gr-icon title="You need to add both a credit and description.">help</gr-icon>
                 </span>
-                <div class="result-editor__info-item--png-warning"ng:if="ctrl.invalidReasons['is_invalid_png']">
-                    <strong>PNG</strong>: This type currently not supported
-                    <button
-                     gr-tooltip="{{ctrl.invalidPngHelp}}"
-                        gr-tooltip-position="right">
-                        <gr-icon>help</gr-icon></button>
-                </div>
             </div>
 
             <gr-archiver-status class="result-editor__archiver"

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -67,10 +67,14 @@
                 <span class="result-editor__status status status--invalid"
                       ng:switch-when="invalid">
                         Invalid
-                    <gr-icon title="You need to add both a credit and description, (PNGs are also invalid).">help</gr-icon>
+                    <gr-icon title="You need to add both a credit and description, (Some PNGs are also invalid).">help</gr-icon>
                 </span>
                 <div class="result-editor__info-item--png-warning"ng:if="ctrl.invalidReasons['is_invalid_png']">
-                    <strong>PNG</strong>: This type currently not supported.
+                    <strong>PNG</strong>: This type currently not supported
+                    <button
+                     gr-tooltip={{ctrl.invalidPngHelp}}
+                        gr-tooltip-position="right">
+                        <gr-icon>help</gr-icon></button>
                 </div>
             </div>
 

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -70,7 +70,7 @@
                     <gr-icon title="You need to add both a credit and description, (PNGs are also invalid).">help</gr-icon>
                 </span>
                 <div class="result-editor__info-item--png-warning"ng:if="ctrl.invalidReasons['is_invalid_png']">
-                    <strong>PNG</strong>: Pngs with transparency not supported!
+                    <strong>PNG</strong>: This type currently not supported.
                 </div>
             </div>
 

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -48,7 +48,8 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.status = ctrl.image.data.valid ? 'ready' : 'invalid';
     ctrl.usageRights = imageService(ctrl.image).usageRights;
     ctrl.invalidReasons = ctrl.image.data.invalidReasons;
-    ctrl.invalidPngHelp = 'Transparent pngs of type Palette are not supported. To crop this image, convert it to True Color and upload it again';
+    ctrl.invalidPngHelp = 'Transparent pngs of type Palette are not supported. ' +
+        'To crop this image, convert it to True Color and upload it again';
 
     //TODO put collections in their own directive
     ctrl.addCollection = false;

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -48,6 +48,7 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.status = ctrl.image.data.valid ? 'ready' : 'invalid';
     ctrl.usageRights = imageService(ctrl.image).usageRights;
     ctrl.invalidReasons = ctrl.image.data.invalidReasons;
+    ctrl.invalidPngHelp = 'Transparent pngs of type Palette are not supported. To crop this image, convert it to True Color and upload it again';
 
     //TODO put collections in their own directive
     ctrl.addCollection = false;

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -48,8 +48,6 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.status = ctrl.image.data.valid ? 'ready' : 'invalid';
     ctrl.usageRights = imageService(ctrl.image).usageRights;
     ctrl.invalidReasons = ctrl.image.data.invalidReasons;
-    ctrl.invalidPngHelp = 'Transparent pngs of type Palette are not supported. ' +
-        'To crop this image, convert it to True Color and upload it again';
 
     //TODO put collections in their own directive
     ctrl.addCollection = false;

--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -20,9 +20,9 @@ imageDownloadsService.factory('imageDownloadsService', ['imgops', '$http', funct
 
         if (filename) {
             const basename = stripExtension(filename);
-            return `${basename} (${imageId}).jpg`;
+            return `${basename} (${imageId}).` + extension;
         } else {
-            return `${imageId}.jpg`;
+            return `${imageId}` + extension;
         }
     }
 

--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -16,6 +16,7 @@ imageDownloadsService.factory('imageDownloadsService', ['imgops', '$http', funct
     function imageName(imageData) {
         const filename = imageData.uploadInfo.filename;
         const imageId = imageData.id;
+        const extension = imageData.source.mimeType === 'image/jpeg' ? 'jpg' : 'png';
 
         if (filename) {
             const basename = stripExtension(filename);

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -19,10 +19,16 @@ object ImageExtras {
 
   def hasCredit(meta: ImageMetadata) = optToBool(meta.credit)
   def hasDescription(meta: ImageMetadata) = optToBool(meta.description)
-  def isInvalidPng(image: Image) =
-    image.source.mimeType == Some("image/png") &&
-      image.fileMetadata.colourModelInformation.get("colorType").getOrElse("") != "True Color"
 
+  def isInvalidPng(image: Image) =
+    image.source.mimeType match {
+      case Some("image/png") => {
+        val colourType = image.fileMetadata.colourModelInformation.get("colorType").getOrElse("")
+        colourType != "True Color" && colourType != "True Color with Alpha"
+      }
+      case _ => false
+    }
+  
   def validityMap(image: Image): Map[String, Boolean] = Map(
     "missing_credit"              -> !hasCredit(image.metadata),
     "missing_description"         -> !hasDescription(image.metadata),

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -10,8 +10,7 @@ object ImageExtras {
 
   val validityDescription = Map(
     "missing_credit"              -> "Missing credit information",
-    "missing_description"         -> "Missing description",
-    "is_invalid_png"              -> "PNG images with this type cannot be used"
+    "missing_description"         -> "Missing description"
   )
 
   private def optToBool[T](o: Option[T]): Boolean =
@@ -20,19 +19,9 @@ object ImageExtras {
   def hasCredit(meta: ImageMetadata) = optToBool(meta.credit)
   def hasDescription(meta: ImageMetadata) = optToBool(meta.description)
 
-  def isInvalidPng(image: Image) =
-    image.source.mimeType match {
-      case Some("image/png") => {
-        val colourType = image.fileMetadata.colourModelInformation.get("colorType").getOrElse("")
-        colourType != "True Color" && colourType != "True Color with Alpha"
-      }
-      case _ => false
-    }
-
   def validityMap(image: Image): Map[String, Boolean] = Map(
     "missing_credit"              -> !hasCredit(image.metadata),
-    "missing_description"         -> !hasDescription(image.metadata),
-    "is_invalid_png"              -> isInvalidPng(image)
+    "missing_description"         -> !hasDescription(image.metadata)
   )
 
   def invalidReasons(validityMap: Map[String, Boolean]) = validityMap

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -11,7 +11,7 @@ object ImageExtras {
   val validityDescription = Map(
     "missing_credit"              -> "Missing credit information",
     "missing_description"         -> "Missing description",
-    "is_invalid_png"              -> "PNG images with transparency cannot be used"
+    "is_invalid_png"              -> "PNG images with this type cannot be used"
   )
 
   private def optToBool[T](o: Option[T]): Boolean =
@@ -28,7 +28,7 @@ object ImageExtras {
       }
       case _ => false
     }
-  
+
   def validityMap(image: Image): Map[String, Boolean] = Map(
     "missing_credit"              -> !hasCredit(image.metadata),
     "missing_description"         -> !hasDescription(image.metadata),


### PR DESCRIPTION
Allow cropping pngs with transparency. Optimised the generated assets with pngquant. 

Getting this working working locally requires installing pngquant. If installing pngquant with brew, create a symlink from /usr/local/bin/pngquant to /urs/bin/pngquant