### PR TITLE
Bump panda-session to fix grid login issues (hopefully)!

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -3568,15 +3568,6 @@
           "dev": true,
           "optional": true
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3585,6 +3576,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -5274,9 +5274,9 @@
       "dev": true
     },
     "panda-session": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/panda-session/-/panda-session-0.1.4.tgz",
-      "integrity": "sha1-UdMZplgTei2dl6lzIsl+9VnsO/Q="
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/panda-session/-/panda-session-0.1.6.tgz",
+      "integrity": "sha1-zbT1gMmKuHGJ/SD3U0Ifm6hdf1g="
     },
     "pandular": {
       "version": "0.1.6",
@@ -7031,15 +7031,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7071,6 +7062,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -16,7 +16,7 @@
     "javascript-detect-element-resize": "^0.5.3",
     "jszip": "2.6.0",
     "moment": "^2.9.0",
-    "panda-session": "0.1.4",
+    "panda-session": "0.1.6",
     "pandular": "0.1.6",
     "pikaday": "^1.3.2",
     "raven-js": "^1.1.18",


### PR DESCRIPTION
This change bumps `panda-session` to `0.1.6`. We don't explicitly depend on `panda-session` but it's used by `pandular` (an angular helper that wraps `panda-session`), which actually depend on `0.1.4`. Because of `npm` we can force this to depend on `0.1.6` by explicitly declaring it here.

## The fix
So we figured out that two `419` requests would both try to reauth and each get differeny ant-forgery tokens - something that I think [Ophan had a problem with](https://github.com/guardian/ophan/pull/2622). We managed to fix this by making sure that any reauth requests (managed through loading an iframe in the page) would look for existing reauths and just wait for those instead of spawning a new request.

We implemented this and it worked! However, @mbarton then managed to [find the PR where this had already been done](https://github.com/guardian/panda-session/pull/1) in `panda-session`, it just hadn't been updated by `pandular` 😢 

## TL;DR
We believe this will stop the **BIG RED MESSAGE**!

We'll deploy this and see if that helps and then following that we can bump `panda-session` in `pandular` to do this _The Right Way_™️ ...