### PR TITLE
Delete manually uploaded images

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -43,7 +43,10 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
 
   def loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]) =
     auth.async(DigestBodyParser.create(createTempFile("requestBody"))) { req =>
-      loadFile(uploadedBy, identifiers, uploadTime, filename)(req)
+      val result = loadFile(uploadedBy, identifiers, uploadTime, filename)(req)
+      result.onComplete { _ => req.body.file.delete() }
+
+      result
     }
 
   def importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]) =


### PR DESCRIPTION
This function was previously performed by the [AuthenticatedUpload](https://github.com/guardian/grid/blob/4b268f3130f6b3b4abc92f78c41aabe95a7c9883/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala#L51) action builder which was removed in the Play 2.6 upgrade (#2124).

Wire image imports are unaffected since they already have code to delete the file.