### PR TITLE
check if filter is already set before unsetting it

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -162,8 +162,11 @@ query.controller('SearchQueryCtrl',
     mediaApi.getSession().then(session => {
         ctrl.user = session.user;
         ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
-        ctrl.filter.nonFree = session.user.permissions.showPaid ?
-          session.user.permissions.showPaid : undefined;
+
+        if (ctrl.filter.nonFree === undefined) {
+          ctrl.filter.nonFree = session.user.permissions.showPaid ?
+            session.user.permissions.showPaid : undefined;
+        }
     });
 
     function resetQuery() {


### PR DESCRIPTION
The permissions change had an unwanted side effect of resetting the `nonFree` query param whenever you went back to the search page.