### PR TITLE
Spell MacLeod correctly

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -106,7 +106,7 @@ object MetadataConfig {
     "Louise Hagger"       -> "The Guardian",
     "Martin Godwin"       -> "The Guardian",
     "Mike Bowers"         -> "The Guardian",
-    "Murdo Macleod"       -> "The Guardian",
+    "Murdo MacLeod"       -> "The Guardian",
     "Sarah Lee"           -> "The Guardian",
     "Tom Jenkins"         -> "The Guardian",
     "Tristram Kenton"     -> "The Guardian",

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -38,8 +38,8 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     it ("should correct casing of photographer") {
       val image = createImageFromMetadata("byline" -> "Murdo MacLeod")
       val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(ContractPhotographer("Murdo Macleod", Option("The Guardian")))
-      processedImage.metadata.byline should be(Some("Murdo Macleod"))
+      processedImage.usageRights should be(ContractPhotographer("Murdo MacLeod", Option("The Guardian")))
+      processedImage.metadata.byline should be(Some("Murdo MacLeod"))
     }
   }
 

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -84,7 +84,7 @@ object UsageRightsProperty {
 
     case CommissionedPhotographer => List(
       publicationField(false),
-      photographerField("Sophia Evans, Murdo Macleod")
+      photographerField("Sophia Evans, Murdo MacLeod")
     )
 
     case ContractIllustrator => List(


### PR DESCRIPTION
After noticing inconsistent spelling, contacting Murdo himself and the Style Police, an executive decision was taken (not by me), to spell it MacLeod.

There is [this test](https://github.com/guardian/grid/blob/mk-macleod-spelling/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala#L38), which not only looks odd now, but also worries me a bit. Do we need exception [in here](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CapitaliseProperty.scala)?
~[**UPDATE**: yeah, sorry, test fails, what does the monkey do now?]~

I will spend the rest of my days fixing past usages, cause images aren’t atoms.

- [x] Tested and working correctly on TEST (looks like `CapitaliseProperty` is not applied for Usage-derived values :)