### PR TITLE
update inferred rights when updating an image's photoshoot

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -27,7 +27,9 @@ case class Image(
   leases:              LeaseByMedia     = LeaseByMedia.build(Nil),
   collections:         List[Collection] = Nil,
   syndicationRights:   Option[SyndicationRights] = None
-)
+) {
+  def rcsPublishDate: Option[DateTime] = syndicationRights.flatMap(_.published)
+}
 
 object Image {
 

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -108,7 +108,7 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
   def setPhotoshoot(id: String) = auth.async(parse.json) { req => {
     (req.body \ "data").asOpt[Photoshoot].map(photoshoot => {
       store.jsonAdd(id, "photoshoot", caseClassToMap(photoshoot))
-        .map(publish(id))
+        .map(publish(id, "update-image-photoshoot"))
         .map(_ => respond(photoshoot))
     }).getOrElse(
       Future.successful(respondError(BadRequest, "invalid-form-data", "Invalid form data"))
@@ -116,7 +116,9 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
   }}
 
   def deletePhotoshoot(id: String) = auth.async {
-    store.removeKey(id, "photoshoot").map(publish(id)).map(_ => Accepted)
+    store.removeKey(id, "photoshoot")
+      .map(publish(id, "update-image-photoshoot"))
+      .map(_ => Accepted)
   }
 
   def addLabels(id: String) = auth.async(parse.json) { req =>
@@ -213,7 +215,7 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
   def labelsCollection(id: String, labels: Set[String]): (URI, Seq[EmbeddedEntity[String]]) =
     (labelsUri(id), labels.map(setUnitEntity(id, "labels", _)).toSeq)
 
-  def publish(id: String)(metadata: JsObject): Edits = {
+  def publish(id: String, subject: String = "update-image-user-metadata")(metadata: JsObject): Edits = {
     val edits = metadata.as[Edits]
     val message = Json.obj(
       "id" -> id,
@@ -221,7 +223,7 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
       "lastModified" -> printDateTime(new DateTime())
     )
 
-    notifications.publish(message, "update-image-user-metadata")
+    notifications.publish(message, subject)
 
     edits
   }

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -9,14 +9,15 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
 
   val store = new ThrallStore(config)
   val dynamoNotifications = new DynamoNotifications(config)
-  val thrallNotifications = new ThrallNotifications(config)
   val thrallMetrics = new ThrallMetrics(config)
 
   val es = new ElasticSearch(config, thrallMetrics)
   es.ensureAliasAssigned()
 
+  private val thrallNotifications = new ThrallNotifications(config)
+  val syndicationNotifications = new SyndicationNotifications(thrallNotifications)
 
-  val thrallMessageConsumer = new ThrallMessageConsumer(config, es, thrallMetrics, store, dynamoNotifications, thrallNotifications)
+  val thrallMessageConsumer = new ThrallMessageConsumer(config, es, thrallMetrics, store, dynamoNotifications, syndicationNotifications)
   
   thrallMessageConsumer.startSchedule()
   context.lifecycle.addStopHook {

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -17,7 +17,9 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   private val thrallNotifications = new ThrallNotifications(config)
   val syndicationNotifications = new SyndicationNotifications(thrallNotifications)
 
-  val thrallMessageConsumer = new ThrallMessageConsumer(config, es, thrallMetrics, store, dynamoNotifications, syndicationNotifications)
+  val syndicationOps = new SyndicationRightsOps(es, syndicationNotifications)
+
+  val thrallMessageConsumer = new ThrallMessageConsumer(config, es, thrallMetrics, store, dynamoNotifications, syndicationOps)
   
   thrallMessageConsumer.startSchedule()
   context.lifecycle.addStopHook {

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -290,7 +290,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
       }
   }
 
-  def getImagesWithInferredSyndicationRights(photoshoot: Photoshoot, excludedImage: Option[Image])(implicit ex: ExecutionContext): Future[List[Image]] = {
+  def getInferredSyndicationRights(photoshoot: Photoshoot, excludedImage: Option[Image])(implicit ex: ExecutionContext): Future[List[Image]] = {
     // absence of `published` field means `syndicationRights` hasn't come from RCS
     val inferredSyndicationRights = missingFilter("syndicationRights.published")
 
@@ -314,7 +314,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
       .map(_.map(_.as[Image]))
   }
 
-  def getMostRecentSyndicationRights(photoshoot: Photoshoot, excludedImage: Option[Image])(implicit ex: ExecutionContext): Future[Option[Image]] = {
+  def getLatestSyndicationRights(photoshoot: Photoshoot, excludedImage: Option[Image])(implicit ex: ExecutionContext): Future[Option[Image]] = {
     // presence of `published` field means `syndicationRights` has come from RCS
     val nonInferredSyndicationRights = existsFilter("syndicationRights.published")
 

--- a/thrall/app/lib/SyndicationNotifications.scala
+++ b/thrall/app/lib/SyndicationNotifications.scala
@@ -1,0 +1,40 @@
+package lib
+
+import com.gu.mediaservice.lib.logging.GridLogger
+import com.gu.mediaservice.model.{Image, SyndicationRights}
+import play.api.libs.json.Json
+
+class SyndicationNotifications(thrallNotifications: ThrallNotifications) {
+  def sendRemoval(images: List[Image]): Unit =
+    images.foreach(sendRemoval)
+
+  def sendRemoval(image: Image): Unit = {
+    GridLogger.info("deleting inferred rights", image.id)
+    thrallNotifications.publish(
+      Json.obj("id" -> image.id),
+      subject = SyndicationNotifications.deleteSubject
+    )
+  }
+
+  def sendRefresh(images: List[Image], syndicationRights: SyndicationRights): Unit =
+    images.foreach(sendRefresh(_, syndicationRights))
+
+  def sendRefresh(image: Image, syndicationRights: SyndicationRights): Unit = {
+    GridLogger.info(s"refreshing inferred rights", image.id)
+    val inferredRights = syndicationRights.copy(published = None)
+
+    val message = Json.obj(
+      "id" -> image.id,
+      "data" -> Json.toJson(inferredRights)
+    )
+    thrallNotifications.publish(
+      message,
+      subject = SyndicationNotifications.refreshSubject
+    )
+  }
+}
+
+object SyndicationNotifications {
+  val refreshSubject = "refresh-inferred-rights"
+  val deleteSubject = "delete-inferred-rights"
+}

--- a/thrall/app/lib/SyndicationRightsOps.scala
+++ b/thrall/app/lib/SyndicationRightsOps.scala
@@ -1,0 +1,90 @@
+package lib
+
+import com.gu.mediaservice.lib.logging.GridLogger
+import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
+
+import scala.concurrent.ExecutionContext
+
+class SyndicationRightsOps(
+  es: ElasticSearch,
+  notifications: SyndicationNotifications
+)(implicit ex: ExecutionContext) {
+
+  def refreshInferredRights(image: Image, rights: SyndicationRights) = {
+    image.userMetadata.flatMap(_.photoshoot) match {
+      case Some(photoshoot) if !rights.isInferred =>
+        refreshRightsInferenceInPhotoshoot(photoshoot, rights, Some(image))
+        image
+      case _ => image
+    }
+  }
+
+  def moveExplicitRightsToPhotoshoot(image: Image, maybeNewPhotoshoot: Option[Photoshoot]) = {
+    def updateOldPhotoshoot(photoshoot: Photoshoot) = {
+      es.getLatestSyndicationRights(photoshoot, Some(image)) map {
+        case Some(latestImageWithExplicitRights) if image.rcsPublishDate.get.isAfter(latestImageWithExplicitRights.rcsPublishDate.get) => {
+          GridLogger.info(s"refreshing inferred syndication rights for images using ${latestImageWithExplicitRights.id} because ${image.id} has moved", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
+          refreshRightsInferenceInPhotoshoot(photoshoot, latestImageWithExplicitRights.syndicationRights.get, None)
+        }
+        case None => {
+          GridLogger.info(s"removing inferred rights from photoshoot as it no longer contains an image with direct rights", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
+          es.getInferredSyndicationRights(photoshoot, None)
+            .map(notifications.sendRemoval)
+        }
+        case _ => None // no-op
+      }
+    }
+
+    def updateNewPhotoshoot(photoshoot: Photoshoot) = {
+      es.getLatestSyndicationRights(photoshoot, None) map {
+        case Some(mostRecentImage) if image.rcsPublishDate.get.isAfter(mostRecentImage.rcsPublishDate.get) => {
+          GridLogger.info(s"refreshing inferred syndication rights for images using ${image.id} because its the most recent", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
+          refreshRightsInferenceInPhotoshoot(photoshoot, image.syndicationRights.get, None)
+        }
+        case None => {
+          GridLogger.info(s"refreshing inferred syndication rights for images using ${image.id} because none previously existed", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
+          refreshRightsInferenceInPhotoshoot(photoshoot, image.syndicationRights.get, None)
+        }
+        case _ => None // no-op
+      }
+    }
+
+    for {
+      _ <- image.userMetadata.flatMap(_.photoshoot).map(updateOldPhotoshoot)
+      _ <- maybeNewPhotoshoot.map(updateNewPhotoshoot)
+    } yield {
+      image
+    }
+  }
+
+  def moveInferredRightsToPhotoshoot(image: Image, maybeNewPhotoshoot: Option[Photoshoot]) = {
+    val maybeOldPhotoshoot  = image.userMetadata.flatMap(_.photoshoot)
+
+    (maybeOldPhotoshoot, maybeNewPhotoshoot) match {
+      case (Some(_), None) => {
+        GridLogger.info("image removed from photoshoot, removing inferred rights", image.id)
+        notifications.sendRemoval(image)
+      }
+      case (_, Some(newPhotoshoot)) => {
+        es.getLatestSyndicationRights(newPhotoshoot, None) map {
+          case Some(i) => {
+            GridLogger.info(s"inferring rights from ${i.id} as its the most recent in new photoshoot", image.id)
+            notifications.sendRefresh(image, i.syndicationRights.get)
+          }
+          case None => {
+            GridLogger.info("cannot infer rights from new photoshoot, removing inferred rights", image.id)
+            notifications.sendRemoval(image)
+          }
+        }
+      }
+      case (None, None) => None // no-op, shouldn't happen
+    }
+  }
+
+  private def refreshRightsInferenceInPhotoshoot(photoshoot: Photoshoot, syndicationRights: SyndicationRights, excludedImage: Option[Image]) = {
+    GridLogger.info("refreshing inference of rights on photoshoot", Map("photoshoot" -> photoshoot.title))
+
+    es.getInferredSyndicationRights(photoshoot, excludedImage)
+      .map(notifications.sendRefresh(_, syndicationRights))
+  }
+}

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -3,7 +3,7 @@ package lib
 import play.api.libs.json._
 import com.gu.mediaservice.lib.aws.MessageConsumer
 import com.gu.mediaservice.lib.logging.GridLogger
-import com.gu.mediaservice.model.{Image, SyndicationRights}
+import com.gu.mediaservice.model.{Edits, Image, Photoshoot, SyndicationRights}
 import org.elasticsearch.action.delete.DeleteResponse
 import org.elasticsearch.action.update.UpdateResponse
 
@@ -38,6 +38,8 @@ class ThrallMessageConsumer(
       case "delete-usages"              => deleteAllUsages
       case "upsert-rcs-rights"          => upsertSyndicationRights
       case "refresh-inferred-rights"    => upsertSyndicationRights
+      case "update-image-photoshoot"    => updateImagePhotoshoot
+      case "delete-inferred-rights"     => deleteInferredRights
     }
   }
 
@@ -115,16 +117,131 @@ class ThrallMessageConsumer(
     )
   }
 
+  def updateImagePhotoshoot(message: JsValue) = {
+    (message \ "data").validate[Edits].fold(
+      err => {
+        val msg = s"Unable to parse message as Edits ${JsError.toJson(err).toString}"
+        GridLogger.error(msg)
+        Future.failed(SNSBodyParseError(msg))
+      },
+      upcomingEdits => withImageId(message) { id => {
+        GridLogger.info("updating photoshoot", id)
+
+        es.getImage(id) map {
+          case Some(image) => {
+            image.syndicationRights match {
+              case Some(rights) if !rights.isInferred => notInferred(image, upcomingEdits)
+              case _ => inferred(image, upcomingEdits)
+            }
+
+            updateImageUserMetadata(message)
+          }
+          case _ => {
+            GridLogger.info(s"image not found", id)
+            None
+          }
+        }
+      }}
+    )
+  }
+
+  def deleteInferredRights(message: JsValue) = {
+    Future.sequence(
+      withImageId(message) { id =>
+        GridLogger.info("deleting inferred rights", id)
+        es.deleteSyndicationRights(id)
+      }
+    )
+  }
+
+  private def notInferred(image: Image, upcomingEdits: Edits) = {
+    image.userMetadata.flatMap(_.photoshoot).foreach(currentPhotoshoot => {
+      // lookup latest rcs published image in current shoot
+      // compare to this image
+      // if this image is most recent
+      //    refresh shoot with second most recent if exists, else remove inferred rights
+      // else no-op
+
+      es.getMostRecentSyndicationRights(currentPhotoshoot, Some(image)) map {
+        case Some(mostRecentImage) if image.rcsPublishDate.get.isAfter(mostRecentImage.rcsPublishDate.get) => {
+          GridLogger.info(s"refreshing inferred syndication rights for images using ${mostRecentImage.id} because ${image.id} has moved", Map("image-id" -> image.id, "photoshoot" -> currentPhotoshoot.title))
+          refreshInferredSyndicationRightsAcrossPhotoshoot(currentPhotoshoot, mostRecentImage.syndicationRights.get, None)
+        }
+        case None => {
+          // remove all inferred syndication rights from photoshoot
+          GridLogger.info(s"removing inferred rights from photoshoot as it no longer contains an image with direct rights", Map("image-id" -> image.id, "photoshoot" -> currentPhotoshoot.title))
+          es.getImagesWithInferredSyndicationRights(currentPhotoshoot, None)
+            .map(initiateRightsRemoval)
+        }
+        case _ => None // no-op
+      }
+    })
+
+    upcomingEdits.photoshoot.foreach(newPhotoshoot => {
+      // lookup latest rcs published image in new shoot
+      // compare to this image
+      // if this image is more recent, copy
+      // else no-op
+
+      es.getMostRecentSyndicationRights(newPhotoshoot, None) map {
+        case Some(mostRecentImage) if image.rcsPublishDate.get.isAfter(mostRecentImage.rcsPublishDate.get) => {
+          GridLogger.info(s"refreshing inferred syndication rights for images using ${image.id} because its the most recent", Map("image-id" -> image.id, "photoshoot" -> newPhotoshoot.title))
+          refreshInferredSyndicationRightsAcrossPhotoshoot(newPhotoshoot, image.syndicationRights.get, None)
+        }
+        case None => {
+          GridLogger.info(s"refreshing inferred syndication rights for images using ${image.id} because none previously existed", Map("image-id" -> image.id, "photoshoot" -> newPhotoshoot.title))
+          refreshInferredSyndicationRightsAcrossPhotoshoot(newPhotoshoot, image.syndicationRights.get, None)
+        }
+        case _ => None // no-op
+      }
+    })
+  }
+
+  private def inferred(image: Image, upcomingEdits: Edits) = {
+    val maybeCurrentPhotoshoot = image.userMetadata.flatMap(_.photoshoot)
+    val maybeNewPhotoshoot = upcomingEdits.photoshoot
+
+    (maybeCurrentPhotoshoot, maybeNewPhotoshoot) match {
+      case (Some(_), None) => {
+        // removed from photoshoot, remove inferred rights
+        GridLogger.info("image removed from photoshoot, removing inferred rights", image.id)
+        initiateRightsRemoval(List(image))
+      }
+      case (_, Some(newPhotoshoot)) => {
+        // moved to new photoshoot
+        // lookup latest rcs published image in new photoshoot
+        // if exists replace inferred rights
+        // else remove inferred rights
+
+        es.getMostRecentSyndicationRights(newPhotoshoot, None) map {
+          case Some(i) => {
+            GridLogger.info(s"inferring rights from ${i.id} as its the most recent in photoshoot", image.id)
+            initiateInferredRightsRefresh(List(image), i.syndicationRights.get)
+          }
+          case None => {
+            GridLogger.info("cannot infer rights from new photoshoot", image.id)
+            initiateRightsRemoval(List(image))
+          }
+        }
+      }
+      case (None, None) => None // no-op, shouldn't happen
+    }
+  }
+
+  private def initiateRightsRemoval(images: List[Image]) = {
+    images.foreach(image => thrallNotifications.publish(
+      Json.obj("id" -> image.id),
+      subject = "delete-inferred-rights"
+    ))
+  }
+
   private def refreshInferredSyndicationRights(id: String, syndicationRights: SyndicationRights) = {
     es.getImage(id) map {
       case Some(image) => {
         image.userMetadata.map { edits =>
           edits.photoshoot match {
             case Some(photoshoot) if !syndicationRights.isInferred => {
-              // Image is in a photoshoot and has real rights
-              // Update the other images in the photoshoot
-              es.getImagesWithInferredSyndicationRights(photoshoot, image)
-                .map(initiateInferredRightsRefresh(_, syndicationRights))
+              refreshInferredSyndicationRightsAcrossPhotoshoot(photoshoot, syndicationRights, Some(image))
               image
             }
             case _ => image
@@ -136,6 +253,12 @@ class ThrallMessageConsumer(
         None
       }
     }
+  }
+
+  private def refreshInferredSyndicationRightsAcrossPhotoshoot(photoshoot: Photoshoot, syndicationRights: SyndicationRights, excludedImage: Option[Image]) = {
+    GridLogger.info("setting inferred rights for photoshoot")
+    es.getImagesWithInferredSyndicationRights(photoshoot, excludedImage)
+      .map(initiateInferredRightsRefresh(_, syndicationRights))
   }
 
   private def initiateInferredRightsRefresh(images: List[Image], rightsFromRcs: SyndicationRights) = {


### PR DESCRIPTION
When an image moves between photoshoots, we need to be sure any inferred syndication rights are up-to-date in the old and new photoshoot.

Image has inferred rights:
- if we're removing it from a photoshoot, remove its inferred rights
- if we're moving it into a photoshoot, recalculate its inferred rights:
  - if the photoshoot has images with explicit rights, use the latest
  - else remove the inferred rights

Image has explicit rights:
- if the image was in a photoshoot, refresh the inferred rights for images in that photoshoot:
  - use the latest explicit rights in the photoshoot that's not this image. If none, clear inferred rights across the photoshoot
- if we're moving into a photoshoot and this image's rights is the latest, copy the rights across the photoshoot
- if we're moving into a photoshoot and this image's rights is not the latest, do nothing (TODO record these as a metric to know how often it happens)