### PR TITLE
Encode space as %20

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -149,7 +149,7 @@ class CollectionsController(authenticated: Authentication, config: CollectionsCo
     }
 
   def removeCollection(collectionPath: String) = authenticated.async { req =>
-    val path = CollectionsManager.uriToPath(UriOps.encode(collectionPath))
+    val path = CollectionsManager.uriToPath(UriOps.encodePlus(collectionPath))
 
     hasChildren(path).flatMap { noRemove =>
       if(noRemove) {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/net/URI.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/net/URI.scala
@@ -3,6 +3,8 @@ package com.gu.mediaservice.lib.net
 import java.net.{URLDecoder, URLEncoder}
 
 object URI {
-  def encode(uri: String) = URLEncoder.encode(uri, "UTF-8")
-  def decode(uri: String) = URLDecoder.decode(uri, "UTF-8")
+  def encode(uri: String): String = URLEncoder.encode(uri, "UTF-8").replace("+", "%20")
+  def decode(uri: String): String = URLDecoder.decode(uri, "UTF-8")
+
+  def encodePlus(uri: String): String = uri.replace("+", "%2B")
 }


### PR DESCRIPTION
Both the `+` character and the space character reached the controller as `+` creating confusion when decoding.

This ensures space is encoded as `%20` and `+` as `%2B`.