### PR TITLE
log endpoint to measure usage

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -7,6 +7,7 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth._
+import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.model.UploadInfo
 import lib._
 import lib.imaging.MimeTypeDetection
@@ -49,6 +50,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
 
   def importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]) =
     auth.async { request =>
+      GridLogger.info(s"request to import an image", request.user.apiKey)
       Try(URI.create(uri)) map { validUri =>
         val tmpFile = createTempFile("download")
 


### PR DESCRIPTION
The imports endpoint in image-loader currently accepts any url from the internet, which is only a little scary! This endpoint should only be used by S3 Watcher, but log out who is using it to be sure.

Ultimately, this endpoint will be rewritten to accept an S3 object path rather than a URL. This:
- will reduce the amount of logic in S3 Watcher
- be more secure as only images from the S3 Watcher inject bucket will be accepted
- enable reindexing to reuse this route