### PR TITLE
add `has` query to Kahuna in form of chip

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -28,7 +28,8 @@ export const filterFields = [
     'usages@<added',
     'usages@>added',
     'usages@platform',
-    'usages@status'
+    'usages@status',
+    'has'
 ];
 // TODO: add date fields
 
@@ -135,7 +136,6 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'by':       return listPhotographers().then(prefixFilter(value));
         case 'illustrator': return listIllustrators().then(prefixFilter(value));
         case 'category': return listCategories().then(prefixFilter(value));
-
         // No suggestions
         default:         return [];
         }

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -149,6 +149,14 @@
                 Has a suggestion list: filter by print or digital usage.
             </dd>
         </dl>
+        <dl class="advanced-search-example">
+            <dt class="advanced-search-example__field">
+                <gr-chip-example gr:filter-field="has" gr:example-search="crops"></gr-chip-example>
+            </dt>
+            <dd class="advanced-search-example__explanation">
+                Checks for the existence of a field. For example crops, xmp metadata, location etc.
+            </dd>
+        </dl>
     </div>
 
 


### PR DESCRIPTION
No suggestions as it seems to break free text search. That is, if the suggestion list is `crops` and `title`, these are the only values that can be used and you're unable to specify a different one.

# Basic `has:crops` example:
![has-chip-ii](https://user-images.githubusercontent.com/836140/41892070-bf137668-790e-11e8-953b-7886a03476b0.gif)

# Advanced `has:fileMetadata.xmp` example:
![has-chip](https://user-images.githubusercontent.com/836140/41892103-dcbbceb8-790e-11e8-906d-443cfec773f0.gif)

depends on #2190 and is an updated version of #2187
