### PR TITLE
Enable optional decompression

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
     "org.elasticsearch" % "elasticsearch" % "1.7.6",
     "com.gu" %% "box" % "0.2.0",
+    "com.gu" %% "thrift-serializer" % "3.0.0",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
     "com.drewnoakes" % "metadata-extractor" % "2.11.0",
     "org.im4java" % "im4java" % "1.4.0",
@@ -58,7 +59,8 @@ lazy val commonLib = project("common-lib").settings(
     // i.e. to only log to disk in DEV
     // see: https://logback.qos.ch/setup.html#janino
     "org.codehaus.janino" % "janino" % "3.0.6"
-  )
+  ),
+  dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 )
 
 lazy val auth = playProject("auth", 9011)


### PR DESCRIPTION
Reads off the Kinesis stream and tries to decompress the payload. Crier will soon be using ZStandard to compress messages dispatched on the stream; this changes makes sure it is able to handle both compressed and uncompressed events.