### PR TITLE
Don’t attribute EPA to Getty if it contains GIFT

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -174,7 +174,7 @@ trait GettyProcessor {
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   def apply(image: Image): Image = {
     val excludedCredit = List(
-      "newspix international", "i-images", "photoshot", "Ian Jones", "Avalon", "INS News Agency Ltd"
+      "newspix international", "i-images", "photoshot", "Ian Jones", "Avalon", "INS News Agency Ltd", "EPA"
     )
 
     val excludedSource = List(


### PR DESCRIPTION
Quite a [big whole](https://media.gutools.co.uk/search?query=supplier:%22Getty%20Images%22%20credit:EPA&nonFree=true) in our weak attribution logic. Never spotted, cause both are free.

BTW, we should also batch-fix the above. But I‘m not doing it manually [100 images at a time](https://github.com/guardian/grid/issues/1508)…