### PR TITLE
Set shoot query limit to 200

### DIFF
--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -338,6 +338,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
 
     client.prepareSearch(imagesAlias).setTypes(imageType)
       .setQuery(filteredQuery)
+      .setSize(200)
       .executeAndLog(s"get images in photoshoot ${photoshoot.title} with inferred syndication rights")
       .map(_.getHits.hits.toList.flatMap(_.sourceOpt))
       .map(_.map(_.as[Image]))


### PR DESCRIPTION
Prior to this, when querying a photo shoot only 10 images were being returned. This meant that updating inferred syndication rights would only happen to 10 images when an image _with_ rights was moved to that album. As discussed IRL with @marialivia16 200 seems like a good upper bound ... for now.