### PR TITLE
Adding more illustrators

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -126,7 +126,8 @@ object MetadataConfig {
     "Mona Chalabi",
     "Jan Diehm",
     "Nadja Popovich",
-    "Guardian US Interactive Team"
+    "Guardian US Interactive Team",
+    "Guardian Design Team"
   )
 
   val contractIllustrators = List(


### PR DESCRIPTION
This adds "Guardian Design Team" as an option under staff illustrators. This requested 18/11 by Duarte Carrilho da Graca