### PR TITLE
“PA Archive/PA Images” matches PA credit

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -223,6 +223,7 @@ object PaParser extends ImageProcessor {
     "PA Wire/PA Photos",
     "PA Wire/Press Association Images",
     "PA Archive/PA Photos",
+    "PA Archive/PA Images",
     "PA Archive/Press Association Ima",
     "PA Archive/Press Association Images",
     "Press Association Images"


### PR DESCRIPTION
We attempt to automatically select rights and restrictions for images based on the EXIF credit field.

This PR adds another string to the auto-detection for PA images.