### PR TITLE
Creating leases for images uploaded before 2016

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -401,7 +401,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
 
   private val addLeaseScript =
     """| if (ctx._source.leases == null || ctx._source.leases.leases == null) {
-       |   ctx._source.leases = [leases: lease];
+       |   ctx._source.leases = [leases: [lease]];
        | } else {
        |   ctx._source.leases.leases += lease;
        | }

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -400,7 +400,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
     """ctx._source.syndicationRights = syndicationRights;"""
 
   private val addLeaseScript =
-    """| if (ctx._source.leases.leases == null) {
+    """| if (ctx._source.leases == null || ctx._source.leases.leases == null) {
        |   ctx._source.leases.leases = lease;
        | } else {
        |   ctx._source.leases.leases += lease;

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -401,7 +401,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
 
   private val addLeaseScript =
     """| if (ctx._source.leases == null || ctx._source.leases.leases == null) {
-       |   ctx._source.leases.leases = lease;
+       |   ctx._source.leases = [leases: lease];
        | } else {
        |   ctx._source.leases.leases += lease;
        | }


### PR DESCRIPTION
Images before 2016 didn't have the concept of leases, so the top level element was `null`. Because we introduced the notion of upserting leases last week (https://github.com/guardian/grid/pull/2339), old images without leases were failing when creating new leases.