### PR TITLE
edit metadata inline in kahuna

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -42,6 +42,7 @@
                 <dt class="metadata-line metadata-line__key">Title</dt>
                 <dd class="image-info__title metadata-line__info"
                     editable-text="ctrl.metadata.title"
+                    ng:hide="titleEditForm.$visible"
                     onbeforesave="ctrl.updateMetadataField('title', $data)"
                     e:ng-class="{'image-info__editor--error': $error,
                                  'image-info__editor--saving': titleEditForm.$waiting,
@@ -57,6 +58,7 @@
                 <dt class="metadata-line metadata-line__key">Description</dt>
                 <dd class="image-info__description"
                     editable-textarea="ctrl.metadata.description"
+                    ng:hide="descriptionEditForm.$visible"
                     onbeforesave="ctrl.updateMetadataField('description', $data)"
                     e:msd-elastic
                     e:ng-class="{'image-info__editor--error': $error,
@@ -76,6 +78,7 @@
             <dt class="metadata-line metadata-line__key">Special instructions</dt>
             <dd class="image-info__special-instructions"
                 editable-textarea="ctrl.metadata.specialInstructions"
+                ng:hide="specialInstructionsEditForm.$visible"
                 onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
                 e:msd-elastic
                 e:ng-class="{'image-info__editor--error': $error,
@@ -99,6 +102,7 @@
                     >✎</button>
                         <span class="image-info__byline"
                               editable-text="ctrl.metadata.byline"
+                              ng:hide="bylineEditForm.$visible"
                               onbeforesave="ctrl.updateMetadataField('byline', $data)"
                               e:ng-class="{'image-info__editor--error': $error,
                                            'image-info__editor--saving': bylineEditForm.$waiting,
@@ -124,6 +128,7 @@
 
                         <span class="metadata-line__info"
                               editable-text="ctrl.metadata.credit"
+                              ng:hide="creditEditForm.$visible"
                               e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
                               onbeforesave="ctrl.updateMetadataField('credit', $data)"
                               e:ng-class="{'image-info__editor--error': $error,
@@ -143,10 +148,16 @@
 
             <dt ng:if="ctrl.hasLocationInformation" class="image-info__group--dl__key metadata-line__key image-info__wrap">Location</dt>
             <dd ng:if="ctrl.hasLocationInformation" class="image-info__group--dl__value metadata-line__info">
-                        <span ng:repeat="prop in ['subLocation', 'city', 'state', 'country']" ng:if="ctrl.metadata[prop]">
-                            <span class="metadata-line__info">
-                                <a ui:sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">{{ctrl.metadata[prop]}}</a></span><span ng:if="! $last">,</span>
-                        </span>
+                <span ng:repeat="prop in ['subLocation', 'city', 'state', 'country']" ng:if="ctrl.metadata[prop]">
+                    <span class="metadata-line__info">
+                        <a ui:sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">
+                            {{ctrl.metadata[prop]}}
+                        </a>
+                    </span>
+                    <span ng:if="! $last">
+                        ,
+                    </span>
+                </span>
             </dd>
 
 
@@ -159,6 +170,7 @@
                     >✎</button>
                         <span class="image-info__copyright"
                               editable-text="ctrl.metadata.copyright"
+                              ng:hide="copyrightEditForm.$visible"
                               onbeforesave="ctrl.updateMetadataField('copyright', $data)"
                               e:ng-class="{'image-info__editor--error': $error,
                                            'image-info__editor--saving': copyrightEditForm.$waiting,

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -74,6 +74,7 @@
                     <dt class="metadata-line metadata-line__key">Title</dt>
                     <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
                          editable-text="ctrl.metadata.title"
+                         ng:hide="titleEditForm.$visible"
                          onbeforesave="ctrl.updateMetadataField('title', $data)"
                          e:form="titleEditForm"
                          e:ng-class="{'image-info__editor--error': $error,
@@ -110,6 +111,7 @@
                     <dt class="metadata-line metadata-line__key">Description</dt>
                     <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
                          editable-textarea="ctrl.metadata.description"
+                         ng:hide="descriptionEditForm.$visible"
                          onbeforesave="ctrl.updateMetadataField('description', $data)"
                          e:msd-elastic
                          e:form="descriptionEditForm"
@@ -157,6 +159,7 @@
 
                 <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
                      editable-textarea="ctrl.metadata.specialInstructions"
+                     ng:hide="specialInstructionsEditForm.$visible"
                      onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
                      e:msd-elastic
                      e:form="specialInstructionsEditForm"
@@ -202,6 +205,7 @@
                             >✎</button>
                     <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
                           editable-text="ctrl.metadata.byline"
+                          ng:hide="bylineEditForm.$visible"
                           onbeforesave="ctrl.updateMetadataField('byline', $data)"
                           e:form="bylineEditForm"
                           e:ng-class="{'image-info__editor--error': $error,
@@ -236,6 +240,7 @@
 
                     <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
                           editable-text="ctrl.metadata.credit"
+                          ng:hide="creditEditForm.$visible"
                           e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
                           onbeforesave="ctrl.updateMetadataField('credit', $data)"
                           e:form="creditEditForm"
@@ -270,6 +275,7 @@
                             >✎</button>
                     <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
                           editable-text="ctrl.metadata.copyright"
+                          ng:hide="copyrightEditForm.$visible"
                           onbeforesave="ctrl.updateMetadataField('copyright', $data)"
                           e:form="copyrightEditForm"
                           e:ng-class="{'image-info__editor--error': $error,

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -225,6 +225,11 @@ button[disabled],
     color: white;
 }
 
+.button-save,
+.button-cancel {
+    margin-left: 5px;
+}
+
 .button--confirm-delete {
     background: red;
 }
@@ -1731,8 +1736,8 @@ FIXME: what to do with touch devices
 .image-info__wrap .editable-buttons {
     display: flex;
     justify-content: flex-end;
-    float: right;
     padding-top: 2px;
+    margin-bottom: 5px;
 }
 
 .image-info__usage-rights .ure {


### PR DESCRIPTION
We seem to have introduced a regression somewhere as we were previously doing this (see the gif in https://github.com/guardian/grid/pull/1115)

Also add some spacing between elements because its all too tight atm.

# Before
![before](https://user-images.githubusercontent.com/836140/42576829-27416958-851b-11e8-9d6e-861081bec280.gif)

# After
![after](https://user-images.githubusercontent.com/836140/42578385-48a86daa-851e-11e8-927a-82c0ffa56e8f.gif)

