### PR TITLE
Revert "Ability to pick illustrator publication"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -130,26 +130,25 @@ object MetadataConfig {
     "Guardian Design"
   )
 
-  val contractIllustrators: Map[String, String] = Map(
-    "Ben Lamb"              -> "The Guardian",
-    "Andrzej Krauze"        -> "The Guardian",
-    "Chris Ware"            -> "The Guardian",
-    "David Squires"         -> "The Guardian",
-    "First Dog on the Moon" -> "The Guardian",
-    "Harry Venning"         -> "The Guardian",
-    "Kipper Williams"       -> "The Guardian",
-    "Martin Rowson"         -> "The Guardian",
-    "Matt Kenyon"           -> "The Guardian",
-    "Matthew Blease"        -> "The Guardian",
-    "Nicola Jennings"       -> "The Guardian",
-    "Rosalind Asquith"      -> "The Guardian",
-    "Steve Bell"            -> "The Guardian",
-    "Steven Appleby"        -> "The Guardian",
-    "Ben Jennings"          -> "The Guardian",
-    "Chris Riddell"         -> "The Observer",
-    "David Foldvari"        -> "The Observer",
-    "David Simonds"         -> "The Observer",
-    "Ian Tovey"             -> "The Observer",
+  val contractIllustrators = List(
+    "Ben Lamb",
+    "Andrzej Krauze",
+    "Chris Riddell",
+    "Chris Ware",
+    "David Foldvari",
+    "David Simonds",
+    "David Squires",
+    "First Dog on the Moon",
+    "Harry Venning",
+    "Ian Tovey",
+    "Kipper Williams",
+    "Martin Rowson",
+    "Matt Kenyon",
+    "Matthew Blease",
+    "Nicola Jennings",
+    "Rosalind Asquith",
+    "Steve Bell",
+    "Steven Appleby"
   )
 
   val allPhotographers = staffPhotographers ++ contractedPhotographers
@@ -158,7 +157,6 @@ object MetadataConfig {
   val staffPhotographersMap = PhotographersList.creditBylineMap(staffPhotographers)
   val contractPhotographersMap = PhotographersList.creditBylineMap(contractedPhotographers)
   val allPhotographersMap = PhotographersList.creditBylineMap(allPhotographers)
-  val contractIllustratorsMap = PhotographersList.creditBylineMap(contractIllustrators)
 
   val creativeCommonsLicense = List(
     "CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0"

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -412,7 +412,7 @@ object StaffIllustrator extends UsageRightsSpec {
     UsageRights.subtypeFormat(StaffIllustrator.category)(Json.format[StaffIllustrator])
 }
 
-final case class ContractIllustrator(creator: String, publication: Option[String] = None, restrictions: Option[String] = None)
+final case class ContractIllustrator(creator: String, restrictions: Option[String] = None)
   extends Illustrator {
   val defaultCost = ContractIllustrator.defaultCost
 }
@@ -427,7 +427,8 @@ object ContractIllustrator extends UsageRightsSpec {
     UsageRights.subtypeFormat(ContractIllustrator.category)(Json.format[ContractIllustrator])
 }
 
-final case class CommissionedIllustrator(creator: String, publication: Option[String] = None, restrictions: Option[String] = None)
+
+final case class CommissionedIllustrator(creator: String, restrictions: Option[String] = None)
   extends Illustrator {
   val defaultCost = CommissionedIllustrator.defaultCost
 }

--- a/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
+++ b/metadata-editor/app/lib/UsageRightsMetadataMapper.scala
@@ -9,9 +9,9 @@ object UsageRightsMetadataMapper {
       case u: StaffPhotographer        => ImageMetadata(byline = Some(u.photographer), credit = Some(u.publication))
       case u: ContractPhotographer     => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
       case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
-      case u: ContractIllustrator      => ImageMetadata(byline = Some(u.creator),      credit = u.publication)
+      case u: ContractIllustrator      => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: StaffIllustrator         => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
-      case u: CommissionedIllustrator  => ImageMetadata(byline = Some(u.creator),      credit = u.publication)
+      case u: CommissionedIllustrator  => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
       case u: Composite                => ImageMetadata(credit = Some(u.suppliers))
       case u: Screengrab               => ImageMetadata(credit = u.source)
     }

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -24,7 +24,7 @@ object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import MetadataConfig.{contractPhotographersMap, staffPhotographersMap, contractIllustratorsMap, staffIllustrators, creativeCommonsLicense}
+  import MetadataConfig.{contractPhotographersMap, staffPhotographersMap, contractIllustrators, staffIllustrators, creativeCommonsLicense}
   import UsageRightsConfig.freeSuppliers
 
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
@@ -57,10 +57,6 @@ object UsageRightsProperty {
     requiredStringField("photographer", "Photographer",
       optionsMap = Some(photographers), optionsMapKey = Some(key))
 
-  private def illustratorField(illustrators: OptionsMap, key: String) =
-    requiredStringField("illustrator", "Illustrator",
-      optionsMap = Some(illustrators), optionsMapKey = Some(key))
-
   private def restrictionProperties(u: UsageRightsSpec): List[UsageRightsProperty] = u match {
     case NoRights => List()
     case _ => List(UsageRightsProperty("restrictions", "Restrictions", "text", u.defaultCost.contains(Conditional)))
@@ -92,15 +88,12 @@ object UsageRightsProperty {
     )
 
     case ContractIllustrator => List(
-      publicationField(true),
-      illustratorField(contractIllustratorsMap, "publication")
-    )
+      requiredStringField("creator", "Illustrator", Some(sortList(contractIllustrators))))
 
     case StaffIllustrator => List(
       requiredStringField("creator", "Illustrator", Some(sortList(staffIllustrators))))
 
     case CommissionedIllustrator => List(
-      publicationField(false),
       requiredStringField("creator", "Illustrator", examples = Some("Ellie Foreman Peck, Matt Bors")))
 
     case CreativeCommons => List(


### PR DESCRIPTION
We are seeing `Error: invalid-form-data`. Reverting pending an investigation.

Reverts guardian/grid#2362.