### PR TITLE
Fix batch downloading

### DIFF
--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -35,7 +35,7 @@ object KahunaSecurityConfig {
     val connectSources = s"connect-src ${(services :+ config.imageOrigin).mkString(" ")} 'self'"
 
     val cropOrigin = config.cropOrigin.map { s => s"https://$s" }.getOrElse("")
-    val imageSources = s"img-src ${config.services.imgopsBaseUri} https://${config.fullOrigin} https://${config.thumbOrigin} $cropOrigin 'self'"
+    val imageSources = s"img-src data:* ${config.services.imgopsBaseUri} https://${config.fullOrigin} https://${config.thumbOrigin} $cropOrigin 'self'"
 
     base.copy(
       // covered by frame-ancestors in contentSecurityPolicy

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -32,7 +32,7 @@ object KahunaSecurityConfig {
 
     val frameSources = s"frame-src ${config.services.authBaseUri} https://accounts.google.com"
     val frameAncestors = s"frame-ancestors *.${config.services.composerDomain}"
-    val connectSources = s"connect-src ${services.mkString(" ")} 'self'"
+    val connectSources = s"connect-src ${(services :+ config.imageOrigin).mkString(" ")} 'self'"
 
     val cropOrigin = config.cropOrigin.map { s => s"https://$s" }.getOrElse("")
     val imageSources = s"img-src ${config.services.imgopsBaseUri} https://${config.fullOrigin} https://${config.thumbOrigin} $cropOrigin 'self'"

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -17,4 +17,5 @@ class KahunaConfig(override val configuration: Configuration) extends CommonConf
   val thumbOrigin: String = properties("origin.thumb")
   val fullOrigin: String = properties("origin.full")
   val cropOrigin: Option[String] = properties.get("origin.crops")
+  val imageOrigin: String = properties("origin.images")
 }

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -55,6 +55,7 @@ function getKahunaConfig(config) {
         |aws.region=${config.aws.region}
         |origin.full=${config.stackProps.ImageBucket}.s3.${config.aws.region}.amazonaws.com
         |origin.thumb=${config.stackProps.ThumbBucket}.s3.${config.aws.region}.amazonaws.com
+        |origin.images=${config.stackProps.ImageBucket}.s3.${config.aws.region}.amazonaws.com
         |`;
 }
 


### PR DESCRIPTION
which works by downloading each image individually in the browser and constructing a ZIP file in Javascript...

Yeah...

The content security policy therefore needs to allow `connect-src` to the image bucket itself.

I've also allowed `data:` uris in images to fix another CSP warning.