### PR TITLE
Fix silly cast to BoxedUnit exception

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -59,7 +59,7 @@ class DynamoDB(config: CommonConfig, tableName: String) {
 
   def deleteItem(id: String)(implicit ex: ExecutionContext): Future[Unit] = Future {
     table.deleteItem(new DeleteItemSpec().withPrimaryKey(IdKey, id))
-  }.mapTo[Unit]
+  }
 
   def booleanGet(id: String, key: String)
                 (implicit ex: ExecutionContext): Future[Option[Boolean]] =


### PR DESCRIPTION
An upgrade to Scanamo changed the return type of `deleteItem` from `Unit` to an AWS SDK `DeleteItemOutcome`, hence the following call to `mapTo[Unit]` failed.

This meant users deleting a collection were shown an error message even though the delete worked just fine. The solution is to simply avoid `mapTo` and the compiler works everything out.