### PR TITLE
Rex/Shutterstock

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -258,11 +258,12 @@ object ReutersParser extends ImageProcessor {
 object RexParser extends ImageProcessor {
   val rexAgency = Agencies.get("rex")
   val SlashRex = ".+/ Rex Features".r
-
+  val SlashRexShutterstock = ".+/REX/Shutterstock".r
   def apply(image: Image): Image = (image.metadata.source, image.metadata.credit) match {
     // TODO: cleanup byline/credit
     case (Some("Rex Features"), _) => image.copy(usageRights = rexAgency)
     case (_, Some(SlashRex()))     => image.copy(usageRights = rexAgency)
+    case (_, Some(SlashRexShutterstock())) => image.copy(usageRights = rexAgency)
     case _ => image
   }
 }


### PR DESCRIPTION
add `/REX/Shutterstock` to Rex Parser

Rex have changed their credit! We need to understand why, but for now lets update the parser to stop picture editors granting unnecessary leases.