### PR TITLE
Make clear that crop deletion deletes ALL crops

### DIFF
--- a/kahuna/public/js/components/gr-delete-crops/gr-delete-crops.js
+++ b/kahuna/public/js/components/gr-delete-crops/gr-delete-crops.js
@@ -53,7 +53,7 @@ deleteCrops.directive('grDeleteCrops', [function () {
         template: `
             <gr-confirm-delete
                 ng:if="ctrl.active"
-                gr:label="Delete crops"
+                gr:label="Delete ALL crops"
                 gr:on-confirm="ctrl.delete()">
             </gr-confirm-delete>
         `


### PR DESCRIPTION
Related to https://trello.com/c/dOzaycL8/3-ability-to-delete-just-one-crop-from-the-grid.

I HATE capitalisation, so if you STRONGLY agree, change it to `Delete all crops`.