### PR TITLE
use types for lease checks rather than strings

### DIFF
--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -28,8 +28,10 @@ object ImageExtras {
   def hasRights(rights: UsageRights) = !(rights == NoRights)
   def hasCredit(meta: ImageMetadata) = meta.credit.isDefined
   def hasDescription(meta: ImageMetadata) = meta.description.isDefined
-  def hasCurrentAllowLease(leases: LeaseByMedia) = leases.current.exists(_.access.name == "allow")
-  def hasCurrentDenyLease(leases: LeaseByMedia) = leases.current.exists(_.access.name == "deny")
+
+  def hasCurrentAllowLease(leases: LeaseByMedia) = leases.current.exists(_.access == AllowUseLease)
+
+  def hasCurrentDenyLease(leases: LeaseByMedia) = leases.current.exists(_.access == DenyUseLease)
 
   def validityMap(image: Image, withWritePermission: Boolean)(
     implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {


### PR DESCRIPTION
We've introduced two new lease types for syndication and accidentally broke leases as the Allow/Deny use lease names changed. Fix this by pattern matching on the type rather than on a string.