### PR TITLE
Upgrade Panda (configurable settings and OAuth providers)

### DIFF
--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -6,7 +6,7 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.PandaUser
 import com.gu.mediaservice.lib.auth.{Authentication, Permissions, PermissionsHandler}
-import com.gu.pandomainauth.service.GoogleAuthException
+import com.gu.pandomainauth.service.OAuthException
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
@@ -81,9 +81,9 @@ class AuthController(auth: Authentication, val config: AuthConfig,
     // We use the `Try` here as the `GoogleAuthException` are thrown before we
     // get to the asynchronicity of the `Future` it returns.
     // We then have to flatten the Future[Future[T]]. Fiddly...
-    Future.fromTry(Try(auth.processGoogleCallback)).flatten.recover {
+    Future.fromTry(Try(auth.processOAuthCallback())).flatten.recover {
       // This is when session session args are missing
-      case e: GoogleAuthException => respondError(BadRequest, "google-auth-exception", e.getMessage, auth.loginLinks)
+      case e: OAuthException => respondError(BadRequest, "google-auth-exception", e.getMessage, auth.loginLinks)
 
       // Class `missing anti forgery token` as a 4XX
       // see https://github.com/guardian/pan-domain-authentication/blob/master/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala#L63

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.typesafe.play" %% "play" % "2.6.20", ws,
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
     "com.typesafe.play" %% "filters-helpers" % "2.6.20",
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.1",
+    "com.gu" %% "pan-domain-auth-play_2-6" % "0.8.0",
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.auth
 
 import akka.actor.ActorSystem
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.{AuthenticatedService, PandaUser}
@@ -69,8 +70,9 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
     new PanDomainAuthSettingsRefresher(
       domain = config.services.domainRoot,
       system = "media-service",
-      actorSystem = actorSystem,
-      awsCredentialsProvider = config.awsCredentials
+      bucketName = "pan-domain-auth-settings",
+      settingsFileKey = s"${config.services.domainRoot}.settings",
+      s3Client = AmazonS3ClientBuilder.standard().withRegion(config.awsRegion).withCredentials(config.awsCredentials).build()
     )
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/auth/AuthenticationTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/auth/AuthenticationTest.scala
@@ -1,0 +1,33 @@
+package com.gu.mediaservice.lib.auth
+
+import java.time.Instant
+
+import com.gu.pandomainauth.model.{AuthenticatedUser, User}
+import org.scalatest.{FunSuite, MustMatchers}
+
+class AuthenticationTest extends FunSuite with MustMatchers {
+  import Authentication.validateUser
+
+  val user = AuthenticatedUser(User("Barry", "Chuckle", "barry.chuckle@guardian.co.uk", None),
+    "media-service", Set("media-service"), Instant.now().plusSeconds(100).toEpochMilli, multiFactor = true)
+
+  test("user fails email domain validation") {
+    validateUser(user, "chucklevision.biz", None) must be(false)
+  }
+
+  test("user passes email domain validation") {
+    validateUser(user, "guardian.co.uk", None) must be(true)
+  }
+
+  test("user passes mfa check if no mfa checker configured") {
+    validateUser(user.copy(multiFactor = false), "guardian.co.uk", None) must be(true)
+  }
+
+  test("user fails mfa check if missing mfa") {
+    validateUser(user.copy(multiFactor = false), "guardian.co.uk", Some(null)) must be(false)
+  }
+
+  test("user passes mfa check") {
+    validateUser(user, "guardian.co.uk", Some(null)) must be(true)
+  }
+}


### PR DESCRIPTION
The latest version of Panda (0.18) supports non-Google OAuth providers, including AWS Cognito. It also removes an incorrectly hard-coded check that users emails end with `guardian.co.uk`. https://github.com/guardian/pan-domain-authentication/pull/45.

This PR adds support for these to the Grid and allows the user email domain check in `validateUser` to be fully customised. If none of the new settings are present, it falls back to the old Guardian-specific defaults. The multi-factor check in `validateUser` is only performed if the multi-factor checker itself is enabled (via Pandas own configuration).

New settings:

`panda.userDomain` - the domain to user in the `email.endsWith` check in validate user
`panda.system` - the name of the system in the panda cookie
`panda.bucketName` - the bucket where the panda settings file is stored
`panda.settingsFileKey` - the key for the settings file