### PR TITLE
add `hasRightsAcquired` filter to media api

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -30,7 +30,7 @@ class MediaApi(auth: Authentication, notifications: Notifications, elasticSearch
     "since", "until", "modifiedSince", "modifiedUntil", "takenSince", "takenUntil",
     "uploadedBy", "archived", "valid", "free", "payType",
     "hasExports", "hasIdentifier", "missingIdentifier", "hasMetadata",
-    "persisted", "usageStatus", "usagePlatform").mkString(",")
+    "persisted", "usageStatus", "usagePlatform", "hasRightsAcquired").mkString(",")
 
   private val searchLinkHref = s"${config.rootUri}/images{?$searchParamList}"
 

--- a/media-api/app/controllers/SearchParams.scala
+++ b/media-api/app/controllers/SearchParams.scala
@@ -38,7 +38,8 @@ case class SearchParams(
   persisted: Option[Boolean] = None,
   usageStatus: List[String] = List.empty,
   usagePlatform: List[String] = List.empty,
-  tier: Tier
+  tier: Tier,
+  hasRightsAcquired: Option[Boolean] = None
 )
 
 case class InvalidUriParams(message: String) extends Throwable
@@ -105,7 +106,8 @@ object SearchParams {
       request.getQueryString("persisted") flatMap parseBooleanFromQuery,
       commaSep("usageStatus"),
       commaSep("usagePlatform"),
-      request.user.apiKey.tier
+      request.user.apiKey.tier,
+      request.getQueryString("hasRightsAcquired") flatMap parseBooleanFromQuery
     )
   }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -99,12 +99,28 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       params.usageStatus.toNel.map(filters.terms(usagesField("status"), _)) ++
       params.usagePlatform.toNel.map(filters.terms(usagesField("platform"), _))
 
+    val rightsAcquiredFilter = params.hasRightsAcquired.map(searchFilters.rightsAcquiredFilter)
+
     val filterOpt = (
-      metadataFilter.toList ++ persistFilter ++ labelFilter ++ archivedFilter ++
-      uploadedByFilter ++ idsFilter ++ validityFilter ++ simpleCostFilter ++ costFilter ++
-      hasExports ++ hasIdentifier ++ missingIdentifier ++ dateFilter ++
-      usageFilter ++ hasRightsCategory ++ searchFilters.tierFilter(params.tier)
+      metadataFilter.toList
+      ++ persistFilter
+      ++ labelFilter
+      ++ archivedFilter
+      ++ uploadedByFilter
+      ++ idsFilter
+      ++ validityFilter
+      ++ simpleCostFilter
+      ++ costFilter
+      ++ hasExports
+      ++ hasIdentifier
+      ++ missingIdentifier
+      ++ dateFilter
+      ++ usageFilter
+      ++ hasRightsCategory
+      ++ searchFilters.tierFilter(params.tier)
+      ++ rightsAcquiredFilter
     ).toNel.map(filter => filter.list.reduceLeft(filters.and(_, _)))
+
     val filter = filterOpt getOrElse filters.matchAll
 
     val queryFiltered = new FilteredQueryBuilder(query, filter)

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -72,10 +72,16 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
 
   val staffFilter: FilterBuilder = filters.term("usageRights.category", StaffPhotographer.category)
 
-  val syndicatableFilter: FilterBuilder = filters.bool.must(filters.boolTerm("syndicationRights.rights.acquired", value = true))
+  def rightsAcquiredFilter(isAcquired: Boolean): FilterBuilder =
+    filters.bool.must(
+      filters.boolTerm(
+        field = "syndicationRights.rights.acquired",
+        value = isAcquired
+      )
+    )
 
   def tierFilter(tier: Tier): Option[FilterBuilder] = tier match {
-    case Syndication => Some(syndicatableFilter)
+    case Syndication => Some(rightsAcquiredFilter(isAcquired = true))
     case _ => None
   }
 


### PR DESCRIPTION
`hasRightsAcquired` is an optional parameter:
- `true` returns images that have rights acquired
- `false` returns images that do not have rights acquired

Note: setting this value will only return images that have been processed by the RCS feed.