### PR TITLE
add gu-date-range-x directive

### DIFF
--- a/kahuna/public/js/components/gu-date/gu-date-range-x.html
+++ b/kahuna/public/js/components/gu-date/gu-date-range-x.html
@@ -1,0 +1,4 @@
+<div>
+    <gu-date class="full-width" label="from" date="start" max-date="end"></gu-date>
+    <gu-date class="full-width" label="to" date="end" min-date="start"></gu-date>
+</div>

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -4,6 +4,7 @@ import Pikaday from 'pikaday';
 import 'pikaday/css/pikaday.css';
 
 import template from './gu-date.html';
+import rangeTemplate from './gu-date-range-x.html';
 import './gu-date.css';
 
 const ISO8601_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
@@ -97,6 +98,16 @@ guDate.directive('guDate', [function () {
             $scope.$on('$destroy', () => pika.destroy);
 
             pika.setDate($scope.date);
+        }
+    };
+}]);
+
+guDate.directive('guDateRangeX', [function () {
+    return {
+        template: rangeTemplate,
+        scope: {
+            start: '=',
+            end: '='
         }
     };
 }]);

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -71,13 +71,10 @@
         </gu-date>
     </div>
     <div ng-switch-default>
-        <gu-date-range class="lease__date"
-           ng:if="ctrl.access"
-           gu:start-date="ctrl.newLease.startDate"
-           gu:end-date="ctrl.newLease.endDate"
-           gu:show-extras="false"
-           gu:first-day="1">
-        </gu-date-range>
+        <gu-date-range-x ng:if="ctrl.access"
+                        start="ctrl.newLease.startDate"
+                        end="ctrl.newLease.endDate">
+        </gu-date-range-x>
     </div>
   </div>
 


### PR DESCRIPTION
The aim is for this to, eventually, replace the current `gu-date-range` by being more componentised.

`gu-date-range` is very complicated as it has presets baked into the component which are not needed in all cases. It could benefit from component composition... next PR!

# Before
![image](https://user-images.githubusercontent.com/836140/44267703-2308be80-a227-11e8-90a6-b5d804189ad8.png)


# After
![image](https://user-images.githubusercontent.com/836140/44267672-0c626780-a227-11e8-8e70-15689adc5efa.png)
