### PR TITLE
Usage improvements

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,8 +89,7 @@ object Dependencies {
 
   val thriftDeps = Seq(
     "com.twitter" %% "scrooge-core" % "4.6.0",
-    "org.apache.thrift" % "libthrift" % "0.9.1" force(),
-    "com.gu" %% "thrift-serializer" % "1.1.0"
+    "org.apache.thrift" % "libthrift" % "0.9.1" force()
   )
 
   val legacyBlockingHttp = Seq("org.scalaj" %% "scalaj-http" % "1.1.4")

--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -1,9 +1,11 @@
 package lib
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.{RegionUtils, Region}
+import com.amazonaws.services.identitymanagement._
 import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppConfig, CommonPlayAppProperties}
-import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
-import Config.stage
+import com.amazonaws.auth.{AWSCredentialsProviderChain, BasicAWSCredentials, AWSCredentials}
+import com.amazonaws.regions.Regions
 
 import scala.util.Try
 
@@ -55,6 +57,22 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   val crierPreviewKinesisStream = properties("crier.preview.name")
   val crierLiveArn = properties("crier.live.arn")
   val crierPreviewArn = properties("crier.preview.arn")
-  val liveAppName = s"media-service-live-${stage}"
-  val previewAppName = s"media-service-preview-${stage}"
+
+  val credentialsProvider = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("media-service")
+  )
+
+  private val iamClient: AmazonIdentityManagement = new AmazonIdentityManagementClient(credentialsProvider)
+    .withRegion(Regions.EU_WEST_1)
+
+  val postfix = if (stage == "DEV") {
+
+    iamClient.getUser().getUser().getUserName()
+
+  } else {
+    stage
+  }
+
+  val liveAppName = s"media-service-livex-${stage}"
+  val previewAppName = s"media-service-previewx-${stage}"
 }

--- a/usage/app/lib/ContentStream.scala
+++ b/usage/app/lib/ContentStream.scala
@@ -1,18 +1,18 @@
 package lib
 
-import _root_.rx.lang.scala.subjects.ReplaySubject
+import _root_.rx.lang.scala.subjects.PublishSubject
 import com.gu.contentapi.client.model.v1.Content
 import org.joda.time.DateTime
 
 trait ContentStream {
-  val observable: ReplaySubject[ContentContainer]
+  val observable = PublishSubject[ContentContainer]
 }
 object LiveCrierContentStream extends ContentStream {
-  val observable = ReplaySubject[ContentContainer]()
+  override val observable = PublishSubject[ContentContainer]()
 }
 
 object PreviewCrierContentStream extends ContentStream {
-  val observable = ReplaySubject[ContentContainer]()
+  override val observable = PublishSubject[ContentContainer]()
 }
 
 trait ContentContainer {

--- a/usage/app/lib/KinesisStreamReader.scala
+++ b/usage/app/lib/KinesisStreamReader.scala
@@ -38,7 +38,7 @@ class CrierStreamReader {
     Config.crierLiveKinesisStream,
     LiveKinesisCredentialsProvider,
     dynamoCredentialsProvider,
-    null,
+    credentialsProvider,
     workerId)
     .withInitialPositionInStream(initialPosition)
     .withRegionName(Config.awsRegionName)
@@ -48,7 +48,7 @@ class CrierStreamReader {
     Config.crierPreviewKinesisStream,
     previewKinesisCredentialsProvider,
     dynamoCredentialsProvider,
-    null,
+    credentialsProvider,
     workerId)
     .withInitialPositionInStream(initialPosition)
     .withRegionName(Config.awsRegionName)

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -50,6 +50,8 @@ object UsageGroup {
 
   def extractImages(content: Content) = content.elements.map(elements => {
     elements.filter(_.`type` == ElementType.Image)
+      .groupBy(_.id)
+      .map(_._2.head).to[collection.immutable.Seq]
   })
 }
 


### PR DESCRIPTION
- Use publish subject instead of replay subject
- wait for thrift deserialization before processing event to save memory
- process only one usage per image and content