### PR TITLE
sort collections alphabetically on addition

### DIFF
--- a/kahuna/public/js/services/api/collections-api.js
+++ b/kahuna/public/js/services/api/collections-api.js
@@ -36,9 +36,15 @@ collectionsApi.factory('collections',
 
     function addChildTo(node, childName) {
         return node.perform('add-child', {body: {data: childName}}).then(childResource => {
-            // NOTE: The child will always be prepended, but the default view for the tree
-            // is alphabetical, so this will change after reload.
-            const updatedChildren = node.data.children = [childResource].concat(node.data.children);
+            const updatedChildren = node.data.children = [childResource].concat(node.data.children).sort((a, b) => {
+                if (a.data.basename < b.data.basename) {
+                    return -1;
+                }
+                if (a.data.basename > b.data.basename) {
+                    return 1;
+                }
+                return 0;
+            });
             return updatedChildren;
         });
     }

--- a/kahuna/public/js/services/api/collections-api.js
+++ b/kahuna/public/js/services/api/collections-api.js
@@ -36,7 +36,7 @@ collectionsApi.factory('collections',
 
     function addChildTo(node, childName) {
         return node.perform('add-child', {body: {data: childName}}).then(childResource => {
-            const updatedChildren = node.data.children = [childResource].concat(node.data.children).sort((a, b) => {
+            const updatedChildren = [childResource].concat(node.data.children).sort((a, b) => {
                 if (a.data.basename < b.data.basename) {
                     return -1;
                 }
@@ -45,6 +45,9 @@ collectionsApi.factory('collections',
                 }
                 return 0;
             });
+
+            node.data.children = updatedChildren;
+
             return updatedChildren;
         });
     }


### PR DESCRIPTION
rather than require a page reload to sort the collections (the server responds in order), do it client-side

# before
![before](https://user-images.githubusercontent.com/836140/39878866-4cdc8722-5471-11e8-92c4-7314c05986b3.gif)

# after
![after](https://user-images.githubusercontent.com/836140/39878870-4fc48d04-5471-11e8-9f68-92a86879f0c4.gif)
