### PR TITLE
Request correctly sized imgops preview image in Firefox

### DIFF
--- a/kahuna/public/js/imgops/service.js
+++ b/kahuna/public/js/imgops/service.js
@@ -7,10 +7,18 @@ imgops.factory('imgops', ['$window', function($window) {
 
     const lowResMaxWidth  = 800;
     const lowResMaxHeight = 800;
-
+    const isFF = !!$window.navigator.userAgent.match(/firefox/i);
 
     function getFullScreenUri(image) {
-        const { width: w, height: h } = $window.screen;
+        let { width: w, height: h } = $window.screen;
+        if (isFF) {
+            const zoom = $window.devicePixelRatio;
+            if (zoom !== 1) {
+                h = Math.round(h * zoom);
+                w = Math.round(w * zoom);
+            }
+        }
+
         return getOptimisedUri(image, { w, h, q: quality });
     }
 


### PR DESCRIPTION
Because, unlike Chrome, [Firefox differs](https://bugzilla.mozilla.org/show_bug.cgi?id=1292571) `screen.width` with zoom, we need to [treat it differently](https://stackoverflow.com/questions/30557404/get-screen-resolution-independent-of-zoom-in-firefox/34368907#34368907) to correctly request screen-sized preview image.

Thanks @mbarton and @RichieAHB (who actually wrote all this).

- [x] test on TEST