### PR TITLE
log to disk in addition to stdout

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,3 @@
 -J-Xmx4096M
 -J-XX:MaxMetaspaceSize=1024M
+-DSTAGE=DEV

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,10 @@ lazy val commonLib = project("common-lib").settings(
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
     "org.scalacheck" %% "scalacheck" % "1.14.0",
+
+    // needed to parse conditional statements in `logback.xml`
+    // i.e. to only log to disk in DEV
+    // see: https://logback.qos.ch/setup.html#janino
     "org.codehaus.janino" % "janino" % "3.0.6"
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,8 @@ lazy val commonLib = project("common-lib").settings(
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
-    "org.scalacheck" %% "scalacheck" % "1.14.0"
+    "org.scalacheck" %% "scalacheck" % "1.14.0",
+    "org.codehaus.janino" % "janino" % "3.0.6"
   )
 )
 

--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -30,8 +30,14 @@
     <logger name="request" level="INFO" />
 
     <root level="WARN">
-        <appender-ref ref="LOGFILE"/>
         <appender-ref ref="ASYNCSTDOUT" />
+
+        <!-- only log to disk in DEV -->
+        <if condition='property("STAGE").contains("DEV")'>
+            <then>
+                <appender-ref ref="LOGFILE"/>
+            </then>
+        </if>
     </root>
 
 </configuration>

--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -2,6 +2,19 @@
 
     <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${application.home}/logs/application.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${application.home}/logs/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date - [%level] - from %logger in %thread %n%message%n%xException%n</pattern>
+        </encoder>
+    </appender>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
@@ -17,6 +30,7 @@
     <logger name="request" level="INFO" />
 
     <root level="WARN">
+        <appender-ref ref="LOGFILE"/>
         <appender-ref ref="ASYNCSTDOUT" />
     </root>
 


### PR DESCRIPTION
Now that we're running all projects in a single command, filtering the logs from a specific app is impossible. Logging to disk allows us to see app specific logs under the logs directory of the app.