### PR TITLE
further limit images returned to syndication tier

### DIFF
--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -8,6 +8,7 @@ import org.elasticsearch.index.query.{BoolFilterBuilder, FilterBuilder}
 import scalaz.syntax.std.list._
 import scalaz.NonEmptyList
 import lib.MediaApiConfig
+import org.joda.time.DateTime
 
 
 class SearchFilters(config: MediaApiConfig) extends ImageFields {
@@ -80,8 +81,15 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
       )
     )
 
+  def syndicationRightsAcquiredFilter(): FilterBuilder = {
+    filters.and(
+      rightsAcquiredFilter(isAcquired = true),
+      filters.date(field = "syndicationRights.published", None, Some(DateTime.now)).get
+    )
+  }
+
   def tierFilter(tier: Tier): Option[FilterBuilder] = tier match {
-    case Syndication => Some(rightsAcquiredFilter(isAcquired = true))
+    case Syndication => Some(syndicationRightsAcquiredFilter())
     case _ => None
   }
 

--- a/media-api/test/lib/ElasticSearchHelper.scala
+++ b/media-api/test/lib/ElasticSearchHelper.scala
@@ -58,13 +58,13 @@ trait ElasticSearchHelper extends MockitoSugar {
     )
   }
 
-  def createImageWithSyndicationRights(usageRights: UsageRights, rightsAcquired: Boolean): Image = {
+  def createImageWithSyndicationRights(usageRights: UsageRights, rightsAcquired: Boolean, publishDate: Option[DateTime]): Image = {
     val rights = List( Right("test", Some(rightsAcquired), Nil) )
-    val syndicationRights = SyndicationRights(None, Nil, rights)
+    val syndicationRights = SyndicationRights(publishDate, Nil, rights)
     createImage(usageRights, Some(syndicationRights))
   }
 
-  def createExampleImage(): Image = createImageWithSyndicationRights(Handout(), rightsAcquired = true).copy(id = "id-abc")
+  def createExampleImage(): Image = createImageWithSyndicationRights(Handout(), rightsAcquired = true, None).copy(id = "id-abc")
 
   def saveToES(image: Image) = {
     val json = Json.toJson(image)


### PR DESCRIPTION
only return images where `syndicationRights.published` is in the past, i.e non-draft content