### PR TITLE
distinguish staff photographers

### DIFF
--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -29,7 +29,8 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
             isValid: image.data.valid,
             canDelete: imageLogic.canBeDeleted(image),
             canArchive: imageLogic.canBeArchived(image),
-            persistedReasons: imageLogic.getPersistenceExplanation(image).join('; ')
+            persistedReasons: imageLogic.getPersistenceExplanation(image).join('; '),
+            isStaffPhotographer: imageLogic.isStaffPhotographer(image)
         };
     }
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -30,6 +30,7 @@
        ui:drag-data="ctrl.image | asImageDragData">
        <div class="preview__fade"></div>
        <img class="preview__image"
+            ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
             alt="{{::ctrl.image.data.metadata.description}}"
             ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
             gr:image-fade-on-load />

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -27,11 +27,12 @@
 
     <a ng:if="! ctrl.selectionMode" class="preview__link"
        ui:sref="image({imageId: ctrl.image.data.id})"
-       ui:drag-data="ctrl.image | asImageDragData">
+       ui:drag-data="ctrl.image | asImageDragData"
+       title="{{::ctrl.imageDescription}}">
        <div class="preview__fade"></div>
        <img class="preview__image"
             ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
-            alt="{{::ctrl.image.data.metadata.description}}"
+            alt="{{::ctrl.imageDescription}}"
             ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
             gr:image-fade-on-load />
     </a>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -49,6 +49,10 @@ image.controller('uiPreviewImageCtrl', [
 
     ctrl.states = imageService(ctrl.image).states;
 
+    ctrl.imageDescription = ctrl.states.isStaffPhotographer ?
+        `Staff Image: ${ctrl.image.data.metadata.description}` :
+        ctrl.image.data.metadata.description;
+
     const hasRights = ctrl.states.hasRights;
 
     ctrl.flagState = hasRights ? ctrl.states.cost : 'no_rights';

--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -28,6 +28,17 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
                isPersisted ? 'archived' : 'unarchived';
     }
 
+    function isStaffPhotographer(image) {
+        const staffCategories = [
+            'staff-photographer',
+            'contract-photographer',
+            'commissioned-photographer'
+        ];
+
+        return image.data.usageRights &&
+            staffCategories.includes(image.data.usageRights.category);
+    }
+
     function getPersistenceExplanation(image) {
         const persistReasons = imageAccessor.readPersistedReasons(image);
         return persistReasons.map(reason => {
@@ -54,7 +65,8 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
         canBeDeleted,
         canBeArchived,
         getArchivedState,
-        getPersistenceExplanation
+        getPersistenceExplanation,
+        isStaffPhotographer
     };
 }]);
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -848,6 +848,11 @@ textarea.ng-invalid {
     margin: 5px;
     background-color: #393939;
 }
+
+.result .preview__image--staff {
+    border: 10px solid #005689;
+}
+
 .result--seen {
     opacity: .5;
 }


### PR DESCRIPTION
add a blue border around staff images to promote usage of them over agency images

![image](https://user-images.githubusercontent.com/836140/33318436-8866b494-d432-11e7-8a61-1d1037f36aff.png)

a border was chosen over a [badge](https://material.io/icons/#ic_verified_user) as @paperboyo and I were concerned about badge overload