### PR TITLE
[Docs] Swap installation order of GD / Nginx

### DIFF
--- a/imgops/README.md
+++ b/imgops/README.md
@@ -2,12 +2,12 @@
 Local version of the imgops service
 
 ## Requirements
-* [Nginx with with image filter module](http://nginx.org/en/docs/http/ngx_http_image_filter_module.html)
-  * Linux: `sudo apt-get install nginx nginx-extras`
-  * Mac: `brew install homebrew/nginx/nginx-full --with-image-filter`
 * [GD](http://libgd.github.io/)
   * Linux: `sudo apt-get install libgd-dev`
   * Mac:  `brew install gd`
+* [Nginx with with image filter module](http://nginx.org/en/docs/http/ngx_http_image_filter_module.html)
+  * Linux: `sudo apt-get install nginx nginx-extras`
+  * Mac: `brew install homebrew/nginx/nginx-full --with-image-filter`
 
 ## Installation
 ``` Bash


### PR DESCRIPTION
GD doesn't seem to be a dependency of install NGINX in brew, but it checks its location:

```bash
checking for GD library ... not found
checking for GD library in /usr/local/ ... not found
checking for GD library in /usr/pkg/ ... not found
checking for GD library in /opt/local/ ... not found
```

So, you need to install GD first.