### PR TITLE
Add AMI update deployment

### DIFF
--- a/media-api/conf/riff-raff.yaml
+++ b/media-api/conf/riff-raff.yaml
@@ -1,7 +1,20 @@
 stacks: [media-service]
 regions: [eu-west-1]
 deployments:
+  ami-update:
+    type: ami-cloudformation-parameter
+    parameters:
+      cloudFormationStackByTags: false
+      cloudFormationStackName: media-service
+      prependStackToCloudFormationStackName: false
+      amiTags:
+        BuiltBy: amigo
+        AmigoStage: PROD
+        Recipe: editorial-tools-xenial-java8
+      amiParameter: ImageIdMediaApi
   media-api:
     parameters:
       bucket: media-service-dist
     type: autoscaling
+    dependencies:
+    - ami-update


### PR DESCRIPTION
Automatically update media API AMI when deployed.

Relies on https://github.com/guardian/grid-infra/pull/295