### PR TITLE
Retire SVG animation vulnerability warning. 

### DIFF
--- a/kahuna/README.md
+++ b/kahuna/README.md
@@ -1,9 +1,3 @@
 # Kahuna
 
 The media search & management app.
-
-## Note
-
-This app uses Angular 1.4.3 which is subject to https://www.sourceclear.com/registry/security/arbitrary-code-execution-through-svg-animation-functionality/javascript/sid-2253/fix.
-
-This does not in it's current state effect the application as user uploaded SVGs are not allowed, though if this were to change in the future Angular must also be upgraded to avoid a security issue.


### PR DESCRIPTION
Currently uses Angular 1.6 with the mentioned vulnerability believed to be patched in Angular 1.5.

https://snyk.io/vuln/npm:angular:20150310
https://github.com/angular/angular.js/pull/11290