### PR TITLE
Adding photoshot to excluded getty xmp providers

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -171,7 +171,7 @@ trait GettyProcessor {
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   // including 'newspix internation' because they're sending us lots with that in the credit
-  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images")
+  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot")
     .map(ex => s"(?i)$ex".r)
 
   // Some people send over Getty XMP data, but are not affiliated with Getty


### PR DESCRIPTION
We have no identified that our supplier model is wrong in that it assumes that any photo with Getty XMP is a Getty photo, which is incorrect, we should simply acknowledge the metadata and classify them as we would otherwise. 

However, this particular bug, on this particular day (due to Cannes) is actively costing us money. So i'm going to take the pseudo short-cut for now. 