### PR TITLE
remove example endpoint

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -248,7 +248,7 @@ class MediaApi(
     }
   }
 
-  def imageSearch(isExample: Boolean) = auth.async { request =>
+  def imageSearch() = auth.async { request =>
     val include = getIncludedFromParams(request)
 
     def hitToImageEntity(elasticId: String, source: JsValue): Future[EmbeddedEntity[JsValue]] = {
@@ -265,14 +265,8 @@ class MediaApi(
       }
     }
 
-    def imageJsonToSearchResult(jsonOpt: Option[JsValue]): SearchResults = jsonOpt.map { json =>
-      SearchResults(hits = Seq((config.exampleImageId, json)), total = 1)
-    }.getOrElse(SearchResults(hits = Seq.empty, 0))
-
     def respondSuccess(searchParams: SearchParams) = for {
-      SearchResults(hits, totalCount) <-
-        if(isExample) elasticSearch.getImageById(config.exampleImageId).map(imageJsonToSearchResult)
-        else elasticSearch.search(searchParams)
+      SearchResults(hits, totalCount) <- elasticSearch.search(searchParams)
       imageEntities <- Future.sequence(hits map (hitToImageEntity _).tupled)
       prevLink = getPrevLink(searchParams)
       nextLink = getNextLink(searchParams, totalCount)

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -39,8 +39,6 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
         "App"   -> Seq(elasticsearchApp)
       ))
 
-  lazy val exampleImageId: String = stringOpt("example.image.id").getOrElse(properties("example.image.id"))
-
   lazy val imageBucket: String = properties("s3.image.bucket")
   lazy val thumbBucket: String = properties("s3.thumb.bucket")
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -121,7 +121,6 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       ++ hasRightsCategory
       ++ searchFilters.tierFilter(params.tier)
       ++ rightsAcquiredFilter
-      ++ (if (params.tier == Syndication) searchFilters.exampleImageFilter else None)
     ).toNel.map(filter => filter.list.reduceLeft(filters.and(_, _)))
 
     val filter = filterOpt getOrElse filters.matchAll

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -74,8 +74,6 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
 
   val nonPersistedFilter: FilterBuilder = filters.not(persistedFilter)
 
-  val exampleImageFilter: Option[FilterBuilder] = Some(filters.bool.mustNot(filters.term("id", config.exampleImageId)))
-
   def rightsAcquiredFilter(isAcquired: Boolean): FilterBuilder =
     filters.bool.must(
       filters.boolTerm(

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -12,7 +12,6 @@ GET     /images/edits/:field                          controllers.SuggestionCont
 GET     /images/aggregations/date/:field              controllers.AggregationController.dateHistogram(field: String, q: Option[String])
 
 # Images
-GET     /images/example                               controllers.MediaApi.imageSearch(isExample: Boolean = true)
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
@@ -20,7 +19,7 @@ GET     /images/:imageId/export                       controllers.MediaApi.getIm
 GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)
 POST    /images/:id/reindex                           controllers.MediaApi.reindexImage(id: String)
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
-GET     /images                                       controllers.MediaApi.imageSearch(isExample: Boolean = false)
+GET     /images                                       controllers.MediaApi.imageSearch
 
 # completion
 GET     /suggest/metadata/credit                      controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])

--- a/media-api/test/lib/ElasticSearchHelper.scala
+++ b/media-api/test/lib/ElasticSearchHelper.scala
@@ -21,7 +21,6 @@ trait ElasticSearchHelper extends MockitoSugar {
     "es.cluster" -> "media-service-test",
     "es.port" -> "9301",
     "persistence.identifier" -> "picdarUrn",
-    "example.image.id" -> "id-abc",
     "es.index.aliases.read" -> "readAlias")))
   private val mediaApiMetrics = new MediaApiMetrics(mediaApiConfig)
   private val searchFilters = new SearchFilters(mediaApiConfig)
@@ -100,8 +99,6 @@ trait ElasticSearchHelper extends MockitoSugar {
 
     createImage(StaffPhotographer("Tom Jenkins", "The Guardian"), Some(syndicationRights), imageId, leaseByMedia, usages)
   }
-
-  def createExampleImage(): Image = createImageForSyndication(rightsAcquired = true, None, None).copy(id = "id-abc")
 
   def createSyndicationUsage(): Usage = {
     createUsage(SyndicationUsageReference, SyndicationUsage, SyndicatedUsageStatus)

--- a/media-api/test/lib/ElasticSearchTest.scala
+++ b/media-api/test/lib/ElasticSearchTest.scala
@@ -43,9 +43,7 @@ class ElasticSearchTest extends FunSpec with BeforeAndAfterAll with Matchers wit
     createImageForSyndication(rightsAcquired = true, Some(DateTime.parse("2018-07-03T00:00:00")), Some(false)),
 
     // no rights acquired, not available for syndication
-    createImageForSyndication(rightsAcquired = false, None, None),
-
-    createExampleImage()
+    createImageForSyndication(rightsAcquired = false, None, None)
   )
 
   override def beforeAll {
@@ -61,7 +59,7 @@ class ElasticSearchTest extends FunSpec with BeforeAndAfterAll with Matchers wit
   }
 
   describe("ES") {
-    it("ES should return only rights acquired pictures with an allow syndication lease for a syndication tier search and filter out example image") {
+    it("ES should return only rights acquired pictures with an allow syndication lease for a syndication tier search") {
       val searchParams = SearchParams(tier = Syndication, uploadedBy = Some(testUser))
       val searchResult = ES.search(searchParams)
       whenReady(searchResult, timeout, interval) { result =>


### PR DESCRIPTION
`/example` was created as a demonstration of what the api would return for syndication partners whist we built the remaining infrastructure. Its no longer needed.