### PR TITLE
endpoint for POSTing fronts usage

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -218,6 +218,11 @@ object Mappings {
       "partnerName" -> nonAnalyzedString
     )
 
+  val frontUsageMetadata = nonDynamicObj(
+    "addedBy" -> nonAnalyzedString,
+    "front" -> nonAnalyzedString
+  )
+
   val usagesMapping =
     nonDynamicObjWithAttrs(
       "id"           -> nonAnalyzedString,
@@ -231,7 +236,8 @@ object Mappings {
       "lastModified" -> dateFormat,
       "printUsageMetadata" -> printUsageMetadata,
       "digitalUsageMetadata" -> digitalUsageMetadata,
-      "syndicationUsageMetadata" -> syndicationUsageMetadata
+      "syndicationUsageMetadata" -> syndicationUsageMetadata,
+      "frontUsageMetadata" -> frontUsageMetadata
     )(nestedType)
 
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/FrontUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/FrontUsageMetadata.scala
@@ -1,0 +1,18 @@
+package com.gu.mediaservice.model.usage
+
+import play.api.libs.json._
+
+case class FrontUsageMetadata(
+  addedBy: String,
+  front: String
+) extends UsageMetadata {
+  override def toMap: Map[String, Any] = Map(
+    "addedBy" -> addedBy,
+    "front" -> front
+  )
+}
+
+object FrontUsageMetadata {
+  implicit val reader: Reads[FrontUsageMetadata] = Json.reads[FrontUsageMetadata]
+  implicit val writer: Writes[FrontUsageMetadata] = Json.writes[FrontUsageMetadata]
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
@@ -17,7 +17,8 @@ case class Usage(
   // TODO collapse this field into an `Option[UsageMetadata]`
   printUsageMetadata: Option[PrintUsageMetadata] = None,
   digitalUsageMetadata: Option[DigitalUsageMetadata] = None,
-  syndicationUsageMetadata: Option[SyndicationUsageMetadata] = None
+  syndicationUsageMetadata: Option[SyndicationUsageMetadata] = None,
+  frontUsageMetadata: Option[FrontUsageMetadata] = None
 )
 object Usage {
   import JodaWrites._

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReferenceType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReferenceType.scala
@@ -8,6 +8,7 @@ trait UsageReferenceType {
     case FrontendUsageReference => "frontend"
     case ComposerUsageReference => "composer"
     case SyndicationUsageReference => "syndication"
+    case FrontUsageReference => "front"
   }
 }
 
@@ -20,6 +21,7 @@ object UsageReferenceType {
     case "frontend" => FrontendUsageReference
     case "composer" => ComposerUsageReference
     case "syndication" => SyndicationUsageReference
+    case "front" => FrontUsageReference
   }
 }
 
@@ -27,3 +29,4 @@ object InDesignUsageReference extends UsageReferenceType
 object FrontendUsageReference extends UsageReferenceType
 object ComposerUsageReference extends UsageReferenceType
 object SyndicationUsageReference extends UsageReferenceType
+object FrontUsageReference extends UsageReferenceType

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
@@ -8,6 +8,7 @@ sealed trait UsageStatus {
     case PublishedUsageStatus => "published"
     case RemovedUsageStatus => "removed"
     case SyndicatedUsageStatus => "syndicated"
+    case UnknownUsageStatus => "unknown"
   }
 }
 
@@ -17,6 +18,7 @@ object UsageStatus {
     case "published" => PublishedUsageStatus
     case "removed" => RemovedUsageStatus
     case "syndicated" => SyndicatedUsageStatus
+    case "unknown" => UnknownUsageStatus
   }
 
   implicit val reads: Reads[UsageStatus] = JsPath.read[String].map(UsageStatus(_))
@@ -30,3 +32,7 @@ object PendingUsageStatus extends UsageStatus
 object PublishedUsageStatus extends UsageStatus
 object RemovedUsageStatus extends UsageStatus
 object SyndicatedUsageStatus extends UsageStatus
+
+// For Fronts usages as we don't know if a front is in draft or is live
+// TODO remove this once we do!
+object UnknownUsageStatus extends UsageStatus

--- a/usage/app/lib/UsageBuilder.scala
+++ b/usage/app/lib/UsageBuilder.scala
@@ -18,7 +18,8 @@ object UsageBuilder {
     usage.lastModified,
     usage.printUsageMetadata,
     usage.digitalUsageMetadata,
-    usage.syndicationUsageMetadata
+    usage.syndicationUsageMetadata,
+    usage.frontUsageMetadata
   )
 
   private def buildStatusString(usage: MediaUsage): UsageStatus = if (usage.isRemoved) RemovedUsageStatus else usage.status
@@ -29,7 +30,7 @@ object UsageBuilder {
 
   private def buildUsageReference(usage: MediaUsage): List[UsageReference] = {
     usage.usageType match {
-      case DigitalUsage => buildWebUsageReference(usage)
+      case DigitalUsage => buildDigitalUsageReference(usage)
       case PrintUsage => buildPrintUsageReference(usage)
       case SyndicationUsage => buildSyndicationUsageReference(usage)
     }
@@ -48,13 +49,17 @@ object UsageBuilder {
 
     }).getOrElse(List[UsageReference]())
 
-  private def buildWebUsageReference(usage: MediaUsage): List[UsageReference] = usage.digitalUsageMetadata.map(metadata => {
-    List(
-      UsageReference(FrontendUsageReference, Some(metadata.webUrl), Some(metadata.webTitle))
-    ) ++ metadata.composerUrl.map(url => UsageReference(ComposerUsageReference, Some(url)))
-  }).getOrElse(
-    List[UsageReference]()
-  )
+  private def buildDigitalUsageReference(usage: MediaUsage): List[UsageReference] = {
+    (usage.digitalUsageMetadata, usage.frontUsageMetadata) match {
+      case (Some(metadata), None) => List(
+        UsageReference(FrontendUsageReference, Some(metadata.webUrl), Some(metadata.webTitle))
+      ) ++ metadata.composerUrl.map(url => UsageReference(ComposerUsageReference, Some(url)))
+      case (None, Some(metadata)) => List(
+        UsageReference(FrontUsageReference, None, name = Some(metadata.front))
+      )
+      case (_, _) => List[UsageReference]()
+    }
+  }
 
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -3,12 +3,21 @@ package lib
 import java.net.URI
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.mediaservice.model.usage.{DigitalUsageMetadata, PrintImageSize, PrintUsageMetadata, SyndicationUsageMetadata}
+import com.gu.mediaservice.model.usage._
 import org.joda.time.format.ISODateTimeFormat
 
 import scala.util.Try
 
 class UsageMetadataBuilder(config: UsageConfig) {
+
+  def buildFront(metadataMap: Map[String, Any]): Option[FrontUsageMetadata] = {
+    Try {
+      FrontUsageMetadata(
+        metadataMap("addedBy").asInstanceOf[String],
+        metadataMap("front").asInstanceOf[String]
+      )
+    }.toOption
+  }
 
   def buildSyndication(metadataMap: Map[String, Any]): Option[SyndicationUsageMetadata] = {
     Try {

--- a/usage/app/model/FrontUsageRequest.scala
+++ b/usage/app/model/FrontUsageRequest.scala
@@ -1,0 +1,24 @@
+package model
+
+import com.gu.mediaservice.model.usage.{FrontUsageMetadata, UnknownUsageStatus, UsageStatus}
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+
+case class FrontUsageRequest (
+  dateAdded: DateTime,
+  addedBy: String,
+  front: String,
+  mediaId: String
+) {
+  val metadata: FrontUsageMetadata = FrontUsageMetadata(addedBy, front)
+  val status: UsageStatus = UnknownUsageStatus
+}
+
+object FrontUsageRequest {
+  import JodaWrites._
+  import JodaReads._
+
+  implicit val reads: Reads[FrontUsageRequest] = Json.reads[FrontUsageRequest]
+  implicit val writes: Writes[FrontUsageRequest] = Json.writes[FrontUsageRequest]
+}

--- a/usage/app/model/MediaUsage.scala
+++ b/usage/app/model/MediaUsage.scala
@@ -18,6 +18,7 @@ case class MediaUsage(
   printUsageMetadata: Option[PrintUsageMetadata],
   digitalUsageMetadata: Option[DigitalUsageMetadata],
   syndicationUsageMetadata: Option[SyndicationUsageMetadata],
+  frontUsageMetadata: Option[FrontUsageMetadata],
   lastModified: DateTime,
   dateAdded: Option[DateTime] = None,
   dateRemoved: Option[DateTime] = None
@@ -54,6 +55,8 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
         .map(_.asScala.toMap).flatMap(usageMetadataBuilder.buildDigital),
       Option(item.getMap[Any]("syndication_metadata"))
         .map(_.asScala.toMap).flatMap(usageMetadataBuilder.buildSyndication),
+      Option(item.getMap[Any]("front_metadata"))
+        .map(_.asScala.toMap).flatMap(usageMetadataBuilder.buildFront),
       new DateTime(item.getLong("last_modified")),
       Try { item.getLong("date_added") }.toOption.map(new DateTime(_)),
       Try { item.getLong("date_removed") }.toOption.map(new DateTime(_))
@@ -67,6 +70,7 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
     "image",
     printUsage.usageStatus,
     Some(printUsage.printUsageMetadata),
+    None,
     None,
     None,
     printUsage.dateAdded
@@ -85,6 +89,7 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
       printUsageMetadata = None,
       digitalUsageMetadata = Some(mediaWrapper.usageMetadata),
       None,
+      None,
       lastModified = mediaWrapper.lastModified
     )
   }
@@ -101,7 +106,26 @@ class MediaUsageOps(usageMetadataBuilder: UsageMetadataBuilder) {
       printUsageMetadata = None,
       digitalUsageMetadata = None,
       syndicationUsageMetadata = Some(syndicationUsageRequest.metadata),
+      None,
       lastModified = syndicationUsageRequest.dateAdded
+    )
+  }
+
+  def build(frontUsageRequest: FrontUsageRequest, groupId: String): MediaUsage = {
+    val usageId = UsageId.build(frontUsageRequest)
+
+    MediaUsage (
+      usageId,
+      groupId,
+      frontUsageRequest.mediaId,
+      DigitalUsage,
+      mediaType = "image",
+      frontUsageRequest.status,
+      printUsageMetadata = None,
+      digitalUsageMetadata = None,
+      syndicationUsageMetadata = None,
+      frontUsageMetadata = Some(frontUsageRequest.metadata),
+      lastModified = frontUsageRequest.dateAdded
     )
   }
 }

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -32,6 +32,13 @@ class UsageGroupOps(config: UsageConfig, mediaUsageOps: MediaUsageOps, liveConte
     ).mkString("_"))
   }"
 
+  def buildId(frontUsageRequest: FrontUsageRequest): String = s"front/${
+    MD5.hash(List(
+      frontUsageRequest.mediaId,
+      frontUsageRequest.metadata.front
+    ).mkString("_"))
+  }"
+
   def build(content: Content, status: UsageStatus, lastModified: DateTime, isReindex: Boolean) =
     ContentWrapper.build(content, status, lastModified).map(contentWrapper => {
       val usages = createUsages(contentWrapper, isReindex)
@@ -58,6 +65,16 @@ class UsageGroupOps(config: UsageConfig, mediaUsageOps: MediaUsageOps, liveConte
       usageGroupId,
       syndicationUsageRequest.status,
       syndicationUsageRequest.dateAdded
+    )
+  }
+
+  def build(frontUsageRequest: FrontUsageRequest): UsageGroup = {
+    val usageGroupId = buildId(frontUsageRequest)
+    UsageGroup(
+      Set(mediaUsageOps.build(frontUsageRequest, usageGroupId)),
+      usageGroupId,
+      frontUsageRequest.status,
+      frontUsageRequest.dateAdded
     )
   }
 

--- a/usage/app/model/UsageId.scala
+++ b/usage/app/model/UsageId.scala
@@ -29,4 +29,10 @@ object UsageId {
     Some(syndicationUsageRequest.metadata.partnerName),
     Some(syndicationUsageRequest.status)
   ))
+
+  def build(frontUsageRequest: FrontUsageRequest) = buildId(List(
+    Some(frontUsageRequest.mediaId),
+    Some(frontUsageRequest.metadata.front),
+    Some(frontUsageRequest.status)
+  ))
 }

--- a/usage/app/model/UsageRecord.scala
+++ b/usage/app/model/UsageRecord.scala
@@ -2,7 +2,7 @@ package model
 
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder.{M, N, S}
-import com.gu.mediaservice.model.usage.{DigitalUsageMetadata, PrintUsageMetadata, SyndicationUsageMetadata, UsageType}
+import com.gu.mediaservice.model.usage._
 import scalaz.syntax.id._
 
 import scala.collection.JavaConverters._
@@ -19,6 +19,7 @@ case class UsageRecord(
   printUsageMetadata: Option[PrintUsageMetadata] = None,
   digitalUsageMetadata: Option[DigitalUsageMetadata] = None,
   syndicationUsageMetadata: Option[SyndicationUsageMetadata] = None,
+  frontUsageMetadata: Option[FrontUsageMetadata] = None,
   dateAdded: Option[DateTime] = None,
   // Either is used here to represent 3 possible states:
   // remove-date, add-date and no-date
@@ -35,6 +36,7 @@ case class UsageRecord(
         printUsageMetadata.map(_.toMap).map(map => M("print_metadata").set(map.asJava)),
         digitalUsageMetadata.map(_.toMap).map(map => M("digital_metadata").set(map.asJava)),
         syndicationUsageMetadata.map(_.toMap).map(map => M("syndication_metadata").set(map.asJava)),
+        frontUsageMetadata.map(_.toMap).map(map => M("front_metadata").set(map.asJava)),
         dateAdded.map(dateAdd => N("date_added").set(dateAdd.getMillis)),
         dateRemoved.fold(
           _ => Some(N("date_removed").remove),
@@ -61,7 +63,9 @@ object UsageRecord {
     Some(mediaUsage.lastModified),
     Some(mediaUsage.status.toString),
     mediaUsage.printUsageMetadata,
-    mediaUsage.digitalUsageMetadata
+    mediaUsage.digitalUsageMetadata,
+    mediaUsage.syndicationUsageMetadata,
+    mediaUsage.frontUsageMetadata
   )
 
   def buildCreateRecord(mediaUsage: MediaUsage) = UsageRecord(
@@ -75,6 +79,7 @@ object UsageRecord {
     mediaUsage.printUsageMetadata,
     mediaUsage.digitalUsageMetadata,
     mediaUsage.syndicationUsageMetadata,
+    mediaUsage.frontUsageMetadata,
     Some(mediaUsage.lastModified),
     Left("clear")
   )

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -5,6 +5,7 @@ GET     /usages/media/:mediaId                          controllers.UsageApi.for
 DELETE  /usages/media/:mediaId                          controllers.UsageApi.deleteUsages(mediaId: String)
 POST    /usages/print                                   controllers.UsageApi.setPrintUsages
 POST    /usages/syndication                             controllers.UsageApi.setSyndicationUsages
+POST    /usages/front                                   controllers.UsageApi.setFrontUsages
 
 GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
 


### PR DESCRIPTION
https://github.com/guardian/grid/pull/2248 take 2 after all the changes for syndication usages.

Payload example:
```json
{
  "data": {
    "dateAdded": "2018-08-06T00:00:00",
    "addedBy": "foo.bar@guardian.co.uk",
    "front": "uk-news",
    "mediaId": "grid-image-id"
  }
}
```