### PR TITLE
handling getty's sloppy AssetId capitalisation

### DIFF
--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -78,8 +78,12 @@ object FileMetadataReader {
 
       def readProperty(name: String): Option[String] = xmpProperties.get(name) flatMap nonEmptyTrimmed
 
+      def readAssetId : Option[String] = {
+        readProperty("GettyImagesGIFT:AssetId").orElse(readProperty("GettyImagesGIFT:AssetID"))
+      }
+
       Map(
-        "Asset ID"                  -> readProperty("GettyImagesGIFT:AssetID"),
+        "Asset ID"                  -> readAssetId,
         "Call For Image"            -> readProperty("GettyImagesGIFT:CallForImage"),
         "Camera Filename"           -> readProperty("GettyImagesGIFT:CameraFilename"),
         "Camera Make Model"         -> readProperty("GettyImagesGIFT:CameraMakeModel"),


### PR DESCRIPTION
For ages we've only been catching "AssetID" and after they bothered us about this again we looked at their data again and they have been sending "AssetID" sometimes and "AssetId" other times. 

we've informed them of this, but as we're already a few years behind on using this id, we figured it'd be good to start storing it asap