### PR TITLE
log get by usage id endpoint

### DIFF
--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -14,6 +14,7 @@ import play.api.libs.json.{JsError, JsValue, Json}
 import play.api.mvc._
 import play.utils.UriEncoding
 import com.gu.mediaservice.lib.argo.model.{Action => ArgoAction}
+import com.gu.mediaservice.lib.logging.GridLogger
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -51,6 +52,7 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
   def index = auth { indexResponse }
 
   def forUsage(usageId: String) = auth.async {
+    GridLogger.info(s"Request for single usage $usageId")
     val usageFuture = usageTable.queryByUsageId(usageId)
 
     usageFuture.map[play.api.mvc.Result]((mediaUsageOption: Option[MediaUsage]) => {


### PR DESCRIPTION
There's a suspicion that this endpoint is not being used and can be removed. Add some logging to record access levels.