### PR TITLE
add missing config from generation

### DIFF
--- a/scripts/generate-dot-properties/config.json5
+++ b/scripts/generate-dot-properties/config.json5
@@ -44,5 +44,11 @@
 
   composer: {
     url: ''
+  },
+
+  google: {
+    tracking: {
+      id: ''
+    }
   }
 }

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -56,6 +56,7 @@ function getKahunaConfig(config) {
         |origin.full=${config.stackProps.ImageBucket}.s3.${config.aws.region}.amazonaws.com
         |origin.thumb=${config.stackProps.ThumbBucket}.s3.${config.aws.region}.amazonaws.com
         |origin.images=${config.stackProps.ImageBucket}.s3.${config.aws.region}.amazonaws.com
+        |origin.crops=${config.stackProps.ImageOriginBucket}
         |google.tracking.id=${config.google.tracking.id}
         |`;
 }
@@ -82,6 +83,8 @@ function getMediaApiConfig(config) {
         |s3.usagemail.bucket=${config.stackProps.UsageMailBucket}
         |persistence.identifier=picdarUrn
         |es.index.aliases.read=readAlias
+        |es.port=9300
+        |es.cluster=media-service
         |quota.store.key=rcs-quota.json
         |`;
 }
@@ -121,6 +124,8 @@ function getThrallConfig(config) {
         |es.index.aliases.write=writeAlias
         |es.index.aliases.read=readAlias
         |indexed.image.sns.topic.arn=${config.stackProps.IndexedImageTopicArn}
+        |es.port=9300
+        |es.cluster=media-service
         |`;
 }
 
@@ -138,6 +143,7 @@ function getUsageConfig(config) {
         |crier.preview.arn=${config.crier.preview.roleArn}
         |crier.preview.name=${config.crier.preview.streamName}
         |crier.live.name=${config.crier.live.streamName}
+        |app.name=usage
         |`;
 }
 


### PR DESCRIPTION
We've added/changed the config in the app, however we've not kept the [config generator](https://github.com/guardian/grid/tree/master/scripts/generate-dot-properties) up to date. This adds the missing properties to the generator.