### PR TITLE
Remove preview capi

### DIFF
--- a/ci/play-build.sh
+++ b/ci/play-build.sh
@@ -27,8 +27,7 @@ pushd ..
 
 echo "Building $PROJECT"
 
-java -Xmx1024m \
-    -XX:MaxPermSize=256m \
+java -Xmx2048m \
     -XX:ReservedCodeCacheSize=128m \
     -XX:+CMSClassUnloadingEnabled \
     -Dsbt.log.noformat=true \

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -150,9 +150,6 @@ function getUsageConfig(config) {
         |aws.region=${config.aws.region}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |capi.live.url=${config.capi.live.url}
-        |capi.preview.url=${config.capi.preview.url}
-        |capi.preview.user=${config.capi.preview.user}
-        |capi.preview.password=${config.capi.preview.password}
         |capi.apiKey=${config.capi.live.key}
         |dynamo.tablename.usageRecordTable=${config.stackProps.UsageRecordTable}
         |composer.baseUrl=${config.composer.url}

--- a/usage/app/lib/Config.scala
+++ b/usage/app/lib/Config.scala
@@ -42,9 +42,6 @@ object Config extends CommonPlayAppProperties with CommonPlayAppConfig {
 
   val capiLiveUrl = properties("capi.live.url")
   val capiApiKey = properties("capi.apiKey")
-  val capiPreviewUrl = properties("capi.preview.url")
-  val capiPreviewUser = properties("capi.preview.user")
-  val capiPreviewPassword = properties("capi.preview.password")
   val capiPageSize = Try(properties("capi.page.size").toInt).getOrElse[Int](defaultPageSize)
   val capiMaxRetries = Try(properties("capi.maxRetries").toInt).getOrElse[Int](defaultMaxRetries)
 

--- a/usage/app/lib/ContentApi.scala
+++ b/usage/app/lib/ContentApi.scala
@@ -4,14 +4,9 @@ import com.gu.contentapi.client.GuardianContentClient
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.buildinfo.CapiBuildInfo
 
-import scala.concurrent.{ExecutionContext, Future}
-
-import com.ning.http.client.Realm.{RealmBuilder, AuthScheme}
-import com.ning.http.client.{AsyncHttpClientConfig, AsyncHttpClient}
+import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig.Builder
-
 import org.joda.time.{DateTime, DateTimeZone}
-
 import dispatch.Http
 
 trait ContentHelpers {
@@ -21,21 +16,6 @@ trait ContentHelpers {
     date = new DateTime(firstPublicationDate.iso8601, DateTimeZone.UTC)
   } yield date
 
-}
-
-object PreviewContentApi extends ContentApiRequestBuilder {
-  override val targetUrl = Config.capiPreviewUrl
-
-  val realm = new RealmBuilder()
-    .setPrincipal(Config.capiPreviewUser)
-    .setPassword(Config.capiPreviewPassword)
-    .setUsePreemptiveAuth(true)
-    .setScheme(AuthScheme.BASIC)
-    .build()
-
-  val previewBuilder = builder.setRealm(realm)
-
-  override val client = new AsyncHttpClient(previewBuilder.build)
 }
 
 object LiveContentApi extends ContentApiRequestBuilder {


### PR DESCRIPTION
`PreviewContentApi` is not used anywhere, so no need to migrate to the new preview endpoint