### PR TITLE
Don’t attribute Panoramic/Avalon to Getty if it contains GIFT

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -174,7 +174,7 @@ trait GettyProcessor {
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   def apply(image: Image): Image = {
     val excludedCredit = List(
-      "newspix international", "i-images", "photoshot", "Ian Jones", "Avalon", "INS News Agency Ltd", "EPA"
+      "newspix international", "i-images", "photoshot", "Ian Jones", "Panoramic/Avalon", "Avalon", "INS News Agency Ltd", "EPA"
     )
 
     val excludedSource = List(


### PR DESCRIPTION
The usual. Thanks.