### PR TITLE
confirm collection deletion

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -31,13 +31,11 @@
             {{:: node.data.data.description}}
         </a>
 
-
-        <button class="node__action clickable" type="button"
-                title="Delete this collection"
-                ng:if="ctrl.deletable && grCollectionTreeCtrl.editing"
-                ng:click="ctrl.remove()">
-            <gr-icon-label gr-icon="delete"></gr-icon-label>
-        </button>
+        <gr-confirm-delete class="node__action clickable"
+                           title="Delete this collection"
+                           ng:if="ctrl.deletable && grCollectionTreeCtrl.editing"
+                           gr-on-confirm="ctrl.remove()">
+        </gr-confirm-delete>
 
         <button class="node__action clickable"
                 type="button"


### PR DESCRIPTION
We sometimes delete collections by accident as the button is next to the "add sub collection" one. Reuse the deletion confirmation button to provide a similar ux to other delete buttons across the app.

# Before
![before](https://user-images.githubusercontent.com/836140/45208386-5cf73e80-b282-11e8-8426-59be54ad4248.gif)

# After
![after](https://user-images.githubusercontent.com/836140/45208393-5ff22f00-b282-11e8-8bdd-3a01b3040dba.gif)
