### PR TITLE
Configurable oauth domain 

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Panda.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Panda.scala
@@ -16,12 +16,9 @@ trait PanDomainAuthActions extends AuthActions {
     val oauthDomain:String = properties.getOrElse("panda.oauth.domain", "guardian.co.uk")
     val oauthDomainMultiFactorEnabled:Boolean = Try(properties("panda.oauth.multifactor.enable").toBoolean).getOrElse(true)
     // check if the user email domain is the one configured
-    var authorized:Boolean = (authedUser.user.emailDomain == oauthDomain)
+    val isAuthorized:Boolean = (authedUser.user.emailDomain == oauthDomain)
     // if authorized check if multifactor is to be evaluated
-    if(authorized && oauthDomainMultiFactorEnabled) {
-      authorized = authorized && authedUser.multiFactor
-    }
-    return authorized
+    if (oauthDomainMultiFactorEnabled) isAuthorized && authedUser.multiFactor else isAuthorized
   }
 
   val authCallbackBaseUri: String

--- a/docker/configs/generators/generators/resources/templates/dot-properties/panda.properties.template
+++ b/docker/configs/generators/generators/resources/templates/dot-properties/panda.properties.template
@@ -1,3 +1,5 @@
 panda.domain={{panda_domain}}
 panda.aws.key={{panda_aws_key}}
 panda.aws.secret={{panda_aws_secret}}
+panda.oauth.domain={{panda_oauth_domain}}
+panda.oauth.multifactor.enable={{panda_oauth_multifactor_enable | lower}}

--- a/docker/configs/generators/grid-settings.yml.template
+++ b/docker/configs/generators/grid-settings.yml.template
@@ -14,6 +14,12 @@ properties:
   # Configuration for pan domain authentication. See https://github.com/guardian/pan-domain-authentication
   - panda_domain:
 
+  # Configuration for google oauth domain to authenticate against (default if prop not set: guardian.co.uk)
+  - panda_oauth_domain: guardian.co.uk
+
+  # Configuration for google oauth, whenever the multifactor should be enabled (default if prop not set: true)
+  - panda_oauth_multifactor_enable: true
+
   # Configuration for pan domain authentication. See https://github.com/guardian/pan-domain-authentication
   - panda_aws_key:
 


### PR DESCRIPTION
Add
panda_oauth_domain: guardian.co.uk
panda_oauth_multifactor_enable: true

properties to configure the google authentication domain 

see guardian/grid#1381