### PR TITLE
Rename create index method

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -56,10 +56,10 @@ trait ElasticSearchClient {
     val indexExists = client.admin.indices.prepareExists(index)
                         .execute.actionGet.isExists
 
-    if (!indexExists) createIndex(index)
+    if (!indexExists) createImageIndex(index)
   }
 
-  def createIndex(index: String) {
+  def createImageIndex(index: String) {
     Logger.info(s"Creating index $index")
     client.admin.indices
       .prepareCreate(index)

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -145,7 +145,7 @@ object Reindex extends EsScript {
 
       // if no 'from' time parameter is passed, create a new index
       if(from.isEmpty) {
-        EsClient.createIndex(newIndex)
+        EsClient.createImageIndex(newIndex)
       } else {
         println(s"Reindexing documents modified since: ${from.toString}")
       }


### PR DESCRIPTION
Makes it explicit that this call only makes a specific type of index (one with image mappings).