### PR TITLE
retain collections, leases and usages on image re-upload

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -254,7 +254,10 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
       (__ \ "uploadTime").json.prune andThen
       (__ \ "userMetadata").json.prune andThen
       (__ \ "exports").json.prune andThen
-      (__ \ "uploadedBy").json.prune
+      (__ \ "uploadedBy").json.prune andThen
+      (__ \ "collections").json.prune andThen
+      (__ \ "leases").json.prune andThen
+      (__ \ "usages").json.prune
 
     image.transform(removeUploadInformation).get
   }


### PR DESCRIPTION
We're currently losing some information when an image is re-uploaded. I wrote [this gist](https://gist.github.com/akash1810/780156b68945637cb718b15a9f54827f) to work out the difference.

When an image is uploaded (or re-uploaded), we send an [`image` message](https://github.com/guardian/grid/blob/master/thrall/app/lib/ThrallMessageConsumer.scala#L16) to Thrall for indexing. The data in this message represents an [Image](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala#L8-L29).

When Thrall sees this message, it performs an [upsert](https://github.com/guardian/grid/blob/master/thrall/app/lib/ElasticSearch.scala#L37-L45). However it doesn't upsert the exact message, but rather it [removes some keys](https://github.com/guardian/grid/blob/master/thrall/app/lib/ElasticSearch.scala#L252-L260) from the `image` blob to retain some information, such as `exports` and `userMetadata` for metadata overrides.

We're currently not removing `collections`, `leases` or `usages` from the incoming json and so are falling back to their default of [`Nil`](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala#L25-L27). This has the effect of a re-upload deleting `collections`, `leases` and `usages` from and image 😱.

This PR retains that information by pruning the incoming json.