### PR TITLE
Add “INS News Agency Ltd” to the list of exclusions that may contain…

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -173,7 +173,7 @@ trait GettyProcessor {
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   // including 'newspix internation' because they're sending us lots with that in the credit
-  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot", "Ian Jones", "Avalon")
+  val excludeFromPatterns = List("newspix international", "newspix internation", "i-images", "photoshot", "Ian Jones", "Avalon", "INS News Agency Ltd")
     .map(ex => s"(?i)$ex".r)
 
   // Some people send over Getty XMP data, but are not affiliated with Getty


### PR DESCRIPTION
…Getty GIFT, but aren’t Getty.

We are ([wrongly](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala#L185)) identifying Getty by the mere presence of Getty-GIFT block. But it [may be present](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala#L179) on non-Getty images, too! We may want one day to switch to maybe identifying Getty by the presence of `xmp.getty.Asset ID` instead? (@blishen).