### PR TITLE
small refactor to syndication model

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
@@ -9,7 +9,15 @@ import play.api.libs.functional.syntax._
 case class SyndicationRights(
   published: Option[DateTime],
   suppliers: Seq[Supplier],
-  rights: Seq[Right])
+  rights: Seq[Right]) {
+
+  def isAvailableForSyndication: Boolean = {
+    val rightsAcquired = rights.flatMap(_.acquired).contains(true)
+    val isPublished = published.exists(_.isBeforeNow)
+
+    rightsAcquired && isPublished
+  }
+}
 object SyndicationRights {
   implicit val dateWrites = jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
   implicit val dateReads = jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -98,10 +98,10 @@ class MediaApi(auth: Authentication, notifications: Notifications, elasticSearch
     isUploaderOrHasPermission(request, source, Permissions.DeleteImage)
   }
 
-  private def isSyndicateable(json: JsValue): Boolean = (json \ "syndicationRights" \ "rights" \ "acquired").validate[Boolean].getOrElse(false)
+  private def isAvailableForSyndication(image: Image): Boolean = image.syndicationRights.exists(_.isAvailableForSyndication)
 
   private def hasPermission(request: Authentication.Request[Any], json: JsValue): Boolean = request.user.apiKey.tier match {
-    case Syndication => isSyndicateable(json)
+    case Syndication => isAvailableForSyndication(json.as[Image])
     case _ => true
   }
 


### PR DESCRIPTION
Pushes `isAvailableForSyndication` to the case class for better organisation.

This is the start of using the `Image` model rather than `JsValue` too, because strong types are... strong!