### PR TITLE
fix riff-raff.yaml

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/LogConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/LogConfig.scala
@@ -58,7 +58,7 @@ object LogConfig {
       val customFields = makeCustomFields(config)
       val context      = rootLogger.getLoggerContext
       val layout       = makeLayout(customFields)
-      val bufferSize   = 1000;
+      val bufferSize   = 1000
 
       val appender     = makeKinesisAppender(layout, context,
         KinesisAppenderConfig(

--- a/usage/conf/riff-raff.yaml
+++ b/usage/conf/riff-raff.yaml
@@ -8,15 +8,15 @@ templates:
         parameters:
             bucket: media-service-dist
 deployments:
-    upload:
+    usage:
         template: autoscaling
         actions: [uploadArtifacts]
     deployUsage:
         template: autoscaling
         actions: [deploy]
-        dependencies: [upload]
+        dependencies: [usage]
     deployUsageStream:
         template: autoscaling
         app: usage-stream
         actions: [deploy]
-        dependencies: [upload]
+        dependencies: [usage]


### PR DESCRIPTION
Riffraff uses the package name to determine where to upload the artefact in S3. That is, it was uploading to `/media-service-dist/upload/TEST/app.zip` rather than `/media-service-dist/TEST/usage/app.zip`

Tested and working on TEST 🎉 