### PR TITLE
Rv crop link layout

### DIFF
--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.css
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.css
@@ -1,6 +1,6 @@
 .gr-display-crops {
-    display: flex;
-    justify-content: space-between;
+    color: #999;
+    font-size: 1.4rem;
 }
 
 .gr-display-crops__crop {

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -1,19 +1,11 @@
 <div class="image-info">
     <dl class="image-info__group image-info__wrap" ng:if="ctrl.crops.length > 0">
         <div class="gr-display-crops">
-            <dt class="image-info__heading image-info__wrap">Crops</dt>
-            <button
-                ng-if="!ctrl.showCrops"
-                ng-click="ctrl.showCrops=true"
-            >
-                <gr-icon>expand_more</gr-icon>
-            </button>
-
-            <button
-                ng-if="ctrl.showCrops"
-                ng-click="ctrl.showCrops=false"
-            >
-                <gr-icon>expand_less</gr-icon>
+            <button class="gr-display-crops"
+                    ng:click="ctrl.showCrops = !ctrl.showCrops">
+                <span ng:hide="ctrl.showCrops">▸ Show</span>
+                <span ng:show="ctrl.showCrops">▾ Hide</span>
+                crops
             </button>
         </div>
 

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.js
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.js
@@ -8,7 +8,7 @@ displayCrops.controller('GrDisplayCrops', [function() {
 
     let ctrl = this;
 
-    ctrl.displayCrops = false;
+    ctrl.showCrops = false;
 }]);
 
 displayCrops.directive('grDisplayCrops', [function () {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -279,3 +279,4 @@
         </dd>
     </dl>
 </div>
+<gr-display-crops gr-small="true" crops="ctrl.image.allCrops"></gr-display-crops>

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -97,7 +97,7 @@ image.controller('ImageCtrl', [
 
         ctrl.cropSelected = cropSelected;
 
-        ctrl.allCrops = [];
+        ctrl.image.allCrops = [];
 
         imageService(ctrl.image).states.canDelete.then(deletable => {
             ctrl.canBeDeleted = deletable;
@@ -125,7 +125,7 @@ image.controller('ImageCtrl', [
             ctrl.crop = crops.find(crop => crop.id === cropKey);
             ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');
             ctrl.crops = crops.filter(crop => crop.specification.type === 'crop');
-            ctrl.allCrops = ctrl.fullCrop ? [ctrl.fullCrop].concat(ctrl.crops) : ctrl.crops;
+            ctrl.image.allCrops = ctrl.fullCrop ? [ctrl.fullCrop].concat(ctrl.crops) : ctrl.crops;
             //boolean version for use in template
             ctrl.hasFullCrop = angular.isDefined(ctrl.fullCrop);
             ctrl.hasCrops = ctrl.crops.length > 0;

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -164,7 +164,6 @@
 
         <gr-image-metadata gr-image="ctrl.image" ng:if="showMetadata"></gr-image-metadata>
         <gr-image-usage gr-image="ctrl.image" ng:if="! showMetadata"></gr-image-usage>
-        <gr-display-crops gr-small="true" crops="ctrl.allCrops"></gr-display-crops>
     </div>
 </div>
 


### PR DESCRIPTION
Styles the show png crops button similarly to the show metadata button and places the crop links with the metadata so that they are not displayed when viewing usages. 