### PR TITLE
fixing cryptic amazon 403 when starting up usages with temp credentials

### DIFF
--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -85,7 +85,13 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
       .withRegion(Regions.EU_WEST_1)
 
   val postfix = if (stage == "DEV") {
-    iamClient.getUser().getUser().getUserName()
+    try {
+      iamClient.getUser().getUser().getUserName()
+    } catch {
+      case e:com.amazonaws.AmazonServiceException=>
+        Logger.warn("Unable to determine current IAM user, probably because you're using temp credentials.  Usage may not be able to determine the live/preview app names")
+        "tempcredentials"
+    }
   } else {
     stage
   }


### PR DESCRIPTION
I don't fully understand what usages is doing with these values, so I've just reduced the fatal error to a warning for the time being.  This does work fine on my system though, @kenoir @Reettaphant please could you advise if this is likely to break anything.

thanks

also @clloyd 