### PR TITLE
fix leases in info panel on search page

### DIFF
--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -76,11 +76,11 @@
 
 
 <div class="leases__wrapper image-info__wrap">
-  <div class="image-info__lease" ng:if="ctrl.images.length > 1">
+  <div class="image-info__lease" ng:if="ctrl.totalImages > 1">
     {{ctrl.leases.current.length}} current leases + {{ctrl.inactiveLeases(ctrl.leases)}} inactive leases
   </div>
 
-  <ul ng:if="ctrl.images.length === 1">
+  <ul ng:if="ctrl.totalImages === 1">
     <li ng-repeat="lease in ctrl.leases.leases"
         gr:tooltip="{{ctrl.toolTip(lease)}}"
         class="lease__item"

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -197,12 +197,12 @@ leases.controller('LeasesCtrl', [
             ctrl.updateLeases();
         });
 
-        $scope.$watch(() => ctrl.images.length, () => {
+        $scope.$watchCollection(() => Array.from(ctrl.images), () => {
+            ctrl.totalImages = ctrl.images.size;
             ctrl.updateLeases();
         });
 
         ctrl.resetLeaseForm();
-        ctrl.updateLeases();
 }]);
 
 leases.directive('grLeases', [function() {


### PR DESCRIPTION
Fixes https://github.com/guardian/grid/issues/2179.

`ctrl.images` is a `Set` which doesn't have a `length` property 🤦‍♂️

Multi leases may need some attention for the syndication workflow, but I think that's a separate PR.

# Single image selected
![image](https://user-images.githubusercontent.com/836140/43476174-cf5e3ca4-94ef-11e8-88e7-366815b1014f.png)

# Multiple images selected
![image](https://user-images.githubusercontent.com/836140/43476103-a2337b5e-94ef-11e8-9e54-195c4fdbd92d.png)
