### PR TITLE
Adds usage reindex from CAPI endpoint

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   )
 
   val guDeps = Seq(
-    "com.gu" %% "content-api-client" % "9.0",
+    "com.gu" %% "content-api-client" % "9.4",
     "com.gu" % "content-api-models" % "8.16"
   )
 

--- a/usage/app/Global.scala
+++ b/usage/app/Global.scala
@@ -30,7 +30,7 @@ object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilt
   }
 
   override def onStop(app: Application) {
-    //previewSubscription.unsubscribe
-    //liveSubscription.unsubscribe
+    previewSubscription.unsubscribe
+    liveSubscription.unsubscribe
   }
 }

--- a/usage/app/Global.scala
+++ b/usage/app/Global.scala
@@ -30,7 +30,7 @@ object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilt
   }
 
   override def onStop(app: Application) {
-    previewSubscription.unsubscribe
-    liveSubscription.unsubscribe
+    //previewSubscription.unsubscribe
+    //liveSubscription.unsubscribe
   }
 }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -114,7 +114,7 @@ object UsageApi extends Controller with ArgoHelpers {
     result
       .map(_ => Accepted)
       .recover { case error: Exception => {
-        Logger.error("UsageApi reindex for for content failed!", error)
+        Logger.error(s"UsageApi reindex for for content (${contentId}) failed!", error)
         InternalServerError
       }}
   }

--- a/usage/app/lib/ContentApi.scala
+++ b/usage/app/lib/ContentApi.scala
@@ -1,6 +1,7 @@
 package lib
 
 import com.gu.contentapi.client.GuardianContentClient
+import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.buildinfo.CapiBuildInfo
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -9,8 +10,18 @@ import com.ning.http.client.Realm.{RealmBuilder, AuthScheme}
 import com.ning.http.client.{AsyncHttpClientConfig, AsyncHttpClient}
 import com.ning.http.client.AsyncHttpClientConfig.Builder
 
+import org.joda.time.{DateTime, DateTimeZone}
+
 import dispatch.Http
 
+trait ContentHelpers {
+  def getContentFirstPublished(content: Content) = for {
+    fields <- content.fields
+    firstPublicationDate <- fields.firstPublicationDate
+    date = new DateTime(firstPublicationDate.iso8601, DateTimeZone.UTC)
+  } yield date
+
+}
 
 object PreviewContentApi extends ContentApiRequestBuilder {
   override val targetUrl = Config.capiPreviewUrl
@@ -31,7 +42,7 @@ object LiveContentApi extends ContentApiRequestBuilder {
   override val targetUrl = Config.capiLiveUrl
 }
 
-class ContentApiRequestBuilder extends GuardianContentClient(apiKey = Config.capiApiKey) {
+class ContentApiRequestBuilder extends GuardianContentClient(apiKey = Config.capiApiKey) with ContentHelpers {
   override val userAgent = "content-api-scala-client/"+CapiBuildInfo.version
 
   val builder = new Builder()

--- a/usage/app/lib/ContentStream.scala
+++ b/usage/app/lib/ContentStream.scala
@@ -18,7 +18,8 @@ object PreviewCrierContentStream extends ContentStream {
 trait ContentContainer {
   val content: Content
   val lastModified: DateTime
+  val isReindex: Boolean
 }
 
-case class LiveContentItem(content: Content, lastModified: DateTime) extends ContentContainer
-case class PreviewContentItem(content: Content, lastModified: DateTime) extends ContentContainer
+case class LiveContentItem(content: Content, lastModified: DateTime, isReindex: Boolean = false) extends ContentContainer
+case class PreviewContentItem(content: Content, lastModified: DateTime, isReindex: Boolean = false) extends ContentContainer

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -77,8 +77,13 @@ object UsageRecorder {
       val usageGroup   = matchUsageGroup.usageGroup
 
       val deletes = (dbUsageGroup.usages -- usageGroup.usages).map(UsageTable.delete)
-      val creates = (usageGroup.usages -- dbUsageGroup.usages).map(UsageTable.create)
-      val updates = (usageGroup.usages & dbUsageGroup.usages).map(UsageTable.update)
+      val creates = (if(usageGroup.isReindex) { usageGroup.usages } else {(usageGroup.usages -- dbUsageGroup.usages)})
+        .map(UsageTable.create)
+      val updates = (if(usageGroup.isReindex) { Set() } else {usageGroup.usages & dbUsageGroup.usages})
+        .map(UsageTable.update)
+
+      //val creates = (usageGroup.usages -- dbUsageGroup.usages).map(UsageTable.create)
+      //val updates = (usageGroup.usages & dbUsageGroup.usages).map(UsageTable.update)
 
       Observable.from(deletes ++ updates ++ creates).flatten[JsObject]
         .map(recordUpdate)

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -82,9 +82,6 @@ object UsageRecorder {
       val updates = (if(usageGroup.isReindex) { Set() } else {usageGroup.usages & dbUsageGroup.usages})
         .map(UsageTable.update)
 
-      //val creates = (usageGroup.usages -- dbUsageGroup.usages).map(UsageTable.create)
-      //val updates = (usageGroup.usages & dbUsageGroup.usages).map(UsageTable.update)
-
       Observable.from(deletes ++ updates ++ creates).flatten[JsObject]
         .map(recordUpdate)
         .toSeq.map(MatchedUsageUpdate(_, matchUsageGroup))

--- a/usage/app/lib/UsageStream.scala
+++ b/usage/app/lib/UsageStream.scala
@@ -19,15 +19,14 @@ object UsageStream {
   val liveObservable: Observable[UsageGroup] = getObservable(liveContentStream)
 
   def createStatus(container: ContentContainer) = container match {
-    case PreviewContentItem(_,_) => PendingUsageStatus()
-    case LiveContentItem(_,_) => PublishedUsageStatus()
+    case PreviewContentItem(_,_,_) => PendingUsageStatus()
+    case LiveContentItem(_,_,_) => PublishedUsageStatus()
   }
 
   private def getObservable(contentStream: Observable[ContentContainer]) = {
     contentStream.flatMap((container: ContentContainer) => {
-
       val usageGroupOption: Option[Option[UsageGroup]] = UsageGroup
-        .build(container.content, createStatus(container), container.lastModified)
+        .build(container.content, createStatus(container), container.lastModified, container.isReindex)
 
       val observable: Observable[UsageGroup] = usageGroupOption match {
         case Some(usageGroup) => Observable.from(usageGroup)

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -4,6 +4,8 @@ GET     /usages/:id                                     controllers.UsageApi.for
 GET     /usages/media/:mediaId                          controllers.UsageApi.forMedia(mediaId: String)
 POST    /usages/print                                   controllers.UsageApi.setPrintUsages
 
+GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
+
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest


### PR DESCRIPTION
This adds a REST endpoint which when called gets the content by id from CAPI, re-extracts images and then overwrites any existing usages with the resulting usages.