### PR TITLE
$state.reload behaviour

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -245,14 +245,8 @@ results.controller('SearchResultsCtrl', [
         }
 
         function revealNewImages() {
-            // FIXME: should ideally be able to just call $state.reload(),
-            // but there seems to be a bug (alluded to in the docs) when
-            // notify is false, so forcing to true explicitly instead:
-            $state.transitionTo($state.current, $stateParams, {
-                reload: true, inherit: false, notify: true
-            });
+           $state.reload();
         }
-
 
         var seenSince;
         const lastSeenKey = 'search.seenFrom';


### PR DESCRIPTION
The upstream notify behaviour of $state.reload appears to have changed to match our local override.

https://github.com/guardian/grid/commit/a5a9a38dd15677aa2146177768017e74b0f40f77