### PR TITLE
use millis for datetime searching

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
@@ -20,9 +20,9 @@ package object formatting {
       withZoneUTC
   }
 
-  val dateTimeFormat = ISODateTimeFormat.dateTimeNoMillis.withZoneUTC
+  val dateTimeFormat = parseDateTimeFormat.withZoneUTC
 
-  def printDateTime(date: DateTime): String = dateTimeFormat.print(date)
+  def printDateTime(date: DateTime): String = date.toString()
   def printOptDateTime(date: Option[DateTime]): Option[String] = date.map(printDateTime)
 
   // Only use this on dates that have been confidently written using printDateTime


### PR DESCRIPTION
https://github.com/guardian/grid/pull/2180 is storing dates at a more granular level. As this is on TEST, there are images in ES that fail to parse when a different branch is released.

This change would result in storing and reading `000` as millis, until #2180 is in master, thus allowing us to release other branches to TEST.

Discovered in the following log line after releasing #2190 to TEST:
```console
play.api.UnexpectedException: Unexpected exception[IllegalArgumentException: Invalid format: "2018-06-26T09:35:13.618Z" is malformed at ".618Z"]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:247)
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:178)
	at play.core.server.AkkaHttpServer$$anonfun$2.applyOrElse(AkkaHttpServer.scala:343)
	at play.core.server.AkkaHttpServer$$anonfun$2.applyOrElse(AkkaHttpServer.scala:341)
	at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:413)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:37)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:43)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```