### PR TITLE
Asset Fingerprinting for Kahuna

### DIFF
--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -15,8 +15,8 @@
     <link rel="preconnect" href="@mediaApiUri"/>
     <link rel="preconnect" href="@authApiUri"/>
 
-    <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/grid-favicon-32.png")"/>
-    <link rel="assets" href="@routes.Assets.at("")"/>
+    <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/grid-favicon-32.png")"/>
+    <link rel="assets" href="@routes.Assets.versioned("")"/>
     <link rel="media-api-uri" href="@mediaApiUri" />
     <link rel="reauth-uri" href="@reauthUri" />
 @watUri.map { uri =>
@@ -25,7 +25,7 @@
 @sentryDsn.map { dsn =>
     <link rel="sentry-dsn" href="@dsn" />
 }
-    <link rel="stylesheet" href="@routes.Assets.at("stylesheets/main.css")" />
+    <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 
     <style>
         .ng-cloak { display: none }
@@ -39,8 +39,8 @@
 
     <ui-global-errors></ui-global-errors>
 
-    <script src="@routes.Assets.at("jspm_packages/system.js")"></script>
-    <script src="@routes.Assets.at("config.js")"></script>
+    <script src="@routes.Assets.versioned("jspm_packages/system.js")"></script>
+    <script src="@routes.Assets.versioned("config.js")"></script>
     <script>
       System.import("js/main").catch(function(error) {
           setTimeout(function(){ throw error; });

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -8,7 +8,7 @@ GET     /images/$id<[0-9a-z]+>/crop controllers.Application.index(id)
 GET     /search                     controllers.Application.index(ignored="")
 GET     /upload                     controllers.Application.index(ignored="")
 
-GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
 
 # Empty page to return to the same domain as the app
 GET     /ok                         controllers.Application.ok

--- a/kahuna/dist-fingerprint.sh
+++ b/kahuna/dist-fingerprint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sed -i -- "s/\/build\.js/\/`md5sum public/js/dist/build.js | awk '{print $1}'`-build\.js/g" public/config.js

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "test": "npm run lint",
     "lint": "jscs public/js/ && jshint public/js --exclude public/js/dist/build.js --exclude public/js/main.js && htmllint public/js/**/*.html",
-    "dist": "jspm bundle js/main public/js/dist/build.js -m --inject --no-mangle",
+    "dist": "jspm bundle js/main public/js/dist/build.js -m --inject --no-mangle && ./dist-fingerprint.sh",
     "undist": "jspm unbundle && rm -f public/js/dist/build.js*",
     "postinstall": "jspm install"
   },

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,8 +81,14 @@ object Build extends Build {
   val thrall = playProject("thrall")
     .libraryDependencies(elasticsearchDeps ++ awsDeps ++ scalazDeps ++ elasticSearchClientDeps)
 
+  import com.typesafe.sbt.web.SbtWeb
+  import com.typesafe.sbt.web.Import._
+  import com.typesafe.sbt.digest.Import._
+
   val kahuna = playProject("kahuna")
     .libraryDependencies(playWsDeps)
+    .enablePlugins(SbtWeb)
+    .settings(pipelineStages := Seq(digest))
 
   val auth = playProject("auth")
     .libraryDependencies(playWsDeps)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 addSbtPlugin("com.gu" % "sbt-version-info-plugin" % "2.8")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.0.0")


### PR DESCRIPTION
In order to cache-bust assets when serving through Cloudfront.

Depended on by https://github.com/guardian/grid-infra/pull/244