### PR TITLE
introduce `has` query to api

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -49,6 +49,7 @@ trait ImageFields {
     case f if editsFields.contains(f)       => editsField(f)
     case f if collectionsFields.contains(f) => collectionsField(f)
     case f if usagesFields.contains(f)      => usagesField(f)
+    case "crops" => "exports"
     case f => f
   }
 

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -5,6 +5,7 @@ import lib.querysyntax._
 import com.gu.mediaservice.lib.elasticsearch.ImageFields
 import org.elasticsearch.index.query.{MatchQueryBuilder, MultiMatchQueryBuilder, NestedQueryBuilder}
 import org.elasticsearch.index.query.QueryBuilders._
+import org.elasticsearch.index.query.FilterBuilders._
 
 
 class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
@@ -38,6 +39,10 @@ class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
     case HierarchyField => condition.value match {
       case Phrase(value) => termQuery(getFieldPath("pathHierarchy"), value)
       case _ => throw InvalidQuery("Cannot accept non-Phrase value for HierarchyField Match")
+    }
+    case HasField => condition.value match {
+      case HasValue(value) => boolQuery().must(filteredQuery(null, existsFilter(getFieldPath(value))))
+      case _ => throw InvalidQuery(s"Cannot perform booleanQuery on ${condition.value}")
     }
   }
 

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -29,11 +29,17 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   }
 
   def Filter = rule {
+    HasMatch ~> Match |
     ScopedMatch ~> Match | HashMatch | CollectionRule |
     DateConstraintMatch |
     DateRangeMatch ~> Match | AtMatch |
     AnyMatch
   }
+
+  def HasMatch = rule { HasMatchField ~ ':' ~ HasMatchValue }
+  def HasMatchField = rule { capture(HasFieldName) ~> (_ => HasField) }
+  def HasFieldName = rule { "has" }
+  def HasMatchValue = rule { String ~> HasValue }
 
   def NestedMatch = rule { ParentField ~ "@" ~ NestedField ~ ':' ~ MatchValue }
   def NestedDateMatch = rule { ParentField ~ "@" ~ DateConstraintMatch ~> (

--- a/media-api/app/lib/querysyntax/model.scala
+++ b/media-api/app/lib/querysyntax/model.scala
@@ -8,13 +8,15 @@ final case class Match(field: Field, value: Value) extends Condition
 final case class Nested(parentField: Field, field: Field, value: Value) extends Condition
 
 sealed trait Field
-case object AnyField extends Field
+final case object AnyField extends Field
 final case object HierarchyField extends Field
 final case class SingleField(name: String) extends Field
 final case class MultipleField(names: List[String]) extends Field
+final case object HasField extends Field
 
 sealed trait Value
 final case class Words(string: String) extends Value
 final case class Phrase(string: String) extends Value
 final case class Date(date: DateTime) extends Value
 final case class DateRange(startDate: DateTime, endDate: DateTime) extends Value
+final case class HasValue(string: String) extends Value

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -396,4 +396,32 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
     }
 
   }
+
+  describe("has filter") {
+    it("should find images with crops") {
+      Parser.run("has:crops") should be (List(
+        Match(HasField, HasValue("crops"))
+      ))
+    }
+
+    it("should match multiple terms and the has query") {
+      Parser.run("cats dogs has:rightsSyndication") should be (List(
+        Match(AnyField, Words("cats dogs")),
+        Match(HasField, HasValue("rightsSyndication"))
+      ))
+    }
+
+    it("should match negated has queries") {
+      Parser.run("-has:foo") should be (List(
+        Negation(Match(HasField, HasValue("foo")))
+      ))
+    }
+
+    it("should match aliases and a has query") {
+      Parser.run("by:cats has:paws") should be (List(
+        Match(bylineField, Words("cats")),
+        Match(HasField, HasValue("paws"))
+      ))
+    }
+  }
 }


### PR DESCRIPTION
Support the ability to query the api for images that have a field, for example:
- `has:crops` for images that have been cropped
- `has:rightsSyndication` for images that have RCS information
- `has:fileMetadata.xmp` for images that have xmp metadata

NB A cropped image is saved with `exports` in ES. We allow this field to be queried as `crops` for simplicity.