### PR TITLE
remove syndicated usages from the syndication tier

### DIFF
--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -4,6 +4,7 @@ import com.gu.mediaservice.lib.auth.{Syndication, Tier}
 import com.gu.mediaservice.lib.elasticsearch.ImageFields
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.lib.config.UsageRightsConfig
+import com.gu.mediaservice.model.usage.SyndicationUsage
 import org.elasticsearch.index.query.{BoolFilterBuilder, FilterBuilder}
 import scalaz.syntax.std.list._
 import scalaz.NonEmptyList
@@ -87,7 +88,10 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
     filters.and(
       rightsAcquiredFilter(isAcquired = true),
       filters.date(field = "syndicationRights.published", None, Some(DateTime.now)).get,
-      filters.term(field = "leases.leases.access", term = AllowSyndicationLease.name)
+      filters.term(field = "leases.leases.access", term = AllowSyndicationLease.name),
+      filters.bool.mustNot(
+        filters.term("usages.platform", term = SyndicationUsage.toString)
+      )
     )
   }
 


### PR DESCRIPTION
When we send an image for syndication, we record a syndication usage.

In order to not send the same image again and again, remove images with a syndication usage from the syndication tier.

This is a slightly hacky solution as it doesn't scale beyond one syndication partner. For example, if partner A takes an image, partner B will no longer see it. However, we only have 1 partner at the moment.

A scalable solution would be to record a syndication key against an usage and filter accordingly. We could do this once we have to support multiple syndication partners.