### PR TITLE
render front usages a bit nicer

### DIFF
--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
@@ -28,6 +28,7 @@ module.controller('grImageUsageCtrl', [
         const usages$ = usages.groupedByState$.map((u) => u.toJS());
         const usagesCount$ = usages.count$;
 
+      // TODO match on `platform` rather than `type` as `platform` includes more detail
         ctrl.usageTypeToName = (usageType) => {
             switch (usageType) {
                 case 'removed':
@@ -36,6 +37,8 @@ module.controller('grImageUsageCtrl', [
                     return 'Pending publication';
                 case 'published':
                     return 'Published';
+                case 'unknown':
+                    return 'Front'; // currently only fronts have an `unknown` type, see TODO above
                 default:
                     return usageType;
             }

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -16,7 +16,15 @@ imageUsagesService.factory('imageUsagesService', [function() {
     return {
         getUsages: (imageResource) => {
 
+            function frontsUsageTitle(usage) {
+              const metadata = usage.get('frontUsageMetadata');
+              return `${metadata.get('front')}, ${metadata.get('addedBy')}`;
+            }
+
             function usageTitle(usage) {
+                if (usage.has('frontUsageMetadata')) {
+                  return frontsUsageTitle(usage);
+                }
                 const referenceType =
                     usage.get('platform') == 'print' ? 'indesign' : 'frontend';
 


### PR DESCRIPTION
This is a little hacky, but gets us moving.

# Before
![image](https://user-images.githubusercontent.com/836140/43949816-854e2572-9c86-11e8-922c-5a06fdab5ace.png)


# After
![image](https://user-images.githubusercontent.com/836140/43949784-70362d1a-9c86-11e8-8036-90f658908709.png)
