### PR TITLE
Track suspected barely/never used features

### DIFF
--- a/kahuna/public/js/components/gr-toggle-button/gr-toggle-button.js
+++ b/kahuna/public/js/components/gr-toggle-button/gr-toggle-button.js
@@ -4,7 +4,7 @@ import template from './gr-toggle-button.html';
 
 export const toggleButton = angular.module('gr.toggleButton', []);
 
-toggleButton.directive('grToggleButton', [function() {
+toggleButton.directive('grToggleButton', [function($rootScope) {
     return {
         restrict: 'E',
         template: template,
@@ -20,6 +20,14 @@ toggleButton.directive('grToggleButton', [function() {
             };
 
             scope.toggle = function() {
+                $rootScope.$emit(
+                  'track:event',
+                  'Toggle',
+                  'Clicked',
+                  null,
+                  null,
+                  {value: scope.toggleVar}
+                );
                 scope.toggleVar = !scope.toggleVar;
                 setName();
             };

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -260,6 +260,9 @@ results.controller('SearchResultsCtrl', [
             var val = {};
             val[key] = image.data.uploadTime;
 
+            // Tracking to potentially kill this feature off
+            $rootScope.$emit('track:event', 'Mark as seen', 'Clicked', null, null, {image: image});
+
             return val;
         }
 


### PR DESCRIPTION
It's strongly suspected that the 'viewed up to' (https://github.com/guardian/grid/issues/1854) and 'Show Preview' actions are never used.

In the interest of thoroughness, I've added tracking to these actions so we can make a decision about killing them off.

Blocked by #2172