### PR TITLE
Make restricted use invalid without lease

### DIFF
--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -16,7 +16,8 @@ object ImageExtras {
     "missing_credit"              -> "Missing credit information",
     "missing_description"         -> "Missing description",
     "paid_image"                  -> "Paid imagery requires a lease",
-    "over_quota"                  -> "The quota for this supplier has been exceeded"
+    "over_quota"                  -> "The quota for this supplier has been exceeded",
+    "conditional_paid"            -> "This image is restricted use"
   )
 
   private def optToBool[T](o: Option[T]): Boolean =
@@ -41,6 +42,7 @@ object ImageExtras {
 
   def validityMap(image: Image): Map[String, Boolean] = Map(
     "paid_image"           -> Costing.isPay(image.usageRights),
+    "conditional_paid"     -> Costing.isConditional(image.usageRights),
     "no_rights"            -> !hasRights(image.usageRights),
     "missing_credit"       -> !hasCredit(image.metadata),
     "missing_description"  -> !hasDescription(image.metadata),

--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -15,6 +15,9 @@ trait CostCalculator {
       if (free) Some(Free) else None
   }
 
+  def isConditional(usageRights: UsageRights): Boolean =
+    getCost(usageRights) == Conditional
+
   def isPay(usageRights: UsageRights): Boolean =
     getCost(usageRights) == Pay
 


### PR DESCRIPTION
These changes make images without restrictions "invalid" for cropping, previously restrictions overrode validity making them croppable.

![restrict_is_invalid](https://cloud.githubusercontent.com/assets/953792/17513857/6ba60544-5e27-11e6-9937-f5b152d3b745.png)
