### PR TITLE
Enable cluster transport sniffing when running as a server

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -15,6 +15,7 @@ trait ElasticSearchClient {
   def port: Int
   def cluster: String
   def imagesAlias: String
+  def clientTransportSniff: Boolean
 
   protected val imagesIndexPrefix = "images"
   protected val imageType = "image"
@@ -24,7 +25,7 @@ trait ElasticSearchClient {
   private lazy val settings: Settings =
     ImmutableSettings.settingsBuilder
       .put("cluster.name", cluster)
-      .put("client.transport.sniff", false)
+      .put("client.transport.sniff", clientTransportSniff)
       .build
 
   lazy val client: Client =

--- a/elasticsearch/test/elasticsearch.yml
+++ b/elasticsearch/test/elasticsearch.yml
@@ -1,7 +1,9 @@
 cluster.name: media-service-test
 
-# necessary for running within Docker so apps running on the host can connect using the transport client on 9300
+# necessary for running within Docker so apps running on the host can connect using the transport client on 9301
 network.publish_host: 127.0.0.1
+transport.publish_port: 9301
+http.publish_port: 9201
 
 script.inline: on
 script.indexed: on

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -48,6 +48,7 @@ class ElasticSearch(config: MediaApiConfig, searchFilters: SearchFilters, mediaA
   lazy val host = config.elasticsearchHost
   lazy val port = config.int("es.port")
   lazy val cluster = config("es.cluster")
+  lazy val clientTransportSniff = true
 
   def getImageById(id: String)(implicit ex: ExecutionContext): Future[Option[JsValue]] =
     prepareGet(id).executeAndLog(s"get image by id $id") map (_.sourceOpt)

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -24,6 +24,7 @@ object MoveIndex extends EsScript {
       val port = esPort
       val host = esHost
       val cluster = esCluster
+      val clientTransportSniff = false
 
       def move {
         val srcIndex = getCurrentAlias.get // TODO: error handling if alias isn't attached
@@ -55,6 +56,7 @@ object Reindex extends EsScript {
       val port = esPort
       val host = esHost
       val cluster = esCluster
+      val clientTransportSniff = false
       val initTime = DateTime.now()
       val currentIndex = getCurrentIndices.reverse.head
       val nextIndex = nextIndexName(currentIndex)
@@ -184,6 +186,7 @@ object UpdateMapping extends EsScript {
       val port = esPort
       val host = esHost
       val cluster = esCluster
+      val clientTransportSniff = false
 
       def updateMappings(specifiedIndex: Option[String]) {
         val index = getCurrentAlias.getOrElse(imagesAlias)
@@ -215,6 +218,7 @@ object GetMapping extends EsScript {
       val port = esPort
       val host = esHost
       val cluster = esCluster
+      val clientTransportSniff = false
 
       def getMappings(specifiedIndex: Option[String]) {
         val index = getCurrentAlias.getOrElse(imagesAlias)
@@ -251,6 +255,7 @@ object UpdateSettings extends EsScript {
       val port = esPort
       val host = esHost
       val cluster = esCluster
+      val clientTransportSniff = false
 
       if (esHost != "localhost") {
         System.err.println(s"You can only run UpdateSettings on localhost, not '$esHost'")

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -29,6 +29,7 @@ class ElasticSearch(config: ThrallConfig, metrics: ThrallMetrics) extends Elasti
   lazy val host = config.elasticsearchHost
   lazy val port = config.int("es.port")
   lazy val cluster = config("es.cluster")
+  lazy val clientTransportSniff = true
 
   val scriptType = ScriptService.ScriptType.valueOf("INLINE")
 


### PR DESCRIPTION
PR #2170 inadvertently switched cluster transport sniffing off for the media API. The change was intended to be isolated to the scripts but wound up being applied everywhere as the change was made in a common component.

Cluster transport sniffing tells the elastic search client to keep track of all ES servers itself. When disabled the list of nodes is static the client will stay connected to the first node it reaches unless that node goes down. When enabled, the ES client will update the list of nodes every 5 seconds and will happily deal with nodes appearing and disappearing - even if eventually none of the original nodes are present.

More details at https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/transport-client.html

This PR adds this as an option that is configurable for each instances of the EsClient. In this case the scripts disable it whilst the use in servers enable it.