### PR TITLE
Add style guide byline cleaners

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleByline.scala
@@ -1,0 +1,29 @@
+package com.gu.mediaservice.lib.cleanup
+
+import com.gu.mediaservice.model.ImageMetadata
+
+object GuardianStyleByline extends MetadataCleaner {
+  override def clean(metadata: ImageMetadata): ImageMetadata = {
+    metadata.copy(
+      byline = metadata.byline.map(applyCleaners)
+    )
+  }
+
+  private def applyCleaners(byline: String): String =  {
+    val curly = replaceStraightQuoteWithCurly(byline)
+    cleanInitials(curly)
+  }
+
+  private def replaceStraightQuoteWithCurly(byline: String): String = {
+    byline.replace("'", "’")
+  }
+
+  // Guardian style guide says there shoulnd't be full stops after intials
+  private def cleanInitials(byline: String): String = {
+    val noDots = byline.replaceAll("\\b(\\w)\\.(?:\\s|\\b|$)", "$1 ").trim
+
+    // Squish initials together if there's two
+    noDots.replaceAll("\\b(\\p{Lu})\\s(\\p{Lu})\\b", "$1$2")
+  }
+
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -21,6 +21,7 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
   ) ++ attrCreditFromBylineCleaners ++ List(
     StripBylineFromCredit,
     CountryCode,
+    GuardianStyleByline,
     CapitaliseByline,
     CapitaliseCountry,
     CapitaliseState,

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleBylineTest.scala
@@ -1,0 +1,48 @@
+package com.gu.mediaservice.lib.cleanup
+
+import org.scalatest.{FunSpec, Matchers}
+
+class GuardianStyleBylineTest extends FunSpec with Matchers with MetadataHelper {
+  it("should replace straight quotes with curly quotes") {
+    val metadata = createImageMetadata("byline" -> "Sam O'neill")
+    val cleanedMetadata = GuardianStyle.clean(metadata)
+
+    cleanedMetadata.byline should be (Some("Sam O’neill"))
+  }
+
+  it("should remove dots in initials") {
+    val metadata = createImageMetadata("byline" -> "First M. Last")
+    val cleanedMetadata = GuardianStyle.clean(metadata)
+
+    cleanedMetadata.byline should be (Some("First M Last"))
+  }
+
+  it("should remove dots in initials and squish initials together at the start") {
+    val metadata = createImageMetadata("byline" -> "C. P. Scott")
+    val cleanedMetadata = GuardianStyle.clean(metadata)
+
+    cleanedMetadata.byline should be (Some("CP Scott"))
+  }
+
+  it("should remove dots in initials and squish initials together in the middle") {
+    val metadata = createImageMetadata("byline" -> "First A. B. Last")
+    val cleanedMetadata = GuardianStyle.clean(metadata)
+
+    cleanedMetadata.byline should be (Some("First AB Last"))
+  }
+
+  it("should remove dots in initials and squish initials together at the end") {
+    val metadata = createImageMetadata("byline" -> "First A. B.")
+    val cleanedMetadata = GuardianStyle.clean(metadata)
+
+    cleanedMetadata.byline should be (Some("First AB"))
+  }
+
+  it("should remove dots in initials and insert spaces in unusual cases") {
+    val metadata = createImageMetadata("byline" -> "Ishara S.kodikara")
+    val cleanedMetadata = GuardianStyle.clean(metadata)
+
+    // NOTE: The capitalisation cleaner should handle this becoming Title Case
+    cleanedMetadata.byline should be (Some("Ishara S kodikara"))
+  }
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleBylineTest.scala
@@ -5,42 +5,42 @@ import org.scalatest.{FunSpec, Matchers}
 class GuardianStyleBylineTest extends FunSpec with Matchers with MetadataHelper {
   it("should replace straight quotes with curly quotes") {
     val metadata = createImageMetadata("byline" -> "Sam O'neill")
-    val cleanedMetadata = GuardianStyle.clean(metadata)
+    val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     cleanedMetadata.byline should be (Some("Sam O’neill"))
   }
 
   it("should remove dots in initials") {
     val metadata = createImageMetadata("byline" -> "First M. Last")
-    val cleanedMetadata = GuardianStyle.clean(metadata)
+    val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     cleanedMetadata.byline should be (Some("First M Last"))
   }
 
   it("should remove dots in initials and squish initials together at the start") {
     val metadata = createImageMetadata("byline" -> "C. P. Scott")
-    val cleanedMetadata = GuardianStyle.clean(metadata)
+    val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     cleanedMetadata.byline should be (Some("CP Scott"))
   }
 
   it("should remove dots in initials and squish initials together in the middle") {
     val metadata = createImageMetadata("byline" -> "First A. B. Last")
-    val cleanedMetadata = GuardianStyle.clean(metadata)
+    val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     cleanedMetadata.byline should be (Some("First AB Last"))
   }
 
   it("should remove dots in initials and squish initials together at the end") {
     val metadata = createImageMetadata("byline" -> "First A. B.")
-    val cleanedMetadata = GuardianStyle.clean(metadata)
+    val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     cleanedMetadata.byline should be (Some("First AB"))
   }
 
   it("should remove dots in initials and insert spaces in unusual cases") {
     val metadata = createImageMetadata("byline" -> "Ishara S.kodikara")
-    val cleanedMetadata = GuardianStyle.clean(metadata)
+    val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     // NOTE: The capitalisation cleaner should handle this becoming Title Case
     cleanedMetadata.byline should be (Some("Ishara S kodikara"))


### PR DESCRIPTION
Often our photographers will submit their names in a way that doesn't conform to our style guide. 

This adds a single cleaner that applies three of the major causes of style guide violations in photographer bylines. Curly quotes rather than straight quotes, removing the full stop after an initial and squishing together pairs of initials.