### PR TITLE
highlight staff images even in selection mode

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -40,6 +40,7 @@
     <span ng:if="ctrl.selectionMode" class="preview__no-link">
         <div class="preview__fade"></div>
         <img class="preview__image"
+             ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
              alt="{{::ctrl.image.data.metadata.description}}"
              ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
              ui:drag-data="ctrl.image | asImageDragData"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -849,10 +849,6 @@ textarea.ng-invalid {
     background-color: #393939;
 }
 
-.result .preview__image--staff {
-    border: 10px solid #005689;
-}
-
 .result--seen {
     opacity: .5;
 }
@@ -1121,6 +1117,10 @@ textarea.ng-invalid {
     max-width: 100%;
     max-height: 100%;
     margin: 0 auto;
+}
+
+.preview__image.preview__image--staff {
+    border: 10px solid #005689;
 }
 
 .preview__info {


### PR DESCRIPTION
building on https://github.com/guardian/grid/pull/2102.

I hadn't realised we `ng-if` [here](https://github.com/guardian/grid/compare/aa-staff?expand=1#diff-b0adc273d4eb8af691690a0f30abcd26R28) so we were not highlight staff images when in selection mode, as mentioned by Jonny.

This change also makes the css rule more specific.