### PR TITLE
Set more flexible content security policy to prevent (and allow) iFraming

### DIFF
--- a/kahuna/app/Global.scala
+++ b/kahuna/app/Global.scala
@@ -19,7 +19,7 @@ object SecurityOptions {
 
   lazy val frameOptionsConfig: SecurityHeadersConfig =
     securityHeadersConfig.copy(
-      contentSecurityPolicy = Some(s"frame-ancestors *.gutools.co.uk *.dev-gutools.co.uk"),
+      contentSecurityPolicy = Config.originUri.map(origin => s"frame-ancestors *.$origin"),
       frameOptions = None
     )
 

--- a/kahuna/app/Global.scala
+++ b/kahuna/app/Global.scala
@@ -19,7 +19,7 @@ object SecurityOptions {
 
   lazy val frameOptionsConfig: SecurityHeadersConfig =
     securityHeadersConfig.copy(
-      contentSecurityPolicy = Config.originUri.map(origin => s"frame-ancestors *.$origin"),
+      contentSecurityPolicy = Config.allowedIframeLocations.map(locations => s"frame-ancestors $locations"),
       frameOptions = None
     )
 

--- a/kahuna/app/Global.scala
+++ b/kahuna/app/Global.scala
@@ -19,8 +19,8 @@ object SecurityOptions {
 
   lazy val frameOptionsConfig: SecurityHeadersConfig =
     securityHeadersConfig.copy(
-      contentSecurityPolicy = None,
-      frameOptions = Some(s"ALLOW-FROM ${Config.services.composerBaseUri}")
+      contentSecurityPolicy = Some(s"frame-ancestors *.gutools.co.uk *.dev-gutools.co.uk"),
+      frameOptions = None
     )
 
   lazy val filter = SecurityHeadersFilter(frameOptionsConfig)

--- a/kahuna/app/lib/Config.scala
+++ b/kahuna/app/lib/Config.scala
@@ -15,6 +15,6 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val sentryDsn: Option[String] = properties.get("sentry.dsn").filterNot(_.isEmpty)
   val watUri: Option[String] = properties.get("wat.uri").filterNot(_.isEmpty)
-  val originUri: Option[String] = properties.get("domain.origin").filterNot(_.isEmpty)
+  val allowedIframeLocations: Option[String] = properties.get("domain.allowedIframeLocations").filterNot(_.isEmpty)
 
 }

--- a/kahuna/app/lib/Config.scala
+++ b/kahuna/app/lib/Config.scala
@@ -15,5 +15,6 @@ object Config extends CommonPlayAppConfig with CommonPlayAppProperties {
 
   val sentryDsn: Option[String] = properties.get("sentry.dsn").filterNot(_.isEmpty)
   val watUri: Option[String] = properties.get("wat.uri").filterNot(_.isEmpty)
+  val originUri: Option[String] = properties.get("domain.origin").filterNot(_.isEmpty)
 
 }


### PR DESCRIPTION
This replaces the older Frame options which wasn't flexible enough to allow embeds from all gutools domains with the newer CSP allowing wildcards.