### PR TITLE
allow blob images in csp

### DIFF
--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -35,7 +35,7 @@ object KahunaSecurityConfig {
     val frameAncestors = s"frame-ancestors ${config.services.toolsDomains.map(domain => s"*.$domain").mkString(" ")}"
     val connectSources = s"connect-src ${(services :+ config.imageOrigin).mkString(" ")} 'self' www.google-analytics.com"
 
-    val imageSources = s"img-src data: ${config.services.imgopsBaseUri} https://${config.fullOrigin} https://${config.thumbOrigin} ${config.cropOrigin} www.google-analytics.com 'self'"
+    val imageSources = s"img-src data: blob: ${config.services.imgopsBaseUri} https://${config.fullOrigin} https://${config.thumbOrigin} ${config.cropOrigin} www.google-analytics.com 'self'"
 
     base.copy(
       // covered by frame-ancestors in contentSecurityPolicy


### PR DESCRIPTION
When we upload an image, we display a preview of it via a blob url. Currently, the preview is a broken image as csp blocks the request.

![before](https://user-images.githubusercontent.com/836140/43327836-6648abfc-91b4-11e8-8bde-852d0fa24d0a.gif)


This fixes it.

![after](https://user-images.githubusercontent.com/836140/43327855-72df988a-91b4-11e8-94fd-27d49ae9be59.gif)
