### PR TITLE
Improve leases reliability

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -258,7 +258,7 @@ object Mappings {
   val leasesMapping =
     nonDynamicObj(
       "leases"       -> leaseMapping,
-      "current"      -> leaseMapping,
+      "current"      -> leaseMapping, //Field not used anymore
       "lastModified" -> dateFormat
     )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -24,7 +24,7 @@ case class Image(
   originalUsageRights: UsageRights,
   exports:             List[Crop]       = Nil,
   usages:              List[Usage]      = Nil,
-  leases:              LeaseByMedia     = LeaseByMedia.build(Nil),
+  leases:              LeasesByMedia     = LeasesByMedia.build(Nil),
   collections:         List[Collection] = Nil,
   syndicationRights:   Option[SyndicationRights] = None
 ) {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -78,7 +78,7 @@ object Image {
       (__ \ "originalUsageRights").readNullable[UsageRights].map(_ getOrElse NoRights) ~
       (__ \ "exports").readNullable[List[Crop]].map(_ getOrElse List()) ~
       (__ \ "usages").readNullable[List[Usage]].map(_ getOrElse List()) ~
-      (__ \ "leases").readNullable[LeaseByMedia].map(_ getOrElse LeaseByMedia.build(Nil)) ~
+      (__ \ "leases").readNullable[LeasesByMedia].map(_ getOrElse LeasesByMedia.build(Nil)) ~
       (__ \ "collections").readNullable[List[Collection]].map(_ getOrElse Nil) ~
       (__ \ "syndicationRights").readNullable[SyndicationRights]
     )(Image.apply _)
@@ -101,7 +101,7 @@ object Image {
       (__ \ "originalUsageRights").write[UsageRights] ~
       (__ \ "exports").write[List[Crop]] ~
       (__ \ "usages").write[List[Usage]] ~
-      (__ \ "leases").write[LeaseByMedia] ~
+      (__ \ "leases").write[LeasesByMedia] ~
       (__ \ "collections").write[List[Collection]] ~
       (__ \ "syndicationRights").writeNullable[SyndicationRights]
     )(unlift(Image.unapply))

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -9,22 +9,20 @@ import JodaWrites._
 
 case class LeasesByMedia(
   leases: List[MediaLease],
-  lastModified: Option[DateTime],
-  current: Option[MediaLease]
+  lastModified: Option[DateTime]
 )
-case object LeasesByMedia {
+
+object LeasesByMedia {
   implicit val reader : Reads[LeasesByMedia] = (__ \ "leases").read[List[MediaLease]].map(LeasesByMedia.build)
 
   implicit val writer = new Writes[LeasesByMedia] {
     def writes(leaseByMedia: LeasesByMedia) = {
       LeasesByMedia.toJson(
         Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.current),
         Json.toJson(leaseByMedia.lastModified.map(lm => Json.toJson(lm)))
       )
     }
   }
-
 
   def build(leases: List[MediaLease]): LeasesByMedia = {
     def sortLease(a: MediaLease, b: MediaLease) =
@@ -33,20 +31,17 @@ case object LeasesByMedia {
     val sortedLeases = leases
       .sortWith(sortLease)
 
-    val currentLease = sortedLeases.find(lease => lease.active && lease.isUse)
-
     val lastModified = sortedLeases
       .headOption
       .map(_.createdAt)
 
-    LeasesByMedia(sortedLeases, lastModified, currentLease)
+    LeasesByMedia(sortedLeases, lastModified)
   }
 
-  def toJson(leases: JsValue, current: JsValue, lastModified: JsValue) : JsObject = {
+  def toJson(leases: JsValue, lastModified: JsValue) : JsObject = {
     JsObject(
       Seq(
         "leases" -> leases,
-        "current" -> current,
         "lastModified" -> lastModified
       )
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -10,7 +10,7 @@ case class LeasesByMedia(
 )
 
 object LeasesByMedia {
-  implicit val reader : Reads[LeasesByMedia] = (__ \ "leases").read[List[MediaLease]].map(LeasesByMedia.build)
+  implicit val reader: Reads[LeasesByMedia] = (__ \ "leases").read[List[MediaLease]].map(LeasesByMedia.build)
 
   implicit val writer = new Writes[LeasesByMedia] {
     def writes(leaseByMedia: LeasesByMedia) = {
@@ -21,14 +21,12 @@ object LeasesByMedia {
     }
   }
 
+  implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
+
   def build(leases: List[MediaLease]): LeasesByMedia = {
-    def sortLease(a: MediaLease, b: MediaLease) =
-      a.createdAt.isAfter(b.createdAt)
+    val sortedLeases = leases.sortBy(_.createdAt).reverse
 
-    val sortedLeases = leases
-      .sortWith(sortLease)
-
-    val lastModified = sortedLeases
+    val lastModified: Option[DateTime] = sortedLeases
       .headOption
       .map(_.createdAt)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -7,17 +7,17 @@ import com.gu.mediaservice.lib.argo.model._
 import org.joda.time.DateTime
 import JodaWrites._
 
-case class LeaseByMedia(
+case class LeasesByMedia(
   leases: List[MediaLease],
   lastModified: Option[DateTime],
   current: Option[MediaLease]
 )
-case object LeaseByMedia {
-  implicit val reader : Reads[LeaseByMedia] = (__ \ "leases").read[List[MediaLease]].map(LeaseByMedia.build(_))
+case object LeasesByMedia {
+  implicit val reader : Reads[LeasesByMedia] = (__ \ "leases").read[List[MediaLease]].map(LeasesByMedia.build)
 
-  implicit val writer = new Writes[LeaseByMedia] {
-    def writes(leaseByMedia: LeaseByMedia) = {
-      LeaseByMedia.toJson(
+  implicit val writer = new Writes[LeasesByMedia] {
+    def writes(leaseByMedia: LeasesByMedia) = {
+      LeasesByMedia.toJson(
         Json.toJson(leaseByMedia.leases),
         Json.toJson(leaseByMedia.current),
         Json.toJson(leaseByMedia.lastModified.map(lm => Json.toJson(lm)))
@@ -26,7 +26,7 @@ case object LeaseByMedia {
   }
 
 
-  def build(leases: List[MediaLease]): LeaseByMedia = {
+  def build(leases: List[MediaLease]): LeasesByMedia = {
     def sortLease(a: MediaLease, b: MediaLease) =
       a.createdAt.isAfter(b.createdAt)
 
@@ -39,7 +39,7 @@ case object LeaseByMedia {
       .headOption
       .map(_.createdAt)
 
-    LeaseByMedia(sortedLeases, lastModified, currentLease)
+    LeasesByMedia(sortedLeases, lastModified, currentLease)
   }
 
   def toJson(leases: JsValue, current: JsValue, lastModified: JsValue) : JsObject = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -1,9 +1,6 @@
 package com.gu.mediaservice.model
 
-
 import play.api.libs.json._
-import play.api.libs.functional.syntax._
-import com.gu.mediaservice.lib.argo.model._
 import org.joda.time.DateTime
 import JodaWrites._
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
@@ -55,17 +55,13 @@ case class MediaLease(
     case _ => this
   }
 
-  private def withValidEndDateField: MediaLease = if (access == AllowSyndicationLease) {
-    this.copy(endDate = None) // an allow-syndication cannot end
-  } else {
-    this
-  }
+  private def withValidEndDateField: MediaLease =
+    if (access == AllowSyndicationLease) this.copy(endDate = None) // an allow-syndication cannot end
+    else this
 
-  private def withValidStartDateField: MediaLease = if (access == DenySyndicationLease) {
-    this.copy(startDate = None) // a deny-syndication cannot start
-  } else {
-    this
-  }
+  private def withValidStartDateField: MediaLease =
+    if (access == DenySyndicationLease) this.copy(startDate = None) // a deny-syndication cannot start
+    else this
 
   def prepareForSave: MediaLease = this
     .withValidNotesField

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
@@ -2,10 +2,11 @@ package com.gu.mediaservice.model
 
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
-
 import org.joda.time.DateTime
 import JodaWrites._
 import JodaReads._
+import com.gu.mediaservice.lib.formatting.printDateTime
+import com.gu.mediaservice.model.MediaLease.MediaLeasePlainWrites
 
 
 sealed trait MediaLeaseType { def name: String }
@@ -74,14 +75,20 @@ case class MediaLease(
 
   def isUse = access == AllowUseLease || access == DenyUseLease
 }
-case object MediaLease {
+object MediaLease {
   implicit val MediaLeaseReads = Json.reads[MediaLease]
 
   val MediaLeasePlainWrites = Json.writes[MediaLease]
 
-  implicit val MediaLeaseWrites = new Writes[MediaLease] {
+  implicit val MediaLeaseWrites: Writes[MediaLease] = new Writes[MediaLease] {
     def writes(mediaLease: MediaLease) =
       Json.toJson(mediaLease)(MediaLeasePlainWrites).as[JsObject] +
-        ("active" -> JsBoolean(mediaLease.active))
+        ("active" -> JsString(mediaLease.active.toString))
   }
+
+  def toJson(lease: MediaLease): JsValue = Json.obj(
+    "id" -> lease.mediaId,
+    "data" -> Json.toJson(lease),
+    "lastModified" -> printDateTime(DateTime.now())
+  )
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
@@ -1,13 +1,10 @@
 package com.gu.mediaservice.model
 
 import play.api.libs.json._
-import play.api.libs.functional.syntax._
 import org.joda.time.DateTime
 import JodaWrites._
 import JodaReads._
 import com.gu.mediaservice.lib.formatting.printDateTime
-import com.gu.mediaservice.model.MediaLease.MediaLeasePlainWrites
-
 
 sealed trait MediaLeaseType { def name: String }
 object MediaLeaseType {
@@ -75,16 +72,14 @@ case class MediaLease(
 
   def isUse = access == AllowUseLease || access == DenyUseLease
 }
+
 object MediaLease {
-  implicit val MediaLeaseReads = Json.reads[MediaLease]
+  implicit val MediaLeaseReads: Reads[MediaLease] = Json.reads[MediaLease]
 
-  val MediaLeasePlainWrites = Json.writes[MediaLease]
+  val MediaLeasePlainWrites: OWrites[MediaLease] = Json.writes[MediaLease]
 
-  implicit val MediaLeaseWrites: Writes[MediaLease] = new Writes[MediaLease] {
-    def writes(mediaLease: MediaLease) =
-      Json.toJson(mediaLease)(MediaLeasePlainWrites).as[JsObject] +
-        ("active" -> JsString(mediaLease.active.toString))
-  }
+  implicit val MediaLeaseWrites: Writes[MediaLease] = (mediaLease: MediaLease) =>
+    Json.toJson(mediaLease)(MediaLeasePlainWrites).as[JsObject] + ("active" -> JsBoolean(mediaLease.active))
 
   def toJson(lease: MediaLease): JsValue = Json.obj(
     "id" -> lease.mediaId,

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
@@ -102,7 +102,6 @@ class ImageTest extends FunSpec with Matchers {
 
       val leaseByMedia = LeasesByMedia(
         lastModified = None,
-        current = None,
         leases = List(MediaLease(
           id = None,
           leasedBy = None,
@@ -141,7 +140,6 @@ class ImageTest extends FunSpec with Matchers {
 
     val leaseByMedia = LeasesByMedia(
       lastModified = None,
-      current = None,
       leases = List(MediaLease(
         id = None,
         leasedBy = None,
@@ -170,7 +168,6 @@ class ImageTest extends FunSpec with Matchers {
 
     val leaseByMedia = LeasesByMedia(
       lastModified = None,
-      current = None,
       leases = List(MediaLease(
         id = None,
         leasedBy = None,

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FunSpec, Matchers}
 
 class ImageTest extends FunSpec with Matchers {
 
-  def createImage(id: String = UUID.randomUUID().toString, usages: List[Usage] = List(), leases: Option[LeaseByMedia] = None, syndicationRights: Option[SyndicationRights] = None): Image = {
+  def createImage(id: String = UUID.randomUUID().toString, usages: List[Usage] = List(), leases: Option[LeasesByMedia] = None, syndicationRights: Option[SyndicationRights] = None): Image = {
     Image(
       id = id,
       uploadTime = DateTime.now(),
@@ -36,7 +36,7 @@ class ImageTest extends FunSpec with Matchers {
 
       syndicationRights = syndicationRights,
       usages = usages,
-      leases = leases.getOrElse(LeaseByMedia.build(Nil))
+      leases = leases.getOrElse(LeasesByMedia.build(Nil))
     )
   }
 
@@ -100,7 +100,7 @@ class ImageTest extends FunSpec with Matchers {
         digitalUsage
       )
 
-      val leaseByMedia = LeaseByMedia(
+      val leaseByMedia = LeasesByMedia(
         lastModified = None,
         current = None,
         leases = List(MediaLease(
@@ -139,7 +139,7 @@ class ImageTest extends FunSpec with Matchers {
   it("should be QueuedForSyndication if there is an allow syndication lease and no syndication usage") {
     val imageId = UUID.randomUUID().toString
 
-    val leaseByMedia = LeaseByMedia(
+    val leaseByMedia = LeasesByMedia(
       lastModified = None,
       current = None,
       leases = List(MediaLease(
@@ -168,7 +168,7 @@ class ImageTest extends FunSpec with Matchers {
   it("should be BlockedForSyndication if there is a deny syndication lease and no syndication usage") {
     val imageId = UUID.randomUUID().toString
 
-    val leaseByMedia = LeaseByMedia(
+    val leaseByMedia = LeasesByMedia(
       lastModified = None,
       current = None,
       leases = List(MediaLease(

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -183,9 +183,7 @@ leases.controller('LeasesCtrl', [
         ctrl.leaseStatus = (lease) => {
             const active = lease.active ? 'active ' : ' ';
 
-            const current = ctrl.leases.current
-                .filter((lease) => lease !== null)
-                .find(l => l.id == lease.id) ? 'current ' : '';
+            const current = (lease.active && lease.access.match(/-use/i)) ? 'current' : '';
 
             const access = (lease.access.match(/allow/i)) ? 'allowed' : 'denied';
 

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -183,6 +183,7 @@ leases.controller('LeasesCtrl', [
         ctrl.leaseStatus = (lease) => {
             const active = lease.active ? 'active ' : ' ';
 
+            // Current only makes sense for use leases
             const current = (lease.active && lease.access.match(/-use/i)) ? 'current' : '';
 
             const access = (lease.access.match(/allow/i)) ? 'allowed' : 'denied';

--- a/leases/app/controllers/MediaLeaseController.scala
+++ b/leases/app/controllers/MediaLeaseController.scala
@@ -32,6 +32,7 @@ class MediaLeaseController(auth: Authentication, store: LeaseStore, config: Leas
   }
 
   private def notify(mediaId: String): Unit =  notifications.send(mediaId)
+  private def notify(mediaId: MediaLease): Unit =  notifications.send(mediaId)
 
   private def clearLease(id: String) = store.get(id).map { lease =>
     store.delete(id).map { _ => notify(lease.mediaId) }
@@ -46,7 +47,7 @@ class MediaLeaseController(auth: Authentication, store: LeaseStore, config: Leas
 
   private def addLease(mediaLease: MediaLease, userId: Option[String]) = store
     .put(mediaLease.prepareForSave.copy(leasedBy = userId)).map { _ =>
-      notify(mediaLease.mediaId)
+      notify(mediaLease)
     }
 
   def index = auth { _ => indexResponse }

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -2,7 +2,7 @@ package lib
 
 import com.gu.mediaservice.lib.aws.SNS
 import com.gu.mediaservice.lib.formatting._
-import com.gu.mediaservice.model.LeaseByMedia
+import com.gu.mediaservice.model.{LeaseByMedia, MediaLease}
 import org.joda.time.DateTime
 import play.api.libs.json._
 
@@ -26,6 +26,10 @@ object LeaseNotice {
       )
     }
   }
+  def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
+    mediaLease.mediaId,
+    Json.toJson(LeaseByMedia.build(List(mediaLease)))
+  )
 }
 
 class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends SNS(config, config.topicArn) {
@@ -36,5 +40,9 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends SNS(config,
 
   def send(mediaId: String) = {
     publish(build(mediaId).toJson, "update-image-leases")
+  }
+
+  def send(mediaLease: MediaLease) = {
+    publish(LeaseNotice(mediaLease).toJson, "update-image-leases")
   }
 }

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -37,11 +37,20 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends SNS(config,
     LeaseNotice(mediaId, Json.toJson(LeasesByMedia.build(leases)))
   }
 
-  def send(mediaId: String) = {
+  def sendReindexLeases(mediaId: String) = {
     publish(build(mediaId).toJson, "update-image-leases")
   }
 
-  def send(mediaLease: MediaLease) = {
+  def sendAddLease(mediaLease: MediaLease) = {
     publish(MediaLease.toJson(mediaLease), "add-image-lease")
+  }
+
+  def sendRemoveLease(mediaId: String, leaseId: String) = {
+    val leaseInfo = Json.obj(
+      "leaseId" -> leaseId,
+      "id" -> mediaId,
+      "lastModified" -> printDateTime(DateTime.now())
+    )
+    publish(leaseInfo, "remove-image-lease")
   }
 }

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -21,7 +21,6 @@ object LeaseNotice {
     def writes(leaseByMedia: LeasesByMedia) = {
       LeasesByMedia.toJson(
         Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.current),
         Json.toJson(leaseByMedia.lastModified.map(lm => Json.toJson(lm)))
       )
     }

--- a/leases/app/lib/LeaseStore.scala
+++ b/leases/app/lib/LeaseStore.scala
@@ -23,7 +23,7 @@ class LeaseStore(config: LeasesConfig) extends DynamoDB(config, config.leasesTab
   def getForMedia(id: String): List[MediaLease] = Scanamo.queryIndex[MediaLease](client)(tableName, "mediaId")('mediaId -> id).flatMap(_.toOption)
 
   def put(lease: MediaLease) =
-    ScanamoAsync.put[MediaLease](client)(tableName)(lease.copy(id=Some(UUID.randomUUID().toString)))
+    ScanamoAsync.put[MediaLease](client)(tableName)(lease)
 
   def delete(id: String) = ScanamoAsync.delete(client)(tableName)('id -> id)
 

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -30,9 +30,9 @@ object ImageExtras {
   def hasCredit(meta: ImageMetadata) = meta.credit.isDefined
   def hasDescription(meta: ImageMetadata) = meta.description.isDefined
 
-  def hasCurrentAllowLease(leases: LeaseByMedia) = leases.current.exists(_.access == AllowUseLease)
+  def hasCurrentAllowLease(leases: LeasesByMedia) = leases.current.exists(_.access == AllowUseLease)
 
-  def hasCurrentDenyLease(leases: LeaseByMedia) = leases.current.exists(_.access == DenyUseLease)
+  def hasCurrentDenyLease(leases: LeasesByMedia) = leases.current.exists(_.access == DenyUseLease)
 
   def validityMap(image: Image, withWritePermission: Boolean)(
     implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -30,9 +30,11 @@ object ImageExtras {
   def hasCredit(meta: ImageMetadata) = meta.credit.isDefined
   def hasDescription(meta: ImageMetadata) = meta.description.isDefined
 
-  def hasCurrentAllowLease(leases: LeasesByMedia) = leases.current.exists(_.access == AllowUseLease)
+  private def isCurrent(lease: MediaLease): Boolean = lease.active && lease.isUse
 
-  def hasCurrentDenyLease(leases: LeasesByMedia) = leases.current.exists(_.access == DenyUseLease)
+  def hasCurrentAllowLease(leases: LeasesByMedia): Boolean = leases.leases.exists(lease => lease.access == AllowUseLease && isCurrent(lease))
+
+  def hasCurrentDenyLease(leases: LeasesByMedia): Boolean = leases.leases.exists(lease => lease.access == DenyUseLease && isCurrent(lease))
 
   def validityMap(image: Image, withWritePermission: Boolean)(
     implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -36,7 +36,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   type UsagesEntity = EmbeddedEntity[List[UsageEntity]]
 
   type MediaLeaseEntity = EmbeddedEntity[MediaLease]
-  type MediaLeasesEntity = EmbeddedEntity[LeaseByMedia]
+  type MediaLeasesEntity = EmbeddedEntity[LeasesByMedia]
 
   def hasPersistenceIdentifier(image: Image) =
     image.identifiers.contains(config.persistenceIdentifier)
@@ -325,7 +325,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     (__ \ "usages").write[UsagesEntity]
       .contramap(usagesEntity(id, _: List[Usage])) ~
     (__ \ "leases").write[MediaLeasesEntity]
-        .contramap(leasesEntity(id, _: LeaseByMedia)) ~
+        .contramap(leasesEntity(id, _: LeasesByMedia)) ~
     (__ \ "collections").write[List[EmbeddedEntity[CollectionResponse]]]
       .contramap((collections: List[Collection]) => collections.map(c => collectionsEntity(id, c))) ~
     (__ \ "syndicationRights").write[Option[SyndicationRights]]
@@ -343,8 +343,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   def usagesEntity(id: String, usages: List[Usage]) =
     EmbeddedEntity[List[UsageEntity]](usagesUri(id), Some(usages.map(usageEntity)))
 
-  def leasesEntity(id: String, leaseByMedia: LeaseByMedia) =
-    EmbeddedEntity[LeaseByMedia](leasesUri(id), Some(leaseByMedia))
+  def leasesEntity(id: String, leaseByMedia: LeasesByMedia) =
+    EmbeddedEntity[LeasesByMedia](leasesUri(id), Some(leaseByMedia))
 
   def collectionsEntity(id: String, c: Collection): EmbeddedEntity[CollectionResponse] =
       collectionEntity(config.collectionsUri, id, c)

--- a/media-api/test/lib/ElasticSearchHelper.scala
+++ b/media-api/test/lib/ElasticSearchHelper.scala
@@ -83,7 +83,6 @@ trait ElasticSearchHelper extends MockitoSugar {
 
     val leaseByMedia = lease.map(l => LeasesByMedia(
       lastModified = None,
-      current = None,
       leases = List(l)
     ))
 

--- a/media-api/test/lib/ElasticSearchHelper.scala
+++ b/media-api/test/lib/ElasticSearchHelper.scala
@@ -29,11 +29,11 @@ trait ElasticSearchHelper extends MockitoSugar {
   val testUser = "yellow-giraffe@theguardian.com"
 
   def createImage(
-     id: String,
-     usageRights: UsageRights,
-     syndicationRights: Option[SyndicationRights] = None,
-     leases: Option[LeaseByMedia] = None,
-     usages: List[Usage] = Nil
+                   id: String,
+                   usageRights: UsageRights,
+                   syndicationRights: Option[SyndicationRights] = None,
+                   leases: Option[LeasesByMedia] = None,
+                   usages: List[Usage] = Nil
   ): Image = {
     Image(
       id = id,
@@ -63,7 +63,7 @@ trait ElasticSearchHelper extends MockitoSugar {
       originalUsageRights = usageRights,
       exports = Nil,
       syndicationRights = syndicationRights,
-      leases = leases.getOrElse(LeaseByMedia.build(Nil)),
+      leases = leases.getOrElse(LeasesByMedia.build(Nil)),
       usages = usages
     )
   }
@@ -81,7 +81,7 @@ trait ElasticSearchHelper extends MockitoSugar {
 
     val syndicationRights = SyndicationRights(rcsPublishDate, Nil, rights)
 
-    val leaseByMedia = lease.map(l => LeaseByMedia(
+    val leaseByMedia = lease.map(l => LeasesByMedia(
       lastModified = None,
       current = None,
       leases = List(l)

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -32,6 +32,7 @@ class ThrallMessageConsumer(
       case "update-image-user-metadata" => updateImageUserMetadata
       case "update-image-usages"        => updateImageUsages
       case "update-image-leases"        => updateImageLeases
+      case "add-image-lease"            => addImageLease
       case "set-image-collections"      => setImageCollections
       case "heartbeat"                  => heartbeat
       case "delete-usages"              => deleteAllUsages
@@ -66,6 +67,9 @@ class ThrallMessageConsumer(
 
   def updateImageLeases(leaseByMedia: JsValue) =
     Future.sequence( withImageId(leaseByMedia)(id => es.updateImageLeases(id, leaseByMedia \ "data", leaseByMedia \ "lastModified")) )
+
+  def addImageLease(lease: JsValue) =
+    Future.sequence( withImageId(lease)(id => es.addImageLease(id, lease \ "data", lease \ "lastModified")) )
 
   def setImageCollections(collections: JsValue) =
     Future.sequence(withImageId(collections)(id => es.setImageCollection(id, collections \ "data")) )


### PR DESCRIPTION
When adding a lease to a batch selection some were randomly failing to sync in ES.
That's because we are saving the lease in Dynamo, query Dynamo and send the result to ES. 

To make it more reliable this PR sends messages to ES without relying on Dynamo to have the right answer. This introduces 2 new thrall messages: one that appends a lease and one that removes a lease from the list.

PR also includes refactoring of the `current` lease.