### PR TITLE
Encode path when delete

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -15,6 +15,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc.{BaseController, ControllerComponents}
 import store.{CollectionsStore, CollectionsStoreError}
+import com.gu.mediaservice.lib.net.{ URI => UriOps }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -148,11 +149,11 @@ class CollectionsController(authenticated: Authentication, config: CollectionsCo
     }
 
   def removeCollection(collectionPath: String) = authenticated.async { req =>
-    val path = CollectionsManager.uriToPath(collectionPath)
+    val path = CollectionsManager.uriToPath(UriOps.encode(collectionPath))
 
     hasChildren(path).flatMap { noRemove =>
       if(noRemove) {
-        throw new HasChildrenError(
+        throw HasChildrenError(
           s"$collectionPath has children, can't delete!"
         )
       } else {


### PR DESCRIPTION
We have a collection that contains a `+` character in the path which means it can't be deleted.

The reason is because the `+` will be decoded into a space and when we look for it in DynamoDb it won't match anything.

e.g:
Given collection `Sport/gsport/AL+Cricket` with the DynamoDb entry `sport/gsport/al+cricket` => it'll be transformed into `sport/gsport/al cricket` => nothing will be deleted as it doesn't exist.