### PR TITLE
fix post stack script

### DIFF
--- a/cloud-formation/scripts/post-dev-stack-creation.sh
+++ b/cloud-formation/scripts/post-dev-stack-creation.sh
@@ -15,7 +15,7 @@ echo "Uploading config to stack $STACK_NAME"
 export AWS_PROFILE=media-service
 
 lower_case_random_string() {
-    echo `head -c 1024 /dev/urandom | md5hash | tr '[:upper:]' '[:lower:]' | cut -c1-20`
+    echo `head -c 1024 /dev/urandom | md5sum | tr '[:upper:]' '[:lower:]' | cut -c1-20`
 }
 
 get_stack_resource_physical_id() {


### PR DESCRIPTION
We've introduced a regression. [Previously](https://github.com/guardian/grid/commit/dd3fce2c61c35312e6ae8a33de751ba0b823be2a#diff-bf3ab15dc8a1ee8a37466f5bf987288e), we had aliased md5hash to be `md5sum` on linux and `md5` on osx.

As the [docs suggest osx users install the brew formula md5Sum](https://github.com/guardian/grid/blob/master/docs/02.01-dev-setup.md#optional-requirements), we should use the `md5sum` across platforms.