### PR TITLE
Add News to subjects

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/Subject.scala
@@ -14,6 +14,7 @@ object Subject extends Enumeration {
   val Labour = Value("labour")
   val Lifestyle = Value("lifestyle")
   val Nature = Value("nature")
+  val News = Value("news")
   val Politics = Value("politics")
   val Religion = Value("religion")
   val Science = Value("science")
@@ -25,12 +26,15 @@ object Subject extends Enumeration {
   // These category codes are now deprecated but still populated
   def create(category: String): Option[Subject.Value] = category.toLowerCase match {
     // ANPA-1312 Codes: https://en.wikipedia.org/wiki/ANPA-1312
+    // http://www.eznews.com/help/ezsend/index.html?ANPAStandard
     case "f" => Some(Finance)
     case "l" => Some(Lifestyle)
     case "e" => Some(Arts)
     case "s" => Some(Sport)
     case "o" => Some(Weather)
     case "p" => Some(Politics)
+    case "i" => Some(News)
+    case "a" => Some(News)
 
     // See: https://www.iptc.org/std/photometadata/documentation/GenericGuidelines/index.htm#!Documents/guidelineformappingcategorycodestosubjectnewscodes.htm
     case "ace" => Some(Arts)

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -45,6 +45,7 @@ const subjects = [
     'labour',
     'lifestyle',
     'nature',
+    'news',
     'politics',
     'religion',
     'science',


### PR DESCRIPTION
Out of ~5m pics our current subjects [cover ~800k](https://media.gutools.co.uk/search?query=has:subjects&nonFree=true). The subjects we do not cover from [this ancient list](http://www.eznews.com/help/ezsend/index.html?ANPAStandard) cover [another ~900k](https://media.gutools.co.uk/search?query=has:fileMetadata.iptc.Category%20-has:subjects%20category:agency&nonFree=true). This PR merges `i` & `a` (“Domestic, non-Washington, general news item” & “International news, including United Nations dateline and undated roundups keyed to foreign events.”) and calls it `News`. I’ve merged them because US vs. The World is not my thing.  Could have called it `General News`, maybe? Or should we treat them separately and call them `News US` and `News non-US`?

Next step would be to see what’s left from the ancient list and how correct/useful this is, but this requires a reindex.

Next-next step would be to incorporate [newer attempt](http://xml.coverpages.org/NITF30-subject-codes.html) at news ontology, but before we can search **all** metadata, there is no way of knowing how prevalent these are. I know of one cricket picture... Plus, our suggestions engine would need to change to be able to handle all these subjects...

This is all possible because of @akash1810’s [amazing work](https://github.com/guardian/grid/pull/2190).

Thanks to @mbarton for holding my hand.

Currently on TEST.