### PR TITLE
Replace "Invalid" with "Unusable"

### DIFF
--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,5 +1,5 @@
 <div ng:if="!image.data.valid" class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
-    <strong>Invalid Image</strong>
+    <strong>Unusable Image <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon></strong>
     <ul>
         <li ng:repeat="(key, reason) in image.data.invalidReasons">
             {{reason}}

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -67,8 +67,8 @@
                 <a class="result-editor__status status status--invalid"
                    ng:switch-when="invalid"
                    ui:sref="image({imageId: ctrl.image.data.id})">
-                        Invalid
-                    <gr-icon title="This image will be uncroppable">help</gr-icon>
+                        Unusable
+                   <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
                 </a>
             </div>
 


### PR DESCRIPTION
Which is more descriptive of the actual state of the image, also adds a title hint to use leases.

Image page:
![unusable_image](https://cloud.githubusercontent.com/assets/953792/17550505/2c51a044-5eed-11e6-8b44-e66a5470380d.png)

Upload page:
![unusable_upload](https://cloud.githubusercontent.com/assets/953792/17550506/2c527136-5eed-11e6-88e3-9cd61af56fa0.png)
