### PR TITLE
read stack name from file

### DIFF
--- a/cloud-formation/scripts/stack-name.sh
+++ b/cloud-formation/scripts/stack-name.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
-if [ -z "$GRID_STACK_NAME" ];
-then
+STACK_NAME_FILE="${HOME}/.gu/grid/dev_stack_name"
+
+if [ -f ${STACK_NAME_FILE} ]; then
+    export STACK_NAME=`cat ${STACK_NAME_FILE}`
+else
     USER_NAME=`aws iam get-user`
 
     if [ $? != "0" ]; then
         echo -e "\033[1;41m    FAILED!    \033[m"
         echo '`iam get-user` failed. Are you using temporary credentials?'
-        echo 'If you are using temporary credentials please set the GRID_STACK_NAME environment variable and try again:'
+        echo "If you are using temporary credentials please create ${STACK_NAME_FILE} with the name of your stack"
         echo ''
-        echo "  export GRID_STACK_NAME=foo && $0"
+        echo "  echo media-service-DEV-foobar > ${STACK_NAME_FILE} && $0"
         echo ''
         exit 1
     else
         export STACK_NAME="media-service-DEV-`$USER_NAME | jq '.User.UserName' | tr -d '"' | tr [A-Z] [a-z]`"
     fi
-else
-    export STACK_NAME="media-service-DEV-$GRID_STACK_NAME"
 fi

--- a/docker/configs/generators/generators/cloudformation.py
+++ b/docker/configs/generators/generators/cloudformation.py
@@ -5,6 +5,7 @@ import os
 
 LOGGER_NAME = os.path.splitext(os.path.basename(__file__))[0]
 LOGGER = logging.getLogger(LOGGER_NAME)
+STACK_NAME_FILE = os.path.join(os.path.expanduser('~'), '.gu', 'grid', 'dev_stack_name')
 
 
 def _boto_session():
@@ -14,12 +15,13 @@ def _boto_session():
 
 
 def _get_stack_name():
-    user = os.getenv('GRID_STACK_NAME')
-
-    if not user:
+    if os.path.isfile(STACK_NAME_FILE):
+        with open(STACK_NAME_FILE, 'r') as f:
+            stack_name = f.read().strip()
+    else:
         user = boto3.resource('iam').CurrentUser().user_name
+        stack_name = 'media-service-DEV-{}'.format(user)
 
-    stack_name = 'media-service-DEV-{}'.format(user)
     LOGGER.info('Using stack {}'.format(stack_name))
     return stack_name
 


### PR DESCRIPTION
easier for docker as the ~/.gu/grid directory is already shared and saves having to share env vars

`GRID_STACK_NAME` env var feels a bit ugly as we prepend it with `media-service-DEV-` - cleaner to just read a value from disk and use it.