### PR TITLE
add `isInferred` to SyndicationRights model

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -128,7 +128,8 @@ object Mappings {
   val syndicationRightsMapping = nonDynamicObj(
     "published" -> dateFormat,
     "suppliers" -> suppliersMapping,
-    "rights" -> syndicationRightsListMapping
+    "rights" -> syndicationRightsListMapping,
+    "isInferred" -> boolean
   )
 
   val exportsMapping =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
@@ -9,7 +9,9 @@ import play.api.libs.functional.syntax._
 case class SyndicationRights(
   published: Option[DateTime],
   suppliers: Seq[Supplier],
-  rights: Seq[Right]) {
+  rights: Seq[Right],
+  isInferred: Boolean = false
+) {
 
   def isAvailableForSyndication: Boolean = {
     val rightsAcquired = rights.flatMap(_.acquired).contains(true)
@@ -17,19 +19,19 @@ case class SyndicationRights(
 
     rightsAcquired && isPublished
   }
-
-  def isInferred = published.isEmpty
 }
 object SyndicationRights {
   implicit val dateWrites = jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
   implicit val dateReads = jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
 
-  val reads: Reads[SyndicationRights] = Json.reads[SyndicationRights]
+  val reads: Reads[SyndicationRights] = Json.using[Json.WithDefaultValues].reads[SyndicationRights]
+
   val writes: Writes[SyndicationRights] = (
     (__ \ "published").write[Option[DateTime]] ~
     (__ \ "suppliers").write[Seq[Supplier]] ~
-    (__ \ "rights").write[Seq[Right]]
-  ){ sr: SyndicationRights => (sr.published, sr.suppliers, sr.rights) }
+    (__ \ "rights").write[Seq[Right]] ~
+    (__ \ "isInferred").write[Boolean]
+  ){ sr: SyndicationRights => (sr.published, sr.suppliers, sr.rights, sr.isInferred) }
 
   implicit val formats: Format[SyndicationRights] = Format(reads, writes)
 }

--- a/thrall/app/lib/SyndicationNotifications.scala
+++ b/thrall/app/lib/SyndicationNotifications.scala
@@ -21,7 +21,7 @@ class SyndicationNotifications(thrallNotifications: ThrallNotifications) {
 
   def sendRefresh(image: Image, syndicationRights: SyndicationRights): Unit = {
     GridLogger.info(s"refreshing inferred rights", image.id)
-    val inferredRights = syndicationRights.copy(published = None)
+    val inferredRights = syndicationRights.copy(isInferred = true)
 
     val message = Json.obj(
       "id" -> image.id,


### PR DESCRIPTION
The motivation behind this is to copy the publish date across to inferred images as we only want to send images to syndication partners if they've been published.

Previously, we were using the absence of `published` as an indicator for inferred rights and to know which images to propagate rights to. With the above rule, we would not be sending all the images we should be!