### PR TITLE
make leases trigger persistence

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -43,6 +43,9 @@ object ImageResponse extends EditsResponse {
   def hasUsages(image: Image) =
     image.usages.nonEmpty
 
+  def hasLeases(image: Image) =
+    image.leases.leases.nonEmpty
+
   def isPhotographerCategory[T <: UsageRights](usageRights: T) =
     usageRights match {
       case _:Photographer => true
@@ -84,6 +87,9 @@ object ImageResponse extends EditsResponse {
 
     if (isAgencyCommissionedCategory(image.usageRights))
       reasons += CommissionedAgency.category
+
+    if (hasLeases(image))
+      reasons += "leases"
 
     reasons.toList
   }


### PR DESCRIPTION
I noticed some images with leases have been removed by reaper. 

How do we feel about this, should having a lease (expired or current) trigger persistence? 

I was tempted to say if theres a "current" lease don't delete it, but there were a few expired leases with useful notes and some leases might be in the future and therefore not current. 