### PR TITLE
Excluded getty metadata

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -170,7 +170,9 @@ trait GettyProcessor {
 }
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
-  val excludeFromPatterns = List("newspix international", "i-Images").map(ex => s"(?i)${ex}".r)
+  // including 'newspix internation' because they're sending us lots with that in the credit
+  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images")
+    .map(ex => s"(?i)$ex".r)
 
   // Some people send over Getty XMP data, but are not affiliated with Getty
   def excludedCredit(credit: Option[String]) = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -170,10 +170,12 @@ trait GettyProcessor {
 }
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
-  val excludeFrom = List("newspix international")
+  val excludeFromPatterns = List("newspix international", "i-Images").map(ex => s"(?i)${ex}".r)
 
   // Some people send over Getty XMP data, but are not affiliated with Getty
-  def excludedCredit(credit: Option[String]) = credit.map(_.toLowerCase).exists(excludeFrom.contains)
+  def excludedCredit(credit: Option[String]) = {
+    excludeFromPatterns.flatMap( _.findFirstMatchIn(credit.getOrElse("")) ).nonEmpty
+  }
 
   def apply(image: Image): Image = (excludedCredit(image.metadata.credit), image.fileMetadata.getty.isEmpty) match {
     // Only images supplied by Getty have getty fileMetadata


### PR DESCRIPTION
Some providers send us the Getty xmp metadata block when they shouldn't. 

We already had a convention to handle this situation, but I had to modify it to make it 

a) case sensitive
b) added "newspix internation" because they were sending us some with that and the regex wasn't matching. 

If I didn't do it the right scala way just hollar ^____^