### PR TITLE
move tooltip to bottom

### DIFF
--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -2,7 +2,7 @@
         ng:click="ctrl.editing = true"
         ng:if="ctrl.userCanEdit"
         gr:tooltip="Add lease"
-        gr:tooltip-position="left">
+        gr:tooltip-position="bottom">
 
     <gr-icon ng-show="!ctrl.editing" ng:class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span>
@@ -84,7 +84,7 @@
     <li ng-repeat="lease in ctrl.leases.leases"
         gr:tooltip="{{ctrl.toolTip(lease)}}"
         class="lease__item"
-        gr:tooltip-position="left">
+        gr:tooltip-position="bottom">
 
         <div class="lease__current" ng:class="ctrl.leaseStatus(lease).current" ng:if="ctrl.leaseStatus(lease).current"></div>
 


### PR DESCRIPTION
The tooltip for a lease includes important information - who added the lease.

When its on the left, its behind the image. Thus making it impossible to view. It was either move the tooltip or adjust the z-index... this was faster.

# Before
![image](https://user-images.githubusercontent.com/836140/44154714-4b0506e4-a0a3-11e8-8c11-2209eb4149ab.png)


# After
![image](https://user-images.githubusercontent.com/836140/44154653-231058aa-a0a3-11e8-9bdc-9780161cdac6.png)
