### PR TITLE
put leases with rights on upload page

### DIFF
--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -120,6 +120,19 @@
                     </gr-usage-rights-editor>
                 </div>
             </div>
+
+            <div class="result-editor__field-container flex-container">
+                <span class="result-editor__field-label flex-no-shrink text-small">
+                    Leases
+                </span>
+                <div class="result-editor__field-container__leases flex-spacer">
+                    <gr-leases gr:images="[ctrl.image]"
+                        with-batch="ctrl.withBatch"
+                        class="leases-flex"
+                        gr:user-can-edit="true">
+                    </gr-leases>
+                </div>
+            </div>
         </section>
 
         <section>
@@ -132,23 +145,6 @@
                 image="ctrl.image"
                 with-batch="ctrl.withBatch"
             ></ui-required-metadata-editor>
-        </section>
-
-        <section>
-            <h1>Management</h1>
-            <div class="result-editor__field-container flex-container">
-              <span class="result-editor__field-label flex-no-shrink text-small">
-                  Leases
-              </span>
-              <div class="result-editor__field-container__leases flex-spacer">
-                  <gr-leases
-                      gr:images="[ctrl.image]"
-                      with-batch="ctrl.withBatch"
-                      class="leases-flex"
-                      gr:user-can-edit="true">
-                  </gr-leases>
-                </div>
-            </div>
         </section>
 
         <section>


### PR DESCRIPTION
As pointed out by @JonnyWeeks, leases are directly related to rights and restrictions, so putting them close together makes more sense.

# Before
![image](https://user-images.githubusercontent.com/836140/43705154-adb897fc-9959-11e8-8a62-37082d1ded6c.png)

# After
![image](https://user-images.githubusercontent.com/836140/43705113-994058a0-9959-11e8-8166-657d26b6072d.png)
