### PR TITLE
Fix inferring of syndication rights in photoshoots

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -10,9 +10,9 @@ import org.elasticsearch.action.update.{UpdateRequestBuilder, UpdateResponse}
 import org.elasticsearch.action.updatebyquery.UpdateByQueryResponse
 import org.elasticsearch.client.UpdateByQueryClientWrapper
 import org.elasticsearch.index.engine.{DocumentMissingException, VersionConflictEngineException}
-import org.elasticsearch.index.query.FilterBuilders.{andFilter, idsFilter, missingFilter, notFilter, termFilter}
-import org.elasticsearch.index.query.FilteredQueryBuilder
+import org.elasticsearch.index.query.FilterBuilders._
 import org.elasticsearch.index.query.QueryBuilders.{boolQuery, filteredQuery, matchAllQuery, matchQuery}
+import org.elasticsearch.index.query.{BaseFilterBuilder, FilteredQueryBuilder}
 import org.elasticsearch.script.ScriptService
 import org.elasticsearch.search.sort.{SortBuilders, SortOrder}
 import org.joda.time.DateTime
@@ -321,7 +321,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
   }
 
   def getInferredSyndicationRights(photoshoot: Photoshoot, excludedImage: Option[Image])(implicit ex: ExecutionContext): Future[List[Image]] = {
-    val inferredSyndicationRights = termFilter("syndicationRights.isInferred", true)
+    val inferredSyndicationRights = notFilter(termFilter("syndicationRights.isInferred", false)) // Using 'not' to include nulls
 
     val filter = excludedImage match {
       case Some(image) => andFilter(

--- a/thrall/app/lib/SyndicationRightsOps.scala
+++ b/thrall/app/lib/SyndicationRightsOps.scala
@@ -3,48 +3,42 @@ package lib
 import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class SyndicationRightsOps(
   es: ElasticSearch,
   notifications: SyndicationNotifications
 )(implicit ex: ExecutionContext) {
 
-  def refreshInferredRights(image: Image, rights: SyndicationRights) = {
+  def refreshInferredRights(image: Image, rights: SyndicationRights): Future[Unit] =
     image.userMetadata.flatMap(_.photoshoot) match {
       case Some(photoshoot) if !rights.isInferred =>
         refreshRightsInferenceInPhotoshoot(photoshoot, rights, Some(image))
-        image
-      case _ => image
+      case _ => Future.successful(())
     }
-  }
 
-  def moveExplicitRightsToPhotoshoot(image: Image, maybeNewPhotoshoot: Option[Photoshoot]) = {
-    def updateOldPhotoshoot(photoshoot: Photoshoot) = {
+  def moveExplicitRightsToPhotoshoot(image: Image, maybeNewPhotoshoot: Option[Photoshoot]): Option[Image] = {
+    def updateOldPhotoshoot(photoshoot: Photoshoot): Future[Object] = {
       es.getLatestSyndicationRights(photoshoot, Some(image)) map {
-        case Some(latestImageWithExplicitRights) if image.rcsPublishDate.get.isAfter(latestImageWithExplicitRights.rcsPublishDate.get) => {
+        case Some(latestImageWithExplicitRights) if image.rcsPublishDate.get.isAfter(latestImageWithExplicitRights.rcsPublishDate.get) =>
           GridLogger.info(s"refreshing inferred syndication rights for images using ${latestImageWithExplicitRights.id} because ${image.id} has moved", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
           refreshRightsInferenceInPhotoshoot(photoshoot, latestImageWithExplicitRights.syndicationRights.get, None)
-        }
-        case None => {
+        case None =>
           GridLogger.info(s"removing inferred rights from photoshoot as it no longer contains an image with direct rights", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
           es.getInferredSyndicationRights(photoshoot, None)
             .map(notifications.sendRemoval)
-        }
         case _ => None // no-op
       }
     }
 
-    def updateNewPhotoshoot(photoshoot: Photoshoot) = {
+    def updateNewPhotoshoot(photoshoot: Photoshoot): Future[Object] = {
       es.getLatestSyndicationRights(photoshoot, None) map {
-        case Some(mostRecentImage) if image.rcsPublishDate.get.isAfter(mostRecentImage.rcsPublishDate.get) => {
+        case Some(mostRecentImage) if image.rcsPublishDate.get.isAfter(mostRecentImage.rcsPublishDate.get) =>
           GridLogger.info(s"refreshing inferred syndication rights for images using ${image.id} because its the most recent", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
           refreshRightsInferenceInPhotoshoot(photoshoot, image.syndicationRights.get, None)
-        }
-        case None => {
+        case None =>
           GridLogger.info(s"refreshing inferred syndication rights for images using ${image.id} because none previously existed", Map("image-id" -> image.id, "photoshoot" -> photoshoot.title))
           refreshRightsInferenceInPhotoshoot(photoshoot, image.syndicationRights.get, None)
-        }
         case _ => None // no-op
       }
     }
@@ -52,36 +46,30 @@ class SyndicationRightsOps(
     for {
       _ <- image.userMetadata.flatMap(_.photoshoot).map(updateOldPhotoshoot)
       _ <- maybeNewPhotoshoot.map(updateNewPhotoshoot)
-    } yield {
-      image
-    }
+    } yield image
   }
 
-  def moveInferredRightsToPhotoshoot(image: Image, maybeNewPhotoshoot: Option[Photoshoot]) = {
+  def moveInferredRightsToPhotoshoot(image: Image, maybeNewPhotoshoot: Option[Photoshoot]): Unit = {
     val maybeOldPhotoshoot  = image.userMetadata.flatMap(_.photoshoot)
 
     (maybeOldPhotoshoot, maybeNewPhotoshoot) match {
-      case (Some(_), None) => {
-        GridLogger.info("image removed from photoshoot, removing inferred rights", image.id)
+      case (Some(oldPhotoshoot), None) =>
+        GridLogger.info("image removed from photoshoot, removing inferred rights", Map("image-id" -> image.id, "photoshoot" -> oldPhotoshoot.title))
         notifications.sendRemoval(image)
-      }
-      case (_, Some(newPhotoshoot)) => {
+      case (_, Some(newPhotoshoot)) =>
         es.getLatestSyndicationRights(newPhotoshoot, None) map {
-          case Some(i) => {
-            GridLogger.info(s"inferring rights from ${i.id} as its the most recent in new photoshoot", image.id)
+          case Some(i) =>
+            GridLogger.info(s"inferring rights from ${i.id} as its the most recent in new photoshoot", Map("image-id" -> image.id, "photoshoot" -> newPhotoshoot.title))
             notifications.sendRefresh(image, i.syndicationRights.get)
-          }
-          case None => {
-            GridLogger.info("cannot infer rights from new photoshoot, removing inferred rights", image.id)
+          case None =>
+            GridLogger.info("cannot infer rights from new photoshoot, removing inferred rights", Map("image-id" -> image.id, "photoshoot" -> newPhotoshoot.title))
             notifications.sendRemoval(image)
-          }
         }
-      }
-      case (None, None) => None // no-op, shouldn't happen
+      case (None, None) => // no-op, shouldn't happen
     }
   }
 
-  private def refreshRightsInferenceInPhotoshoot(photoshoot: Photoshoot, syndicationRights: SyndicationRights, excludedImage: Option[Image]) = {
+  private def refreshRightsInferenceInPhotoshoot(photoshoot: Photoshoot, syndicationRights: SyndicationRights, excludedImage: Option[Image]): Future[Unit] = {
     GridLogger.info("refreshing inference of rights on photoshoot", Map("photoshoot" -> photoshoot.title))
 
     es.getInferredSyndicationRights(photoshoot, excludedImage)

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -124,7 +124,6 @@ class ThrallMessageConsumer(
             )
           case _ =>
             GridLogger.info(s"image $id not found")
-            None
         }
       }
     )
@@ -137,7 +136,7 @@ class ThrallMessageConsumer(
         GridLogger.error(msg)
         Future.failed(SNSBodyParseError(msg))
       },
-      upcomingEdits => withImageId(message) { id => {
+      upcomingEdits => withImageId(message) { id =>
         GridLogger.info("updating photoshoot", id)
 
         es.getImage(id) map {
@@ -154,7 +153,7 @@ class ThrallMessageConsumer(
             GridLogger.info(s"image not found", id)
             None
         }
-      }}
+      }
     )
   }
 


### PR DESCRIPTION
There were issues when moving images with syndication rights from no album to an album because we were using a for comprehension to chain operations.

Also issues when an image in an album is the first one to receive syndication rights. In this case we were querying for other images in the album that have inferred rights, when we actually want to get all the other images that have either inferred right or null syndication rights.