### PR TITLE
allow credit to have no slash

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ByLineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ByLineCreditReorganise.scala
@@ -29,7 +29,7 @@ object ByLineCreditReorganise extends MetadataCleaner {
 
         // if we have a split, and the first split is the same, remove if from credit
         // and use it as byline, the rest is the credit
-        case (b1 :: bTail, c1 :: cTail)if b1 == c1 => (b1, cTail.head)
+        case (b1 :: _, c1 :: c2 :: _) if b1 == c1 => (b1, c2)
         case _ => (byline, credit)
       }
     }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -14,6 +14,11 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
     .whenCleaned("Man/In/Suit"  , "Presseye/INPHO/REX")
   }
 
+  it ("should leave matching credit in byline") {
+    CreditByline("Silver River TV/BBC", "Silver River TV")
+      .whenCleaned("Silver River TV/BBC", "Silver River TV")
+  }
+
   it ("should leave non matching byline and credit") {
     CreditByline("Ella/BPI/REX", "Ella Ling/BPI/REX")
     .whenCleaned("Ella/BPI/REX", "Ella Ling/BPI/REX")


### PR DESCRIPTION
Update BylineCreditReorganise cleaner, allowing credit to be a single element.

This allows the byline to be `foo/bar` and credit to be `foo`. This was previously failing as `credit` had no tail.

Ideally this cleaner would produce `byline:None` and `credit:foo/bar` however it would require a bit of a refactor to support an `Option[String]` type...maybe later?