### PR TITLE
display usage statuses correctly

### DIFF
--- a/usage/app/lib/EventProcessor.scala
+++ b/usage/app/lib/EventProcessor.scala
@@ -118,7 +118,7 @@ private class CrierLiveEventProcessor() extends EventProcessor {
     records.asScala.map { record =>
 
       val buffer: Array[Byte] = record.getData.array()
-      CrierDeserializer.deserialize(buffer)
+      CrierDeserializer.deserialize(buffer).map(processEvent)
     }
   }
 }


### PR DESCRIPTION
Usages was not picking usage events from the live stream stream. Deleted usages were only read from the preview stream, and that's why they were not displayed. 