### PR TITLE
set crop type hint in the preview page too

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -50,6 +50,7 @@ image.controller('ImageCtrl', [
     '$rootScope',
     '$scope',
     '$state',
+    '$stateParams',
     '$window',
     '$filter',
     'inject$',
@@ -67,6 +68,7 @@ image.controller('ImageCtrl', [
     function ($rootScope,
               $scope,
               $state,
+              $stateParams,
               $window,
               $filter,
               inject$,
@@ -110,7 +112,11 @@ image.controller('ImageCtrl', [
 
         ctrl.image.allCrops = [];
 
-        ctrl. cropType = storage.getJs('cropType', true);
+        if ($stateParams.cropType) {
+            storage.setJs('cropType', $stateParams.cropType, true);
+        }
+
+        ctrl.cropType = storage.getJs('cropType', true);
 
         imageService(ctrl.image).states.canDelete.then(deletable => {
             ctrl.canBeDeleted = deletable;

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -23,7 +23,7 @@ image.config(['$stateProvider',
               function($stateProvider) {
 
     $stateProvider.state('image', {
-        url: '/images/:imageId?crop',
+        url: '/images/:imageId?crop?cropType',
         template: imageTemplate,
         controller: 'ImageCtrl',
         controllerAs: 'ctrl',


### PR DESCRIPTION
The cropType querystring is used to hint to Grid that only certain ratios should be enabled, for example video trails should only be landscape (5:3).

Allow the cropType hint to be read on the image preview page (previously it was only being read on the crop page).

Related to https://github.com/guardian/grid/pull/2072