### PR TITLE
reorder initial squish to avoid capitalizer ruining everything

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleByline.scala
@@ -20,10 +20,7 @@ object GuardianStyleByline extends MetadataCleaner {
 
   // Guardian style guide says there shoulnd't be full stops after intials
   private def cleanInitials(byline: String): String = {
-    val noDots = byline.replaceAll("\\b(\\w)\\.(?:\\s|\\b|$)", "$1 ").trim
-
-    // Squish initials together if there's two
-    noDots.replaceAll("\\b(\\p{Lu})\\s(\\p{Lu})\\b", "$1$2")
+    byline.replaceAll("\\b(\\w)\\.(?:\\s|\\b|$)", "$1 ").trim
   }
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerByline.scala
@@ -1,0 +1,12 @@
+package com.gu.mediaservice.lib.cleanup
+
+import com.gu.mediaservice.model.ImageMetadata
+
+object InitialJoinerByline extends MetadataCleaner {
+  // Squish together pairs of dangling initials. For example: "C P Scott" -> "CP Scott"
+  override def clean(metadata: ImageMetadata): ImageMetadata = {
+    metadata.copy(
+      byline = metadata.byline.map(_.replaceAll("\\b(\\p{Lu})\\s(\\p{Lu})\\b", "$1$2"))
+    )
+  }
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -23,6 +23,7 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
     CountryCode,
     GuardianStyleByline,
     CapitaliseByline,
+    InitialJoinerByline,
     CapitaliseCountry,
     CapitaliseState,
     CapitaliseCity,

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleBylineTest.scala
@@ -17,32 +17,11 @@ class GuardianStyleBylineTest extends FunSpec with Matchers with MetadataHelper 
     cleanedMetadata.byline should be (Some("First M Last"))
   }
 
-  it("should remove dots in initials and squish initials together at the start") {
-    val metadata = createImageMetadata("byline" -> "C. P. Scott")
-    val cleanedMetadata = GuardianStyleByline.clean(metadata)
-
-    cleanedMetadata.byline should be (Some("CP Scott"))
-  }
-
-  it("should remove dots in initials and squish initials together in the middle") {
-    val metadata = createImageMetadata("byline" -> "First A. B. Last")
-    val cleanedMetadata = GuardianStyleByline.clean(metadata)
-
-    cleanedMetadata.byline should be (Some("First AB Last"))
-  }
-
-  it("should remove dots in initials and squish initials together at the end") {
-    val metadata = createImageMetadata("byline" -> "First A. B.")
-    val cleanedMetadata = GuardianStyleByline.clean(metadata)
-
-    cleanedMetadata.byline should be (Some("First AB"))
-  }
-
   it("should remove dots in initials and insert spaces in unusual cases") {
     val metadata = createImageMetadata("byline" -> "Ishara S.kodikara")
     val cleanedMetadata = GuardianStyleByline.clean(metadata)
 
     // NOTE: The capitalisation cleaner should handle this becoming Title Case
-    cleanedMetadata.byline should be (Some("Ishara S kodikara"))
+    cleanedMetadata.byline should be(Some("Ishara S kodikara"))
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerBylineTest.scala
@@ -1,0 +1,27 @@
+package com.gu.mediaservice.lib.cleanup
+
+import org.scalatest.{FunSpec, Matchers}
+
+class InitialJoinerBylineTest extends FunSpec with Matchers with MetadataHelper {
+  it("should squish initials together at the start") {
+    val metadata = createImageMetadata("byline" -> "C P Scott")
+    val cleanedMetadata = InitialJoinerByline.clean(metadata)
+
+    cleanedMetadata.byline should be(Some("CP Scott"))
+  }
+
+  it("should squish initials together in the middle") {
+    val metadata = createImageMetadata("byline" -> "First A B Last")
+    val cleanedMetadata = InitialJoinerByline.clean(metadata)
+
+    cleanedMetadata.byline should be(Some("First AB Last"))
+  }
+
+  it("should squish initials together at the end") {
+    val metadata = createImageMetadata("byline" -> "First A B")
+    val cleanedMetadata = InitialJoinerByline.clean(metadata)
+
+    cleanedMetadata.byline should be(Some("First AB"))
+  }
+
+}


### PR DESCRIPTION
Having the initials squished before the capitaliser caused the following bad behaviour:

`Original → Dots removed → Squish    → Capitalise`
`C. P. Scott → C P Scott         → CP Scott → Cp Scott`

This is bad, reodereding the initial squish to be after the title casing prevents this.