### PR TITLE
Docs updates

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -44,3 +44,10 @@ on GNU Linux, it may be something like
 
 ### Grid-runner
 - When using grid-runner to run grid, individual services have to sometimes be restarted when switching branches
+
+### Accepting certificates
+- You have to manually accept the certificates for the urls for the different grid services.
+- To do this, go the network tab and look for request that failed with error `net::ERR_INSECURE_RESPONSE`
+- Click on the url the request was made to and accept the certificate
+- Not being able to access the services can lead to a lot of errors showing up on the client so you might
+have spend some time searching for the original error that caused the problems

--- a/cloud-formation/scripts/create-dev-stack.sh
+++ b/cloud-formation/scripts/create-dev-stack.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cd "${0%/*}"
 STACK_NAME=$1
 
 if [ -z ${STACK_NAME} ];

--- a/cloud-formation/scripts/delete-dev-stack.sh
+++ b/cloud-formation/scripts/delete-dev-stack.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cd "${0%/*}"
 STACK_NAME=$1
 
 if [ -z ${STACK_NAME} ];

--- a/cloud-formation/scripts/update-dev-stack.sh
+++ b/cloud-formation/scripts/update-dev-stack.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cd "${0%/*}"
 STACK_NAME=$1
 
 if [ -z ${STACK_NAME} ];

--- a/docker/configs/generators/generate-dot-properties.sh
+++ b/docker/configs/generators/generate-dot-properties.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 
-if [ $# -lt 1 ]
-then
-    echo 'usage: generate-dot-properties.sh <DESTINATION_DIR>'
-    exit 1
-fi
-
-DESTINATION=$1
+cd "${0%/*}"
+DESTINATION="/etc/gu"
 
 if [ ! -f ".venv/bin/python" ]; then
     echo 'creating a virtualenv'

--- a/docs/01-dev-setup.md
+++ b/docs/01-dev-setup.md
@@ -68,12 +68,12 @@ server {
 
 ### NGINX, Play & SNI
 As the Play Framework does not yet support [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)
- NGINX can't always work out which certificate to send where when there are multiple services on the same IP. 
+ NGINX can't always work out which certificate to send where when there are multiple services on the same IP.
  This might result in NGINX sending the incorrect certificate resulting in a `HostnameVerifier Exception`.
 
 #### Resolution
 
-When the correct cert to send is ambiguous, NGINX simply sends the first cert it sees in it's configuration, 
+When the correct cert to send is ambiguous, NGINX simply sends the first cert it sees in it's configuration,
 which is loaded from config files in alphabetical order.
 
 To resolve this problem, prefix your grid config filename with `0-`.
@@ -113,15 +113,15 @@ Delete a stack by running:
 ```
 
 ### Note around IAM and Temporary Credentials obtained with `GetFederationToken`
-If you are using temporary credentials obtained via `GetFederationToken` you will not be able to use these scripts 
-as you will not have permission to create IAM Users. 
+If you are using temporary credentials obtained via `GetFederationToken` you will not be able to use these scripts
+as you will not have permission to create IAM Users.
 
 You will have to manage your DEV stack directly within the AWS web console instead.
 
 ## .properties files
 Once you have a DEV stack running, you can generate the necessary`.properties` configuration files in `/etc/gu`.
 
-This can be done by following the instructions [here](./docker/configs/generators/README.md).
+This can be done by following the instructions [here](../docker/configs/generators/README.md).
 
 Guardian devs can follow the guide in the dev-utils folder of this private [repo](https://github.com/guardian/grid-infra).
 This will give you some tips about our specific configuration.

--- a/kahuna/setup.sh
+++ b/kahuna/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd "${0%/*}"
 echo Installing NPM dependencies
 npm install
 NPM_RC=$?


### PR DESCRIPTION
Update docs
- fix broken link to dot properties
- run scripts from the folder they are in
- add a note about accepting certificates

We specify the url that the app will be running on. This is specific to the organisation that is running it but maybe we could add the guardian link somewhere visible?