### PR TITLE
reduce size of collections panel

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.css
@@ -65,7 +65,7 @@ gr-nodes, gr-node,
     padding: 5px 10px;
     border-bottom: 1px solid #565656;
     position: fixed;
-    width: 270px;
+    width: 250px;
     background-color: #444;
     margin-top: -35px;
     z-index: 10;
@@ -82,5 +82,5 @@ gr-collection-tree > :first-child {
 }
 
 gr-collection-tree {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
 }

--- a/kahuna/public/js/components/gr-panels/gr-panels.css
+++ b/kahuna/public/js/components/gr-panels/gr-panels.css
@@ -14,6 +14,11 @@
     width: 290px;
 }
 
+.gr-panel--locked:first-child {
+  width: 230px;
+  box-sizing: border-box; /* @TODO: Apply border-box to everything, then resize everything that breaks */
+}
+
 .gr-panel__content {
     width: 290px;
     position: fixed;
@@ -32,6 +37,7 @@
 }
 .gr-panel__content--left {
     left: 0;
+    width: 250px;
 }
 
 .gr-panel__content--right {


### PR DESCRIPTION
For something relatively small, it took up an awful lot of screen estate up, especially on a laptop

## Before:
![largercollections](https://user-images.githubusercontent.com/2104095/40912551-cdfbf7da-67e9-11e8-8474-52f90e5f84ee.png)


## After:
![smaller-collections](https://user-images.githubusercontent.com/2104095/40912523-b9c7e09e-67e9-11e8-933c-5577be31e241.png)
