### PR TITLE
Ignore SNS notification keys (and remove excess logging)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
@@ -44,7 +44,9 @@ abstract class BaseStore[TStoreKey, TStoreVal](bucket: String, credentials: AWSC
   }
 
   protected def getLatestS3Stream: Option[InputStream] = {
-    val objects = s3.client.listObjects(bucket).getObjectSummaries.asScala
+    val objects = s3.client
+      .listObjects(bucket).getObjectSummaries.asScala
+      .filterNot(_.getKey == "AMAZON_SES_SETUP_NOTIFICATION")
 
     if (objects.nonEmpty) {
       val obj = objects.maxBy(_.getLastModified)

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -157,7 +157,6 @@ class UsageStore(
     Logger.info(s"Last usage file has ${lines.length} lines")
 
     val summary: List[SupplierUsageSummary] = csvParser(lines)
-    Logger.info(s"Raw usage summary: $summary")
 
     def copyAgency(supplier: SupplierUsageSummary, id: String) = Agencies.all.get(id)
       .map(a => supplier.copy(agency = a))
@@ -171,8 +170,6 @@ class UsageStore(
         case s if s.agency.supplier.contains("Alamy") => copyAgency(s, "alamy")
         case s => s
       }
-
-    Logger.info(s"Cleaned usage summary: $summary")
 
     quotaStore.getQuota.map { supplierQuota => {
       cleanedSummary
@@ -214,8 +211,6 @@ class QuotaStore(
     val summary = Json
       .parse(quotaFileString)
       .as[List[SupplierUsageQuota]]
-
-    Logger.info(s"Latest quota summary: $summary")
 
       summary.foldLeft(Map[String,SupplierUsageQuota]())((memo, quota) => {
         memo + (quota.agency.supplier -> quota)


### PR DESCRIPTION
#2046 was barfing when SES sent friendly notification objects to the bucket (which became the latest key).

This PR ignores them and tones down the investigative logging I introduced in #2048 to find the problem.