### PR TITLE
(temp) remove album field from uploads page

### DIFF
--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -119,17 +119,6 @@
             </div>
         </div>
 
-        <div class="result-editor__field-container flex-container flex-center">
-            <span class="result-editor__field-label flex-no-shrink text-small">
-                Album
-            </span>
-            <gr-album class="flex-spacer"
-                      images="[ctrl.image]"
-                      with-batch="ctrl.withBatch"
-                      edit-inline="true">
-            </gr-album>
-        </div>
-
         <ui-required-metadata-editor
             class="result-editor__metadata-editor"
             resource="ctrl.image.data.userMetadata.data.metadata"


### PR DESCRIPTION
We've not yet shown this feature to picture editors and have been getting questions about it as some users are confusing it with the description field (muscle memory!).

Remove the field from the uploads page until we've talked with pic eds (next week).