### PR TITLE
enable cursor key navigation again

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.js
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.js
@@ -94,7 +94,8 @@ guDateRange.directive('guDateRange', [function () {
               maxDate: tenYearsFromNow,
               yearRange: 100,
               firstDay: parseInt(ctrl.guFirstDay),
-              format: iso8601Format
+              format: iso8601Format,
+              keyboardInput: false
           });
 
           var pikaEnd = new Pikaday({
@@ -104,7 +105,8 @@ guDateRange.directive('guDateRange', [function () {
               maxDate: tenYearsFromNow,
               firstDay: parseInt(ctrl.guFirstDay),
               format: iso8601Format,
-              yearRange: 100
+              yearRange: 100,
+              keyboardInput: false
           });
 
           $scope.$watch('pikaStartValue', function (pikaStartValue) {


### PR DESCRIPTION
Pikaday is hijacking keyboard navigation on the [entire document(!)](https://github.com/dbushell/Pikaday/blob/master/pikaday.js#L628), resulting in cursor navigation failing in regular `input` fields such as search and caption boxes (its impossible to go left!).

Remove the event listeners from pikaday, see https://github.com/dbushell/Pikaday/pull/610 and https://github.com/dbushell/Pikaday/issues/607.

# Before
![image](https://user-images.githubusercontent.com/836140/42464958-94c4c44a-83a2-11e8-9f97-e8569178535c.png)

# After
![image](https://user-images.githubusercontent.com/836140/42464931-761a01e0-83a2-11e8-94e2-48fc61132759.png)
