### PR TITLE
Auth logs to elk stack and log error code when auth fails

### DIFF
--- a/auth/app/Global.scala
+++ b/auth/app/Global.scala
@@ -5,17 +5,14 @@ import play.api.libs.concurrent.Akka
 import play.api.{Logger, Application, GlobalSettings}
 import play.api.mvc.WithFilters
 import play.filters.gzip.GzipFilter
-
-import controllers.{Authed}
-
-import lib.Config
-
+import controllers.Authed
+import lib.{Config, LogConfig}
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
-
 
 object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilter) with GlobalSettings {
 
   override def beforeStart(app: Application) {
+    LogConfig.init(Config)
 
     val allAppConfig: Seq[(String, ConfigValue)] =
       Config.appConfig.underlying.entrySet.asScala.toSeq.map(entry => (entry.getKey, entry.getValue))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -55,7 +55,7 @@ trait ArgoHelpers extends Results {
 
   // TODO: find a nicer way to serialise ErrorResponse[Nothing] without this hack
   def respondError(errorStatus: Status, errorKey: String, errorMessage: String, links: List[Link] = Nil): Result = {
-    Logger.warn(s"Responding with error status $errorStatus, $errorMessage")
+    Logger.warn(s"Responding with error status ${errorStatus.header.status}, $errorMessage")
     val response = ErrorResponse[Int](
       errorKey     = errorKey,
       errorMessage = errorMessage,

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -3,6 +3,7 @@ package com.gu.mediaservice.lib.argo
 import java.net.URI
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.{Results, Result}
+import play.api.Logger
 
 import com.gu.mediaservice.lib.argo.model._
 
@@ -54,6 +55,7 @@ trait ArgoHelpers extends Results {
 
   // TODO: find a nicer way to serialise ErrorResponse[Nothing] without this hack
   def respondError(errorStatus: Status, errorKey: String, errorMessage: String, links: List[Link] = Nil): Result = {
+    Logger.warn(s"Responding with error status $errorStatus, $errorMessage")
     val response = ErrorResponse[Int](
       errorKey     = errorKey,
       errorMessage = errorMessage,


### PR DESCRIPTION
@kenoir I've followed the previous implementation https://github.com/guardian/grid/pull/1134 and it looks like auth should be cloudformed to push logs https://github.com/guardian/grid-infra/pull/119/files

I haven't got this running this locally as I haven't got my properties set up correctly yet. Perhaps could use test environment to check?