### PR TITLE
delete usage endpoint

### DIFF
--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -24,6 +24,7 @@ object ThrallMessageConsumer extends MessageConsumer(
       case "update-image-leases"        => updateImageLeases
       case "set-image-collections"      => setImageCollections
       case "heartbeat"                  => heartbeat
+      case "delete-usages"              => deleteAllUsages
     }
   }
 
@@ -76,6 +77,9 @@ object ThrallMessageConsumer extends MessageConsumer(
         }
       }
     )
+
+  def deleteAllUsages(usage: JsValue) =
+    Future.sequence( withImageId(usage)(id => ElasticSearch.deleteAllImageUsages(id) ))
 }
 
 // TODO: improve and use this (for logging especially) else where.

--- a/thrall/app/lib/ThrallMetrics.scala
+++ b/thrall/app/lib/ThrallMetrics.scala
@@ -21,6 +21,8 @@ object ThrallMetrics extends CloudWatchMetrics(s"$stage/Thrall", awsCredentials)
 
   val failedQueryUpdates = new CountMetric("FailedQueryUpdates")
 
+  val failedDeletedAllUsages = new CountMetric("FailedDeletedAllUsages")
+
   val processingLatency = new TimeMetric("ProcessingLatency")
 
 }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -159,8 +159,8 @@ object UsageApi extends Controller with ArgoHelpers {
     }
   }
 
-  def deleteUsages(id: String) = Authenticated.async {
-    UsageTable.queryByImageId(id).map(usages => {
+  def deleteUsages(mediaId: String) = Authenticated.async {
+    UsageTable.queryByImageId(mediaId).map(usages => {
       usages.foreach(usage => {
         Logger.info(s"removing usage ${usage.usageId} for media id ${usage.mediaId}")
         UsageTable.delete(usage)
@@ -171,7 +171,7 @@ object UsageApi extends Controller with ArgoHelpers {
         respondError(InternalServerError, "image-usage-delete-failed", error.getMessage())
       }
     }
-    Notifications.publish(Json.obj("id" -> id), "delete-usages")
+    Notifications.publish(Json.obj("id" -> mediaId), "delete-usages")
     Future.successful(Ok)
   }
 }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -161,17 +161,17 @@ object UsageApi extends Controller with ArgoHelpers {
 
   def deleteUsages(id: String) = Authenticated.async {
     UsageTable.queryByImageId(id).map(usages => {
-      Notifications.publish(Json.obj("id" -> id), "delete-usages")
       usages.foreach(usage => {
-        UsageTable.delete(usage).map()
+        Logger.info(s"removing usage ${usage.usageId} for media id ${usage.mediaId}")
+        UsageTable.delete(usage)
       })
-      Ok
     }).recover{
       case error: Exception => {
         Logger.error("UsageApi returned an error.", error)
-        respondError(InternalServerError, "image-usage-retrieve-failed", error.getMessage())
+        respondError(InternalServerError, "image-usage-delete-failed", error.getMessage())
       }
     }
+    Notifications.publish(Json.obj("id" -> id), "delete-usages")
     Future.successful(Ok)
   }
 }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -161,10 +161,7 @@ object UsageApi extends Controller with ArgoHelpers {
 
   def deleteUsages(mediaId: String) = Authenticated.async {
     UsageTable.queryByImageId(mediaId).map(usages => {
-      usages.foreach(usage => {
-        Logger.info(s"removing usage ${usage.usageId} for media id ${usage.mediaId}")
-        UsageTable.delete(usage)
-      })
+      usages.foreach(UsageTable.deleteRecord)
     }).recover{
       case error: Exception => {
         Logger.error("UsageApi returned an error.", error)

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -5,28 +5,22 @@ import java.net.URI
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
-
 import org.joda.time.DateTime
-
-import play.api.libs.json.JsError
+import play.api.libs.json.{JsError, Json}
 import play.api.Logger
 import play.api.mvc.Controller
 import play.api.mvc.Results._
-import play.api.mvc.{Controller, BodyParsers}
+import play.api.mvc.{BodyParsers, Controller}
 import play.utils.UriEncoding
-
 import rx.lang.scala.Observable
-
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.contentapi.client.model.ItemQuery
-
 import com.gu.mediaservice.lib.argo.ArgoHelpers
-import com.gu.mediaservice.lib.argo.model.{Action, Link, EntityResponse}
+import com.gu.mediaservice.lib.argo.model.{Action, EntityResponse, Link}
 import com.gu.mediaservice.lib.auth
 import com.gu.mediaservice.lib.auth.KeyStore
 import com.gu.mediaservice.lib.aws.NoItemFound
-import com.gu.mediaservice.model.{Usage, PrintUsageRequest}
-
+import com.gu.mediaservice.model.{PrintUsageRequest, Usage}
 import lib._
 import model._
 
@@ -163,5 +157,21 @@ object UsageApi extends Controller with ArgoHelpers {
         }
       )
     }
+  }
+
+  def deleteUsages(id: String) = Authenticated.async {
+    UsageTable.queryByImageId(id).map(usages => {
+      Notifications.publish(Json.obj("id" -> id), "delete-usages")
+      usages.foreach(usage => {
+        UsageTable.delete(usage).map()
+      })
+      Ok
+    }).recover{
+      case error: Exception => {
+        Logger.error("UsageApi returned an error.", error)
+        respondError(InternalServerError, "image-usage-retrieve-failed", error.getMessage())
+      }
+    }
+    Future.successful(Ok)
   }
 }

--- a/usage/app/lib/Notifications.scala
+++ b/usage/app/lib/Notifications.scala
@@ -1,0 +1,5 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.SNS
+
+object Notifications extends SNS(Config.awsCredentials, Config.topicArn)

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -2,8 +2,8 @@ GET     /                                               controllers.UsageApi.ind
 
 GET     /usages/:id                                     controllers.UsageApi.forUsage(id: String)
 GET     /usages/media/:mediaId                          controllers.UsageApi.forMedia(mediaId: String)
+DELETE  /usages/media/:mediaId                          controllers.UsageApi.deleteUsages(mediaId: String)
 POST    /usages/print                                   controllers.UsageApi.setPrintUsages
-DELETE  /usages/:id/                                    controllers.UsageApi.deleteUsages(id: String)
 
 GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
 

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -3,6 +3,7 @@ GET     /                                               controllers.UsageApi.ind
 GET     /usages/:id                                     controllers.UsageApi.forUsage(id: String)
 GET     /usages/media/:mediaId                          controllers.UsageApi.forMedia(mediaId: String)
 POST    /usages/print                                   controllers.UsageApi.setPrintUsages
+DELETE  /usages/:id/                                    controllers.UsageApi.deleteUsages(id: String)
 
 GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
 


### PR DESCRIPTION
We disallow image deletion if it has been used. However, in some cases, usages are incorrectly recorded.

This PR introduces a new `DELETE` endpoint that'll remove usages from the usage api (dynamo) and then send a message to thrall to update elasticsearch, deleting the usages from document.

# Testing
- Upload a new image to Grid and note its id
- Confirm there are no usages in the usage api and media api
- Issue a `POST` request to the usage api to record a usage
- Confirm there is 1 usage in the usage api and media api
- Issue a `DELETE` request to the usage api
- Confirm there are no usages in the usage api and media api

See [this gist](https://gist.github.com/akash1810/548a834fc784c179482378b9e181825d) for helpful `curl` commands.
