### PR TITLE
explicitly set projectName for node-riffraff-artefact

### DIFF
--- a/s3watcher/lambda/package.json
+++ b/s3watcher/lambda/package.json
@@ -27,5 +27,6 @@
   "repository": "https://github.com/guardian/grid",
   "isAwsLambda": true,
   "cloudformation": false,
-  "riffraffFile": "../deploy.json"
+  "riffraffFile": "../deploy.json",
+  "projectName": "media-service::jenkins::s3-watcher"
 }


### PR DESCRIPTION
For [consistency](https://github.com/guardian/grid/blob/master/project/Build.scala#L30) of riffraff artefact name with the different Grid apps.

Previously, the riffraff package was called `s3watcher` as `node-riffraff-artefact` uses the [package name by default](https://github.com/guardian/node-riffraff-artefact/blob/master/src/settings.js#L28).