### PR TITLE
Sync Dynamo capacity units in DEV cloud formation

### DIFF
--- a/cloud-formation/dev-template.json
+++ b/cloud-formation/dev-template.json
@@ -328,8 +328,8 @@
                     }
                 ],
                 "ProvisionedThroughput": {
-                    "ReadCapacityUnits" : "1",
-                    "WriteCapacityUnits" : "1"
+                    "ReadCapacityUnits" : "10",
+                    "WriteCapacityUnits" : "5"
                 }
             }
         },
@@ -350,8 +350,8 @@
                     }
                 ],
                 "ProvisionedThroughput": {
-                    "ReadCapacityUnits" : "1",
-                    "WriteCapacityUnits" : "1"
+                    "ReadCapacityUnits" : "5",
+                    "WriteCapacityUnits" : "5"
                 }
             }
         },
@@ -372,8 +372,8 @@
                     }
                 ],
                 "ProvisionedThroughput": {
-                    "ReadCapacityUnits" : "1",
-                    "WriteCapacityUnits" : "1"
+                    "ReadCapacityUnits" : "10",
+                    "WriteCapacityUnits" : "5"
                 }
             }
         },
@@ -397,8 +397,8 @@
                     }
                 ],
                 "ProvisionedThroughput": {
-                    "ReadCapacityUnits" : "1",
-                    "WriteCapacityUnits" : "1"
+                    "ReadCapacityUnits" : "5",
+                    "WriteCapacityUnits" : "5"
                 },
                 "GlobalSecondaryIndexes": [ {
                     "IndexName": "mediaId",
@@ -410,8 +410,8 @@
                         "ProjectionType": "ALL"
                     },
                     "ProvisionedThroughput": {
-                        "ReadCapacityUnits": "1",
-                        "WriteCapacityUnits": "1"
+                        "ReadCapacityUnits": "5",
+                        "WriteCapacityUnits": "5"
                     } }
                 ]
             }
@@ -561,12 +561,12 @@
                     },
                     "ProvisionedThroughput": {
                         "ReadCapacityUnits": "1",
-                        "WriteCapacityUnits": "1"
+                        "WriteCapacityUnits": "4"
                     } }
                 ],
                 "ProvisionedThroughput": {
                     "ReadCapacityUnits": "1",
-                    "WriteCapacityUnits": "1"
+                    "WriteCapacityUnits": "4"
                 }
             }
         },
@@ -618,7 +618,7 @@
                     "KeyType": "HASH"
                 } ],
                 "ProvisionedThroughput": {
-                    "ReadCapacityUnits": "1",
+                    "ReadCapacityUnits": "20",
                     "WriteCapacityUnits": "1"
                 }
             }
@@ -658,7 +658,7 @@
                     "KeyType": "HASH"
                 } ],
                 "ProvisionedThroughput": {
-                    "ReadCapacityUnits": "1",
+                    "ReadCapacityUnits": "20",
                     "WriteCapacityUnits": "1"
                 }
             }


### PR DESCRIPTION
The cloudformation deployed in the shared DEV stack had deviated from that in the repo. This was to reduce the cost of individual DEV stacks but I've gone one further by deleting them entirely!

This PR synchronises them back up.