### PR TITLE
[WIP] Make crops into panel component

### DIFF
--- a/kahuna/public/js/components/gr-crops-panel/gr-crops-panel.html
+++ b/kahuna/public/js/components/gr-crops-panel/gr-crops-panel.html
@@ -1,0 +1,44 @@
+<div class="image-info__group" ng:if="ctrl.exportsList.size < 1">
+    No images with crops selected.
+</div>
+<div class="image-info__group" ng:if="ctrl.exportsList.size == 1">
+    <dl class="image-info__group--dl">
+        <dt class="image-info__heading">Crops</dt>
+        <dd class="image-info__heading--crops">
+        <ul class="image-crops">
+            <li class="image-crop"
+                ng:repeat="crop in ctrl.exportsList.first()"
+                ng:class="{'image-crop--selected': crop == ctrl.crop}">
+                <a draggable="true"
+                   ng:init="extremeAssets = (crop | getExtremeAssets)"
+                   ng:click="ctrl.cropSelected(crop)"
+                   ui:sref="{crop: crop.id}"
+                   ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                   ui:drag-image="extremeAssets.smallest | assetFile">
+
+                    <img class="image-crop__image"
+                         alt="cropped image thumbnail"
+                         ng:src="{{:: extremeAssets.smallest | assetFile}}" />
+                    <div class="image-crop__info"
+                         ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
+                        <div class="flex-container">
+                            {{:: crop.specification.aspectRatio | asAspectRatioWord}}
+                            <span class="flex-spacer"></span>
+                            <span ng:if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
+                        </div>
+
+                        <div class="flex-container image-crop__more-info">
+                            {{:: crop.specification.bounds.width}} &times; {{:: crop.specification.bounds.height}}
+                            <span class="flex-spacer"></span>
+                            <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
+                        </div>
+                    </div>
+                </a>
+            </li>
+        </ul>
+        </dd>
+    </dl>
+</div>
+<div class="image-info__group" ng:if="ctrl.exportsList.size > 1">
+    Multiple images with crops selected.
+</div>

--- a/kahuna/public/js/components/gr-crops-panel/gr-crops-panel.js
+++ b/kahuna/public/js/components/gr-crops-panel/gr-crops-panel.js
@@ -1,0 +1,34 @@
+import angular from 'angular';
+import Rx from 'rx';
+
+import '../../util/rx';
+
+export var grCropsPanel = angular.module('grCropsPanel', [
+    'kahuna.services.panel'
+]);
+
+grCropsPanel.controller('GrCropsPanelCtrl', [
+    '$scope',
+    'inject$',
+    'selectedImagesList$',
+    function (
+        $scope,
+        inject$,
+        selectedImagesList$
+    ) {
+
+    //TODO: Use seperate CSS
+    const ctrl = this;
+    const exportsList$ = selectedImagesList$.map(images =>
+        images
+            .map(image => image.data.exports)
+            .filter(exports => exports.length != 0)
+    );
+
+    //TODO: Remove log
+    exportsList$.subscribe(exports => console.log(exports));
+
+    inject$($scope, exportsList$, ctrl, 'exportsList');
+}]);
+
+

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button.js
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button.js
@@ -7,8 +7,10 @@ export const panelButton = angular.module('gr.panelButton', ['util.rx']);
 
 panelButton.controller('GrPanelButton', ['$scope', 'inject$', function($scope, inject$) {
     const ctrl = this;
-    const panel = ctrl.panel;
+    const panels = ctrl.panel.isArray ? ctrl.panel : [ctrl.panel];
+    const panel = panels[0];
 
+    //TODO: Pay attention to multiple panels
     ctrl.trackingName = 'Panel Button';
     ctrl.trackingData = action => ({
         'Panel name': ctrl.name,

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -13,6 +13,7 @@ import '../lib/data-structure/ordered-set-factory';
 import '../components/gr-top-bar/gr-top-bar';
 import '../components/gr-info-panel/gr-info-panel';
 import '../components/gr-collections-panel/gr-collections-panel';
+import '../components/gr-crops-panel/gr-crops-panel';
 import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
 
 import '../components/gr-panels/gr-panels';
@@ -20,8 +21,8 @@ import '../components/gr-panels/gr-panels';
 import searchTemplate        from './view.html!text';
 import searchResultsTemplate from './results.html!text';
 import panelTemplate        from '../components/gr-info-panel/gr-info-panel.html!text';
-import collectionsPanelTemplate from
-    '../components/gr-collections-panel/gr-collections-panel.html!text';
+import collectionsPanelTemplate from '../components/gr-collections-panel/gr-collections-panel.html!text';
+import cropsPanelTemplate from '../components/gr-crops-panel/gr-crops-panel.html!text';
 
 
 export var search = angular.module('kahuna.search', [
@@ -36,6 +37,7 @@ export var search = angular.module('kahuna.search', [
     'gr.keyboardShortcut',
     'grInfoPanel',
     'grCollectionsPanel',
+    'grCropsPanel',
     'ui.router'
 ]);
 
@@ -80,6 +82,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                      panelService) {
 
             const ctrl = this;
+            ctrl.cropsPanel = panels.cropsPanel;
             ctrl.collectionsPanel = panels.collectionsPanel;
             ctrl.metadataPanel = panels.metadataPanel;
 
@@ -106,10 +109,11 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                 ]);
             }],
             panels: ['panelService', function(panelService) {
+                const cropsPanel = panelService.createPanel(true);
                 const collectionsPanel = panelService.createPanel(true);
                 const metadataPanel = panelService.createPanel(true);
 
-                return { collectionsPanel, metadataPanel };
+                return { cropsPanel, collectionsPanel, metadataPanel };
            }]
         }
     });
@@ -194,6 +198,11 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             collectionPanel: {
                 template: collectionsPanelTemplate,
                 controller: 'GrCollectionsPanelCtrl',
+                controllerAs: 'ctrl'
+            },
+            cropsPanel: {
+                template: cropsPanelTemplate,
+                controller: 'GrCropsPanelCtrl',
                 controllerAs: 'ctrl'
             },
             multiDrag: {

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -18,6 +18,14 @@
                 gr:icon="collections">
             </gr-panel-button-small>
 
+            <gr-panel-button-small
+                class="results-toolbar-item results-toolbar-item--left results-toolbar-item--no-hover"
+                gr:panel="ctrl.cropsPanel"
+                gr:position="left"
+                gr:name="crops"
+                gr:icon="crop">
+            </gr-panel-button-small>
+
             <div class="results-toolbar-item results-toolbar-item--static
                         image-results-count">
                 {{ctrl.totalResults | toLocaleString}} matches

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -88,6 +88,7 @@ results.controller('SearchResultsCtrl', [
         // Panel control
         ctrl.metadataPanel    = panels.metadataPanel;
         ctrl.collectionsPanel = panels.collectionsPanel;
+        ctrl.cropsPanel       = panels.cropsPanel;
 
         ctrl.images = [];
         ctrl.newImagesCount = 0;

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -17,6 +17,11 @@
 </gr-top-bar>
 
 <gr-panels class="search-panels">
+    <gr-panel gr:left="true" gr:panel="ctrl.cropsPanel" gr:icon="crop"
+              gr:remember-scroll="true">
+        <ui-view name="cropsPanel"></ui-view>
+    </gr-panel>
+
     <gr-panel gr:left="true" gr:panel="ctrl.collectionsPanel" gr:icon="collections"
               gr:remember-scroll="true">
         <ui-view name="collectionPanel"></ui-view>


### PR DESCRIPTION
In order that viewing the available crops can be seperated from the
image page. With a view to:

- Generalising a method for making crops unavailable
- Providing a view of crops in the search (and gallery) view

![screenshot from 2016-05-03 13-24-30](https://cloud.githubusercontent.com/assets/953792/14983115/fcf984cc-1132-11e6-8966-5c272bb91eba.png)
