### PR TITLE
don't leak the domain

### DIFF
--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -32,9 +32,6 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   lazy val apiUri = services.apiBaseUri
   lazy val loginUriTemplate = services.loginUriTemplate
 
-  //Used to extract the image ID for poster image on media atoms
-  val mediaIdBaseUri = "https://api.media.gutools.co.uk/images/"
-
   val defaultPageSize = 100
   val defaultMaxRetries = 6
   val defaultMaxPrintRequestSizeInKb = 500

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -144,7 +144,7 @@ object UsageGroup {
     try {
       val posterImage = atom.data.asInstanceOf[AtomData.Media].media.posterImage
       posterImage match {
-        case Some(image) => Some(image.mediaId.replace(Config.mediaIdBaseUri, ""))
+        case Some(image) => Some(image.mediaId.replace(s"${Config.apiUri}/images/", ""))
         case _ => None
       }
     } catch {


### PR DESCRIPTION
instead, use the [`apiBaseUri`](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala#L24).