### PR TITLE
Add avalon to list of Getty credit exclusions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -172,7 +172,7 @@ trait GettyProcessor {
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   // including 'newspix internation' because they're sending us lots with that in the credit
-  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot", "Ian Jones")
+  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot", "Ian Jones", "Avalon")
     .map(ex => s"(?i)$ex".r)
 
   // Some people send over Getty XMP data, but are not affiliated with Getty


### PR DESCRIPTION
Thanks to @susiecoleman.

Adding Avalon to this ever-expanding list. There's a good case for abstracting this away but this'll work for now.