### PR TITLE
Removing unused persistence identifier configuration field.

### DIFF
--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -28,9 +28,6 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
         "App"   -> Seq(elasticsearchApp)
       ))
 
-  // The presence of this identifier prevents deletion
-  lazy val persistenceIdentifier = properties("persistence.identifier")
-
   lazy val healthyMessageRate: Int = properties("sqs.message.min.frequency").toInt
 
   lazy val dynamoTopicArn: String = properties("indexed.image.sns.topic.arn")


### PR DESCRIPTION
This field does not appear to be used. The code attempts the deletion and catches failures rather than making a decision before deleting.