### PR TITLE
unfreeze version of boto3

### DIFF
--- a/docker/configs/generators/requirements.txt
+++ b/docker/configs/generators/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.2.2
+boto3>=1.3.1
 Jinja2==2.8
 PyYAML==3.11


### PR DESCRIPTION
boto3 1.2.2 installs botocore 1.3.30 which is not compatible with the latest awscli package

bumping to a later version of boto3 installs botocore 1.4.24 which the latest version of aws cli is compatible with

This was brought up in https://github.com/guardian/grid/issues/1907.

# before 😢 
```sh
virtualenv .venv
source .venv/bin/activate
pip install awscli
pip install boto3==1.2.1
pip freeze
```

gives
```console
awscli==1.10.34
boto3==1.2.2
botocore==1.3.30
colorama==0.3.3
docutils==0.12
futures==2.2.0
jmespath==0.9.0
pyasn1==0.1.9
python-dateutil==2.5.3
rsa==3.4.2
s3transfer==0.0.1
```

and then running `aws --version` gives

```console
(.venv) root@612e9055dd11:/tmp/grid-master/docker/configs/generators# aws --version
Traceback (most recent call last):
  File "/root/.venv/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/root/.venv/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 50, in main
    return driver.main()
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 176, in main
    parser = self._create_parser()
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 157, in _create_parser
    command_table = self._get_command_table()
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 91, in _get_command_table
    self._command_table = self._build_command_table()
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 111, in _build_command_table
    command_object=self)
  File "/root/.venv/lib/python2.7/site-packages/botocore/session.py", line 675, in emit
    return self._events.emit(event_name, **kwargs)
  File "/root/.venv/lib/python2.7/site-packages/botocore/hooks.py", line 226, in emit
    return self._emit(event_name, kwargs)
  File "/root/.venv/lib/python2.7/site-packages/botocore/hooks.py", line 209, in _emit
    response = handler(**kwargs)
  File "/root/.venv/lib/python2.7/site-packages/awscli/customizations/preview.py", line 71, in mark_as_preview
    service_name=original_command.service_model.service_name,
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 349, in service_model
    return self._get_service_model()
  File "/root/.venv/lib/python2.7/site-packages/awscli/clidriver.py", line 366, in _get_service_model
    api_version = self.session.get_config_variable('api_versions').get(
AttributeError: 'NoneType' object has no attribute 'get'
```

# after 😄 
```sh
virtualenv .venv
source .venv/bin/activate
pip install awscli
pip install boto3>=1.3.1
pip freeze
```

gives
```console
awscli==1.10.34
boto3==1.3.1
botocore==1.4.24
colorama==0.3.3
docutils==0.12
futures==2.2.0
jmespath==0.9.0
pyasn1==0.1.9
python-dateutil==2.5.3
rsa==3.4.2
s3transfer==0.0.1
six==1.10.0
```

and then running `aws --version` gives

```console
(.venv) root@612e9055dd11:/tmp/grid-master/docker/configs/generators# aws --version
aws-cli/1.10.34 Python/2.7.11 Linux/4.4.11-moby botocore/1.4.24
```
