### PR TITLE
Only add labels when they are present

### DIFF
--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -85,7 +85,7 @@ jobs.controller('UploadJobsCtrl', [
                     editsService.updateMetadataField(jobItem.image, 'description', newDescription);
                 }
 
-                if (presetLabels) {
+                if (presetLabels.length > 0) {
                     labelService.add(image, presetLabels);
                 }
 


### PR DESCRIPTION
This fixes an issue where the `labels` endpoint was called even when there were no preset labels defined.