### PR TITLE
include error key in log line

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -55,7 +55,7 @@ trait ArgoHelpers extends Results {
 
   // TODO: find a nicer way to serialise ErrorResponse[Nothing] without this hack
   def respondError(errorStatus: Status, errorKey: String, errorMessage: String, links: List[Link] = Nil): Result = {
-    Logger.warn(s"Responding with error status ${errorStatus.header.status}, $errorMessage")
+    Logger.warn(s"[$errorKey] Responding with error status ${errorStatus.header.status}, $errorMessage")
     val response = ErrorResponse[Int](
       errorKey     = errorKey,
       errorMessage = errorMessage,


### PR DESCRIPTION
this'll help gain an understanding on how often a particular error occurs, by making the logs more searchable

Currently, we can't really search on the `errorMessage` as we just bubble the message from the library that threw (google, amazon etc) and the value varies too much. Logging the `errorKey` means we can work out how often [this](https://github.com/guardian/grid/blob/master/auth/app/controllers/Application.scala#L92) happens.

This should really be markers, but I'd like to do that in a generic way and its probably best to wait until the multi project branch is merged.