### PR TITLE
add script to fetch dev config

### DIFF
--- a/docs/02.02-configuration.md
+++ b/docs/02.02-configuration.md
@@ -2,4 +2,6 @@
 
 Grid services get their configuration from `/etc/gu`.
 
-We can generate the configuration files by following the instructions [here](../scripts/generate-dot-properties/README.md).
+You can generate the configuration files by following the instructions [here](../scripts/generate-dot-properties/README.md).
+
+Alternatively, if you work for the Guardian, you can run [`./fetch-config.sh`](../fetch-config.sh) to download the config for the shared stack we use in DEV.

--- a/fetch-config.sh
+++ b/fetch-config.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Downloads DEV config to /etc/gu
+
+DOWNLOAD_DIR=/etc/gu
+
+aws s3 cp s3://grid-conf/DEV/ \
+    ${DOWNLOAD_DIR}/ \
+    --recursive \
+    --profile media-service \
+    --region eu-west-1


### PR DESCRIPTION
We use a shared stack in DEV, so there's no need for everyone to generate config each time. Also brings Grid setup inline with other Tools.