### PR TITLE
Use the Apache Commons HttpClient lib in Cropper

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -75,7 +75,7 @@ object Build extends Build {
   val lib = project("common-lib")
     .libraryDependencies(loggingDeps ++ awsDeps ++ elasticsearchDeps ++
       playDeps ++ playWsDeps ++ scalazDeps ++ commonsIODeps ++ akkaAgentDeps ++
-      pandaDeps ++ imagingDeps)
+      pandaDeps ++ imagingDeps ++ commonsNetDeps)
     .testDependencies(scalaCheckDeps ++ scalaTestDeps)
 
   val thrall = playProject("thrall")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
 
   val commonsNetDeps = Seq(
     "commons-net" % "commons-net" % "3.3",
-    "org.apache.httpcomponents" % "httpclient" % "4.3.1"
+    "org.apache.httpcomponents" % "httpclient" % "4.5.2"
   )
 
   val commonsIODeps = Seq("commons-io" % "commons-io" % "2.4")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9


### PR DESCRIPTION
... to [talk to Media API](https://github.com/guardian/grid/blob/master/cropper/app/controllers/Application.scala#L143).

There is a bug in Play WS that prevents requests made to secure
endpoints using SNI from handshaking. Cropper is now behind an [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)
secured endpoint and is consequently suffering from this bug:

https://groups.google.com/forum/#!topic/play-framework/T7ZhclgAAMU

This PR moves the request functionality in Cropper to use Apache Commons
HttpClient library which supports SNI as of version 4.3.2, see:

https://issues.apache.org/jira/browse/HTTPCLIENT-1119

This PR is required to move to using Cloudfront for all user facing REST
APIs (in order that out-of-region request times are sped up, and network
reliability increased).

**This has been tested in TEST**