### PR TITLE
Correctly identify Ronald Grant Archive uploads

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -274,8 +274,8 @@ object RexParser extends ImageProcessor {
 
 object RonaldGrantParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
-    case Some("www.ronaldgrantarchive.com") => image.copy(
-      usageRights = Agency("Ronald Grant Archive")
+    case Some("www.ronaldgrantarchive.com") | Some("Ronald Grant Archive") => image.copy(
+      usageRights = Agency("Ronald Grant Archive"),
       metadata    = image.metadata.copy(credit = Some("Ronald Grant"))
     )
     case _ => image

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -22,6 +22,7 @@ object SupplierProcessors {
     PaParser,
     ReutersParser,
     RexParser,
+    RonaldGrantParser,
     PhotographerParser
   )
 
@@ -267,6 +268,16 @@ object RexParser extends ImageProcessor {
     // TODO: cleanup byline/credit
     case (Some("Rex Features"), _) => image.copy(usageRights = rexAgency)
     case (_, Some(SlashRex()))     => image.copy(usageRights = rexAgency)
+    case _ => image
+  }
+}
+
+object RonaldGrantParser extends ImageProcessor {
+  def apply(image: Image): Image = image.metadata.credit match {
+    case Some("www.ronaldgrantarchive.com") => image.copy(
+      usageRights = Agency("Ronald Grant Archive")
+      metadata    = image.metadata.copy(credit = Some("Ronald Grant"))
+    )
     case _ => image
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -424,6 +424,23 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   }
 
 
+  describe("Ronald Grant") {
+    it("should match www.ronaldgrantarchive.com credit") {
+      val image = createImageFromMetadata("credit" -> "www.ronaldgrantarchive.com")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Ronald Grant Archive"))
+      processedImage.metadata.credit should be(Some("Ronald Grant"))
+    }
+    
+    it("should match Ronald Grant Archive credit") {
+      val image = createImageFromMetadata("credit" -> "Ronald Grant Archive")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Ronald Grant Archive"))
+      processedImage.metadata.credit should be(Some("Ronald Grant"))
+    }
+  }
+
+
   def applyProcessors(image: Image): Image =
     SupplierProcessors.process(image)
 


### PR DESCRIPTION
First thingz first, I can’t code in Scala. But I can copy/paste in Scala. Maybe.

Ronald Grant Archive pictures come up as paid when they should be free. This should reduce the amount of manual work needed to fix the misidentification. It also sets the Credit correctly to `Ronald Grant`.

Copy/paste skillz are not enough to rejiggle metadata so that the `copyright`+`/` is capitalised correctly (what about allcaps studio initialisms?) and prepended to credit... (example of what need to be done: d608b584738ff53bb22d8e78b80ea3e72577320e)

- [x] I need to test this on TEST!