### PR TITLE
Add Ian Jones to people-with-getty-xmp-who-arent-getty list

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -171,7 +171,7 @@ trait GettyProcessor {
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   // including 'newspix internation' because they're sending us lots with that in the credit
-  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot")
+  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot", "Ian Jones")
     .map(ex => s"(?i)$ex".r)
 
   // Some people send over Getty XMP data, but are not affiliated with Getty


### PR DESCRIPTION
related to https://github.com/guardian/grid/pull/1901

same issue. having Getty xmp doesn't mean you're a getty supplier. our model is wrong. 

