### PR TITLE
Adds Time & Life Picture to the Getty Collection exclusion list.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -30,6 +30,7 @@ object UsageRightsConfig {
     "Sports Illustrated",
     "Sports Illustrated Classic",
     "Terry O'Neill",
+    "Time & Life Pictures",
     "The Asahi Shimbun Premium",
     "The LIFE Images Collection",
     "The LIFE Picture Collection",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -31,6 +31,7 @@ object UsageRightsConfig {
     "Sports Illustrated Classic",
     "Terry O'Neill",
     "Time & Life Pictures",
+    "Time Life Pictures/Getty Images",
     "The Asahi Shimbun Premium",
     "The LIFE Images Collection",
     "The LIFE Picture Collection",


### PR DESCRIPTION
In order that those images show as pay for.

![screenshot from 2016-11-03 13-49-06](https://cloud.githubusercontent.com/assets/953792/19968395/51122fd0-a1cc-11e6-9eeb-882eb0beee8f.png)
