### PR TITLE
add period to filename to add extension

### DIFF
--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -20,9 +20,9 @@ imageDownloadsService.factory('imageDownloadsService', ['imgops', '$http', funct
 
         if (filename) {
             const basename = stripExtension(filename);
-            return `${basename} (${imageId}).` + extension;
+            return `${basename} (${imageId}).${extension}`;
         } else {
-            return `${imageId}` + extension;
+            return `${imageId}.${extension}`;
         }
     }
 


### PR DESCRIPTION
also use es6 string interpolation

after a conversation with @NickPapacostas around image download filenames, I noticed we weren't adding a `.` character to the filename, so it never got an extension 😛 