### PR TITLE
Crop type selection

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -95,6 +95,7 @@ crop.controller('ImageCropCtrl',
         ctrl.aspect = ctrl.landscapeRatio;
     } else {
         ctrl.aspect = ctrl.landscapeRatio;
+        ctrl.landscapeChecked = true;
     }
 
     ctrl.coords = {

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -53,7 +53,7 @@
         </div>
 
         <label class="top-bar-item clickable side-padded" gr-tooltip="landscape [l]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.landscapeRatio}}" ng-disabled="ctrl.cropType" name="aspect" />
+            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.landscapeRatio}}" ng-checked="ctrl.cropType === 'landscape'" ng-disabled="ctrl.cropType" name="aspect" />
             <gr-icon-label gr-icon="crop_landscape">Landscape</gr-icon-label> ({{::ctrl.getRatioString(ctrl.landscapeRatio)}})
         </label>
 
@@ -63,7 +63,7 @@
         </label>
 
         <label class="top-bar-item clickable side-padded" gr-tooltip="video [v]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.videoRatio}}" ng-disabled="ctrl.cropType" name="video ratio" />
+            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.videoRatio}}" ng-checked="ctrl.cropType === 'video'" ng-disabled="ctrl.cropType" name="video ratio" />
             <gr-icon-label gr-icon="crop_16_9">Video</gr-icon-label> ({{::ctrl.getRatioString(ctrl.videoRatio)}})
         </label>
 

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -53,7 +53,7 @@
         </div>
 
         <label class="top-bar-item clickable side-padded" gr-tooltip="landscape [l]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.landscapeRatio}}" ng-checked="ctrl.cropType === 'landscape'" ng-disabled="ctrl.cropType" name="aspect" />
+            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.landscapeRatio}}" ng-checked="ctrl.landscapeChecked || ctrl.cropType === 'landscape'" ng-disabled="ctrl.cropType" name="aspect" />
             <gr-icon-label gr-icon="crop_landscape">Landscape</gr-icon-label> ({{::ctrl.getRatioString(ctrl.landscapeRatio)}})
         </label>
 

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -117,6 +117,9 @@ image.controller('ImageCtrl', [
         }
 
         ctrl.cropType = storage.getJs('cropType', true);
+        ctrl.capitalisedCropType = ctrl.cropType ?
+            ctrl.cropType[0].toUpperCase() + ctrl.cropType.slice(1) :
+            '';
 
         imageService(ctrl.image).states.canDelete.then(deletable => {
             ctrl.canBeDeleted = deletable;

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -1,4 +1,5 @@
 <img class="image-crop__image"
+     ng:class="{'image-crop__image--disabled': !ctrl.allowCropSelection(crop) }"
      alt="cropped image thumbnail"
      ng:src="{{:: extremeAssets.smallest | assetFile}}" />
 <div class="image-crop__info"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -98,8 +98,8 @@
                                 draggable="false"
                                 ng:init="extremeAssets = (crop | getExtremeAssets)"
                                 ng-switch-when="false"
-                                gr-tooltip="You can only choose {{:: ctrl.cropType}} crops"
-                                gr-tooltip-position="right"
+                                gr-tooltip="{{:: ctrl.capitalisedCropType}} crops only"
+                                gr-tooltip-position="top"
                             >
                               <ng-include src="'/assets/js/image/crop.html'"></ng-include>
                             </div>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1836,8 +1836,12 @@ FIXME: what to do with touch devices
 }
 
 .image-crop--disabled {
-  opacity: 0.5;
+  color: #999;
   cursor: not-allowed;
+}
+
+.image-crop__image--disabled {
+  opacity: 0.5;
 }
 
 .result--selected .preview {


### PR DESCRIPTION

- Make it clear which crop we are selecting (the query params currently only support choice between landscape and video crops)

- Make the tooltip telling users why they can't select a particular crop visible for larger images

![screen shot 2018-11-26 at 09 53 17](https://user-images.githubusercontent.com/3066534/49006507-28986d80-f161-11e8-9bb5-4f57eabb6c4a.png)
![screen shot 2018-11-26 at 09 53 07](https://user-images.githubusercontent.com/3066534/49006515-2cc48b00-f161-11e8-9e7a-e9b3bd087cbb.png)