### PR TITLE
Fix dragging Guardian Witness URL

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -25,6 +25,8 @@ class Services(val domainRoot: String, isProd: Boolean) {
   val leasesBaseUri      = baseUri(leasesHost)
   val authBaseUri        = baseUri(authHost)
 
+  val guardianWitnessBaseUri: String = "https://n0ticeapis.com"
+
   val toolsDomains: Set[String] = if(isProd) {
     Set(domainRoot)
   } else {

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -27,7 +27,8 @@ object KahunaSecurityConfig {
       config.services.usageBaseUri,
       config.services.collectionsBaseUri,
       config.services.leasesBaseUri,
-      config.services.authBaseUri
+      config.services.authBaseUri,
+      config.services.guardianWitnessBaseUri
     )
 
     val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com"

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -135,8 +135,10 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track', 
                 // or `data` (uris etc) ondragenter, only drop.
                 const types       = Array.from(e.dataTransfer.types);
 
-                // Dragging out of the Firefox URL bar uses a Mozilla specific MIME type without text/uri-list as a fallback
-                const isUri       = hasType(types, 'text/uri-list') || hasType(types, 'text/x-moz-url');
+                // Dragging out of the Firefox URL bar uses a Mozilla specific MIME type without
+                // text/uri-list as a fallback
+                const isUri = hasType(types, 'text/uri-list') || hasType(types, 'text/x-moz-url');
+
                 const hasFiles    = hasType(types, 'Files');
                 const isGridImage = hasGridMimetype(types);
 

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -134,7 +134,9 @@ dndUploader.directive('dndUploader', ['$window', 'delay', 'safeApply', 'track', 
                 // we search through the types array as we don't have the `files`
                 // or `data` (uris etc) ondragenter, only drop.
                 const types       = Array.from(e.dataTransfer.types);
-                const isUri       = hasType(types, 'text/uri-list');
+
+                // Dragging out of the Firefox URL bar uses a Mozilla specific MIME type without text/uri-list as a fallback
+                const isUri       = hasType(types, 'text/uri-list') || hasType(types, 'text/x-moz-url');
                 const hasFiles    = hasType(types, 'Files');
                 const isGridImage = hasGridMimetype(types);
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -55,7 +55,7 @@ class MediaApi(auth: Authentication, notifications: Notifications, elasticSearch
       Link("loader",          config.loaderUri),
       Link("edits",           config.metadataUri),
       Link("session",         s"${config.authUri}/session"),
-      Link("witness-report",  s"https://n0ticeapis.com/2/report/{id}"),
+      Link("witness-report",  s"${config.services.guardianWitnessBaseUri}/2/report/{id}"),
       Link("collections",     config.collectionsUri),
       Link("permissions",     s"${config.rootUri}/permissions"),
       Link("leases",          config.leasesUri)


### PR DESCRIPTION
Ronseal. CORS was blocking the JS in Kahuna from talking to the Guardian Witness API to fill in an image import request.

I also found a bug where the dragging didn't work at all from the Firefox address bar since it is using some funny Mozilla-specific MIME type.