### PR TITLE
include angular-hotkeys css to render the modal

### DIFF
--- a/kahuna/public/js/components/gr-keyboard-shortcut/gr-keyboard-shortcut.js
+++ b/kahuna/public/js/components/gr-keyboard-shortcut/gr-keyboard-shortcut.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-hotkeys';
-
+import 'angular-hotkeys/build/hotkeys.min.css';
 import '../../analytics/track';
 
 const module = angular.module('gr.keyboardShortcut', [


### PR DESCRIPTION
We're using the angular-hotkeys module for keyboard shortcuts. We need to include their css for the help modal to render correctly (it currently doesn't render).

I suspect this broke when we moved to webpack. See https://github.com/guardian/grid/pull/1552#issuecomment-165063633.

Not entirely convinced this is webpack best practice either. Maybe [resolve](https://webpack.js.org/configuration/resolve/#resolve-alias) is better? cc @RichieAHB 

# After
Pressing `shift + ?` shows:
![image](https://user-images.githubusercontent.com/836140/41040547-9fdd8c22-6994-11e8-84f4-a3a67e8636bc.png)
