### PR TITLE
Add deny lease description

### DIFF
--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -17,7 +17,8 @@ object ImageExtras {
     "missing_description"         -> "Missing description *",
     "paid_image"                  -> "Paid imagery requires a lease",
     "over_quota"                  -> "The quota for this supplier has been exceeded",
-    "conditional_paid"            -> "This image is restricted use"
+    "conditional_paid"            -> "This image is restricted use",
+    "current_deny_lease"          -> "Cropping has been denied using a lease"
   )
 
   def validityOverrides(image: Image, withWritePermission: Boolean): Map[String, Boolean] = Map(


### PR DESCRIPTION
As reported by Jonny Weeks, the description when an image has a deny lease on is fairly obtuse.

Before:

![picture 104](https://user-images.githubusercontent.com/395805/45353728-8c27eb80-b5b3-11e8-8fa5-088f5bb2662e.png)

After:

![after](https://i.gyazo.com/56e37d9f9128082f245ac1679ffdf631.png)