### PR TITLE
Tweak the inferring syndication rights logic

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -30,7 +30,7 @@ case class Image(
   userMetadataLastModified: Option[DateTime] = None) {
   def rcsPublishDate: Option[DateTime] = syndicationRights.flatMap(_.published)
 
-  def hasInferredSyndicationRights: Boolean = syndicationRights.forall(_.isInferred == true)
+  def hasInferredSyndicationRights: Boolean = syndicationRights.forall(_.isInferred)
 
   def syndicationStatus: SyndicationStatus = {
     val isRightsAcquired: Boolean = syndicationRights.exists(_.isRightsAcquired)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -30,7 +30,7 @@ case class Image(
   userMetadataLastModified: Option[DateTime] = None) {
   def rcsPublishDate: Option[DateTime] = syndicationRights.flatMap(_.published)
 
-  def hasInferredSyndicationRights: Boolean = syndicationRights.forall(_.isInferred)
+  def hasInferredSyndicationRightsOrNoRights: Boolean = syndicationRights.forall(_.isInferred)
 
   def syndicationStatus: SyndicationStatus = {
     val isRightsAcquired: Boolean = syndicationRights.exists(_.isRightsAcquired)

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -105,10 +105,12 @@ class ThrallMessageConsumer(
       withImageId(rights) { id =>
         es.getImage(id) map {
           case Some(image) =>
-            GridLogger.info(s"Upserting syndication rights for image $id", id)
+            val photoshoot = image.userMetadata.flatMap(_.photoshoot)
+            GridLogger.info(s"Upserting syndication rights for image $id in photoshoot $photoshoot with rights $syndicationRights", id)
+
             syndicationRightsOps.upsertOrRefreshRights(
               image = image,
-              currentPhotoshootOpt = image.userMetadata.flatMap(_.photoshoot),
+              currentPhotoshootOpt = photoshoot,
               newRightsOpt =  Some(syndicationRights)
             )
           case _ => GridLogger.info(s"Image $id not found")
@@ -124,11 +126,14 @@ class ThrallMessageConsumer(
           imageOpt <- es.getImage(id)
           prevPhotoshootOpt = imageOpt.flatMap(_.userMetadata.flatMap(_.photoshoot))
           _ <- updateImageUserMetadata(message)
-          _ <- syndicationRightsOps.upsertOrRefreshRights(
-            image = imageOpt.get,
-            currentPhotoshootOpt = upcomingEdits.photoshoot,
-            previousPhotoshootOpt = prevPhotoshootOpt
-          )
+          _ <- {
+            GridLogger.info(s"Upserting syndication rights for image $id. Moving from photoshoot $prevPhotoshootOpt to ${upcomingEdits.photoshoot}.")
+            syndicationRightsOps.upsertOrRefreshRights(
+              image = imageOpt.get,
+              currentPhotoshootOpt = upcomingEdits.photoshoot,
+              previousPhotoshootOpt = prevPhotoshootOpt
+            )
+          }
         } yield GridLogger.info(s"Moved image $id from $prevPhotoshootOpt to ${upcomingEdits.photoshoot}", id)
       }
     }

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -109,9 +109,8 @@ class ThrallMessageConsumer(
             GridLogger.info(s"Upserting syndication rights for image $id in photoshoot $photoshoot with rights $syndicationRights", id)
 
             syndicationRightsOps.upsertOrRefreshRights(
-              image = image,
-              currentPhotoshootOpt = photoshoot,
-              newRightsOpt =  Some(syndicationRights)
+              image = image.copy(syndicationRights = Some(syndicationRights)),
+              currentPhotoshootOpt = photoshoot
             )
           case _ => GridLogger.info(s"Image $id not found")
         }

--- a/thrall/conf/logback-test.xml
+++ b/thrall/conf/logback-test.xml
@@ -11,10 +11,6 @@
     <logger name="play" level="INFO" />
     <logger name="application" level="DEBUG" />
 
-    <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
-    </root>
-
     <logger name="com.amazonaws">
         <level value="ERROR" />
     </logger>

--- a/thrall/test/syndication/SyndicationRightsOpsTestsBase.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsTestsBase.scala
@@ -2,7 +2,7 @@ package syndication
 
 import java.util.UUID
 
-import com.gu.mediaservice.model.{Image, Photoshoot}
+import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
 import helpers.Fixtures
 import lib.{ElasticSearchVersion, SyndicationRightsOps}
 import org.joda.time.DateTime
@@ -41,8 +41,6 @@ trait SyndicationRightsOpsTestsBase extends FreeSpec with Matchers with Fixtures
   def addSyndicationRights(image: Image, someRights: Option[SyndicationRights]) = {
     image.copy(syndicationRights = someRights)
   }
-
-  val syndRightsOps = new SyndicationRightsOps(ES)
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
@@ -130,8 +128,6 @@ trait SyndicationRightsOpsTestsBase extends FreeSpec with Matchers with Fixtures
         withPhotoshoot(photoshootTitle) { images =>
           val imageWithNoRights = images.head
           whenReady(syndRightsOps.upsertOrRefreshRights(image = addSyndicationRights(imageWithNoRights, syndRights), previousPhotoshootOpt = None, currentPhotoshootOpt = Some(photoshootTitle))) { _ =>
-
-            Thread.sleep(5000)
             images.tail.foreach { img =>
               whenReady(ES.getImage(img.id)) { optImg =>
                 optImg.get.syndicationRights shouldBe syndRights.map(_.copy(isInferred = true))


### PR DESCRIPTION
When getting the latest syndication rights make sure the new syndication rights that have been passed through. The rights on the image are not necessary the latest ones. As described in `SyndicationRightsOps.scala`, this logic is needed because ES is eventually consistent.

In addition, I've added more logging to help debugging in the future.