### PR TITLE
Fix Barcroft Supplier String Checks

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -142,7 +142,7 @@ object BarcroftParser extends ImageProcessor {
   def apply(image: Image): Image =
     // We search the credit and the source here as Barcroft seems to use both
     if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
-      List("barcroft media", "barcroft india", "barcroft usa", "barcroft cars").contains(s)
+      List("barcroft media", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
     }) image.copy(usageRights = Agency("Barcroft Media")) else image
 }
 


### PR DESCRIPTION
Barcroft images often include the name of the photographer like `"Sam Cutler / Barcoft Images"`

Previous behaviour checked if "barcroft images" contained the text `"Sam Cutler / Barcoft Images".toLowerCase()`

Invert the contains check to allow more variation in Barcroft supplier strings