### PR TITLE
delay syndication until a specific date

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
@@ -50,7 +50,7 @@ case class MediaLease(
   private def afterStart = startDate.forall(start => new DateTime().isAfter(start))
   private def beforeEnd  = endDate.forall(end => new DateTime().isBefore(end))
 
-  def prepareForSave: MediaLease = if (access == AllowSyndicationLease) this.copy(startDate = None, endDate = None) else this
+  def prepareForSave: MediaLease = if (access == AllowSyndicationLease) this.copy(endDate = None) else this
 
   def active = afterStart && beforeEnd
 

--- a/kahuna/public/js/components/gu-date/gu-date.css
+++ b/kahuna/public/js/components/gu-date/gu-date.css
@@ -1,0 +1,30 @@
+gu-date {
+    display: inline-block;
+}
+
+/* ==========================================================================
+   Override styles provided from pikaday.
+   Applying the .gu-date-range selector to win on specificity and to keep the
+   styles componentised.
+   ========================================================================== */
+gu-date .pika-single {
+    /*
+    HACK When February has 28 days the height of the pikaday element shrinks, creating a jumpy UI.
+    Forcing it to 100% fixes this, however it means its parent needs to have a fixed height of 228px.
+    */
+    height: 100%;
+}
+
+gu-date .pika-button:hover {
+    /*
+    Pikaday uses background-colour: #ff8000. Override this rule to match the theme of The Grid.
+    */
+    background-color: #444 !important;
+}
+
+gu-date .pika-label::after {
+    /*
+    Add an arrow to make it more obvious that its a clickable element.
+    */
+    content: ' \25BE'
+}

--- a/kahuna/public/js/components/gu-date/gu-date.html
+++ b/kahuna/public/js/components/gu-date/gu-date.html
@@ -1,0 +1,22 @@
+<div class="gu-date" ng:init="showingOverlay = false">
+    <span class="flex-container">
+        <button type="button" ng:click="showingOverlay = !showingOverlay">
+            <gr-icon-label gr-icon="event">{{label}}</gr-icon-label>
+            {{displayValue}}
+            <gr-icon ng:show="showingOverlay">expand_less</gr-icon>
+            <gr-icon ng:show="!showingOverlay">expand_more</gr-icon>
+        </button>
+        <span class="flex-spacer"></span>
+        <button type="button"
+                ng:click="clear()"
+                gr:tooltip="clear {{label}}"
+                gr:tooltip-position="left">
+            <gr-icon>close</gr-icon>
+        </button>
+    </span>
+
+    <div ng:show="showingOverlay" class="gu-date__container"></div>
+
+    <input hidden type="text" class="gu-date__value--hidden" ng:model="pikaValue">
+</div>
+

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -1,0 +1,102 @@
+import angular from 'angular';
+import moment from 'moment';
+import Pikaday from 'pikaday';
+import 'pikaday/css/pikaday.css';
+
+import template from './gu-date.html';
+import './gu-date.css';
+
+const ISO8601_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
+const DISPLAY_FORMAT = 'DD MMM YYYY';
+const TEN_YEARS_MILLIS = (10 * 365 * 24 * 60 * 60 * 1000);
+const START_OF_WEEK = 1; // Monday
+
+export const guDate = angular.module('gu.date', []);
+
+guDate.directive('guDate', [function () {
+    return {
+        template: template,
+        scope: {
+            label: '@',
+            date: '=',
+            minDate: '=?',
+            maxDate: '=?'
+        },
+        link: function($scope, el) {
+            if (angular.isDefined($scope.minDate) && angular.isDefined($scope.maxDate)) {
+                throw 'gu-date can have either a minDate or a maxDate. Not both.';
+            }
+
+            function getDateISOString (value) {
+                return angular.isDefined(value)
+                    ? moment(value).toISOString()
+                    : undefined;
+            }
+
+            function getDisplayValue(value) {
+                return angular.isDefined(value)
+                    ? moment(value).format(DISPLAY_FORMAT)
+                    : 'anytime';
+            }
+
+            const tenYearsFromNow = new Date(Date.now() + TEN_YEARS_MILLIS);
+
+            const root = el[0];
+            const input = root.querySelector('input.gu-date__value--hidden');
+            const container = root.querySelector('.gu-date__container');
+
+            const pika = new Pikaday({
+                field: input,
+                container: container,
+                bound: false,
+                minDate: $scope.minDate && new Date($scope.minDate),
+                maxDate: tenYearsFromNow,
+                yearRange: 100,
+                firstDay: START_OF_WEEK,
+                format: ISO8601_FORMAT,
+                keyboardInput: false
+            });
+
+            $scope.clear = () => {
+                pika.setDate();
+                pika.gotoToday();
+            };
+
+            $scope.closeOverlay = () => $scope.showingOverlay = false;
+
+            if (angular.isDefined($scope.minDate)) {
+                $scope.dateRounder = (date) => moment(date).endOf('day').toDate();
+
+                $scope.$watch('minDate', value => {
+                    const dateValue = value ? new Date(value) : new Date();
+                    pika.setMinDate(dateValue);
+                });
+            }
+
+            if (angular.isDefined($scope.maxDate)) {
+                $scope.dateRounder = (date) => moment(date).startOf('day').toDate();
+
+                $scope.$watch('maxDate', value => {
+                    const dateValue = value ? new Date(value) : new Date();
+                    pika.setMaxDate(dateValue);
+                });
+            }
+
+            $scope.$watch('pikaValue', value => {
+                const date = value === ""
+                    ? undefined
+                    : angular.isDefined($scope.dateRounder)
+                        ? $scope.dateRounder(value)
+                        : value;
+
+                $scope.date = getDateISOString(date);
+                $scope.displayValue = getDisplayValue(date);
+                $scope.closeOverlay();
+            });
+
+            $scope.$on('$destroy', () => pika.destroy);
+
+            pika.setDate($scope.date);
+        }
+    };
+}]);

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -19,6 +19,7 @@ import '../components/gr-image-usage/gr-image-usage';
 import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
 import '../components/gr-metadata-validity/gr-metadata-validity';
 import '../components/gr-display-crops/gr-display-crops';
+import '../components/gu-date/gu-date';
 
 
 var image = angular.module('kahuna.image.controller', [
@@ -41,7 +42,8 @@ var image = angular.module('kahuna.image.controller', [
     'gr.imageUsage',
     'gr.keyboardShortcut',
     'gr.metadataValidity',
-    'gr.displayCrops'
+    'gr.displayCrops',
+    'gu.date'
 ]);
 
 image.controller('ImageCtrl', [

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -41,21 +41,50 @@
       </optgroup>
   </select>
 
-  <div ng:if="ctrl.access === 'deny-syndication'">
-    <input type="checkbox"
-           ng:model="ctrl.showCalendar" />
-    Expires
+  <div ng-switch="ctrl.access">
+    <div ng-switch-when="deny-syndication">
+        <div class="flex-container">
+            <label class="full-width">
+                <input type="checkbox" ng:model="showCal" />
+                Expire
+            </label>
+        </div>
+        <gu-date ng:if="showCal"
+                 class="full-width"
+                 date="ctrl.newLease.endDate"
+                 min-date="ctrl.midnightTomorrow"
+                 label="after">
+        </gu-date>
+    </div>
+    <div ng-switch-when="allow-syndication">
+        <div class="flex-container">
+            <label class="full-width">
+                <input type="checkbox" ng:model="showCal" />
+                Delay
+            </label>
+        </div>
+        <gu-date ng:if="showCal"
+                 class="full-width"
+                 date="ctrl.newLease.startDate"
+                 min-date="ctrl.midnightTomorrow"
+                 label="after">
+        </gu-date>
+    </div>
+    <div ng-switch-default>
+        <gu-date-range class="lease__date"
+           ng:if="ctrl.access"
+           gu:start-date="ctrl.newLease.startDate"
+           gu:end-date="ctrl.newLease.endDate"
+           gu:show-extras="false"
+           gu:first-day="1">
+        </gu-date-range>
+    </div>
   </div>
 
-  <gu-date-range class="lease__date"
-     ng:if="ctrl.calendarVisible()"
-     gu:start-date="ctrl.newLease.startDate"
-     gu:end-date="ctrl.newLease.endDate"
-     gu:show-extras="false"
-     gu:first-day="1">
-  </gu-date-range>
-
-  <input type="text" ng:model="ctrl.newLease.notes" placeholder="Notes..."/>
+  <input type="text"
+         ng:if="ctrl.access"
+         ng:model="ctrl.newLease.notes"
+         placeholder="Notes..."/>
 
   <div class="lease__form__buttons">
     <button class="lease__form__buttons__button-cancel button-cancel" type="button" ng:click="ctrl.cancel()" title="Close">

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -41,9 +41,7 @@ leases.controller('LeasesCtrl', [
         ctrl.adding = false;
         ctrl.showCalendar = false;
 
-        ctrl.calendarVisible = () =>
-            ctrl.access !== 'allow-syndication' &&
-            !(ctrl.access === 'deny-syndication' && ctrl.showCalendar === false);
+        ctrl.midnightTomorrow = moment().add(1, 'days').startOf('day').toDate();
 
         ctrl.cancel = () => ctrl.editing = false;
 
@@ -54,8 +52,12 @@ leases.controller('LeasesCtrl', [
                 ctrl.adding = true;
                 ctrl.newLease.createdAt = new Date();
                 ctrl.newLease.access = ctrl.access;
-                if (!ctrl.showCalendar && ctrl.access === 'deny-syndication') {
+
+                if (ctrl.access === 'deny-syndication') {
                     ctrl.newLease.startDate = null;
+                }
+
+                if (ctrl.access === 'allow-syndication') {
                     ctrl.newLease.endDate = null;
                 }
 


### PR DESCRIPTION
`allow-syndication` can have a start date. Image will be sent after this date.
`deny-syndication` can have an end date. Image will require reclassification after this date.

We couldn't re-use `gu-date-range` because we only need a single date. So `gu-date` has been created.

Additionally, we can now refactor `gu-date-range` to be a lot simpler as it can embed two `gu-date`s. That's for another PR though.

# allow-syndication lease
![allow-syndication](https://user-images.githubusercontent.com/836140/44256456-225d3180-a201-11e8-9cb4-a817ab6498d0.gif)


# deny-syndication lease
![deny-syndication](https://user-images.githubusercontent.com/836140/44256476-2ee18a00-a201-11e8-81b4-476d4b6dca7f.gif)


# cropping leases
To demonstrate no regressions 🤗 

![crop-lease](https://user-images.githubusercontent.com/836140/44256491-3739c500-a201-11e8-9d21-a35b118b7b45.gif)
