### PR TITLE
ensure composer url is always https

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/net/URI.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/net/URI.scala
@@ -1,10 +1,22 @@
 package com.gu.mediaservice.lib.net
 
-import java.net.{URLDecoder, URLEncoder}
+import java.net.{URI => JURI, URLDecoder, URLEncoder}
 
 object URI {
   def encode(uri: String): String = URLEncoder.encode(uri, "UTF-8").replace("+", "%20")
   def decode(uri: String): String = URLDecoder.decode(uri, "UTF-8")
 
   def encodePlus(uri: String): String = uri.replace("+", "%2B")
+
+  def ensureSecure(str: String): JURI = {
+    val uri = JURI.create(str)
+
+    val secureString : String = (Option(uri.getScheme), Option(uri.getHost)) match {
+      case (Some("https"), _) => str
+      case (Some("http"), Some(host)) => s"https://$host"
+      case (_, _) => s"https://$str"
+    }
+
+    JURI.create(secureString)
+  }
 }

--- a/usage/app/lib/UsageConfig.scala
+++ b/usage/app/lib/UsageConfig.scala
@@ -6,6 +6,7 @@ import com.amazonaws.regions.{Region, RegionUtils}
 import com.amazonaws.services.identitymanagement._
 import com.gu.mediaservice.lib.config.CommonConfig
 import play.api.{Configuration, Logger}
+import com.gu.mediaservice.lib.net.URI.ensureSecure
 
 import scala.util.Try
 
@@ -39,12 +40,7 @@ class UsageConfig(override val configuration: Configuration) extends CommonConfi
   val topicArn = properties("sns.topic.arn")
 
   private val composerBaseUrlProperty: String = properties("composer.baseUrl")
-  private val composerBaseUrlPropertyURI = URI.create(composerBaseUrlProperty)
-  private val composerBaseUrl: String = (Option(composerBaseUrlPropertyURI.getScheme), Option(composerBaseUrlPropertyURI.getHost)) match {
-    case (Some("https"), _) => composerBaseUrlProperty
-    case (Some("http"), Some(host)) => s"https://$host"
-    case (_, _) => s"https://$composerBaseUrlProperty"
-  }
+  private val composerBaseUrl = ensureSecure(composerBaseUrlProperty)
 
   val composerContentBaseUrl: String = s"$composerBaseUrl/content"
 

--- a/usage/app/lib/UsageConfig.scala
+++ b/usage/app/lib/UsageConfig.scala
@@ -1,5 +1,7 @@
 package lib
 
+import java.net.URI
+
 import com.amazonaws.regions.{Region, RegionUtils}
 import com.amazonaws.services.identitymanagement._
 import com.gu.mediaservice.lib.config.CommonConfig
@@ -36,7 +38,14 @@ class UsageConfig(override val configuration: Configuration) extends CommonConfi
 
   val topicArn = properties("sns.topic.arn")
 
-  val composerBaseUrl: String = properties("composer.baseUrl")
+  private val composerBaseUrlProperty: String = properties("composer.baseUrl")
+  private val composerBaseUrlPropertyURI = URI.create(composerBaseUrlProperty)
+  private val composerBaseUrl: String = (Option(composerBaseUrlPropertyURI.getScheme), Option(composerBaseUrlPropertyURI.getHost)) match {
+    case (Some("https"), _) => composerBaseUrlProperty
+    case (Some("http"), Some(host)) => s"https://$host"
+    case (_, _) => s"https://$composerBaseUrlProperty"
+  }
+
   val composerContentBaseUrl: String = s"$composerBaseUrl/content"
 
   val usageRecordTable = properties("dynamo.tablename.usageRecordTable")


### PR DESCRIPTION
In DEV the propery has an http scheme, in TEST there's none and in PROD its https. 🤷‍♂️

Why not just change config? Enforcing this behaviour in code is more resilient.