### PR TITLE
Enable access to full sized Witness images

### DIFF
--- a/kahuna/public/js/services/api/witness.js
+++ b/kahuna/public/js/services/api/witness.js
@@ -20,27 +20,30 @@ witnessApi.factory('witnessApi', ['mediaApi', function(mediaApi) {
     }
 
     function parseReportResponse(response) {
-	const contributionId = response.id;
+        // We have search for the contribution by urlWord rather than an id; hence this response is an array with our contribution expected as the first element.
+        const contribution = response[0];
 
-	// The full sized image can be obtained by making an auth'ed API call
-	const mediaUsage = response.mediaUsages[0];
-	const mediaUsageId = mediaUsage.id;
+        const contributionId = contribution.id;
 
-	const contriblyAccessToken = "TODO - needs to be provided and stored in configuration rather than source";
+        // The full sized image can be obtained by making an auth'ed API call
+        const mediaUsage = contribution.mediaUsages[0];
+        const mediaUsageId = mediaUsage.id;
+
+	    const contriblyAccessToken = "TODO - needs to be provided and stored in configuration rather than source";
         const fileUri = "https://api.contribly.com/1/contributions/" + contributionId + "/mediausages/" + mediaUsageId + "/artifacts/full.jpg?token=" + contriblyAccessToken;	// TODO push api url up to config
 
         const metadata = {
-            title:       response.headline,
-            description: response.body,
-            byline:      response.via.user.displayName,		// TODO not null safe for anoynomous users
+            title:       contribution.headline,
+            description: contribution.body,
+            byline:      contribution.via.user.displayName,		// TODO not null safe for anoynomous users
             credit:      'GuardianWitness',
-            creditUri:   response.webUrl
+            creditUri:   contribution.webUrl
         };
         const identifiers = {
             // FIXME: all of them?
-            witnessReportUri:    response.apiUrl,
-            witnessReportId:     response.id,
-            witnessAssignmentId: response.assignment.id	// TODO potentially null in the future
+            witnessReportUri:    contribution.apiUrl,
+            witnessReportId:     contribution.id,
+            witnessAssignmentId: contribution.assignment.id	// TODO potentially null in the future
         };
 
         return {fileUri, metadata, identifiers};
@@ -48,10 +51,11 @@ witnessApi.factory('witnessApi', ['mediaApi', function(mediaApi) {
 
     function getReport(urlWord) {
         return mediaApi.root.
-            follow('witness-report', {id}).
+            follow('witness-report', {urlWord}).
             // The API is not auth'd, and if withCredentials is true,
             // CORS fails because they don't support credentials in
             // their CORS headers.
+            // TODO This refers to the legacy n0tice API; is it still relevant to the Contribly API?
             get({}, {withCredentials: false}).
             then(parseReportResponse);
     }

--- a/kahuna/public/js/services/api/witness.js
+++ b/kahuna/public/js/services/api/witness.js
@@ -24,16 +24,16 @@ witnessApi.factory('witnessApi', ['mediaApi', function(mediaApi) {
         const fileUri = update.image.extralarge;
         const metadata = {
             title:       response.headline,
-            description: update.body,
-            byline:      response.user.displayName,
+            description: response.body,	// TODO may by null
+            byline:      response.via.user.displayName,		// TODO not null safe for anoynomous users
             credit:      'GuardianWitness',
             creditUri:   response.webUrl
         };
         const identifiers = {
             // FIXME: all of them?
             witnessReportUri:    response.apiUrl,
-            witnessReportId:     response.id.replace('report/', ''),
-            witnessAssignmentId: response.noticeboard
+            witnessReportId:     response.id,
+            witnessAssignmentId: response.assignment.id	// TODO potentially null in the future
         };
 
         return {fileUri, metadata, identifiers};

--- a/kahuna/public/js/services/api/witness.js
+++ b/kahuna/public/js/services/api/witness.js
@@ -20,11 +20,18 @@ witnessApi.factory('witnessApi', ['mediaApi', function(mediaApi) {
     }
 
     function parseReportResponse(response) {
-        const update = response.updates[0];
-        const fileUri = update.image.extralarge;
+	const contributionId = response.id;
+
+	// The full sized image can be obtained by making an auth'ed API call
+	const mediaUsage = response.mediaUsages[0];
+	const mediaUsageId = mediaUsage.id;
+
+	const contriblyAccessToken = "TODO - needs to be provided and stored in configuration rather than source";
+        const fileUri = "https://api.contribly.com/1/contributions/" + contributionId + "/mediausages/" + mediaUsageId + "/artifacts/full.jpg?token=" + contriblyAccessToken;	// TODO push api url up to config
+
         const metadata = {
             title:       response.headline,
-            description: response.body,	// TODO may by null
+            description: response.body,
             byline:      response.via.user.displayName,		// TODO not null safe for anoynomous users
             credit:      'GuardianWitness',
             creditUri:   response.webUrl

--- a/kahuna/public/js/services/api/witness.js
+++ b/kahuna/public/js/services/api/witness.js
@@ -14,9 +14,9 @@ witnessApi.factory('witnessApi', ['mediaApi', function(mediaApi) {
         return witnessPattern.test(uri);
     }
 
-    function extractReportId(witnessUri) {
-        const [/*all*/, /*assignmentId*/, reportId] = witnessUri.match(witnessPattern) || [];
-        return reportId;
+    function extractReportUrlWord(witnessUri) {
+        const [/*all*/, /*assignmentId*/, reportUrlWord] = witnessUri.match(witnessPattern) || [];
+        return reportUrlWord;
     }
 
     function parseReportResponse(response) {
@@ -46,7 +46,7 @@ witnessApi.factory('witnessApi', ['mediaApi', function(mediaApi) {
         return {fileUri, metadata, identifiers};
     }
 
-    function getReport(id) {
+    function getReport(urlWord) {
         return mediaApi.root.
             follow('witness-report', {id}).
             // The API is not auth'd, and if withCredentials is true,

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -66,9 +66,9 @@ dndUploader.controller('DndUploaderCtrl',
     }
 
     function importWitnessImage(uri) {
-        const witnessReportId = witnessApi.extractReportId(uri);
-        if (witnessReportId) {
-            return witnessApi.getReport(witnessReportId).
+        const witnessReportUrlWord = witnessApi.extractReportUrlWord(uri);
+        if (witnessReportUrlWord) {
+            return witnessApi.getReport(witnessReportUrlWord).
                 then(({fileUri, metadata, identifiers}) => {
                     return loadAndUpdateWitnessImage(fileUri, metadata, identifiers);
                 }).then(imageId => {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -73,7 +73,7 @@ object MediaApi extends Controller with ArgoHelpers {
       Link("loader",          loaderUri),
       Link("edits",           metadataUri),
       Link("session",         s"$authUri/session"),
-      Link("witness-report",  s"https://api.contribly.com/1/contributions/{id}"),
+      Link("witness-report",  s"https://api.contribly.com/1/contributions?urlWords={id}"),
       Link("collections",     collectionsUri),
       Link("permissions",     s"$rootUri/permissions"),
       Link("leases",          leasesUri)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -73,7 +73,7 @@ object MediaApi extends Controller with ArgoHelpers {
       Link("loader",          loaderUri),
       Link("edits",           metadataUri),
       Link("session",         s"$authUri/session"),
-      Link("witness-report",  s"https://n0ticeapis.com/2/report/{id}"),
+      Link("witness-report",  s"https://api.contribly.com/1/contributions/{id}"),
       Link("collections",     collectionsUri),
       Link("permissions",     s"$rootUri/permissions"),
       Link("leases",          leasesUri)


### PR DESCRIPTION
Witness images are currently limited to the size of the largest public image provided by the external suppliers API (the n0tice API). This resolution is lower than the maximum sized used by Guardian galleries.

Witness was recently migrated to a new supplier whose API is able to provide a full sized copy of the user's original image. This full sized artifact is made available subject to the following considerations:
- It is not public.
  Making this artifact public would against the user's reasonable explication that they full resolution media isn't been redistributed.
- It's not the original image; it's a full resolution copy.
  This allows the supplier to deal with all of the format conversions and EXIF rotations etc. Not passing the original user submitted file also closes a potential path for passing malware onto internal systems.

Accessing this image requires an authenticated call to the new API (the Contribly API).

This PR has been penciled in by one of the Contribly developers suggesting where they think the changes need to be made; they haven't been able to run locally to test.

The Grid will need to persist an access token in config to append to it's call for the full sized media.
The domain model of the new API is slightly different can the response parsing changes to reflect this.

The API which the Witness data is now stored in is documented here:
https://github.com/contribly/contribly-documentation/
