### PR TITLE
sort chips alphabetically

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -30,7 +30,7 @@ export const filterFields = [
     'usages@platform',
     'usages@status',
     'has'
-];
+].sort();
 // TODO: add date fields
 
 const subjects = [


### PR DESCRIPTION
Noticed this after the new `has` chip went out.

# Before 🤢 
![image](https://user-images.githubusercontent.com/836140/42032159-982736f2-7ad0-11e8-9272-1f71307193a9.png)


# After 🎉 
![image](https://user-images.githubusercontent.com/836140/42032141-86068c48-7ad0-11e8-945b-19178c3084da.png)
