### PR TITLE
filter for rights acquired images in the frontend via a query string

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -121,7 +121,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
 
     $stateProvider.state('search.results', {
         url: 'search?{query:Query}&ids&since&nonFree&payType&uploadedBy&until&orderBy' +
-             '&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil',
+             '&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil&hasRightsAcquired',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -323,7 +323,8 @@ results.controller('SearchResultsCtrl', [
                 since:      since,
                 offset:     offset,
                 length:     length,
-                orderBy:    orderBy
+                orderBy:    orderBy,
+                hasRightsAcquired: $stateParams.hasRightsAcquired
             }));
         }
 

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -16,8 +16,7 @@ mediaApi.factory('mediaApi',
     function search(query = '', {ids, since, until, archived, valid, free,
                                  payType, uploadedBy, offset, length, orderBy,
                                  takenSince, takenUntil,
-                                 modifiedSince, modifiedUntil} = {}) {
-
+                                 modifiedSince, modifiedUntil, hasRightsAcquired} = {}) {
         return root.follow('search', {
             q:          query,
             since:      since,
@@ -34,8 +33,21 @@ mediaApi.factory('mediaApi',
             archived:   archived,
             offset:     offset,
             length:     angular.isDefined(length) ? length : 50,
-            orderBy:    getOrder(orderBy)
+            orderBy:    getOrder(orderBy),
+            hasRightsAcquired: getHasRightsAcquired(hasRightsAcquired)
         }).get();
+    }
+
+    function getHasRightsAcquired(hasRightsAcquired) {
+        if (hasRightsAcquired === 'true') {
+            return true;
+        }
+
+        if (hasRightsAcquired === 'false') {
+            return false;
+        }
+
+        return undefined;
     }
 
     function getOrder(orderBy) {


### PR DESCRIPTION
depends on https://github.com/guardian/grid/pull/2175

Reads the value of `hasRightsAcquired` from the query string and passes it onto the API.