### PR TITLE
Read usage for supplier from ElasticSearch

### DIFF
--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import scala.concurrent.Future
+
 import play.api.mvc.Controller
 import play.api.mvc.{Results, Result}
 import play.api.libs.concurrent.Execution.Implicits._
@@ -15,6 +17,11 @@ import lib._
 
 object UsageController extends Controller with ArgoHelpers {
   val Authenticated = Authed.action
+
+  def forSupplier(id: String) = Authenticated.async { request =>
+    //TODO: Argoise
+    ElasticSearch.usageForSupplier("meep",30).map(r => { println(r); Ok})
+  }
 
   def quotaForImage(id: String) = Authenticated.async { request =>
     Quotas.usageStatusForImage(id)

--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -8,7 +8,7 @@ import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.JsValue
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
-import com.gu.mediaservice.lib.usage.{UsageStatus, StoreAccess}
+import com.gu.mediaservice.lib.usage.{UsageStatus, StoreAccess, SupplierUsageSummary}
 
 import lib.elasticsearch.ElasticSearch
 
@@ -19,8 +19,14 @@ object UsageController extends Controller with ArgoHelpers {
   val Authenticated = Authed.action
 
   def forSupplier(id: String) = Authenticated.async { request =>
-    //TODO: Argoise
-    ElasticSearch.usageForSupplier("meep",30).map(r => { println(r); Ok})
+    val numberOfDayInPeriod = 30
+
+    ElasticSearch.usageForSupplier(id, numberOfDayInPeriod)
+      .map((s: SupplierUsageSummary) => respond(s))
+      .recover {
+        case e => respondError(InternalServerError, "unknown-error", e.toString)
+      }
+
   }
 
   def quotaForImage(id: String) = Authenticated.async { request =>

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -160,7 +160,6 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
     val search = prepareImagesSearch
       .setQuery(query)
 
-    //TODO: Map this into something more useful!
     search
       .setSearchType(SearchType.COUNT)
       .executeAndLog(s"$id usage search")

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -4,7 +4,8 @@ import java.util.regex.Pattern
 
 import controllers.SuggestionController._
 import lib.querysyntax.Condition
-import org.elasticsearch.index.query.{MatchAllQueryBuilder, FilterBuilder, FilteredQueryBuilder}
+import org.elasticsearch.index.query._
+import org.elasticsearch.index.query.QueryBuilders._
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation
 import org.elasticsearch.search.aggregations.bucket.histogram.{InternalDateHistogram, DateHistogram}
 import org.elasticsearch.search.aggregations.bucket.terms.{Terms, InternalTerms}
@@ -43,14 +44,10 @@ object CompletionSuggestionResults {
   implicit val jsonWrites = Json.writes[CompletionSuggestionResults]
 }
 
-
-
+case class BucketResult(key: String, count: Long)
 object BucketResult {
   implicit val jsonWrites = Json.writes[BucketResult]
 }
-
-case class BucketResult(key: String, count: Long)
-
 
 object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFields {
 
@@ -138,6 +135,33 @@ object ElasticSearch extends ElasticSearchClient with SearchFilters with ImageFi
         val hitsTuples = results.hits.toList flatMap (h => h.sourceOpt map (h.id -> _))
         SearchResults(hitsTuples, results.getTotalHits)
       }
+  }
+
+  def usageForSupplier(id: String, numDays: Int)(implicit ex: ExecutionContext): Future[SearchResponse] = {
+    //TODO: Actually use params
+    val bePublished = termQuery("usages.status","published")
+    val beInLastPeriod = rangeQuery("usages.dateAdded")
+      .gte(s"now-25d/d")
+      .lt("now/d")
+
+    val haveUsageInLastPeriod = boolQuery
+      .must(bePublished)
+      .must(beInLastPeriod)
+
+    val beSupplier = termQuery("usageRights.supplier","Rex Features")
+    val haveNestedUsage = nestedQuery("usages", haveUsageInLastPeriod)
+
+    val query = boolQuery
+      .must(beSupplier)
+      .must(haveNestedUsage)
+
+    val search = prepareImagesSearch
+      .setQuery(query)
+
+    //TODO: Map this into something more useful!
+    search
+      .setSearchType(SearchType.COUNT)
+      .executeAndLog(s"$id usage search")
   }
 
   def dateHistogramAggregate(params: AggregateSearchParams)(implicit ex: ExecutionContext): Future[AggregateSearchResults] = {

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -24,6 +24,7 @@ GET     /images                                       controllers.MediaApi.image
 GET     /suggest/metadata/credit                      controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
 
 # usage quotas
+GET     /usage/suppliers/:id                          controllers.UsageController.forSupplier(id: String)
 GET     /usage/quotas                                 controllers.UsageController.quotas
 GET     /usage/quotas/:id                             controllers.UsageController.quotaForImage(id: String)
 


### PR DESCRIPTION
To replace the current feed from RCS.

In order to increase the stability of the usage information.

Todo:
- [x] Set supplier and period from query
- [x] Look up canonical supplier ID -> supplier name

In another PR: 
- Move agent supplying usage information to use ES as a source