### PR TITLE
fix riff-raff.yaml app names

### DIFF
--- a/collections/conf/riff-raff.yaml
+++ b/collections/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  collections:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/cropper/conf/riff-raff.yaml
+++ b/cropper/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  cropper:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/image-loader/conf/riff-raff.yaml
+++ b/image-loader/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  image-loader:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/kahuna/conf/riff-raff.yaml
+++ b/kahuna/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  kahuna:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/leases/conf/riff-raff.yaml
+++ b/leases/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  leases:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/media-api/conf/riff-raff.yaml
+++ b/media-api/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  media-api:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/metadata-editor/conf/riff-raff.yaml
+++ b/metadata-editor/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  metadata-editor:
     parameters:
       bucket: media-service-dist
     type: autoscaling

--- a/thrall/conf/riff-raff.yaml
+++ b/thrall/conf/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
-  auth:
+  thrall:
     parameters:
       bucket: media-service-dist
     type: autoscaling


### PR DESCRIPTION
All the apps were deploying to `auth`...

![oops](https://media.giphy.com/media/3o7buazaauRBkOsUaQ/giphy.gif)

Lesson learnt: test *all* the apps and/or use @philwills's `deploy.json` -> `riff-raff.yaml` conversion tool instead of crafting the files by hand.

related to #2070 