### PR TITLE
Use version 0.1.6 of Pandular (increase timeout)

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -23,7 +23,7 @@
       "jszip": "npm:jszip@2.5.0",
       "mixpanel-js": "github:mixpanel/mixpanel-js@^2.4.2",
       "moment": "github:moment/moment@^2.9.0",
-      "pandular": "npm:pandular@^0.1.5",
+      "pandular": "npm:pandular@^0.1.6",
       "pikaday": "github:dbushell/Pikaday@^1.3.2",
       "raven-js": "github:getsentry/raven-js@^1.1.18",
       "rx": "npm:rx@^2.5.3",

--- a/kahuna/public/config.js
+++ b/kahuna/public/config.js
@@ -28,7 +28,7 @@ System.config({
     "jszip": "npm:jszip@2.5.0",
     "mixpanel-js": "github:mixpanel/mixpanel-js@2.4.2",
     "moment": "github:moment/moment@2.10.6",
-    "pandular": "npm:pandular@0.1.5",
+    "pandular": "npm:pandular@0.1.6",
     "pikaday": "github:dbushell/Pikaday@1.4.0",
     "raven-js": "github:getsentry/raven-js@1.3.0",
     "rx": "npm:rx@2.5.3",
@@ -170,7 +170,7 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:pandular@0.1.5": {
+    "npm:pandular@0.1.6": {
       "angular": "github:angular/bower-angular@1.4.3",
       "panda-session": "npm:panda-session@0.1.6"
     },

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -52,6 +52,10 @@ var config = {
     // TODO: use link in 4xx response to avoid having to hardcode in HTML page
     'pandular.reAuthUri': reauthLink && reauthLink.getAttribute('href'),
 
+    // Number of millis before pandular stops trying to reauth
+    // This number is relatively hagh to cater for AUS
+    'pandular.reAuthTimeout': 7000,
+
     vndMimeTypes: new Map([
         ['gridImageData',  'application/vnd.mediaservice.image+json'],
         ['gridImagesData', 'application/vnd.mediaservice.images+json'],


### PR DESCRIPTION
Uses the most recent version of Pandular with a configurable timeout.
Sets tge timetout to 7000 millis to (hopefully) better cater for users
with extremely high latency connections (e.g. AUS).