### PR TITLE
Fix usages count on Index page

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import moment from 'moment';
 
 import '../util/rx';
 import '../services/image/usages';

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -89,14 +89,7 @@ image.controller('ImageCtrl', [
         const usages = imageUsagesService.getUsages(ctrl.image);
         const usagesCount$ = usages.count$;
 
-        const recentUsages$ = usages.usages$.map(usageList=>{
-            return usageList.filter(item=> {
-                var nowtime = new Date();
-                var timestamp = item.get('dateAdded');
-                return moment(timestamp)
-                    .isAfter(moment(nowtime).subtract(imageUsagesService.recentTime, 'days'));
-            });
-        });
+        const recentUsages$ = usages.recentUsages$;
 
         inject$($scope, usagesCount$, ctrl, 'usagesCount');
         inject$($scope, recentUsages$, ctrl, 'recentUsages');

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -96,16 +96,16 @@
             </span>
 
             <span class="bottom-bar__meta-item preview__has-print-usages"
-                  title="This image has been used {{ctrl.usageListRecent.length >0 ? 'RECENTLY': '' }} in Print Content"
+                  title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
                   ng:if="ctrl.hasPrintUsages">
-                <gr-icon gr-small ng-class="{'icon-warning': ctrl.usageListRecent.length >0}">local_library</gr-icon>
+                <gr-icon gr-small ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
             </span>
 
             <span class="bottom-bar__meta-item preview__has-web-usages"
-                  title="This image has been used {{ctrl.usageListRecent.length >0 ? 'RECENTLY': '' }} in Digital Content"
+                  title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
                   ng:if="ctrl.hasDigitalUsages">
 
-                <gr-icon gr-small ng-class="{'icon-warning': ctrl.usageListRecent.length >0}">phonelink</gr-icon>
+                <gr-icon gr-small ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
             </span>
         </div>
         <div>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -59,13 +59,13 @@ image.controller('uiPreviewImageCtrl', [
     const hasDigitalUsages$ =
         imageUsagesService.getUsages(ctrl.image).hasDigitalUsages$;
 
-    const usageListRecent$ = imageUsagesService.getUsages(ctrl.image)
-        .usageListAfter$(imageUsagesService.recentTime);
+    const recentUsages$ = imageUsagesService.getUsages(ctrl.image).recentUsages$;
+
     $scope.$on('$destroy', function() {
         freeUpdateListener();
     });
 
-    inject$($scope, usageListRecent$, ctrl, 'usageListRecent');
+    inject$($scope, recentUsages$, ctrl, 'recentUsages');
     inject$($scope, hasPrintUsages$, ctrl, 'hasPrintUsages');
     inject$($scope, hasDigitalUsages$, ctrl, 'hasDigitalUsages');
 

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -43,11 +43,12 @@ imageUsagesService.factory('imageUsagesService', [function() {
             const hasPlatformUsages = (platform) =>
                 filterByPlatform(platform).every((group) => !group.isEmpty());
 
-            const usageListAfter$ = (since) => usages$.map((usagesList) => {
+            const recentUsages$ = usages$.map((usagesList) => {
                     const nowtime = new Date();
-                    return usagesList.filter((usage) => {
-                        return moment(usage.dateAdded)
-                            .isAfter(moment(nowtime).subtract(since, 'days'));
+                    return usagesList.filter(item=> {
+                        const timestamp = item.get('dateAdded');
+                        const recentIfAfter = moment(nowtime).subtract(imageUsagesService.recentTime, 'days');
+                        return moment(timestamp).isAfter(recentIfAfter);
                     });
                 });
 
@@ -65,7 +66,7 @@ imageUsagesService.factory('imageUsagesService', [function() {
                 hasPrintUsages$,
                 hasDigitalUsages$,
                 count$,
-                usageListAfter$
+                recentUsages$
             };
         },
         /*

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -11,6 +11,8 @@ export const imageUsagesService = angular.module('gr.image-usages.service', [
 
 imageUsagesService.factory('imageUsagesService', [function() {
 
+    const recentDays = 7;
+
     return {
         getUsages: (imageResource) => {
 
@@ -44,10 +46,9 @@ imageUsagesService.factory('imageUsagesService', [function() {
                 filterByPlatform(platform).every((group) => !group.isEmpty());
 
             const recentUsages$ = usages$.map((usagesList) => {
-                    const nowtime = new Date();
                     return usagesList.filter(item=> {
                         const timestamp = item.get('dateAdded');
-                        const recentIfAfter = moment(nowtime).subtract(imageUsagesService.recentTime, 'days');
+                        const recentIfAfter = moment().subtract(recentDays, 'days');
                         return moment(timestamp).isAfter(recentIfAfter);
                     });
                 });
@@ -73,7 +74,7 @@ imageUsagesService.factory('imageUsagesService', [function() {
          //If a usage is newer than this number of days,
           then consider it as "recent" and show a warning
          */
-        recentTime: 7
+        recentTime: recentDays
     };
 
 }]);

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -11,7 +11,7 @@ export const imageUsagesService = angular.module('gr.image-usages.service', [
 
 imageUsagesService.factory('imageUsagesService', [function() {
 
-    const recentDays = 7;
+    const recentDays = 90;
 
     return {
         getUsages: (imageResource) => {

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -11,7 +11,7 @@ export const imageUsagesService = angular.module('gr.image-usages.service', [
 
 imageUsagesService.factory('imageUsagesService', [function() {
 
-    const recentDays = 90;
+    const recentDays = 7;
 
     return {
         getUsages: (imageResource) => {


### PR DESCRIPTION
This fixes the issues caused by #2012, the usages count is now based on `.count()` rather than length. Also refactored the usages service to provide a stream on recent usages, which is used by both `controller` and `preview/image.js`

cc @kenoir @paperboyo 