### PR TITLE
Fix tooltips when image(s) persisted because of leases

### DIFF
--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -59,6 +59,8 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
                 return 'added to a persisted collection';
             case 'photoshoot':
                 return 'added to a photoshoot';
+            case 'leases':
+                return 'leased';
             default:
                 return reason;
             }


### PR DESCRIPTION
Hopefully fixes this langarble:
![image](https://user-images.githubusercontent.com/6032869/51396304-be83bf80-1b36-11e9-8e1c-9d2f5e9f2068.png)
