### PR TITLE
Metadata-extractor lib upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val commonLib = project("common-lib").settings(
     "org.elasticsearch" % "elasticsearch" % "1.7.6",
     "com.gu" %% "box" % "0.2.0",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
-    "com.drewnoakes" % "metadata-extractor" % "2.8.1",
+    "com.drewnoakes" % "metadata-extractor" % "2.11.0",
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
@@ -20,9 +20,9 @@ package object formatting {
       withZoneUTC
   }
 
-  val dateTimeFormat = ISODateTimeFormat.dateTimeNoMillis.withZoneUTC
+  val dateTimeFormat = parseDateTimeFormat.withZoneUTC
 
-  def printDateTime(date: DateTime): String = dateTimeFormat.print(date)
+  def printDateTime(date: DateTime): String = date.toString()
   def printOptDateTime(date: Option[DateTime]): Option[String] = date.map(printDateTime)
 
   // Only use this on dates that have been confidently written using printDateTime

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -52,12 +52,16 @@ object ImageMetadataConverter {
   private lazy val randomDateFormat = {
     val parsers = Array(
       // 2014-12-16T02:23:45+01:00 - Standard dateTimeNoMillis
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser,
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
       // 2014-12-16T02:23+01:00 - Same as above but missing seconds lol
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm.SSSZZ").getParser,
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mmZZ").getParser,
       // Tue Dec 16 01:23:45 GMT 2014 - Let's make machine metadata human readable!
-      DateTimeFormat.forPattern("E MMM d HH:mm:ss z yyyy").getParser,
-      DateTimeFormat.forPattern("E MMM d HH:mm:ss 'BST' yyyy").getParser,
+      DateTimeFormat.forPattern("E MMM dd HH:mm:ss.SSS z yyyy").getParser,
+      DateTimeFormat.forPattern("E MMM dd HH:mm:ss z yyyy").getParser,
+      DateTimeFormat.forPattern("E MMM dd HH:mm:ss.SSS 'BST' yyyy").getParser,
+      DateTimeFormat.forPattern("E MMM dd HH:mm:ss 'BST' yyyy").getParser,
       // 2014-12-16 - Maybe it's just a date
       ISODateTimeFormat.date.getParser
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -19,8 +19,7 @@ object ImageMetadataConverter {
       .get("Category")
 
     (supplementalCategories ::: category.toList)
-      .map(Subject.create)
-      .flatten
+      .flatMap(Subject.create)
       .map(_.toString)
       .distinct
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -8,7 +8,6 @@ case class FileMetadata(
   iptc: Map[String, String]                     = Map(),
   exif: Map[String, String]                     = Map(),
   exifSub: Map[String, String]                  = Map(),
-  xmp: Map[String, String]                      = Map(),
   icc: Map[String, String]                      = Map(),
   getty: Map[String, String]                    = Map(),
   colourModel: Option[String]                   = None,
@@ -23,7 +22,6 @@ object FileMetadata {
     (__ \ "iptc").read[Map[String,String]] ~
     (__ \ "exif").read[Map[String,String]] ~
     (__ \ "exifSub").read[Map[String,String]] ~
-    (__ \ "xmp").read[Map[String,String]] ~
     (__ \ "icc").readNullable[Map[String,String]].map(_ getOrElse Map()) ~
     (__ \ "getty").readNullable[Map[String,String]].map(_ getOrElse Map()) ~
     (__ \ "colourModel").readNullable[String] ~

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -8,6 +8,7 @@ case class FileMetadata(
   iptc: Map[String, String]                     = Map(),
   exif: Map[String, String]                     = Map(),
   exifSub: Map[String, String]                  = Map(),
+  xmp: Map[String, String]                      = Map(),
   icc: Map[String, String]                      = Map(),
   getty: Map[String, String]                    = Map(),
   colourModel: Option[String]                   = None,
@@ -22,6 +23,7 @@ object FileMetadata {
     (__ \ "iptc").read[Map[String,String]] ~
     (__ \ "exif").read[Map[String,String]] ~
     (__ \ "exifSub").read[Map[String,String]] ~
+    (__ \ "xmp").read[Map[String,String]] ~
     (__ \ "icc").readNullable[Map[String,String]].map(_ getOrElse Map()) ~
     (__ \ "getty").readNullable[Map[String,String]].map(_ getOrElse Map()) ~
     (__ \ "colourModel").readNullable[String] ~

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -86,6 +86,12 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45")))
   }
 
+  it("should populate the dateTaken field of ImageMetadata from EXIF Date/Time Original Composite with milliseconds (Mon Jun 18 01:23:45.025 BST 2018)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map("Date/Time Original Composite" -> "Mon Jun 18 01:23:45.025 BST 2018"), xmp = Map())
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45.025")))
+  }
+
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Time Created Composite (Mon Jun 18 01:23:45 BST 2018)") {
     val fileMetadata = FileMetadata(iptc = Map("Date Time Created Composite" -> "Mon Jun 18 01:23:45 BST 2018"), exif = Map(), exifSub = Map(), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -78,72 +78,85 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
 
   // Date Taken
 
-  def normalizeDate(dateTime: DateTime) = dateTime.withZone(DateTimeZone.UTC)
+  private def parseDate(dateTime: String) = DateTime.parse(dateTime).withZone(DateTimeZone.UTC)
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (2014-12-16T02:23:45+01:00)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "2014-12-16T02:23:45+01:00"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from EXIF Date/Time Original Composite (Mon Jun 18 01:23:45 BST 2018)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map("Date/Time Original Composite" -> "Mon Jun 18 01:23:45 BST 2018"), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45Z")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45")))
   }
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (2014-12-16T02:23+01:00)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "2014-12-16T02:23+01:00"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from IPTC Date Time Created Composite (Mon Jun 18 01:23:45 BST 2018)") {
+    val fileMetadata = FileMetadata(iptc = Map("Date Time Created Composite" -> "Mon Jun 18 01:23:45 BST 2018"), exif = Map(), exifSub = Map(), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:00Z")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45")))
   }
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 GMT 2014)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 GMT 2014"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16T02:23:45+01:00)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2014-12-16T02:23:45+01:00"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45Z")))
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45Z")))
   }
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 UTC 2014)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 UTC 2014"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16T02:23+01:00)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2014-12-16T02:23+01:00"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45Z")))
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:00Z")))
   }
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 BST 2014)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 BST 2014"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 GMT 2014)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 GMT 2014"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45+01:00").withZone(DateTimeZone.UTC)))
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45Z")))
   }
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (Tue Dec 16 01:23:45 PDT 2014)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "Tue Dec 16 01:23:45 PDT 2014"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 UTC 2014)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 UTC 2014"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T01:23:45-08:00").withZone(DateTimeZone.UTC)))
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45Z")))
   }
 
-  it("should populate the dateTaken field of ImageMetadata from IPTC Date Created (2014-12-16)") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "2014-12-16"), Map(), Map(), Map())
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 BST 2014)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 BST 2014"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45")))
+  }
+
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 PDT 2014)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 PDT 2014"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45-08:00")))
+  }
+
+  it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2014-12-16"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T00:00:00Z")))
   }
 
-  it("should leave the dateTaken field of ImageMetadata empty if IPTC Date Created is not a valid date") {
-    val fileMetadata = FileMetadata(Map("Date Created" -> "not a date"), Map(), Map(), Map())
+  it("should leave the dateTaken field of ImageMetadata empty if no date present") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be ('empty)
+    imageMetadata.dateTaken should be (None)
   }
 
-
-  it("should populate the dateTaken field of ImageMetadata from EXIF Sub Date/Time Original if present") {
-    // Thankfully standard datetime format (albeit weird and with no TZ offset)
-    val fileMetadata = FileMetadata(Map(), Map(), Map("Date/Time Original" -> "2014:12:16 01:23:45"), Map())
+  it("should leave the dateTaken field of ImageMetadata empty if EXIF Date/Time Original Composite is not a valid date") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map("Date/Time Original Composite" -> "not a date"), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    // Note: we assume UTC as timezone (not necessarily correct but no way to tell)
-    imageMetadata.dateTaken should be (Some(new DateTime("2014-12-16T01:23:45Z")))
+    imageMetadata.dateTaken should be (None)
   }
 
-  it("should leave the dateTaken field of ImageMetadata empty if EXIF Sub Date/Time Original is not a valid date") {
-    // Thankfully standard datetime format (albeit weird and with no TZ offset)
-    val fileMetadata = FileMetadata(Map(), Map(), Map("Date/Time Original" -> "not a date"), Map())
+  it("should leave the dateTaken field of ImageMetadata empty if IPTC Date Time Created Composite is not a valid date") {
+    val fileMetadata = FileMetadata(iptc = Map("Date Time Created Composite" -> "not a date"), exif = Map(), exifSub = Map(), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be ('empty)
+    imageMetadata.dateTaken should be (None)
   }
 
+  it("should leave the dateTaken field of ImageMetadata empty if XMP photoshop:DateCreated is not a valid date") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "not a date"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be (None)
+  }
 
   // Keywords
 

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -26,20 +26,14 @@ object FileMetadataReader {
     for {
       metadata <- readMetadata(image)
     }
-    yield {
-      // FIXME: JPEG, JFIF, Photoshop, GPS, File
-
-     getMetadataWithICPTCHeaders(metadata)
-    }
+    yield getMetadataWithICPTCHeaders(metadata) // FIXME: JPEG, JFIF, Photoshop, GPS, File
 
   def fromICPTCHeadersWithColorInfo(image: File): Future[FileMetadata] =
     for {
-      metadata               <- readMetadata(image)
+      metadata <- readMetadata(image)
       colourModelInformation <- getColorModelInformation(image, metadata)
     }
-    yield {
-      getMetadataWithICPTCHeaders(metadata).copy(colourModelInformation = colourModelInformation)
-    }
+    yield getMetadataWithICPTCHeaders(metadata).copy(colourModelInformation = colourModelInformation)
 
   private def getMetadataWithICPTCHeaders(metadata: Metadata): FileMetadata =
     FileMetadata(

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -1,6 +1,8 @@
 package lib.imaging
 
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.concurrent.Executors
 
 import com.drew.imaging.ImageMetadataReader
@@ -64,13 +66,13 @@ object FileMetadataReader {
       directory match {
         case d: IptcDirectory =>
           val dateTimeCreated = try {
-            Map("Date Time Created Composite" -> d.getDateCreated.toString)
+            Map("Date Time Created Composite" -> dateToString(d.getDateCreated))
           } catch {
             case _: Throwable => Map()
           }
 
           val digitalDateTimeCreated = try {
-            Map("Digital Date Time Created Composite" -> d.getDigitalDateCreated.toString)
+            Map("Digital Date Time Created Composite" -> dateToString(d.getDigitalDateCreated))
           } catch {
             case _: Throwable => Map()
           }
@@ -79,7 +81,7 @@ object FileMetadataReader {
 
         case d: ExifSubIFDDirectory =>
           val dateTimeCreated = try {
-            Map("Date/Time Original Composite" -> d.getDateOriginal.toString)
+            Map("Date/Time Original Composite" -> dateToString(d.getDateOriginal))
           } catch {
             case _: Throwable => Map()
           }
@@ -121,6 +123,7 @@ object FileMetadataReader {
       ).flattenOptions
   }
 
+  private def dateToString(date: Date): String = new SimpleDateFormat("E MMM dd HH:mm:ss.SSS z yyyy").format(date.getTime)
 
   def dimensions(image: File, mimeType: Option[String]): Future[Option[Dimensions]] =
     for {

--- a/image-loader/test/scala/lib/ResourceHelpers.scala
+++ b/image-loader/test/scala/lib/ResourceHelpers.scala
@@ -2,7 +2,6 @@ package test.lib
 
 import java.io.File
 
-
 object ResourceHelpers {
 
   def fileAt(resourcePath: String): File = {

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -129,7 +129,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Object Name" -> "CRICKET England Moeen 111162",
         "Reference Date" -> "2015:04:02",
         "Original Transmission Reference" -> "CRICKET_England_Moeen_111162.JPG",
-        "Date Created" -> "Thu Apr 02 16:10:41 BST 2015"
+        "Date Created" -> "2015:04:02",
+        "Date Time Created Composite" -> "Thu Apr 02 16:10:41 BST 2015"
       )
       val exif = Map(
         "Image Description" -> "England's Moeen Ali plays defensively from the bowling of Sri Lanka's Shaminda Eranga, during day five of the second Investec Test match at Headingley, Leeds. PRESS ASSOCIATION Photo. Picture date: Tuesday June 24, 2014. See PA Story CRICKET England. Photo credit should read: Martin Rickett/PA Wire. Editorial use only. RESTRICTIONS: Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
@@ -158,6 +159,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "White Balance" -> "Unknown",
         "Focal Length" -> "600 mm",
         "Date/Time Original" -> "2014:06:24 15:10:41",
+        "Date/Time Original Composite" -> "Tue Jun 24 16:10:41 BST 2014",
         "White Balance Mode" -> "Auto white balance",
         "Exif Image Width" -> "1264 pixels",
         "Gain Control" -> "Low gain up",
@@ -203,7 +205,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Time Created" -> "01:08:44+0000",
       "By-line" -> "Graham Turner",
       "Object Name" -> "Tulips",
-      "Date Created" -> "Wed Apr 15 02:08:44 BST 2015"
+      "Date Created" -> "2015:04:15",
+      "Date Time Created Composite" -> "Wed Apr 15 02:08:44 BST 2015"
     )
     val exif = Map(
       "Image Description" -> "Reuben Smith age 5 from Hampshire and  \"Darwin Hybrid Mix' tulips in the cut flower Garden at Arundel Castle.\n18,000 tulips were planted in  a total of 52,000 spring bulbs last autumn.\nPhotograph: Graham Turner.",
@@ -229,6 +232,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Flash" -> "Flash did not fire, auto",
       "Focal Length" -> "88 mm",
       "Date/Time Original" -> "2015:04:15 01:08:44",
+      "Date/Time Original Composite" -> "Wed Apr 15 02:08:44 BST 2015",
       "White Balance Mode" -> "Auto white balance",
       "Shutter Speed Value" -> "1/1599 sec",
       "Exif Image Width" -> "5760 pixels",

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -1,13 +1,9 @@
 package test.lib.imaging
 
-import java.io.File
-
+import lib.imaging.FileMetadataReader
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.concurrent.ScalaFutures
-
-import lib.imaging.FileMetadataReader
-
 
 /**
  * Test that the Reader returns the expected FileMetadata.
@@ -73,7 +69,6 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       sameMaps(metadata.iptc, iptc)
       sameMaps(metadata.exif, exif)
       sameMaps(metadata.exifSub, Map())
-      sameMaps(metadata.xmp, Map())
       sameMaps(metadata.getty, getty)
     }
   }
@@ -91,6 +86,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Caption/Abstract" -> "01 Apr 2015, Akron, Ohio, USA --- April 1, 2015 - Akron, Ohio, U.S. - Former Navy SEAL CHRISTOPHER HEBEN gestures as he describes how he could only see the eyes for the driver of the car before he was shot during questioning by his lawyer James L. Burdon as he testifies in his own defense in Akron Municipal Court. Heben, 45, is charged with falsification and obstructing official business. (Credit Image: © Mike Cardew/TNS/ZUMA Wire) --- Image by © Mike Cardew/ZUMA Press/Corbis",
         "Credit" -> "© Mike Cardew/ZUMA Press/Corbis",
         "Source" -> "Corbis",
+        "Image Orientation" -> "L",
         "City" -> "Akron",
         "Keywords" -> "Akron;clj;Great Lakes States;Midwest;North America;Ohio;Summit County;thepicturesoftheday.com;USA;zmct;zumapress.com",
         "By-line" -> "Mike Cardew",
@@ -99,16 +95,12 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Province/State" -> "Ohio",
         "Object Name" -> "42-70266837",
         "Original Transmission Reference" -> "70266837",
-        "Date Created" -> "Wed Apr 01 00:00:00 BST 2015"
-      )
-      val xmp = Map(
-        "Subject" -> "Akron clj Great Lakes States Midwest North America Ohio Summit County thepicturesoftheday.com USA zmct zumapress.com"
+        "Date Created" -> "2015:04:01"
       )
 
       sameMaps(metadata.iptc, iptc)
       sameMaps(metadata.exif, Map())
       sameMaps(metadata.exifSub, Map())
-      sameMaps(metadata.xmp, xmp)
       sameMaps(metadata.getty, Map())
     }
   }
@@ -127,6 +119,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Caption/Abstract" -> "File photo dated 24-06-2014 of England's Moeen Ali. PRESS ASSOCIATION Photo. Issue date: Thursday April 2, 2015. Moeen Ali is planning to join England for the latter stages of their Test tour of the West Indies, as his side injury continues to improve. See PA story CRICKET England Moeen. Photo credit should read Martin Rickett/PA Wire.",
         "Credit" -> "PA",
         "Source" -> "PA",
+        "Image Orientation" -> "P",
         "City" -> "Leeds",
         "Keywords" -> "cricket england cricket world cup talking points",
         "Time Created" -> "15:10:41+0000",
@@ -134,9 +127,9 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Special Instructions" -> "FILE PHOTO Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information. Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
         "Headline" -> "Cricket - Moeen Ali File Photo",
         "Object Name" -> "CRICKET England Moeen 111162",
-        "Reference Date" -> "20150402",
+        "Reference Date" -> "2015:04:02",
         "Original Transmission Reference" -> "CRICKET_England_Moeen_111162.JPG",
-        "Date Created" -> "Thu Apr 02 00:00:00 BST 2015"
+        "Date Created" -> "2015:04:02"
       )
       val exif = Map(
         "Image Description" -> "England's Moeen Ali plays defensively from the bowling of Sri Lanka's Shaminda Eranga, during day five of the second Investec Test match at Headingley, Leeds. PRESS ASSOCIATION Photo. Picture date: Tuesday June 24, 2014. See PA Story CRICKET England. Photo credit should read: Martin Rickett/PA Wire. Editorial use only. RESTRICTIONS: Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
@@ -153,7 +146,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Artist" -> "Martin Rickett"
       )
       val exifSub = Map(
-        "CFA Pattern" -> "0 2 0 2 0 1 1 2",
+        "CFA Pattern" -> "[Red,Green][Green,Blue]",
         "Exif Version" -> "2.30",
         "Subject Distance Range" -> "Unknown",
         "Exposure Mode" -> "Manual exposure",
@@ -163,7 +156,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Exif Image Height" -> "1672 pixels",
         "Flash" -> "Flash did not fire",
         "White Balance" -> "Unknown",
-        "Focal Length" -> "600.0 mm",
+        "Focal Length" -> "600 mm",
         "Date/Time Original" -> "2014:06:24 15:10:41",
         "White Balance Mode" -> "Auto white balance",
         "Exif Image Width" -> "1264 pixels",
@@ -182,7 +175,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "FlashPix Version" -> "1.00",
         "Sub-Sec Time" -> "70",
         "Components Configuration" -> "YCbCr",
-        "Focal Length 35" -> "600mm",
+        "Focal Length 35" -> "600 mm",
         "Date/Time Digitized" -> "2014:06:24 15:10:41",
         "Sensitivity Type" -> "Recommended Exposure Index",
         "Contrast" -> "None",
@@ -192,15 +185,10 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Saturation" -> "None",
         "Max Aperture Value" -> "f/4.0"
       )
-      val xmp = Map(
-        "Rating" -> "0.0",
-        "Subject" -> "cricket england cricket world cup talking points"
-      )
 
       sameMaps(metadata.iptc, iptc)
       sameMaps(metadata.exif, exif)
       sameMaps(metadata.exifSub, exifSub)
-      sameMaps(metadata.xmp, xmp)
       sameMaps(metadata.getty, Map())
     }
   }
@@ -215,7 +203,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Time Created" -> "01:08:44+0000",
       "By-line" -> "Graham Turner",
       "Object Name" -> "Tulips",
-      "Date Created" -> "Wed Apr 15 00:00:00 BST 2015"
+      "Date Created" -> "2015:04:15"
     )
     val exif = Map(
       "Image Description" -> "Reuben Smith age 5 from Hampshire and  \"Darwin Hybrid Mix' tulips in the cut flower Garden at Arundel Castle.\n18,000 tulips were planted in  a total of 52,000 spring bulbs last autumn.\nPhotograph: Graham Turner.",
@@ -233,13 +221,13 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Exif Version" -> "2.30",
       "Exposure Mode" -> "Manual exposure",
       "ISO Speed Ratings" -> "320",
-      "Lens Specification" -> "70/1 200/1 0/0 0/0",
+      "Lens Specification" -> "70-200mm",
       "Body Serial Number" -> "093024002053",
       "Custom Rendered" -> "Normal process",
       "Exif Image Height" -> "3840 pixels",
       "Lens Serial Number" -> "000043c4bb",
       "Flash" -> "Flash did not fire, auto",
-      "Focal Length" -> "88.0 mm",
+      "Focal Length" -> "88 mm",
       "Date/Time Original" -> "2015:04:15 01:08:44",
       "White Balance Mode" -> "Auto white balance",
       "Shutter Speed Value" -> "1/1599 sec",
@@ -264,19 +252,11 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Focal Plane X Resolution" -> "1/1600 cm",
       "Max Aperture Value" -> "f/2.8"
     )
-    val xmp = Map(
-      "Rating" -> "0.0",
-      "Serial Number" -> "093024002053",
-      "Firmware" -> "1.2.1",
-      "Lens" -> "EF70-200mm f/2.8L IS II USM",
-      "Lens Information" -> "70/1 200/1 0/0 0/0"
-    )
 
     whenReady(metadataFuture) { metadata =>
       sameMaps(metadata.iptc, iptc)
       sameMaps(metadata.exif, exif)
       sameMaps(metadata.exifSub, exifSub)
-      sameMaps(metadata.xmp, xmp)
       sameMaps(metadata.getty, Map())
     }
   }

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -129,7 +129,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Object Name" -> "CRICKET England Moeen 111162",
         "Reference Date" -> "2015:04:02",
         "Original Transmission Reference" -> "CRICKET_England_Moeen_111162.JPG",
-        "Date Created" -> "2015:04:02"
+        "Date Created" -> "Thu Apr 02 16:10:41 BST 2015"
       )
       val exif = Map(
         "Image Description" -> "England's Moeen Ali plays defensively from the bowling of Sri Lanka's Shaminda Eranga, during day five of the second Investec Test match at Headingley, Leeds. PRESS ASSOCIATION Photo. Picture date: Tuesday June 24, 2014. See PA Story CRICKET England. Photo credit should read: Martin Rickett/PA Wire. Editorial use only. RESTRICTIONS: Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
@@ -203,7 +203,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Time Created" -> "01:08:44+0000",
       "By-line" -> "Graham Turner",
       "Object Name" -> "Tulips",
-      "Date Created" -> "2015:04:15"
+      "Date Created" -> "Wed Apr 15 02:08:44 BST 2015"
     )
     val exif = Map(
       "Image Description" -> "Reuben Smith age 5 from Hampshire and  \"Darwin Hybrid Mix' tulips in the cut flower Garden at Arundel Castle.\n18,000 tulips were planted in  a total of 52,000 spring bulbs last autumn.\nPhotograph: Graham Turner.",

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -130,7 +130,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Reference Date" -> "2015:04:02",
         "Original Transmission Reference" -> "CRICKET_England_Moeen_111162.JPG",
         "Date Created" -> "2015:04:02",
-        "Date Time Created Composite" -> "Thu Apr 02 16:10:41 BST 2015"
+        "Date Time Created Composite" -> "Thu Apr 02 16:10:41.000 BST 2015"
       )
       val exif = Map(
         "Image Description" -> "England's Moeen Ali plays defensively from the bowling of Sri Lanka's Shaminda Eranga, during day five of the second Investec Test match at Headingley, Leeds. PRESS ASSOCIATION Photo. Picture date: Tuesday June 24, 2014. See PA Story CRICKET England. Photo credit should read: Martin Rickett/PA Wire. Editorial use only. RESTRICTIONS: Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
@@ -159,7 +159,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "White Balance" -> "Unknown",
         "Focal Length" -> "600 mm",
         "Date/Time Original" -> "2014:06:24 15:10:41",
-        "Date/Time Original Composite" -> "Tue Jun 24 16:10:41 BST 2014",
+        "Date/Time Original Composite" -> "Tue Jun 24 16:10:41.700 BST 2014",
         "White Balance Mode" -> "Auto white balance",
         "Exif Image Width" -> "1264 pixels",
         "Gain Control" -> "Low gain up",
@@ -206,7 +206,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "By-line" -> "Graham Turner",
       "Object Name" -> "Tulips",
       "Date Created" -> "2015:04:15",
-      "Date Time Created Composite" -> "Wed Apr 15 02:08:44 BST 2015"
+      "Date Time Created Composite" -> "Wed Apr 15 02:08:44.000 BST 2015"
     )
     val exif = Map(
       "Image Description" -> "Reuben Smith age 5 from Hampshire and  \"Darwin Hybrid Mix' tulips in the cut flower Garden at Arundel Castle.\n18,000 tulips were planted in  a total of 52,000 spring bulbs last autumn.\nPhotograph: Graham Turner.",
@@ -232,7 +232,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Flash" -> "Flash did not fire, auto",
       "Focal Length" -> "88 mm",
       "Date/Time Original" -> "2015:04:15 01:08:44",
-      "Date/Time Original Composite" -> "Wed Apr 15 02:08:44 BST 2015",
+      "Date/Time Original Composite" -> "Wed Apr 15 02:08:44.880 BST 2015",
       "White Balance Mode" -> "Auto white balance",
       "Shutter Speed Value" -> "1/1599 sec",
       "Exif Image Width" -> "5760 pixels",


### PR DESCRIPTION
This upgrades the metadata-extractor lib and saves all the new xmp metadata.

As discussed with @paperboyo and @akash1810 

NEEDS TESTING!