### PR TITLE
restrict the crops user is able to pick

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -47,6 +47,7 @@ image.controller('ImageCtrl', [
     '$scope',
     '$state',
     '$window',
+    '$filter',
     'inject$',
     'image',
     'mediaApi',
@@ -57,11 +58,13 @@ image.controller('ImageCtrl', [
     'imageService',
     'imageUsagesService',
     'keyboardShortcut',
+    'storage',
 
     function ($rootScope,
               $scope,
               $state,
               $window,
+              $filter,
               inject$,
               image,
               mediaApi,
@@ -71,7 +74,8 @@ image.controller('ImageCtrl', [
               mediaCropper,
               imageService,
               imageUsagesService,
-              keyboardShortcut) {
+              keyboardShortcut,
+              storage) {
 
         let ctrl = this;
 
@@ -102,9 +106,16 @@ image.controller('ImageCtrl', [
 
         ctrl.image.allCrops = [];
 
+        const cropType = storage.getJs('cropType', true);
+
         imageService(ctrl.image).states.canDelete.then(deletable => {
             ctrl.canBeDeleted = deletable;
         });
+
+        ctrl.allowCropSelection = (crop) => {
+          return !cropType ||
+            $filter('asAspectRatioWord')(crop.specification.aspectRatio) === cropType;
+        };
 
         ctrl.onCropsDeleted = () => {
             // a bit nasty - but it updates the state of the page better than trying to do that in

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -106,15 +106,15 @@ image.controller('ImageCtrl', [
 
         ctrl.image.allCrops = [];
 
-        const cropType = storage.getJs('cropType', true);
+        ctrl. cropType = storage.getJs('cropType', true);
 
         imageService(ctrl.image).states.canDelete.then(deletable => {
             ctrl.canBeDeleted = deletable;
         });
 
         ctrl.allowCropSelection = (crop) => {
-          return !cropType ||
-            $filter('asAspectRatioWord')(crop.specification.aspectRatio) === cropType;
+          return !ctrl.cropType ||
+            $filter('asAspectRatioWord')(crop.specification.aspectRatio) === ctrl.cropType;
         };
 
         ctrl.onCropsDeleted = () => {

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -1,0 +1,17 @@
+<img class="image-crop__image"
+     alt="cropped image thumbnail"
+     ng:src="{{:: extremeAssets.smallest | assetFile}}" />
+<div class="image-crop__info"
+     ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
+  <div class="flex-container">
+    {{:: crop.specification.aspectRatio | asAspectRatioWord}}
+    <span class="flex-spacer"></span>
+    <span ng:if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
+  </div>
+
+  <div class="flex-container image-crop__more-info">
+    {{:: crop.specification.bounds.width}} &times; {{:: crop.specification.bounds.height}}
+    <span class="flex-spacer"></span>
+    <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
+  </div>
+</div>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -84,29 +84,22 @@
                             ng:class="{'image-crop--selected': crop == ctrl.crop}">
                             <a draggable="true"
                                ng:init="extremeAssets = (crop | getExtremeAssets)"
+                               ng-if="ctrl.allowCropSelection(crop)"
                                ng:click="ctrl.cropSelected(crop)"
                                ui:sref="{crop: crop.id}"
                                ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
                                ui:drag-image="extremeAssets.smallest | assetFile">
 
-                                <img class="image-crop__image"
-                                     alt="cropped image thumbnail"
-                                     ng:src="{{:: extremeAssets.smallest | assetFile}}" />
-                                <div class="image-crop__info"
-                                    ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
-                                    <div class="flex-container">
-                                        {{:: crop.specification.aspectRatio | asAspectRatioWord}}
-                                        <span class="flex-spacer"></span>
-                                        <span ng:if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
-                                    </div>
-
-                                    <div class="flex-container image-crop__more-info">
-                                        {{:: crop.specification.bounds.width}} &times; {{:: crop.specification.bounds.height}}
-                                        <span class="flex-spacer"></span>
-                                        <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
-                                    </div>
-                                </div>
+                              <ng-include src="'/assets/js/image/crop.html'"></ng-include>
                             </a>
+                            <div
+                                class="image-crop--disabled"
+                                draggable="false"
+                                ng:init="extremeAssets = (crop | getExtremeAssets)"
+                                ng-if="!ctrl.allowCropSelection(crop)"
+                            >
+                              <ng-include src="'/assets/js/image/crop.html'"></ng-include>
+                            </div>
                         </li>
                     </ul>
                 </dd>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -81,10 +81,11 @@
                     <ul class="image-crops">
                         <li class="image-crop"
                             ng:repeat="crop in ctrl.crops"
+                            ng-switch="ctrl.allowCropSelection(crop)"
                             ng:class="{'image-crop--selected': crop == ctrl.crop}">
                             <a draggable="true"
                                ng:init="extremeAssets = (crop | getExtremeAssets)"
-                               ng-if="ctrl.allowCropSelection(crop)"
+                               ng-switch-when="true"
                                ng:click="ctrl.cropSelected(crop)"
                                ui:sref="{crop: crop.id}"
                                ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
@@ -96,7 +97,9 @@
                                 class="image-crop--disabled"
                                 draggable="false"
                                 ng:init="extremeAssets = (crop | getExtremeAssets)"
-                                ng-if="!ctrl.allowCropSelection(crop)"
+                                ng-switch-when="false"
+                                gr-tooltip="You can only choose {{:: ctrl.cropType}} crops"
+                                gr-tooltip-position="right"
                             >
                               <ng-include src="'/assets/js/image/crop.html'"></ng-include>
                             </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1811,6 +1811,10 @@ FIXME: what to do with touch devices
     border: solid 2px #00adee;
 }
 
+.image-crop--disabled {
+  opacity: 0.5;
+}
+
 .result--selected .preview {
     background-color: #4c4c4c;
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1813,6 +1813,7 @@ FIXME: what to do with touch devices
 
 .image-crop--disabled {
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .result--selected .preview {


### PR DESCRIPTION
When you are cropping an image for mam in the grid, the grid only allows you crop images that are the correct crop type (crop type gets stored in session storage). 

This restriction does not stop people from navigating away from the crop page and choosing the wrong crop size from already existing crops. This pr makes sure that this does not happen by only allowing choosing crops of the correct type. 

When choosing a composer image: 

![screen shot 2017-11-15 at 15 05 07](https://user-images.githubusercontent.com/3066534/32842958-6c60f988-ca16-11e7-88a0-9fc92d41d862.png)
