### PR TITLE
log image downloads (again)

### DIFF
--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -22,7 +22,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val usageQuota = new UsageQuota(config, elasticSearch)
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val mediaApi = new MediaApi(auth, notifications, elasticSearch, imageResponse, config, controllerComponents)
+  val mediaApi = new MediaApi(auth, notifications, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, notifications, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -13,18 +13,26 @@ import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
 import com.gu.mediaservice.model._
 import lib.elasticsearch._
-import lib.{ImageResponse, MediaApiConfig, Notifications}
+import lib._
 import org.http4s.UriTemplate
 import org.joda.time.DateTime
+import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MediaApi(auth: Authentication, notifications: Notifications, elasticSearch: ElasticSearch, imageResponse: ImageResponse,
-               override val config: MediaApiConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
-  extends BaseController with ArgoHelpers with PermissionsHandler {
+class MediaApi(
+  auth: Authentication,
+  notifications: Notifications,
+  elasticSearch: ElasticSearch,
+  imageResponse: ImageResponse,
+  override val config: MediaApiConfig,
+  override val controllerComponents: ControllerComponents,
+  s3Client: S3Client,
+  mediaApiMetrics: MediaApiMetrics
+)(implicit val ec: ExecutionContext) extends BaseController with ArgoHelpers with PermissionsHandler {
 
   private val searchParamList = List("q", "ids", "offset", "length", "orderBy",
     "since", "until", "modifiedSince", "modifiedUntil", "takenSince", "takenUntil",
@@ -174,6 +182,21 @@ class MediaApi(auth: Authentication, notifications: Notifications, elasticSearch
           Future.successful(ImageCannotBeDeleted)
         }
 
+      case _ => Future.successful(ImageNotFound)
+    }
+  }
+
+  def downloadOriginalImage(id: String) = auth.async { request =>
+    elasticSearch.getImageById(id) flatMap {
+      case Some(source) if hasPermission(request, source) => {
+        Logger.info(s"Download original image $id by ${request.user.apiKey.tier}/${request.user.apiKey.name}")
+        mediaApiMetrics.incrementOriginalImageDownload(request.user.apiKey)
+        val image = source.as[Image]
+        val fileUri = image.source.file
+        val imageUrl = s3Client.signUrl(config.imageBucket, fileUri, image)
+
+        Future.successful(Redirect(imageUrl))
+      }
       case _ => Future.successful(ImageNotFound)
     }
   }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -140,7 +140,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val persistenceReasons = imagePersistenceReasons(image)
     val isPersisted = persistenceReasons.nonEmpty
 
-    val data = source.transform(addSecureSourceUrl(image.id))
+    val data = source.transform(addSecureSourceUrl(imageUrl))
       .flatMap(_.transform(wrapUserMetadata(id)))
       .flatMap(_.transform(addSecureThumbUrl(thumbUrl)))
       .flatMap(_.transform(
@@ -247,10 +247,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       root ++ Json.obj("userMetadata" -> editsJson)
     }
 
-  def addSecureSourceUrl(id: String): Reads[JsObject] = {
-    val url = s"${config.rootUri}/images/$id/download"
+  def addSecureSourceUrl(url: String): Reads[JsObject] =
     (__ \ "source").json.update(__.read[JsObject].map(_ ++ Json.obj("secureUrl" -> url)))
-  }
 
   def addSecureOptimisedPngUrl(url: String): Reads[JsObject] =
     (__ \ "optimisedPng").json.update(__.read[JsObject].map(_ ++ Json.obj("secureUrl" -> url)))

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -140,7 +140,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val persistenceReasons = imagePersistenceReasons(image)
     val isPersisted = persistenceReasons.nonEmpty
 
-    val data = source.transform(addSecureSourceUrl(imageUrl))
+    val data = source.transform(addSecureSourceUrl(image.id))
       .flatMap(_.transform(wrapUserMetadata(id)))
       .flatMap(_.transform(addSecureThumbUrl(thumbUrl)))
       .flatMap(_.transform(
@@ -247,8 +247,10 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       root ++ Json.obj("userMetadata" -> editsJson)
     }
 
-  def addSecureSourceUrl(url: String): Reads[JsObject] =
+  def addSecureSourceUrl(id: String): Reads[JsObject] = {
+    val url = s"${config.rootUri}/images/$id/download"
     (__ \ "source").json.update(__.read[JsObject].map(_ ++ Json.obj("secureUrl" -> url)))
+  }
 
   def addSecureOptimisedPngUrl(url: String): Reads[JsObject] =
     (__ \ "optimisedPng").json.update(__.read[JsObject].map(_ ++ Json.obj("secureUrl" -> url)))

--- a/media-api/app/lib/MediaApiMetrics.scala
+++ b/media-api/app/lib/MediaApiMetrics.scala
@@ -1,6 +1,7 @@
 package lib
 
 import com.amazonaws.services.cloudwatch.model.Dimension
+import com.gu.mediaservice.lib.auth.{ApiKey, Syndication}
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 
 class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${config.stage}/MediaApi", config) {
@@ -10,4 +11,18 @@ class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${conf
   def searchTypeDimension(value: String): Dimension =
     new Dimension().withName("SearchType").withValue(value)
 
+  def incrementOriginalImageDownload(apiKey: ApiKey) = {
+    val metric = new CountMetric(apiKey.tier.toString)
+
+    // CW Metrics have a maximum of 10 dimensions per metric.
+    // Create a separate dimension per syndication partner and group other Tier types together.
+    val dimensionValue: String = apiKey.tier match {
+      case Syndication => apiKey.name
+      case _ => apiKey.tier.toString
+    }
+
+    val dimension = new Dimension().withName("OriginalImageDownload").withValue(dimensionValue)
+
+    metric.increment(List(dimension)).run
+  }
 }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -17,6 +17,7 @@ GET     /images/:id                                   controllers.MediaApi.getIm
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
+GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)
 POST    /images/:id/reindex                           controllers.MediaApi.reindexImage(id: String)
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
 GET     /images                                       controllers.MediaApi.imageSearch(isExample: Boolean = false)


### PR DESCRIPTION
An updated version of https://github.com/guardian/grid/pull/2209

Creates a new endpoint `/images/<IMAGE_ID>/download` to download an image with logging and metric recording.

In #2209 we changed the value of `secureUrl` in the API response from an AWS S3 signed url to `/download`. This broke cropping with clients getting a `401` response because `/download` is behind auth and clients hadn't been updated to send their api key, thus `401`.

`/download` will initially be used to track what is being taken for syndication so, rather than break existing clients, expose the new download endpoint as a `Link` in the API response for consumption by new syndication partners and then gradually migrate existing, internal, consumers of the API.

This is also more inline with the [argo spec](https://github.com/argo-rest/spec#link) too.