### PR TITLE
refactor syndication tier access

### DIFF
--- a/media-api/app/controllers/SearchParams.scala
+++ b/media-api/app/controllers/SearchParams.scala
@@ -41,7 +41,6 @@ case class SearchParams(
   usageStatus: List[UsageStatus] = List.empty,
   usagePlatform: List[String] = List.empty,
   tier: Tier,
-  hasRightsAcquired: Option[Boolean] = None,
   syndicationStatus: Option[SyndicationStatus] = None
 )
 
@@ -111,7 +110,6 @@ object SearchParams {
       commaSep("usageStatus").map(UsageStatus(_)),
       commaSep("usagePlatform"),
       request.user.apiKey.tier,
-      request.getQueryString("hasRightsAcquired") flatMap parseBooleanFromQuery,
       request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus
     )
   }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -101,8 +101,6 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       params.usageStatus.toNel.map(status => filters.terms(usagesField("status"), status.map(_.toString))) ++
       params.usagePlatform.toNel.map(filters.terms(usagesField("platform"), _))
 
-    val rightsAcquiredFilter = params.hasRightsAcquired.map(searchFilters.rightsAcquiredFilter)
-
     val syndicationStatusFilter = params.syndicationStatus.map(searchFilters.syndicationStatusFilter)
 
     val filterOpt = (
@@ -122,7 +120,6 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       ++ usageFilter
       ++ hasRightsCategory
       ++ searchFilters.tierFilter(params.tier)
-      ++ rightsAcquiredFilter
       ++ syndicationStatusFilter
     ).toNel.map(filter => filter.list.reduceLeft(filters.and(_, _)))
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -101,7 +101,7 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       params.usageStatus.toNel.map(status => filters.terms(usagesField("status"), status.map(_.toString))) ++
       params.usagePlatform.toNel.map(filters.terms(usagesField("platform"), _))
 
-    val syndicationStatusFilter = params.syndicationStatus.map(searchFilters.syndicationStatusFilter)
+    val syndicationStatusFilter = params.syndicationStatus.map(SyndicationFilter.statusFilter)
 
     val filterOpt = (
       metadataFilter.toList

--- a/media-api/app/lib/elasticsearch/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/SyndicationFilter.scala
@@ -1,0 +1,78 @@
+package lib.elasticsearch
+
+import com.gu.mediaservice.lib.elasticsearch.ImageFields
+import com.gu.mediaservice.model.usage.SyndicationUsage
+import com.gu.mediaservice.model.{AllowSyndicationLease, DenySyndicationLease}
+import model._
+import org.elasticsearch.index.query.FilterBuilder
+import org.joda.time.DateTime
+
+object SyndicationFilter extends ImageFields {
+  private val hasRightsAcquired: FilterBuilder = filters.bool.must(
+    filters.boolTerm(
+      field = "syndicationRights.rights.acquired",
+      value = true
+    )
+  )
+
+  private val hasAllowLease: FilterBuilder = filters.term(
+    "leases.leases.access",
+    AllowSyndicationLease.name
+  )
+
+  private val hasDenyLease: FilterBuilder = filters.term(
+    "leases.leases.access",
+    DenySyndicationLease.name
+  )
+
+  private val hasSyndicationUsage: FilterBuilder = filters.term(
+    "usages.platform",
+    SyndicationUsage.toString
+  )
+
+  private val leaseHasStarted: FilterBuilder = filters.or(
+    filters.existsOrMissing("leases.leases.startDate", exists = false),
+    filters.date("leases.leases.startDate", None, Some(DateTime.now)).get
+  )
+
+  private val leaseHasEnded: FilterBuilder = filters.or(
+    filters.existsOrMissing("leases.leases.endDate", exists = false),
+    filters.date("leases.leases.endDate", Some(DateTime.now), None).get
+  )
+
+  private val syndicationRightsPublished: FilterBuilder = filters.or(
+    filters.existsOrMissing("syndicationRights.published", exists = false),
+    filters.date("syndicationRights.published", None, Some(DateTime.now)).get
+  )
+
+  def statusFilter(status: SyndicationStatus): FilterBuilder = status match {
+    case SentForSyndication => filters.and(
+      hasRightsAcquired,
+      hasAllowLease,
+      hasSyndicationUsage
+    )
+    case QueuedForSyndication => filters.and(
+      hasRightsAcquired,
+      filters.bool.mustNot(hasSyndicationUsage),
+      filters.and(
+        hasAllowLease,
+        leaseHasStarted,
+        syndicationRightsPublished
+      )
+    )
+    case BlockedForSyndication => filters.and(
+      hasRightsAcquired,
+      hasDenyLease
+    )
+    case AwaitingReviewForSyndication => filters.and(
+      hasRightsAcquired,
+      filters.bool.mustNot(
+        hasAllowLease,
+        filters.and(
+          hasDenyLease,
+          leaseHasEnded
+        )
+      )
+    )
+  }
+}

--- a/media-api/test/lib/ElasticSearchHelper.scala
+++ b/media-api/test/lib/ElasticSearchHelper.scala
@@ -29,9 +29,9 @@ trait ElasticSearchHelper extends MockitoSugar {
   val testUser = "yellow-giraffe@theguardian.com"
 
   def createImage(
+     id: String,
      usageRights: UsageRights,
      syndicationRights: Option[SyndicationRights] = None,
-     id: String = UUID.randomUUID().toString,
      leases: Option[LeaseByMedia] = None,
      usages: List[Usage] = Nil
   ): Image = {
@@ -69,35 +69,37 @@ trait ElasticSearchHelper extends MockitoSugar {
   }
 
   def createImageForSyndication(
+    id: String,
     rightsAcquired: Boolean,
     rcsPublishDate: Option[DateTime],
-    allowLease: Option[Boolean],
-    id: Option[String] = None,
+    lease: Option[MediaLease],
     usages: List[Usage] = Nil
   ): Image = {
-    val imageId = id.getOrElse(UUID.randomUUID().toString)
-
     val rights = List(
       Right("test", Some(rightsAcquired), Nil)
     )
 
     val syndicationRights = SyndicationRights(rcsPublishDate, Nil, rights)
 
-    val leaseByMedia = allowLease.map(allowed => LeaseByMedia(
+    val leaseByMedia = lease.map(l => LeaseByMedia(
       lastModified = None,
       current = None,
-      leases = List(MediaLease(
-        id = None,
-        leasedBy = None,
-        startDate = None,
-        endDate = None,
-        access = if (allowed) AllowSyndicationLease else DenySyndicationLease,
-        notes = None,
-        mediaId = imageId
-      ))
+      leases = List(l)
     ))
 
-    createImage(StaffPhotographer("Tom Jenkins", "The Guardian"), Some(syndicationRights), imageId, leaseByMedia, usages)
+    createImage(id, StaffPhotographer("Tom Jenkins", "The Guardian"), Some(syndicationRights), leaseByMedia, usages)
+  }
+
+  def createSyndicationLease(allowed: Boolean, imageId: String, startDate: Option[DateTime] = None, endDate: Option[DateTime] = None): MediaLease = {
+    MediaLease(
+      id = None,
+      leasedBy = None,
+      startDate = startDate,
+      endDate = endDate,
+      access = if (allowed) AllowSyndicationLease else DenySyndicationLease,
+      notes = None,
+      mediaId = imageId
+    )
   }
 
   def createSyndicationUsage(): Usage = {

--- a/media-api/test/lib/ElasticSearchTest.scala
+++ b/media-api/test/lib/ElasticSearchTest.scala
@@ -3,15 +3,16 @@ package lib
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
 import com.gu.mediaservice.model.{Handout, Image, StaffPhotographer}
 import controllers.SearchParams
+import model._
 import org.joda.time.{DateTime, DateTimeUtils}
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 class ElasticSearchTest extends FunSpec with BeforeAndAfterAll with Matchers with ElasticSearchHelper with ScalaFutures {
   val interval = Interval(Span(5, Seconds))
@@ -31,8 +32,8 @@ class ElasticSearchTest extends FunSpec with BeforeAndAfterAll with Matchers wit
     // has syndication usage, not available for syndication
     createImageForSyndication(rightsAcquired = true, Some(DateTime.parse("2018-01-01T00:00:00")), Some(true), None, List(createDigitalUsage(), createSyndicationUsage())),
 
-    // rights acquired, explicit allow syndication lease but unknown publish date, not available for syndication
-    createImageForSyndication(rightsAcquired = true, None, Some(true)),
+    // rights acquired, explicit allow syndication lease and unknown publish date, available for syndication
+    createImageForSyndication(rightsAcquired = true, None, Some(true), Some("test-image-3")),
 
     // explicit deny syndication lease, not available for syndication
     createImageForSyndication(rightsAcquired = true, None, Some(false)),
@@ -58,22 +59,23 @@ class ElasticSearchTest extends FunSpec with BeforeAndAfterAll with Matchers wit
     DateTimeUtils.setCurrentMillisFixed(startDate.getMillis)
   }
 
-  describe("ES") {
+  describe("Tiered API access") {
     it("ES should return only rights acquired pictures with an allow syndication lease for a syndication tier search") {
-      val searchParams = SearchParams(tier = Syndication, uploadedBy = Some(testUser))
+      val searchParams = SearchParams(tier = Syndication)
       val searchResult = ES.search(searchParams)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 2
+        result.total shouldBe 3
 
         val imageIds = result.hits.map(_._1)
-        imageIds.size shouldBe 2
+        imageIds.size shouldBe 3
         imageIds.contains("test-image-1") shouldBe true
         imageIds.contains("test-image-2") shouldBe true
+        imageIds.contains("test-image-3") shouldBe true
       }
     }
 
     it("ES should return all pictures for internal tier search") {
-      val searchParams = SearchParams(tier = Internal, uploadedBy = Some(testUser))
+      val searchParams = SearchParams(tier = Internal)
       val searchResult = ES.search(searchParams)
       whenReady(searchResult, timeout, interval) { result =>
         result.total shouldBe images.size
@@ -81,10 +83,50 @@ class ElasticSearchTest extends FunSpec with BeforeAndAfterAll with Matchers wit
     }
 
     it("ES should return all pictures for readonly tier search") {
-      val searchParams = SearchParams(tier = ReadOnly, uploadedBy = Some(testUser))
+      val searchParams = SearchParams(tier = ReadOnly)
       val searchResult = ES.search(searchParams)
       whenReady(searchResult, timeout, interval) { result =>
         result.total shouldBe images.size
+      }
+    }
+  }
+
+  describe("syndicationStatus query") {
+    it("should return 0 results if a syndication tier specifies a SentForSyndication syndicationStatus") {
+      val search = SearchParams(tier = Syndication, syndicationStatus = Some(SentForSyndication))
+      val searchResult = ES.search(search)
+      whenReady(searchResult, timeout, interval) { result =>
+        result.total shouldBe 0
+      }
+    }
+
+    it("should return 3 results if a syndication tier specifies a QueuedForSyndication syndicationStatus") {
+      val search = SearchParams(tier = Syndication, syndicationStatus = Some(QueuedForSyndication))
+      val searchResult = ES.search(search)
+      whenReady(searchResult, timeout, interval) { result =>
+        result.total shouldBe 3
+
+        val imageIds = result.hits.map(_._1)
+        imageIds.size shouldBe 3
+        imageIds.contains("test-image-1") shouldBe true
+        imageIds.contains("test-image-2") shouldBe true
+        imageIds.contains("test-image-3") shouldBe true
+      }
+    }
+
+    it("should return 0 results if a syndication tier specifies a BlockedForSyndication syndicationStatus") {
+      val search = SearchParams(tier = Syndication, syndicationStatus = Some(BlockedForSyndication))
+      val searchResult = ES.search(search)
+      whenReady(searchResult, timeout, interval) { result =>
+        result.total shouldBe 0
+      }
+    }
+
+    it("should return 0 results if a syndication tier specifies a AwaitingReviewForSyndication syndicationStatus") {
+      val search = SearchParams(tier = Syndication, syndicationStatus = Some(AwaitingReviewForSyndication))
+      val searchResult = ES.search(search)
+      whenReady(searchResult, timeout, interval) { result =>
+        result.total shouldBe 0
       }
     }
   }


### PR DESCRIPTION
- Removes `hasRightsAcquired` query string as its use-case is analogous to `syndicationStatus=review`
- Add tests for `syndicationStatus` query
- Refactor `tierFilter` to use `syndicationStatusFilter`:
  - the syndication tier will return images that are queued for syndication