### PR TITLE
persistable collections

### DIFF
--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -55,6 +55,8 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
                 return 'categorised as illustrator';
             case 'commissioned-agency':
                 return 'categorised as agency commissioned';
+            case 'persisted-collection':
+                return 'is in a persisted collection';
             default:
                 return reason;
             }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -52,6 +52,14 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   def hasLeases(image: Image) =
     image.leases.leases.nonEmpty
 
+  def isInPersistedCollection(image: Image): Boolean = {
+    // list of the first element of each collection's `path`, i.e all the root collections
+    val collectionPaths: List[String] = image.collections.map(_.path.head)
+
+    // is image in at least one persisted collection?
+    (collectionPaths diff config.persistedRootCollections).length < collectionPaths.length
+  }
+
   def isPhotographerCategory[T <: UsageRights](usageRights: T) =
     usageRights match {
       case _:Photographer => true
@@ -96,6 +104,10 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 
     if (hasLeases(image))
       reasons += "leases"
+
+    if (isInPersistedCollection(image)) {
+      reasons += "persisted-collection"
+    }
 
     reasons.toList
   }

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -70,5 +70,10 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   lazy val persistenceIdentifier = properties.getOrElse("persistence.identifier", configuration.get[String]("persistence.identifier"))
   lazy val queriableIdentifiers = Seq(persistenceIdentifier)
 
+  lazy val persistedRootCollections: List[String] = properties.get("persistence.collections") match {
+    case Some(collections) => collections.split(',').toList
+    case None => List("GNM Archive")
+  }
+
   def convertToInt(s: String): Option[Int] = Try { s.toInt }.toOption
 }

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -66,7 +66,8 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
     filters.bool.must(filters.existsOrMissing("usages", exists = true)),
     filters.exists(NonEmptyList(identifierField(config.persistenceIdentifier))),
     filters.bool.must(filters.boolTerm(editsField("archived"), value = true)),
-    filters.bool.must(filters.terms(usageRightsField("category"), persistedCategories))
+    filters.bool.must(filters.terms(usageRightsField("category"), persistedCategories)),
+    filters.bool.must(filters.terms(collectionsField("path"), config.persistedRootCollections.toNel.get))
   )
 
   val nonPersistedFilter: FilterBuilder = filters.not(persistedFilter)


### PR DESCRIPTION
Add configuration for a list of persistable collections. Images in one of these collections will be retained forever.

The primary use-case is for Archive. Currently, they're adding images to the `GNM Archive` collection and adding the `gnmarchive` label and finally manually archive the images. A lot of work! Automating the persistence feels like a quick win.

This implementation isn't brilliant as its putting collection knowledge inside the media-api rather than the collections api. I've done this as the cheapest thing to do.

The correct way would be to update the collections model to include a flag and let this flag be set client-side. However that's quite a bit more work because collections are denormalised. If we get requests to persist more and more collections, then we could revisit this (maybe all collections should be persisted by default?).