### PR TITLE
add `hasCrops` as a query string to Grid

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -120,8 +120,23 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     });
 
     $stateProvider.state('search.results', {
-        url: 'search?{query:Query}&ids&since&nonFree&payType&uploadedBy&until&orderBy' +
-             '&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil&hasRightsAcquired&hasCrops',
+        url: [
+            'search?{query:Query}',
+            'ids',
+            'since',
+            'nonFree',
+            'payType',
+            'uploadedBy',
+            'until',
+            'orderBy',
+            'dateField',
+            'takenSince',
+            'takenUntil',
+            'modifiedSince',
+            'modifiedUntil',
+            'hasRightsAcquired',
+            'hasCrops'
+        ].join('&'),
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -121,7 +121,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
 
     $stateProvider.state('search.results', {
         url: 'search?{query:Query}&ids&since&nonFree&payType&uploadedBy&until&orderBy' +
-             '&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil&hasRightsAcquired',
+             '&dateField&takenSince&takenUntil&modifiedSince&modifiedUntil&hasRightsAcquired&hasCrops',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -324,7 +324,8 @@ results.controller('SearchResultsCtrl', [
                 offset:     offset,
                 length:     length,
                 orderBy:    orderBy,
-                hasRightsAcquired: $stateParams.hasRightsAcquired
+                hasRightsAcquired: $stateParams.hasRightsAcquired,
+                hasCrops: $stateParams.hasCrops
             }));
         }
 

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -16,7 +16,7 @@ mediaApi.factory('mediaApi',
     function search(query = '', {ids, since, until, archived, valid, free,
                                  payType, uploadedBy, offset, length, orderBy,
                                  takenSince, takenUntil,
-                                 modifiedSince, modifiedUntil, hasRightsAcquired} = {}) {
+                                 modifiedSince, modifiedUntil, hasRightsAcquired, hasCrops} = {}) {
         return root.follow('search', {
             q:          query,
             since:      since,
@@ -34,16 +34,16 @@ mediaApi.factory('mediaApi',
             offset:     offset,
             length:     angular.isDefined(length) ? length : 50,
             orderBy:    getOrder(orderBy),
-            hasRightsAcquired: getHasRightsAcquired(hasRightsAcquired)
+            hasRightsAcquired: maybeStringToBoolean(hasRightsAcquired),
+            hasExports: maybeStringToBoolean(hasCrops) // Grid API calls crops exports...
         }).get();
     }
 
-    function getHasRightsAcquired(hasRightsAcquired) {
-        if (hasRightsAcquired === 'true') {
+    function maybeStringToBoolean(maybeString) {
+        if (maybeString === 'true') {
             return true;
         }
-
-        if (hasRightsAcquired === 'false') {
+        if (maybeString === 'false') {
             return false;
         }
 


### PR DESCRIPTION
The API already has a `hasExports` query, so this just exposes that to Kahuna... with a more obvious name...