### PR TITLE
Adding special instructions to metadata on upload

### DIFF
--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -92,6 +92,27 @@
                 ng:click="ctrl.batchApplyMetadata('copyright')"
             >⇔</button>
         </label>
+
+        <label class="job-info--editor__field flex-center">
+            <div class="job-info--editor__label text-small">Special Instructions</div>
+            <input
+                type="text"
+                name="special-instructions"
+                class="text-input job-info--editor__input"
+                ng:model="ctrl.metadata.specialInstructions"
+                ng:change="ctrl.save()"
+                ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+            />
+
+            <button
+                class="job-editor__apply-to-all"
+                title="Apply these instructions to all your current uploads"
+                type="button"
+                ng:if="ctrl.withBatch"
+                ng:click="ctrl.batchApplyMetadata('specialInstructions')"
+            >⇔</button>
+        </label>
     </div>
     <!-- Angular doesn't submit a form without a submit element, bonza!
     see: https://docs.angularjs.org/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action -->

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -74,6 +74,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
             byline: originalMetadata.byline,
             credit: originalMetadata.credit,
             copyright: originalMetadata.copyright,
+            specialInstructions: originalMetadata.specialInstructions,
             description: originalMetadata.description
         };
     }


### PR DESCRIPTION
This was requested by Jonny and seemed reasonable. 

here's what Jonny said:

> 1a. Is it possible for you to make the 'special instructions' metadata field visible at all times (including when uploading) so that we can safely place notes onto images without risk of them being published? At present all we can do is write special notes into the caption and hope that subs spot them and that they don't get published, which seems needlessly risky.
