### PR TITLE
add play button to video crop

### DIFF
--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.css
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.css
@@ -1,0 +1,27 @@
+.easel .video-play-button {
+    display: block;
+    position: absolute;
+    height: 100px;
+    width: 100px;
+    top: 50%;
+    left: 50%;
+    margin-left: -50px;
+    margin-top: -50px;
+    background-color: #eeb629;
+    border-radius: 50%;
+    opacity: .8;
+}
+
+.easel .video-play-button--hidden {
+    display: none;
+}
+
+.easel .video-play-button gr-icon {
+    font-size: 100px;
+    color: #333;
+}
+
+.easel .cropper-center {
+    /* above video-play-button */
+    z-index: 1;
+}


### PR DESCRIPTION
Video crops are rendered with a play button overlay, which is sometimes displayed over key elements of the image.

For example:
<img width="234" alt="screen shot 2016-05-29 at 12 04 35" src="https://cloud.githubusercontent.com/assets/836140/15632821/94bc6344-2595-11e6-919e-bc67f8cca232.png">

<img width="228" alt="screen shot 2016-05-29 at 12 50 15" src="https://cloud.githubusercontent.com/assets/836140/15633066/f7cf518e-259b-11e6-8d35-2d027512233d.png">


Adding this overlay right at the start will help create optimal poster images for video.

Demo:
![crop](https://cloud.githubusercontent.com/assets/836140/15632930/7026a9b0-2598-11e6-9f11-d5ce1835ae75.gif)
