### PR TITLE
add two prefixes to allow-syndication note

### DIFF
--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -69,6 +69,17 @@
                  min-date="ctrl.midnightTomorrow"
                  label="after">
         </gu-date>
+
+        <div class="flex-container">
+            <label class="full-width">
+                <input type="checkbox" ng:model="ctrl.noteCallAgencyClause" />
+                Call Agency
+            </label>
+            <label class="full-width">
+                <input type="checkbox" ng:model="ctrl.notePremiumClause" />
+                Premium
+            </label>
+        </div>
     </div>
     <div ng-switch-default>
         <gu-date-range-x ng:if="ctrl.access"

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -59,6 +59,14 @@ leases.controller('LeasesCtrl', [
 
                 if (ctrl.access === 'allow-syndication') {
                     ctrl.newLease.endDate = null;
+
+                    const noteWithClause = [
+                        ctrl.noteCallAgencyClause ? 'CALL AGENCY' : undefined,
+                        ctrl.notePremiumClause ? 'PREMIUM' : undefined,
+                        ctrl.newLease.notes
+                    ].filter(Boolean);
+
+                    ctrl.newLease.notes = noteWithClause.join(', ');
                 }
 
                 let syndLeases = ctrl.leases.leases.filter((l) =>


### PR DESCRIPTION
For some images, syndication partners are required to call us first to clear a sale. These two checkboxes will prefix the lease note which gets sent to a syndication partner with a clause.

Requested by Joanna.

![lease-note](https://user-images.githubusercontent.com/836140/44270216-b8f41780-a22e-11e8-9295-8489e88afc35.gif)
