### PR TITLE
Fix request logging by adding logback.xml directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,10 +108,14 @@ def playProject(projectName: String, port: Int): Project =
       packageSummary in Linux := description.value,
       packageDescription := description.value,
 
-      mappings in Universal ++= Seq(file("common-lib/src/main/resources/application.conf") -> "conf/application.conf"),
+      mappings in Universal ++= Seq(
+        file("common-lib/src/main/resources/application.conf") -> "conf/application.conf",
+        file("common-lib/src/main/resources/logback.xml") -> "conf/logback.xml"
+      ),
       javaOptions in Universal ++= Seq(
         "-Dpidfile.path=/dev/null",
-        s"-Dconfig.file=/usr/share/$projectName/conf/application.conf"
+        s"-Dconfig.file=/usr/share/$projectName/conf/application.conf",
+        s"-Dlogger.file=/usr/share/$projectName/conf/logback.xml"
       ),
 
       riffRaffManifestProjectName := s"media-service::grid::${name.value}",

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -19,18 +19,5 @@ es {
   port: 9300
 }
 
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root=INFO
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
-
 # PROD only stuff (play secret etc)
 include "/etc/gu/grid-prod.properties"

--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+
+    <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <logger name="play" level="INFO" />
+    <logger name="application" level="INFO" />
+    <logger name="request" level="INFO" />
+
+    <root level="WARN">
+        <appender-ref ref="ASYNCSTDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
#2124 broke request logging. After some investigation we think we needed a logger defined for the name `request`. The easiest way to do that was to add `logback.xml` to the project, copied from the [default in the play docs](https://www.playframework.com/documentation/2.6.x/SettingsLogger).

I've also removed the logging config from `application.conf` which is superseded by `logback.xml`.