### PR TITLE
Use the current check to choose validation message

### DIFF
--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -56,7 +56,7 @@ object ImageExtras {
   }
 
   def invalidReasons(validityMap: ValidMap) = validityMap
-    .filter { case (_, v) => v.invalid }
+    .filter { case (_, v) => !v.isValid }
     .map { case (id, _) => id -> validityDescription.get(id) }
     .map {
       case (id, Some(reason)) => id -> reason

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -82,13 +82,24 @@ class ImageExtrasTest extends FunSpec with Matchers with MockitoSugar {
       validity should be(false)
     }
     it("should report all invalid reasons") {
-      val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = true)
+      val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = false)
       val invalidReasons = ImageExtras.invalidReasons(validityMap)
       val expectedInvalidReasons = Map(
         "paid_image" -> "Paid imagery requires a lease",
         "missing_description" -> "Missing description *",
         "missing_credit" -> "Missing credit information *",
         "no_rights" -> "No rights to use this image"
+      )
+
+      expectedInvalidReasons should be(invalidReasons)
+    }
+
+    it("should report all invalid reasons if write permissions are true") {
+      val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = true)
+      val invalidReasons = ImageExtras.invalidReasons(validityMap)
+      val expectedInvalidReasons = Map(
+        "missing_description" -> "Missing description *",
+        "missing_credit" -> "Missing credit information *"
       )
 
       expectedInvalidReasons should be(invalidReasons)


### PR DESCRIPTION
Fixes a bug described in this trello card: https://trello.com/c/KIMlXl6f/518-grid-invalidreasons-doesnt-account-for-allow-leases

When we were choosing which error messages to display we were using the `invalid` field which is not the check we need to do to determine the validity of the image.