### PR TITLE
store Composer domain in config

### DIFF
--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -51,7 +51,9 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
   val usageDateLimit = Try(properties("usage.dateLimit")).getOrElse(defaultDateLimit)
 
   val topicArn = properties("sns.topic.arn")
-  val composerBaseUrl = properties("composer.baseUrl")
+
+  private val composerDomain = properties("composer.domain")
+  val composerContentBaseUrl: String = s"https://$composerDomain/content"
 
   val usageRecordTable = properties("dynamo.tablename.usageRecordTable")
 

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -59,7 +59,7 @@ object UsageMetadataBuilder {
   def composerUrl(content: Content): Option[String] = content.fields
     .flatMap(_.internalComposerCode)
     .flatMap(composerId => {
-      Try((new URL(s"${Config.composerBaseUrl}/${composerId}")).toString).toOption
+      Try((new URL(s"${Config.composerContentBaseUrl}/${composerId}")).toString).toOption
     })
 
 }

--- a/usage/app/model/ContentDetails.scala
+++ b/usage/app/model/ContentDetails.scala
@@ -32,7 +32,7 @@ object ContentDetails {
   def composerUrl(content: Content): Option[URL] = content.fields
     .flatMap(_.internalComposerCode)
     .flatMap(composerId => {
-      Try(new URL(s"${Config.composerBaseUrl}/${composerId}")).toOption
+      Try(new URL(s"${Config.composerContentBaseUrl}/${composerId}")).toOption
     })
 
 }


### PR DESCRIPTION
rather than the full path to a piece of content; this makes the cloudformation a little nicer