### PR TITLE
make UsageStatus optional

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
@@ -9,7 +9,7 @@ case class Usage(
   references: List[UsageReference],
   platform: String,
   media: String,
-  status: UsageStatus,
+  status: Option[UsageStatus],
   dateAdded: Option[DateTime],
   dateRemoved: Option[DateTime],
   lastModified: DateTime,

--- a/usage/app/lib/UsageBuilder.scala
+++ b/usage/app/lib/UsageBuilder.scala
@@ -20,7 +20,7 @@ object UsageBuilder {
     usage.digitalUsageMetadata
   )
 
-  private def buildStatusString(usage: MediaUsage): UsageStatus = if (usage.isRemoved) RemovedUsageStatus() else usage.status
+  private def buildStatusString(usage: MediaUsage): Option[UsageStatus] = if (usage.isRemoved) Some(RemovedUsageStatus()) else usage.status
 
   private def buildId(usage: MediaUsage): String = {
     UsageTableFullKey.build(usage).toString

--- a/usage/app/model/MediaUsage.scala
+++ b/usage/app/model/MediaUsage.scala
@@ -14,7 +14,7 @@ case class MediaUsage(
   mediaId: String,
   usageType: String,
   mediaType: String,
-  status: UsageStatus,
+  status: Option[UsageStatus],
   printUsageMetadata: Option[PrintUsageMetadata],
   digitalUsageMetadata: Option[DigitalUsageMetadata],
   lastModified: DateTime,
@@ -46,10 +46,7 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
       item.getString("media_id"),
       item.getString("usage_type"),
       item.getString("media_type"),
-      item.getString("usage_status") match {
-        case "pending" => PendingUsageStatus()
-        case "published" => PublishedUsageStatus()
-      },
+      Option(item.getString("usage_status")).map(UsageStatus(_)),
       Option(item.getMap[Any]("print_metadata"))
         .map(_.asScala.toMap).flatMap(usageMetadataBuilder.buildPrint),
       Option(item.getMap[Any]("digital_metadata"))
@@ -65,7 +62,7 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
     printUsage.mediaId,
     "print",
     "image",
-    printUsage.usageStatus,
+    Some(printUsage.usageStatus),
     Some(printUsage.printUsageMetadata),
     None,
     printUsage.dateAdded
@@ -80,7 +77,7 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
       mediaId = mediaWrapper.mediaId,
       usageType = "digital",
       mediaType = "image",
-      status = mediaWrapper.contentStatus,
+      status = Some(mediaWrapper.contentStatus),
       printUsageMetadata = None,
       digitalUsageMetadata = Some(mediaWrapper.usageMetadata),
       lastModified = mediaWrapper.lastModified

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -11,7 +11,7 @@ import org.joda.time.DateTime
 case class UsageGroup(
   usages: Set[MediaUsage],
   grouping: String,
-  status: UsageStatus,
+  status: Option[UsageStatus],
   lastModified: DateTime,
   isReindex: Boolean = false
 )
@@ -29,7 +29,7 @@ class UsageGroupOps(config: UsageConfig, mediaUsageOps: MediaUsageOps, liveConte
     ContentWrapper.build(content, status, lastModified).map(contentWrapper => {
       val usages = createUsages(contentWrapper, isReindex)
       Logger.info(s"Built UsageGroup: ${contentWrapper.id}")
-      UsageGroup(usages.toSet, contentWrapper.id, status, lastModified, isReindex)
+      UsageGroup(usages.toSet, contentWrapper.id, Some(status), lastModified, isReindex)
     })
 
   def build(printUsageRecords: List[PrintUsageRecord]) =
@@ -39,7 +39,7 @@ class UsageGroupOps(config: UsageConfig, mediaUsageOps: MediaUsageOps, liveConte
       UsageGroup(
         Set(mediaUsageOps.build(printUsageRecord, usageId, buildId(printUsageRecord))),
         usageId.toString,
-        printUsageRecord.usageStatus,
+        Some(printUsageRecord.usageStatus),
         printUsageRecord.dateAdded
       )
     })

--- a/usage/app/model/UsageRecord.scala
+++ b/usage/app/model/UsageRecord.scala
@@ -59,7 +59,7 @@ object UsageRecord {
     Some(mediaUsage.usageType),
     Some(mediaUsage.mediaType),
     Some(mediaUsage.lastModified),
-    Some(mediaUsage.status.toString),
+    mediaUsage.status.map(_.toString),
     mediaUsage.printUsageMetadata,
     mediaUsage.digitalUsageMetadata
   )
@@ -71,7 +71,7 @@ object UsageRecord {
     Some(mediaUsage.usageType),
     Some(mediaUsage.mediaType),
     Some(mediaUsage.lastModified),
-    Some(mediaUsage.status.toString),
+    mediaUsage.status.map(_.toString),
     mediaUsage.printUsageMetadata,
     mediaUsage.digitalUsageMetadata,
     Some(mediaUsage.lastModified),

--- a/usage/app/model/UsageTable.scala
+++ b/usage/app/model/UsageTable.scala
@@ -65,13 +65,16 @@ class UsageTable(config: UsageConfig, mediaUsage: MediaUsageOps) extends DynamoD
   }
 
   def hidePendingIfRemoved(usages: Set[MediaUsage]): Set[MediaUsage] = usages.filterNot((mediaUsage: MediaUsage) => {
-    mediaUsage.status.isInstanceOf[PendingUsageStatus] && mediaUsage.isRemoved
+    mediaUsage.status match {
+      case Some(PendingUsageStatus()) => mediaUsage.isRemoved
+      case _ => false
+    }
   })
 
   def hidePendingIfPublished(usages: Set[MediaUsage]): Set[MediaUsage] = usages.groupBy(_.grouping).flatMap {
     case (grouping, groupedUsages) =>
       val publishedUsage = groupedUsages.find(_.status match {
-        case _: PublishedUsageStatus => true
+        case Some(PublishedUsageStatus()) => true
         case _ => false
       })
 


### PR DESCRIPTION
This is to support Fronts usage reporting as we don't know the publish state from this Tool.

I think we need to understand why this is before merging this; as we're rebuilding Fronts, we may have an opportunity to address this? cc @Reettaphant 