### PR TITLE
Remove ‘Team’ from ‘Guardian Design Team’

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -127,7 +127,7 @@ object MetadataConfig {
   val staffIllustrators = List(
     "Mona Chalabi",
     "Sam Morris",
-    "Guardian Design Team"
+    "Guardian Design"
   )
 
   val contractIllustrators = List(


### PR DESCRIPTION
As agreed with The Bosses.

I would also like for this to **not** be applied to Byline field (only to Credit) and for a Byline field to be left empty (so for the logic to be different for this only and different for all named Staff Illustrators). But I’m not sure how to do it, because replicating logic for other entities still won’t get me what I won’t (and because the name in the UI is [derived directly](https://github.com/guardian/grid/blob/master/kahuna/public/js/usage-rights/usage-rights-editor.html#L120)).

Any help appreciated!