### PR TITLE
sanitise lease fields before saving

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
@@ -50,7 +50,27 @@ case class MediaLease(
   private def afterStart = startDate.forall(start => new DateTime().isAfter(start))
   private def beforeEnd  = endDate.forall(end => new DateTime().isBefore(end))
 
-  def prepareForSave: MediaLease = if (access == AllowSyndicationLease) this.copy(endDate = None) else this
+  private def withValidNotesField: MediaLease = notes match {
+    case Some(note) if note.trim.length == 0 => this.copy(notes = None) // cannot save empty string in dynamo
+    case _ => this
+  }
+
+  private def withValidEndDateField: MediaLease = if (access == AllowSyndicationLease) {
+    this.copy(endDate = None) // an allow-syndication cannot end
+  } else {
+    this
+  }
+
+  private def withValidStartDateField: MediaLease = if (access == DenySyndicationLease) {
+    this.copy(startDate = None) // a deny-syndication cannot start
+  } else {
+    this
+  }
+
+  def prepareForSave: MediaLease = this
+    .withValidNotesField
+    .withValidStartDateField
+    .withValidEndDateField
 
   def active = afterStart && beforeEnd
 

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -35,8 +35,13 @@ leaseService.factory('leaseService', [
       }
 
     function add(image, lease) {
-      var newLease = angular.copy(lease);
+      const newLease = angular.copy(lease);
       newLease.mediaId = image.data.id;
+
+      if (angular.isDefined(newLease.notes) && newLease.notes.trim().length === 0) {
+        newLease.notes = null;
+      }
+
       return image.perform('add-lease', {body: newLease});
     }
 


### PR DESCRIPTION
Dynamo doesn't like saving empty string! Sanitise payload client and server side.

We're currently 500ing if we save a lease w/out a note as the payload sent is `""`.