### PR TITLE
Add an demo endpoint for Eyevine

### DIFF
--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -36,6 +36,8 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
         "App"   -> Seq(elasticsearchApp)
       ))
 
+  lazy val exampleImageId = properties("example.image.id")
+
   lazy val imageBucket: String = properties("s3.image.bucket")
   lazy val thumbBucket: String = properties("s3.thumb.bucket")
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -12,13 +12,14 @@ GET     /images/edits/:field                          controllers.SuggestionCont
 GET     /images/aggregations/date/:field              controllers.AggregationController.dateHistogram(field: String, q: Option[String])
 
 # Images
+GET     /images/example                               controllers.MediaApi.imageSearch(isExample: Boolean = true)
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
 POST    /images/:id/reindex                           controllers.MediaApi.reindexImage(id: String)
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
-GET     /images                                       controllers.MediaApi.imageSearch
+GET     /images                                       controllers.MediaApi.imageSearch(isExample: Boolean = false)
 
 # completion
 GET     /suggest/metadata/credit                      controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])


### PR DESCRIPTION
Adding a `/images/example` endpoint for demo purposes that always return the same image.