### PR TITLE
change media-api healthcheck to not hit es

### DIFF
--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -29,7 +29,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, notifications, elasticSearch, usageQuota, controllerComponents)
-  val healthcheckController = new HealthCheck(elasticSearch, controllerComponents)
+  val healthcheckController = new HealthCheck(controllerComponents)
 
   override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, healthcheckController, management)
 }

--- a/media-api/app/controllers/HealthCheck.scala
+++ b/media-api/app/controllers/HealthCheck.scala
@@ -1,15 +1,13 @@
 package controllers
 
-import com.gu.mediaservice.syntax._
-import lib.elasticsearch.ElasticSearch
 import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.ExecutionContext
 
-class HealthCheck(elasticSearch: ElasticSearch, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
+class HealthCheck(override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
   extends BaseController {
 
-  def healthCheck = Action.async {
-    elasticSearch.client.prepareSearch().setSize(0).executeAndLog("Health check") map (_ => Ok("OK"))
+  def healthCheck = Action {
+    Ok("OK")
   }
 }


### PR DESCRIPTION
If es is slow (because aws networking!), the healthcheck fails and the instance cycles. A new instance is launched in its place, and the same thing happens. And then a new instance is launched and...

Change the healthcheck to not depend on es.