### PR TITLE
introduce a syndication tier and replace external with readonly

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import com.gu.editorial.permissions.client.Permission
 import com.gu.mediaservice.lib.argo._
-import com.gu.mediaservice.lib.argo.model.{Action, _}
+import com.gu.mediaservice.lib.argo.model._
 import com.gu.mediaservice.lib.auth.Authentication.{AuthenticatedService, PandaUser, Principal}
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.cleanup.{MetadataCleaners, SupplierProcessors}
@@ -101,10 +101,10 @@ class MediaApi(auth: Authentication, notifications: Notifications, elasticSearch
     isUploaderOrHasPermission(request, source, Permissions.DeleteImage)
   }
 
-  private def hasStaffPhotographer(json: JsValue): Boolean = (json \ "usageRights" \ "category").validate[String].asOpt.contains(StaffPhotographer.category)
+  private def isSyndicateable(json: JsValue): Boolean = (json \ "syndicationRights" \ "rights" \ "acquired").validate[Boolean].getOrElse(false)
 
   private def hasPermission(request: Authentication.Request[Any], json: JsValue): Boolean = request.user.apiKey.tier match {
-    case External if !hasStaffPhotographer(json) => false
+    case Syndication => isSyndicateable(json)
     case _ => true
   }
 

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import com.gu.mediaservice.lib.auth.{External, Tier}
+import com.gu.mediaservice.lib.auth.{Syndication, Tier}
 import com.gu.mediaservice.lib.elasticsearch.ImageFields
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.lib.config.UsageRightsConfig
@@ -72,8 +72,10 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
 
   val staffFilter: FilterBuilder = filters.term("usageRights.category", StaffPhotographer.category)
 
+  val syndicatableFilter: FilterBuilder = filters.bool.must(filters.boolTerm("syndicationRights.rights.acquired", value = true))
+
   def tierFilter(tier: Tier): Option[FilterBuilder] = tier match {
-    case External => Some(staffFilter)
+    case Syndication => Some(syndicatableFilter)
     case _ => None
   }
 

--- a/media-api/test/lib/ElasticSearchHelper.scala
+++ b/media-api/test/lib/ElasticSearchHelper.scala
@@ -25,7 +25,7 @@ trait ElasticSearchHelper extends MockitoSugar {
 
   val testUser = "yellow-giraffe@theguardian.com"
 
-  def createImage(usageRights: UsageRights) = {
+  def createImage(usageRights: UsageRights, syndicationRights: Option[SyndicationRights] = None) = {
     val id = UUID.randomUUID().toString
     Image(
       id = id,
@@ -53,8 +53,15 @@ trait ElasticSearchHelper extends MockitoSugar {
       originalMetadata = ImageMetadata(),
       usageRights = usageRights,
       originalUsageRights = usageRights,
-      exports = Nil
+      exports = Nil,
+      syndicationRights = syndicationRights
     )
+  }
+
+  def createImageWithSyndicationRights(usageRights: UsageRights, rightsAcquired: Boolean): Image = {
+    val rights = List( Right("test", Some(rightsAcquired), Nil) )
+    val syndicationRights = SyndicationRights(None, Nil, rights)
+    createImage(usageRights, Some(syndicationRights))
   }
 
   def saveToES(image: Image) = {


### PR DESCRIPTION
With the new syndication rights model provided by RCS, we can simplfy the api tier policy. The tiers are now:
- Internal - full api access, typically a Grid service such as S3 Watcher. Can perform any action on any image and endpoint.
- Readonly - an Editorial Tool that needs Grid API access, such as Fronts. Can only perform GET actions.
- Syndication - a syndication partner. Can only GET images that are syndicatable, as informed by the RCS feed