### PR TITLE
move date filter to the left

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -803,6 +803,7 @@ textarea.ng-invalid {
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
     padding: 10px;
     position: absolute;
+    right: 0px;
     min-width: 520px;
 }
 


### PR DESCRIPTION
when you're using the Grid on a small width screen, the filter button isn't visible... until now!

# Before
![image](https://user-images.githubusercontent.com/836140/44260922-e54b6c00-a20d-11e8-9c8e-6bb7486b12ce.png)


# After
![image](https://user-images.githubusercontent.com/836140/44260895-cea51500-a20d-11e8-9590-ccb98c1533bc.png)
