### PR TITLE
allow quota store updates to be turned off in DEV

### DIFF
--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -24,6 +24,9 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   lazy val quotaStoreKey: String = properties("quota.store.key")
   lazy val quotaStoreConfig: StoreConfig = StoreConfig(configBucket, quotaStoreKey)
 
+  // quota updates can only be turned off in DEV
+  lazy val quotaUpdateEnabled: Boolean = if (isDev) properties.getOrElse("quota.update.enabled", "false").toBoolean else true
+
   private lazy val ec2Client: AmazonEC2 = withAWSCredentials(AmazonEC2ClientBuilder.standard()).build()
 
   val elasticsearchHost: String =

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -4,6 +4,7 @@ import java.io.InputStream
 import java.util.Properties
 
 import com.gu.mediaservice.lib.BaseStore
+import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.model.{Agencies, Agency, UsageRights}
 import javax.mail.Session
 import javax.mail.internet.{MimeBodyPart, MimeMultipart}
@@ -192,7 +193,11 @@ class QuotaStore(
   def getQuota: Future[Map[String, SupplierUsageQuota]] = Future.successful(store.get())
 
   def update() {
-    store.send(_ => fetchQuota)
+    if (config.quotaUpdateEnabled) {
+      store.send(_ => fetchQuota)
+    } else {
+      GridLogger.info("Quota store updates disabled. Set quota.update.enabled in media-api.properties to enable.")
+    }
   }
 
   private def fetchQuota: Map[String, SupplierUsageQuota] = {


### PR DESCRIPTION
We're not filling the quota bucket with any information, so the logs are quite loud when we try to get data from the bucket.

If we don't try to get the quotas, we'll get quieter logs.