### PR TITLE
syndication icon traffic light

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
@@ -12,13 +12,8 @@ case class SyndicationRights(
   rights: Seq[Right],
   isInferred: Boolean = false
 ) {
-
-  def isAvailableForSyndication: Boolean = {
-    val rightsAcquired = rights.flatMap(_.acquired).contains(true)
-    val isPublished = published.exists(_.isBeforeNow)
-
-    rightsAcquired && isPublished
-  }
+  def isRightsAcquired: Boolean = rights.flatMap(_.acquired).contains(true)
+  def isAvailableForSyndication: Boolean = isRightsAcquired && published.exists(_.isBeforeNow)
 }
 object SyndicationRights {
   implicit val dateWrites = jodaDateWrites("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationStatus.scala
@@ -8,6 +8,7 @@ sealed trait SyndicationStatus {
     case QueuedForSyndication => "queued"
     case BlockedForSyndication => "blocked"
     case AwaitingReviewForSyndication => "review"
+    case UnsuitableForSyndication => "unsuitable"
   }
 }
 
@@ -17,6 +18,7 @@ object SyndicationStatus {
     case "queued" => QueuedForSyndication
     case "blocked" => BlockedForSyndication
     case "review" => AwaitingReviewForSyndication
+    case "unsuitable" => UnsuitableForSyndication
   }
 
   implicit val reads: Reads[SyndicationStatus] = JsPath.read[String].map(SyndicationStatus(_))
@@ -30,3 +32,4 @@ object SentForSyndication extends SyndicationStatus
 object QueuedForSyndication extends SyndicationStatus
 object BlockedForSyndication extends SyndicationStatus
 object AwaitingReviewForSyndication extends SyndicationStatus
+object UnsuitableForSyndication extends SyndicationStatus

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationStatus.scala
@@ -1,4 +1,4 @@
-package model
+package com.gu.mediaservice.model
 
 import play.api.libs.json._
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
@@ -1,0 +1,196 @@
+package com.gu.mediaservice.model
+
+import java.net.URI
+import java.util.UUID
+
+import com.gu.mediaservice.model.usage._
+import org.joda.time.DateTime
+import org.scalatest.{FunSpec, Matchers}
+
+class ImageTest extends FunSpec with Matchers {
+
+  def createImage(id: String = UUID.randomUUID().toString, usages: List[Usage] = List(), leases: Option[LeaseByMedia] = None, syndicationRights: Option[SyndicationRights] = None): Image = {
+    Image(
+      id = id,
+      uploadTime = DateTime.now(),
+      uploadedBy = "test.user@theguardian.com",
+      lastModified = None,
+      identifiers = Map.empty,
+      uploadInfo = UploadInfo(filename = Some(s"test_$id.jpeg")),
+      source = Asset(
+        file = new URI(s"https://file/$id"),
+        size = Some(1L),
+        mimeType = Some("image/jpeg"),
+        dimensions = Some(Dimensions(width = 1, height = 1)),
+        secureUrl = None
+      ),
+      thumbnail = None,
+      optimisedPng = None,
+      fileMetadata = FileMetadata(),
+      userMetadata = None,
+      metadata = ImageMetadata(dateTaken = None, title = Some(s"Test image $id"), keywords = List()),
+      originalMetadata = ImageMetadata(),
+      usageRights = StaffPhotographer("T. Hanks", "The Guardian"),
+      originalUsageRights = StaffPhotographer("T. Hanks", "The Guardian"),
+      exports = Nil,
+
+      syndicationRights = syndicationRights,
+      usages = usages,
+      leases = leases.getOrElse(LeaseByMedia.build(Nil))
+    )
+  }
+
+  val syndicationUsage = Usage(
+    UUID.randomUUID().toString,
+    List(UsageReference(SyndicationUsageReference)),
+    SyndicationUsage,
+    "image",
+    SyndicatedUsageStatus,
+    Some(DateTime.now()),
+    None,
+    DateTime.now()
+  )
+
+  val digitalUsage = Usage(
+    UUID.randomUUID().toString,
+    List(UsageReference(ComposerUsageReference)),
+    DigitalUsage,
+    "image",
+    PublishedUsageStatus,
+    Some(DateTime.now()),
+    None,
+    DateTime.now()
+  )
+
+  val rightsAcquired = SyndicationRights(None, Nil, List(Right("rights-code", Some(true), Nil)))
+  val noRightsAcquired = SyndicationRights(None, Nil, List(Right("rights-code", Some(false), Nil)))
+
+  describe("Image syndication status") {
+    it("should be UnsuitableForSyndication by default") {
+      val image = createImage()
+
+      image.usages.length shouldBe 0
+      image.syndicationRights shouldBe None
+      image.leases.leases.length shouldBe 0
+
+      image.syndicationStatus shouldBe UnsuitableForSyndication
+    }
+
+    it("should be AwaitingReviewForSyndication if syndication rights are acquired") {
+      val image = createImage(
+        syndicationRights = Some(rightsAcquired)
+      )
+
+      image.syndicationStatus shouldBe AwaitingReviewForSyndication
+    }
+
+    it("should be UnsuitableForSyndication if syndication rights are not acquired") {
+      val image = createImage(
+        syndicationRights = Some(noRightsAcquired)
+      )
+
+      image.syndicationStatus shouldBe UnsuitableForSyndication
+    }
+
+    it("should be UnsuitableForSyndication if there is no syndication rights") {
+      val imageId = UUID.randomUUID().toString
+
+      val usages = List(
+        syndicationUsage,
+        digitalUsage
+      )
+
+      val leaseByMedia = LeaseByMedia(
+        lastModified = None,
+        current = None,
+        leases = List(MediaLease(
+          id = None,
+          leasedBy = None,
+          access = AllowSyndicationLease,
+          notes = None,
+          mediaId = imageId
+        ))
+      )
+
+      val image = createImage(
+        id = imageId,
+        usages = usages,
+        leases = Some(leaseByMedia)
+      )
+
+      image.syndicationStatus shouldBe UnsuitableForSyndication
+    }
+
+    it("should be SentForSyndication if there is a syndication usage") {
+      val usages = List(
+        syndicationUsage,
+        digitalUsage
+      )
+
+      val image = createImage(
+        syndicationRights = Some(rightsAcquired),
+        usages = usages
+      )
+
+      image.syndicationStatus shouldBe SentForSyndication
+    }
+  }
+
+  it("should be QueuedForSyndication if there is an allow syndication lease and no syndication usage") {
+    val imageId = UUID.randomUUID().toString
+
+    val leaseByMedia = LeaseByMedia(
+      lastModified = None,
+      current = None,
+      leases = List(MediaLease(
+        id = None,
+        leasedBy = None,
+        access = AllowSyndicationLease,
+        notes = None,
+        mediaId = imageId
+      ))
+    )
+
+    val usages = List(
+      digitalUsage
+    )
+
+    val image = createImage(
+      id = imageId,
+      syndicationRights = Some(rightsAcquired),
+      usages = usages,
+      leases = Some(leaseByMedia)
+    )
+
+    image.syndicationStatus shouldBe QueuedForSyndication
+  }
+
+  it("should be BlockedForSyndication if there is a deny syndication lease and no syndication usage") {
+    val imageId = UUID.randomUUID().toString
+
+    val leaseByMedia = LeaseByMedia(
+      lastModified = None,
+      current = None,
+      leases = List(MediaLease(
+        id = None,
+        leasedBy = None,
+        access = DenySyndicationLease,
+        notes = None,
+        mediaId = imageId
+      ))
+    )
+
+    val usages = List(
+      digitalUsage
+    )
+
+    val image = createImage(
+      id = imageId,
+      syndicationRights = Some(rightsAcquired),
+      usages = usages,
+      leases = Some(leaseByMedia)
+    )
+
+    image.syndicationStatus shouldBe BlockedForSyndication
+  }
+}

--- a/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.css
+++ b/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.css
@@ -1,0 +1,15 @@
+.syndication-status--sent {
+    color: green;
+}
+
+.syndication-status--queued {
+    color: orange;
+}
+
+.syndication-status--blocked {
+    color: red;
+}
+
+.syndication-status--review {
+    color: white;
+}

--- a/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
+++ b/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
@@ -1,0 +1,5 @@
+<div title="{{ ctrl.states.syndicationReason }}">
+    <gr-icon class="syndication-status--{{ ctrl.states.syndicationStatus }}">
+        monetization_on
+    </gr-icon>
+</div>

--- a/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.js
+++ b/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.js
@@ -1,0 +1,29 @@
+import angular from 'angular';
+
+import template from './gr-syndication-icon.html';
+import './gr-syndication-icon.css';
+
+import '../../image/service';
+
+export var syndicationIcon = angular.module('gr.syndicationIcon', [
+    'gr.image.service'
+]);
+
+syndicationIcon.controller('SyndicationIconCtrl', ['imageService', function (imageService) {
+    const ctrl = this;
+
+    ctrl.states = imageService(ctrl.image).states;
+}]);
+
+syndicationIcon.directive('grSyndicationIcon', [function () {
+    return {
+        restrict: 'E',
+        template: template,
+        scope: {
+            image: '='
+        },
+        controller: 'SyndicationIconCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true
+    };
+}]);

--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -31,7 +31,8 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
             canArchive: imageLogic.canBeArchived(image),
             persistedReasons: imageLogic.getPersistenceExplanation(image).join('; '),
             isStaffPhotographer: imageLogic.isStaffPhotographer(image),
-            isSyndicated: imageLogic.isSyndicated(image)
+            syndicationStatus: imageLogic.getSyndicationStatus(image),
+            syndicationReason: imageLogic.getSyndicationReason(image)
         };
     }
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -121,10 +121,8 @@
                 <gr-icon>today</gr-icon>
             </div>
 
-            <div class="bottom-bar__action"
-                 ng-if="ctrl.states.isSyndicated"
-                 title="Image is available to syndication partners">
-                <gr-icon>monetization_on</gr-icon>
+            <div class="bottom-bar__action" ng-if="ctrl.states.syndicationStatus !== 'unsuitable'">
+                <gr-syndication-icon image="ctrl.image"></gr-syndication-icon>
             </div>
 
             <div class="bottom-bar__action bottom-bar__action--cost preview__cost"

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -11,12 +11,14 @@ import '../imgops/service';
 import '../services/image/usages';
 import '../components/gr-add-label/gr-add-label';
 import '../components/gr-archiver-status/gr-archiver-status';
+import '../components/gr-syndication-icon/gr-syndication-icon';
 
 export var image = angular.module('kahuna.preview.image', [
     'gr.image.service',
     'gr.image-usages.service',
     'gr.addLabel',
     'gr.archiverStatus',
+    'gr.syndicationIcon',
     'util.rx',
     'kahuna.imgops'
 ]);

--- a/kahuna/public/js/services/image-accessor.js
+++ b/kahuna/public/js/services/image-accessor.js
@@ -60,6 +60,10 @@ imageAccessor.factory('imageAccessor', function() {
         return image.data.collections;
     }
 
+    function readSyndicationStatus(image) {
+        return image.data.syndicationStatus;
+    }
+
     function getCollectionsIds(image) {
         const collections = readCollections(image);
         return collections.map(col => col.data.pathId);
@@ -82,7 +86,8 @@ imageAccessor.factory('imageAccessor', function() {
         isArchived,
         readCollections,
         getCollectionsIds,
-        getPhotoshoot
+        getPhotoshoot,
+        readSyndicationStatus
     };
 });
 

--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -65,16 +65,23 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
         });
     }
 
-    function isSyndicated(image) {
-        const syndicationRights = image.data.syndicationRights;
+    function getSyndicationStatus(image) {
+        return imageAccessor.readSyndicationStatus(image);
+    }
 
-        const hasSyndicationRights = !!syndicationRights;
-
-        if (!hasSyndicationRights) {
-            return false;
+    function getSyndicationReason(image) {
+        switch (getSyndicationStatus(image)) {
+            case 'sent':
+                return 'image has been sent for syndication';
+            case 'queued':
+                return 'image will soon be sent for syndication';
+            case 'blocked':
+                return 'image will not be sent for syndication';
+            case 'review':
+                return 'image is awaiting editorial review';
+            default:
+                return;
         }
-
-        return syndicationRights.rights.find(_ => _.acquired === true);
     }
 
     return {
@@ -83,7 +90,8 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
         getArchivedState,
         getPersistenceExplanation,
         isStaffPhotographer,
-        isSyndicated
+        getSyndicationStatus,
+        getSyndicationReason
     };
 }]);
 

--- a/media-api/app/controllers/SearchParams.scala
+++ b/media-api/app/controllers/SearchParams.scala
@@ -2,9 +2,9 @@ package controllers
 
 import com.gu.mediaservice.lib.auth.{Authentication, Tier}
 import com.gu.mediaservice.lib.formatting.{parseDateFromQuery, printDateTime}
+import com.gu.mediaservice.model.SyndicationStatus
 import com.gu.mediaservice.model.usage.UsageStatus
 import lib.querysyntax.{Condition, Parser}
-import model.SyndicationStatus
 import org.joda.time.DateTime
 import scalaz.syntax.applicative._
 import scalaz.syntax.std.list._

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -170,7 +170,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       .flatMap(_.transform(addValidity(valid)))
       .flatMap(_.transform(addInvalidReasons(invalidReasons)))
       .flatMap(_.transform(addUsageCost(source)))
-      .flatMap(_.transform(addPersistedState(isPersisted, persistenceReasons))).get
+      .flatMap(_.transform(addPersistedState(isPersisted, persistenceReasons)))
+      .flatMap(_.transform(addSyndicationStatus(image))).get
 
     val links: List[Link] = tier match {
       case Internal => imageLinks(id, imageUrl, pngUrl, withWritePermission, valid)
@@ -255,6 +256,12 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val cost = Costing.getCost(usageRights)
 
     __.json.update(__.read[JsObject].map(_ ++ Json.obj("cost" -> cost.toString)))
+  }
+
+  def addSyndicationStatus(image: Image): Reads[JsObject] = {
+    __.json.update(__.read[JsObject]).map(_ ++ Json.obj(
+      "syndicationStatus" -> image.syndicationStatus
+    ))
   }
 
   def addPersistedState(isPersisted: Boolean, persistenceReasons: List[String]): Reads[JsObject] =

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -9,7 +9,6 @@ import org.elasticsearch.index.query.{BoolFilterBuilder, FilterBuilder}
 import scalaz.syntax.std.list._
 import scalaz.NonEmptyList
 import lib.MediaApiConfig
-import model._
 import org.joda.time.DateTime
 
 

--- a/media-api/app/lib/elasticsearch/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/SyndicationFilter.scala
@@ -7,11 +7,18 @@ import org.elasticsearch.index.query.FilterBuilder
 import org.joda.time.DateTime
 
 object SyndicationFilter extends ImageFields {
+  private def syndicationRightsAcquired(acquired: Boolean): FilterBuilder = filters.boolTerm(
+    field = "syndicationRights.rights.acquired",
+    value = acquired
+  )
+
+  private val noRightsAcquired: FilterBuilder = filters.or(
+    filters.existsOrMissing("syndicationRights.rights.acquired", exists = false),
+    syndicationRightsAcquired(false)
+  )
+
   private val hasRightsAcquired: FilterBuilder = filters.bool.must(
-    filters.boolTerm(
-      field = "syndicationRights.rights.acquired",
-      value = true
-    )
+    syndicationRightsAcquired(true)
   )
 
   private val hasAllowLease: FilterBuilder = filters.term(
@@ -73,5 +80,6 @@ object SyndicationFilter extends ImageFields {
         )
       )
     )
+    case UnsuitableForSyndication => noRightsAcquired
   }
 }

--- a/media-api/app/lib/elasticsearch/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/SyndicationFilter.scala
@@ -2,8 +2,7 @@ package lib.elasticsearch
 
 import com.gu.mediaservice.lib.elasticsearch.ImageFields
 import com.gu.mediaservice.model.usage.SyndicationUsage
-import com.gu.mediaservice.model.{AllowSyndicationLease, DenySyndicationLease}
-import model._
+import com.gu.mediaservice.model._
 import org.elasticsearch.index.query.FilterBuilder
 import org.joda.time.DateTime
 

--- a/media-api/test/lib/ElasticSearchTest.scala
+++ b/media-api/test/lib/ElasticSearchTest.scala
@@ -3,9 +3,8 @@ package lib
 import java.util.UUID
 
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
-import com.gu.mediaservice.model.{Handout, Image, StaffPhotographer}
+import com.gu.mediaservice.model._
 import controllers.SearchParams
-import model._
 import org.joda.time.{DateTime, DateTimeUtils}
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures


### PR DESCRIPTION
Add `syndicationStatus` to API response to create a traffic light in the search page. Putting this in the API keeps the UI simple.

The previous version of this icon doesn't make sense anymore as it signalled that rights had been acquired but nothing about if its been sent at all.

A traffic light allows you to quickly understand what's going on.

- `sent` is green
- `queued` is yellow
- `blocked` is red
- `review` is white

For example:
![orange](https://user-images.githubusercontent.com/836140/44518994-aca30b00-a6c3-11e8-9796-387d4776c5aa.png)
