### PR TITLE
Make Quotas configurable via file in S3

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageStore.scala
@@ -91,10 +91,7 @@ class UsageStore(
 
   def update() {
     lastUpdated.sendOff(_ => DateTime.now())
-    fetchUsage.onComplete(usage => {
-      store.sendOff(_)
-      usage
-    })
+    fetchUsage.onSuccess { case usage => store.send(usage) }
   }
 
   private def fetchUsage: Future[Map[String, UsageStatus]] = {

--- a/media-api/app/Global.scala
+++ b/media-api/app/Global.scala
@@ -20,6 +20,7 @@ object Global extends WithFilters(CorsFilter, RequestLoggingFilter, new GzipFilt
   override def onStart(app: Application) {
     Authed.keyStore.scheduleUpdates(Akka.system(app).scheduler)
     Quotas.usageStore.map(_.scheduleUpdates(Akka.system(app).scheduler))
+    Quotas.quotaStore.map(_.scheduleUpdates(Akka.system(app).scheduler))
   }
 
 }

--- a/media-api/app/controllers/Quotas.scala
+++ b/media-api/app/controllers/Quotas.scala
@@ -4,8 +4,6 @@ import lib.{Config, UsageQuota}
 import com.gu.mediaservice.lib.usage.{UsageStore, QuotaStore}
 
 object Quotas extends UsageQuota {
-    val supplierConfig = Config.quotaConfig
-
     val quotaStore = Config.quotaStoreConfig.map(c => {
       new QuotaStore(
         c.storeKey,

--- a/media-api/app/controllers/Quotas.scala
+++ b/media-api/app/controllers/Quotas.scala
@@ -1,16 +1,26 @@
 package controllers
 
 import lib.{Config, UsageQuota}
-import com.gu.mediaservice.lib.usage.UsageStore
+import com.gu.mediaservice.lib.usage.{UsageStore, QuotaStore}
 
 object Quotas extends UsageQuota {
     val supplierConfig = Config.quotaConfig
+
+    val quotaStore = Config.quotaStoreConfig.map(c => {
+      new QuotaStore(
+        c.storeKey,
+        c.storeBucket,
+        Config.awsCredentials
+      )
+    })
+
     val usageStore = Config.usageStoreConfig.map(c => {
       new UsageStore(
         c.storeKey,
         c.storeBucket,
         Config.awsCredentials,
-        supplierQuota
+        quotaStore.getOrElse(
+          throw new RuntimeException("Invalid quota store config!"))
       )
     })
 }

--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -89,16 +89,4 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
   val persistenceIdentifier = properties("persistence.identifier")
   val queriableIdentifiers = Seq(persistenceIdentifier)
   def convertToInt(s: String): Option[Int] = Try { s.toInt }.toOption
-
-  // Quota Config
-  val rexQuotaConfig   = properties.get("usage.quota.rex").flatMap(convertToInt)
-  val aapQuotaConfig   = properties.get("usage.quota.aap").flatMap(convertToInt)
-  val alamyQuotaConfig = properties.get("usage.quota.alamy").flatMap(convertToInt)
-  val gettyQuotaConfig = properties.get("usage.quota.getty").flatMap(convertToInt)
-
-  val quotaConfig = Map[String,Int]() ++
-    rexQuotaConfig.map(n => "rex" -> n) ++
-    aapQuotaConfig.map(n => "aap" -> n) ++
-    alamyQuotaConfig.map(n => "alamy" -> n) ++
-    gettyQuotaConfig.map(n => "getty" -> n)
 }

--- a/media-api/app/lib/Config.scala
+++ b/media-api/app/lib/Config.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 import com.gu.mediaservice.lib.elasticsearch.EC2._
 import com.gu.mediaservice.lib.config.{Properties, CommonPlayAppConfig, CommonPlayAppProperties}
 
-case class UsageStoreConfig(
+case class StoreConfig(
   storeBucket: String,
   storeKey: String
 )
@@ -27,10 +27,15 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
   val configBucket: String = properties("s3.config.bucket")
 
   val usageStoreKey: Option[String] = properties.get("usage.store.key")
+  val quotaStoreKey: Option[String] = properties.get("quota.store.key")
 
-  val usageStoreConfig: Option[UsageStoreConfig] = for {
+  val usageStoreConfig: Option[StoreConfig] = for {
     key <- usageStoreKey
-  } yield UsageStoreConfig(configBucket, key)
+  } yield StoreConfig(configBucket, key)
+
+  val quotaStoreConfig: Option[StoreConfig] = for {
+    key <-quotaStoreKey
+  } yield StoreConfig(configBucket, key)
 
   val ec2Client: AmazonEC2Client =
     new AmazonEC2Client(awsCredentials) <| (_ setEndpoint awsEndpoint)

--- a/media-api/app/lib/UsageQuota.scala
+++ b/media-api/app/lib/UsageQuota.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import play.api.libs.concurrent.Execution.Implicits._
 
 import com.gu.mediaservice.model.{Image, Agencies, UsageRights}
-import com.gu.mediaservice.lib.usage.{UsageStatus, UsageStore, StoreAccess, SupplierUsageQuota}
+import com.gu.mediaservice.lib.usage._
 import com.gu.mediaservice.lib.FeatureToggle
 
 import lib.elasticsearch.ElasticSearch
@@ -19,6 +19,8 @@ case class NoUsageQuota() extends Exception("No usage found for this image")
 
 trait UsageQuota {
   val supplierConfig: Map[String, Int]
+
+  val quotaStore: Option[QuotaStore]
   val usageStore: Option[UsageStore]
 
   lazy val supplierQuota = supplierConfig.map {

--- a/media-api/app/lib/UsageQuota.scala
+++ b/media-api/app/lib/UsageQuota.scala
@@ -18,13 +18,8 @@ case class BadQuotaConfig() extends Exception("Bad config for usage quotas")
 case class NoUsageQuota() extends Exception("No usage found for this image")
 
 trait UsageQuota {
-  val supplierConfig: Map[String, Int]
-
   val quotaStore: Option[QuotaStore]
   val usageStore: Option[UsageStore]
-
-  lazy val supplierQuota = supplierConfig.map {
-    case (k,v) => k -> SupplierUsageQuota(Agencies.get(k), v)}
 
   def isOverQuota(
     rights: UsageRights,

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -9,8 +9,8 @@ import java.net.URI
 
 class ImageExtrasTest extends FunSpec with Matchers {
   object Quota extends UsageQuota {
-    val supplierConfig = Map[String, Int]()
     val usageStore = None
+    val quotaStore = None
   }
 
   object Costing extends CostCalculator {

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -9,8 +9,8 @@ class CostCalculatorTest extends FunSpec with Matchers {
   describe("from usage rights") {
 
     val usageQuota = new UsageQuota {
-      val supplierConfig = Map[String, Int]()
       val usageStore = None
+      val quotaStore = None
     }
 
     object Costing extends CostCalculator {


### PR DESCRIPTION
This PR moves quotas form cloudformation config in S3 updated via an agent.

Config should be of the form:

```json
[
  { 
    "agency": "rex",
    "count": 500
  }
]
```

**TODO:**
- [x] Add correct config to S3 Bucket
- [x] Config update in grid-infra repo