### PR TITLE
don't log to console in DEV

### DIFF
--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -30,13 +30,14 @@
     <logger name="request" level="INFO" />
 
     <root level="WARN">
-        <appender-ref ref="ASYNCSTDOUT" />
-
         <!-- only log to disk in DEV -->
         <if condition='property("STAGE").contains("DEV")'>
             <then>
                 <appender-ref ref="LOGFILE"/>
             </then>
+            <else>
+                <appender-ref ref="ASYNCSTDOUT" />
+            </else>
         </if>
     </root>
 


### PR DESCRIPTION
With this number of services, it very hard to parse console logs for anything meaningful as the console contains log lines from all the services.

In DEV, lets stick with each service wrtinging to their own log file.