### PR TITLE
Catch more Barcroft imagery

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -142,7 +142,7 @@ object BarcroftParser extends ImageProcessor {
   def apply(image: Image): Image =
     // We search the credit and the source here as Barcroft seems to use both
     if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
-      List("barcroft media", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
+      List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
     }) image.copy(usageRights = Agency("Barcroft Media")) else image
 }
 


### PR DESCRIPTION
There is no way to search the `source` field (sic!), so no idea how many will be added, but here is one example: cca4702c04ad46b1e659d0005858405d1a29a78e.