### PR TITLE
Improve logic to convert true colour PNGs without transparency to JPEG

### DIFF
--- a/cropper/app/lib/Crops.scala
+++ b/cropper/app/lib/Crops.scala
@@ -100,11 +100,17 @@ class Crops(config: CropperConfig, store: CropStore, imageOperations: ImageOpera
     val mediaType = apiImage.source.mimeType.getOrElse(throw MissingMimeType)
     val secureUrl = apiImage.source.secureUrl.getOrElse(throw MissingSecureSourceUrl)
     val colourType = apiImage.fileMetadata.colourModelInformation.getOrElse("colorType", "")
+    val hasAlpha = apiImage.fileMetadata.colourModelInformation.getOrElse("hasAlpha", "true")
 
-    val cropType = if (mediaType == "image/png" && colourType != "True Color")
-      ImageOperations.Png
-    else
+    val cropType = if (mediaType == "image/png") {
+      if (colourType.startsWith("True Color") && hasAlpha == "false") {
+        ImageOperations.Jpeg
+      } else {
+        ImageOperations.Png
+      }
+    } else {
       ImageOperations.Jpeg
+    }
 
     for {
       sourceFile  <- tempFileFromURL(secureUrl, "cropSource", "", config.tempDir)


### PR DESCRIPTION
Improves current logic which I’m not sure even works.
Would be nice to merge #2371 first, as currently logic there provides false positives (see comments referenced there for details).

For the future, we should improve it further, so that it converts to JPEGs not _images_ but _crops_ where there is no transparency.

- [ ] Test on TEST

_this is another occurrence of @itsibitzi impersonating me, so that he can hide his code behind my ignorance!_