### PR TITLE
add syndicationStatus param

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -135,7 +135,8 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             'modifiedSince',
             'modifiedUntil',
             'hasRightsAcquired',
-            'hasCrops'
+            'hasCrops',
+            'syndicationStatus'
         ].join('&'),
         // Non-URL parameters
         params: {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -330,7 +330,8 @@ results.controller('SearchResultsCtrl', [
                 length:     length,
                 orderBy:    orderBy,
                 hasRightsAcquired: $stateParams.hasRightsAcquired,
-                hasCrops: $stateParams.hasCrops
+                hasCrops: $stateParams.hasCrops,
+                syndicationStatus: $stateParams.syndicationStatus
             }));
         }
 

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -16,7 +16,8 @@ mediaApi.factory('mediaApi',
     function search(query = '', {ids, since, until, archived, valid, free,
                                  payType, uploadedBy, offset, length, orderBy,
                                  takenSince, takenUntil,
-                                 modifiedSince, modifiedUntil, hasRightsAcquired, hasCrops} = {}) {
+                                 modifiedSince, modifiedUntil, hasRightsAcquired, hasCrops,
+                                 syndicationStatus} = {}) {
         return root.follow('search', {
             q:          query,
             since:      since,
@@ -35,7 +36,8 @@ mediaApi.factory('mediaApi',
             length:     angular.isDefined(length) ? length : 50,
             orderBy:    getOrder(orderBy),
             hasRightsAcquired: maybeStringToBoolean(hasRightsAcquired),
-            hasExports: maybeStringToBoolean(hasCrops) // Grid API calls crops exports...
+            hasExports: maybeStringToBoolean(hasCrops), // Grid API calls crops exports...
+            syndicationStatus: syndicationStatus
         }).get();
     }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -41,7 +41,7 @@ class MediaApi(
     "since", "until", "modifiedSince", "modifiedUntil", "takenSince", "takenUntil",
     "uploadedBy", "archived", "valid", "free", "payType",
     "hasExports", "hasIdentifier", "missingIdentifier", "hasMetadata",
-    "persisted", "usageStatus", "usagePlatform", "hasRightsAcquired").mkString(",")
+    "persisted", "usageStatus", "usagePlatform", "hasRightsAcquired", "syndicationStatus").mkString(",")
 
   private val searchLinkHref = s"${config.rootUri}/images{?$searchParamList}"
 

--- a/media-api/app/controllers/SearchParams.scala
+++ b/media-api/app/controllers/SearchParams.scala
@@ -4,6 +4,7 @@ import com.gu.mediaservice.lib.auth.{Authentication, Tier}
 import com.gu.mediaservice.lib.formatting.{parseDateFromQuery, printDateTime}
 import com.gu.mediaservice.model.usage.UsageStatus
 import lib.querysyntax.{Condition, Parser}
+import model.SyndicationStatus
 import org.joda.time.DateTime
 import scalaz.syntax.applicative._
 import scalaz.syntax.std.list._
@@ -40,7 +41,8 @@ case class SearchParams(
   usageStatus: List[UsageStatus] = List.empty,
   usagePlatform: List[String] = List.empty,
   tier: Tier,
-  hasRightsAcquired: Option[Boolean] = None
+  hasRightsAcquired: Option[Boolean] = None,
+  syndicationStatus: Option[SyndicationStatus]
 )
 
 case class InvalidUriParams(message: String) extends Throwable
@@ -72,6 +74,7 @@ object SearchParams {
   def parseIntFromQuery(s: String): Option[Int] = Try(s.toInt).toOption
   def parsePayTypeFromQuery(s: String): Option[PayType.Value] = PayType.create(s)
   def parseBooleanFromQuery(s: String): Option[Boolean] = Try(s.toBoolean).toOption
+  def parseSyndicationStatus(s: String): Option[SyndicationStatus] = Some(SyndicationStatus(s))
 
   def apply(request: Authentication.Request[Any]): SearchParams = {
 
@@ -108,7 +111,8 @@ object SearchParams {
       commaSep("usageStatus").map(UsageStatus(_)),
       commaSep("usagePlatform"),
       request.user.apiKey.tier,
-      request.getQueryString("hasRightsAcquired") flatMap parseBooleanFromQuery
+      request.getQueryString("hasRightsAcquired") flatMap parseBooleanFromQuery,
+      request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus
     )
   }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -103,6 +103,8 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
 
     val rightsAcquiredFilter = params.hasRightsAcquired.map(searchFilters.rightsAcquiredFilter)
 
+    val syndicationStatusFilter = params.syndicationStatus.map(searchFilters.syndicationStatusFilter)
+
     val filterOpt = (
       metadataFilter.toList
       ++ persistFilter
@@ -121,6 +123,7 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       ++ hasRightsCategory
       ++ searchFilters.tierFilter(params.tier)
       ++ rightsAcquiredFilter
+      ++ syndicationStatusFilter
     ).toNel.map(filter => filter.list.reduceLeft(filters.and(_, _)))
 
     val filter = filterOpt getOrElse filters.matchAll

--- a/media-api/app/model/SyndicationStatus.scala
+++ b/media-api/app/model/SyndicationStatus.scala
@@ -1,0 +1,32 @@
+package model
+
+import play.api.libs.json._
+
+sealed trait SyndicationStatus {
+  override def toString: String = this match {
+    case SentForSyndication => "sent"
+    case QueuedForSyndication => "queued"
+    case BlockedForSyndication => "blocked"
+    case AwaitingReviewForSyndication => "review"
+  }
+}
+
+object SyndicationStatus {
+  def apply(status: String): SyndicationStatus = status.toLowerCase match {
+    case "sent" => SentForSyndication
+    case "queued" => QueuedForSyndication
+    case "blocked" => BlockedForSyndication
+    case "review" => AwaitingReviewForSyndication
+  }
+
+  implicit val reads: Reads[SyndicationStatus] = JsPath.read[String].map(SyndicationStatus(_))
+
+  implicit val writer = new Writes[SyndicationStatus] {
+    def writes(status: SyndicationStatus) = JsString(status.toString)
+  }
+}
+
+object SentForSyndication extends SyndicationStatus
+object QueuedForSyndication extends SyndicationStatus
+object BlockedForSyndication extends SyndicationStatus
+object AwaitingReviewForSyndication extends SyndicationStatus


### PR DESCRIPTION
to filter by syndication status:
- `sent`: rcs yes, editorial yes, syndication usage
- `queued`: rcs yes, editorial yes, no syndication usage
- `blocked`: rcs yes, editorial no
- `review`: rcs yes, no editorial response

This is a query string value and not a chip, mainly because syndication states isn't useful for the majority of Grid users initially. The query string can be bookmarked. We can add a chip if/when necessary.