### PR TITLE
edit album field on image preview page

### DIFF
--- a/kahuna/public/js/components/gr-album/gr-album.html
+++ b/kahuna/public/js/components/gr-album/gr-album.html
@@ -1,0 +1,24 @@
+<section>
+    <button class="image-info__edit"
+            ng:click="albumEditForm.$show()"
+            ng:hide="albumEditForm.$visible">
+        ✎
+    </button>
+
+    <span editable-text="ctrl.albumData.title"
+          ng:hide="albumEditForm.$visible"
+          e:form="albumEditForm"
+          e:uib-:typeahead="album for album in ctrl.search($viewValue) | limitTo:8"
+          e:ng-class="{'image-info__editor--error': $error,
+                       'image-info__editor--saving': albumEditForm.$waiting,
+                       'text-input': true}"
+          onbeforesave="ctrl.save($data)">
+        <span ng:if="! ctrl.hasAlbumData">
+            Unknown (click ✎ to add)
+        </span>
+
+        <span ng:if="ctrl.hasAlbumData">
+            {{ctrl.albumData.title}}
+        </span>
+    </span>
+</section>

--- a/kahuna/public/js/components/gr-album/gr-album.js
+++ b/kahuna/public/js/components/gr-album/gr-album.js
@@ -1,0 +1,70 @@
+import angular from 'angular';
+
+import template from './gr-album.html';
+
+import '../../image/service';
+import '../../services/album';
+import '../../services/image-accessor';
+
+export const album = angular.module('gr.album', [
+    'gr.image.service',
+    'kahuna.services.image-accessor',
+    'kahuna.services.album'
+]);
+
+album.controller('GrAlbumCtrl', [
+    'imageService',
+    'mediaApi',
+    'imageAccessor',
+    'albumService',
+
+    function(imageService, mediaApi, imageAccessor, albumService) {
+        const ctrl = this;
+
+        ctrl.search = (q) => {
+            return mediaApi.metadataSearch('album', { q })
+                .then(resource => resource.data.map(d => d.key));
+        };
+
+        ctrl.save = (title) => {
+            if (title.trim().length === 0) {
+                return ctrl.remove();
+            }
+
+            return albumService.add({ image: ctrl.image, data: { title }})
+                .then(updatedImage => {
+                    ctrl.image = updatedImage;
+                    ctrl.refresh();
+                });
+        };
+
+        ctrl.remove = () => {
+            return albumService.remove({ image: ctrl.image })
+                .then(updatedImage => {
+                    ctrl.image = updatedImage;
+                    ctrl.refresh();
+                });
+        };
+
+        ctrl.refresh = () => {
+            const albumResource = imageAccessor.getAlbum(ctrl.image);
+            ctrl.hasAlbumData = !!albumResource.data;
+            ctrl.albumData = ctrl.hasAlbumData && albumResource.data;
+        };
+
+        ctrl.refresh();
+    }
+]);
+
+album.directive('grAlbum', [function() {
+    return {
+        restrict: 'E',
+        scope: {
+            image: '='
+        },
+        controller: 'GrAlbumCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true,
+        template
+    };
+}]);

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -32,6 +32,16 @@
         </gr-leases>
     </dl>
 </div>
+
+    <div class="image-info__group">
+        <dl class="image-info__wrap">
+            <dt class="metadata-line metadata-line__key">Album</dt>
+            <dd>
+                <gr-album image="ctrl.image"></gr-album>
+            </dd>
+        </dl>
+    </div>
+
     <div class="image-info__group">
         <dl>
             <div class="image-info__wrap" ng:if="ctrl.metadata.title">

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -5,6 +5,7 @@ import '../services/image/usages';
 import '../image/service';
 
 import '../components/gr-add-label/gr-add-label';
+import '../components/gr-album/gr-album';
 import '../components/gr-archiver/gr-archiver';
 import '../components/gr-collection-overlay/gr-collection-overlay';
 import '../components/gr-crop-image/gr-crop-image';
@@ -27,6 +28,7 @@ var image = angular.module('kahuna.image.controller', [
     'gr.image-usages.service',
 
     'gr.addLabel',
+    'gr.album',
     'gr.archiver',
     'gr.collectionOverlay',
     'gr.cropImage',

--- a/kahuna/public/js/services/album.js
+++ b/kahuna/public/js/services/album.js
@@ -1,0 +1,58 @@
+import angular from 'angular';
+
+export const albumService = angular.module('kahuna.services.album', []);
+
+albumService.factory('albumService', [
+    '$rootScope', '$q', 'apiPoll', 'imageAccessor',
+    function ($rootScope, $q, apiPoll, imageAccessor) {
+        function add({ data, image }) {
+            return batchAdd({ data, images: [image]}).then(updatedImages => updatedImages[0]);
+        }
+
+        function remove({ image }) {
+            return batchRemove({ images: [image]}).then(updatedImages => updatedImages[0]);
+        }
+
+        function batchAdd({ data, images }) {
+            return $q.all(images.map(image => putAlbum({data, image})));
+        }
+
+        function batchRemove({ images }) {
+            return $q.all(images.map(image => deleteAlbum({ image })));
+        }
+
+        function putAlbum({ data, image }) {
+            return imageAccessor.getAlbum(image)
+                .put({ data })
+                .then(newAlbum => apiPoll(() => untilEqual({image, expectedAlbum: newAlbum.data})))
+                .then(newImage => {
+                    $rootScope.$emit('image-updated', newImage, image);
+                    return newImage;
+                });
+        }
+
+        function deleteAlbum({ image }) {
+            return imageAccessor.getAlbum(image)
+                .delete()
+                .then(() => apiPoll(() => untilEqual({image, expectedAlbum: undefined })))
+                .then(newImage => {
+                    $rootScope.$emit('image-updated', newImage, image);
+                    return newImage;
+                });
+        }
+
+        function untilEqual({ image, expectedAlbum }) {
+            return image.get().then(apiImage => {
+                const apiAlbum = imageAccessor.getAlbum(apiImage);
+                return angular.equals(apiAlbum.data, expectedAlbum) ? apiImage : $q.reject();
+            });
+        }
+
+        return {
+            add,
+            remove,
+            batchAdd,
+            batchRemove
+        };
+    }
+]);

--- a/kahuna/public/js/services/image-accessor.js
+++ b/kahuna/public/js/services/image-accessor.js
@@ -65,6 +65,11 @@ imageAccessor.factory('imageAccessor', function() {
         return collections.map(col => col.data.pathId);
     }
 
+    function getAlbum(image) {
+        const userMetadata = extractUserMetadata(image);
+        return userMetadata.data.album;
+    }
+
     return {
         readCost,
         readLabels,
@@ -76,7 +81,8 @@ imageAccessor.factory('imageAccessor', function() {
         isPersisted,
         isArchived,
         readCollections,
-        getCollectionsIds
+        getCollectionsIds,
+        getAlbum
     };
 });
 


### PR DESCRIPTION
Adds a new field to the image preview page to edit the album field.

Things to note:
- Uses typeahead for suggestions
- Setting an empty album deletes it (will add a delete button in a following PR)

Will do the following in separate PRs:
- batch edit from the search page
- allow album to be set on upload
- deletion button
- better styling of suggestion drop down to overlay it rather than change layout

# Example
![album](https://user-images.githubusercontent.com/836140/43125307-883ac730-8f21-11e8-90e3-cc689633b6ef.gif)