### PR TITLE
don't show images for syndication review before training finished

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -101,7 +101,7 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
       params.usageStatus.toNel.map(status => filters.terms(usagesField("status"), status.map(_.toString))) ++
       params.usagePlatform.toNel.map(filters.terms(usagesField("platform"), _))
 
-    val syndicationStatusFilter = params.syndicationStatus.map(SyndicationFilter.statusFilter)
+    val syndicationStatusFilter = params.syndicationStatus.map(status => SyndicationFilter.statusFilter(status, config))
 
     val filterOpt = (
       metadataFilter.toList

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -75,7 +75,7 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
   val nonPersistedFilter: FilterBuilder = filters.not(persistedFilter)
 
   def tierFilter(tier: Tier): Option[FilterBuilder] = tier match {
-    case Syndication => Some(SyndicationFilter.statusFilter(QueuedForSyndication))
+    case Syndication => Some(SyndicationFilter.statusFilter(QueuedForSyndication, config))
     case _ => None
   }
 


### PR DESCRIPTION
Syndication starts on 23 August 2018 as that's when training had been completed. Don't show images uploaded prior to this date to keep the review queue manageable for Editorial by not showing past images that RCS has told us about (~5k images).