### PR TITLE
Bump play version to fix warning when handling Route53 healthchecks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,9 +26,9 @@ Global / concurrentRestrictions := Seq(
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
-    "com.typesafe.play" %% "play" % "2.6.12", ws,
+    "com.typesafe.play" %% "play" % "2.6.13", ws,
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
-    "com.typesafe.play" %% "filters-helpers" % "2.6.12",
+    "com.typesafe.play" %% "filters-helpers" % "2.6.13",
     "com.gu" %% "pan-domain-auth-core" % "0.7.0",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.0",
     "com.gu" %% "editorial-permissions-client" % "0.8",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.13")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
See https://github.com/playframework/playframework/issues/7997.

Akka HTTP is a silly library and was failing to parse the user-agent (why was it even bothering in the first place ARRRRGGGH)