### PR TITLE
DigitalUsageMetadata as a trait for extensibility

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DigitalUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DigitalUsageMetadata.scala
@@ -2,23 +2,41 @@ package com.gu.mediaservice.model
 
 import play.api.libs.json._
 
+sealed trait DigitalUsageMetadata {
+  val url: String
+  val title: String
+  def toMap: Map[String, String]
+}
 
-case class DigitalUsageMetadata(
-  webTitle: String,
+case class ArticleUsageMetadata (
   webUrl: String,
+  webTitle: String,
   sectionId: String,
   composerUrl: Option[String] = None
-) {
-  val placeholderWebTitle = "No title given"
-  val dynamoSafeWebTitle = if (webTitle.isEmpty) placeholderWebTitle else webTitle
+) extends DigitalUsageMetadata {
+  override val url: String = webUrl
+  override val title: String = webTitle
 
-  def toMap = Map(
+  private val placeholderWebTitle = "No title given"
+  private val dynamoSafeWebTitle = if(webTitle.isEmpty) placeholderWebTitle else webTitle
+
+  override def toMap: Map[String, String] = Map(
     "webTitle" -> dynamoSafeWebTitle,
     "webUrl" -> webUrl,
     "sectionId" -> sectionId
   ) ++ composerUrl.map("composerUrl" -> _)
 }
+
+object ArticleUsageMetadata {
+  implicit val reader: Reads[ArticleUsageMetadata] = Json.reads[ArticleUsageMetadata]
+  val writer: Writes[ArticleUsageMetadata] = Json.writes[ArticleUsageMetadata]
+}
+
 object DigitalUsageMetadata {
-  implicit val reads: Reads[DigitalUsageMetadata] = Json.reads[DigitalUsageMetadata]
-  implicit val writes: Writes[DigitalUsageMetadata] = Json.writes[DigitalUsageMetadata]
+  implicit val reads: Reads[DigitalUsageMetadata] =
+    __.read[ArticleUsageMetadata].map(metadata => metadata: DigitalUsageMetadata)
+
+  implicit val writes: Writes[DigitalUsageMetadata] = Writes[DigitalUsageMetadata]{
+    case metadata: ArticleUsageMetadata => ArticleUsageMetadata.writer.writes(metadata)
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DigitalUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DigitalUsageMetadata.scala
@@ -1,30 +1,32 @@
 package com.gu.mediaservice.model
 
+import java.net.URI
 import play.api.libs.json._
+import com.gu.mediaservice.syntax._
 
 sealed trait DigitalUsageMetadata {
-  val url: String
+  val url: URI
   val title: String
   def toMap: Map[String, String]
 }
 
 case class ArticleUsageMetadata (
-  webUrl: String,
+  webUrl: URI,
   webTitle: String,
   sectionId: String,
-  composerUrl: Option[String] = None
+  composerUrl: Option[URI] = None
 ) extends DigitalUsageMetadata {
-  override val url: String = webUrl
+  override val url: URI = webUrl
   override val title: String = webTitle
 
   private val placeholderWebTitle = "No title given"
   private val dynamoSafeWebTitle = if(webTitle.isEmpty) placeholderWebTitle else webTitle
 
   override def toMap: Map[String, String] = Map(
+    "webUrl" -> webUrl.toString,
     "webTitle" -> dynamoSafeWebTitle,
-    "webUrl" -> webUrl,
     "sectionId" -> sectionId
-  ) ++ composerUrl.map("composerUrl" -> _)
+  ) ++ composerUrl.map("composerUrl" -> _.toString)
 }
 
 object ArticleUsageMetadata {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReference.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReference.scala
@@ -1,11 +1,13 @@
 package com.gu.mediaservice.model
 
-import play.api.libs.json._
+import java.net.URI
 
+import play.api.libs.json._
+import com.gu.mediaservice.syntax._
 
 case class UsageReference(
   `type`: String,
-  uri: Option[String] = None,
+  uri: Option[URI] = None,
   name: Option[String] = None
 )
 object UsageReference {

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/PlayJsonSyntax.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/PlayJsonSyntax.scala
@@ -1,7 +1,11 @@
 package com.gu.mediaservice.syntax
 
-import play.api.libs.json.JsResult
+import java.net.URI
+
+import play.api.libs.json._
 import com.gu.mediaservice.lib.json.PlayJsonHelpers
+
+import scala.util.{Failure, Success, Try}
 
 trait PlayJsonSyntax {
 
@@ -9,6 +13,21 @@ trait PlayJsonSyntax {
     def logParseErrors(): Unit = PlayJsonHelpers.logParseErrors(self)
   }
 
+  implicit val uriWrites = new Writes[URI] {
+    override def writes(o: URI): JsValue = JsString(o.toString)
+  }
+
+  implicit val uriReads = new Reads[URI] {
+    override def reads(json: JsValue): JsResult[URI] = json match {
+      case JsString(uriInJson) => Try {
+        new URI(uriInJson)
+      } match {
+        case Success(uri) => JsSuccess(uri)
+        case Failure(_) => JsError(s"Could not parse $uriInJson as valid URI")
+      }
+      case _ => JsError("URI as String expected")
+    }
+  }
 }
 
 object PlayJsonSyntax extends PlayJsonSyntax

--- a/usage/app/lib/UsageBuilder.scala
+++ b/usage/app/lib/UsageBuilder.scala
@@ -46,12 +46,9 @@ object UsageBuilder {
 
     }).getOrElse(List[UsageReference]())
 
-  private def buildWebUsageReference(usage: MediaUsage) =
-    usage.digitalUsageMetadata.map(metadata => {
-      List(
-        UsageReference("frontend", Some(metadata.webUrl), Some(metadata.webTitle))
-      ) ++ metadata.composerUrl.map(url => UsageReference("composer", Some(url)))
-
-    }).getOrElse(List[UsageReference]())
-
+  private def buildWebUsageReference(usage: MediaUsage): List[UsageReference] = usage.digitalUsageMetadata.map {
+    case article: ArticleUsageMetadata => List(
+      UsageReference("frontend", Some(article.webUrl), Some(article.webTitle))
+    ) ++ article.composerUrl.map(url => UsageReference("composer", Some(url)))
+  }.getOrElse(List[UsageReference]())
 }

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -1,9 +1,9 @@
 package lib
 
-import java.net.URL
+import java.net.URI
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.mediaservice.model.{ArticleUsageMetadata, DigitalUsageMetadata, PrintImageSize, PrintUsageMetadata}
+import com.gu.mediaservice.model.{ArticleUsageMetadata, PrintImageSize, PrintUsageMetadata}
 import org.joda.time.format.ISODateTimeFormat
 
 import scala.util.Try
@@ -13,10 +13,10 @@ class UsageMetadataBuilder(config: UsageConfig) {
   def buildDigital(metadataMap: Map[String, Any]): Option[ArticleUsageMetadata] = {
     Try {
       ArticleUsageMetadata(
+        URI.create(metadataMap("webUrl").asInstanceOf[String]),
         metadataMap("webTitle").asInstanceOf[String],
-        metadataMap("webUrl").asInstanceOf[String],
         metadataMap("sectionId").asInstanceOf[String],
-        metadataMap.get("composerUrl").map(_.asInstanceOf[String])
+        metadataMap.get("composerUrl").map(x => URI.create(x.asInstanceOf[String]))
       )
     }.toOption
   }
@@ -47,17 +47,17 @@ class UsageMetadataBuilder(config: UsageConfig) {
 
   def build(content: Content): ArticleUsageMetadata = {
     ArticleUsageMetadata(
+      URI.create(content.webUrl),
       content.webTitle,
-      content.webUrl,
       content.sectionId.getOrElse("none"),
       composerUrl(content)
     )
   }
 
-  def composerUrl(content: Content): Option[String] = content.fields
+  def composerUrl(content: Content): Option[URI] = content.fields
     .flatMap(_.internalComposerCode)
     .flatMap(composerId => {
-      Try(new URL(s"${config.composerContentBaseUrl}/$composerId").toString).toOption
+      Try(URI.create(s"${config.composerContentBaseUrl}/$composerId")).toOption
     })
 
 }

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -3,16 +3,16 @@ package lib
 import java.net.URL
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.mediaservice.model.{DigitalUsageMetadata, PrintImageSize, PrintUsageMetadata}
+import com.gu.mediaservice.model.{ArticleUsageMetadata, DigitalUsageMetadata, PrintImageSize, PrintUsageMetadata}
 import org.joda.time.format.ISODateTimeFormat
 
 import scala.util.Try
 
 class UsageMetadataBuilder(config: UsageConfig) {
 
-  def buildDigital(metadataMap: Map[String, Any]): Option[DigitalUsageMetadata] = {
+  def buildDigital(metadataMap: Map[String, Any]): Option[ArticleUsageMetadata] = {
     Try {
-      DigitalUsageMetadata(
+      ArticleUsageMetadata(
         metadataMap("webTitle").asInstanceOf[String],
         metadataMap("webUrl").asInstanceOf[String],
         metadataMap("sectionId").asInstanceOf[String],
@@ -45,8 +45,8 @@ class UsageMetadataBuilder(config: UsageConfig) {
     }.toOption
   }
 
-  def build(content: Content): DigitalUsageMetadata = {
-    DigitalUsageMetadata(
+  def build(content: Content): ArticleUsageMetadata = {
+    ArticleUsageMetadata(
       content.webTitle,
       content.webUrl,
       content.sectionId.getOrElse("none"),


### PR DESCRIPTION
The motivation behind this is to allow for front usage metadata and syndication usage metadata without creating more options on the `Usage` model.