### PR TITLE
Batch cropping feedback

### DIFF
--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
@@ -2,7 +2,13 @@
      gr:track-click="Full frame button"
      confirmed="false"
      needsConfirmation="false"
+     ng-if="!ctrl.allHaveFullCrops"
      class="inner-clickable clickable">
         <gr-icon-label gr-icon="crop" ng:hide="ctrl.needsConfirmation">Crop<span ng:if="ctrl.cropping">ping</span> full frame<span ng:if="ctrl.cropping">…</span></gr-icon-label>
         <gr-icon-label gr-icon="check_circle" ng:show="ctrl.needsConfirmation">Confirm full frame</gr-icon-label>
+</div>
+<div
+     ng-if="ctrl.allHaveFullCrops"
+     class="inner-clickable inner-clickable--disabled">
+        <gr-icon-label gr-icon="crop">Crop full frame</gr-icon-label>
 </div>

--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
@@ -4,7 +4,7 @@
      needsConfirmation="false"
      ng-if="!ctrl.allHaveFullCrops"
      class="inner-clickable clickable">
-        <gr-icon-label gr-icon="crop" ng:hide="ctrl.needsConfirmation">Crop<span ng:if="ctrl.cropping">ping</span> full frame<span ng:if="ctrl.cropping">…</span></gr-icon-label>
+        <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}" ng:hide="ctrl.needsConfirmation">Crop<span ng:if="ctrl.cropping">ping</span> full frame<span ng:if="ctrl.cropping">…</span></gr-icon-label>
         <gr-icon-label gr-icon="check_circle" ng:show="ctrl.needsConfirmation">Confirm full frame</gr-icon-label>
 </div>
 <div

--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
@@ -8,6 +8,8 @@
         <gr-icon-label gr-icon="check_circle" ng:show="ctrl.needsConfirmation">Confirm full frame</gr-icon-label>
 </div>
 <div
+     gr:tooltip="Selected images have full frames"
+     gr:tooltip-position="bottom"
      ng-if="ctrl.allHaveFullCrops"
      class="inner-clickable inner-clickable--disabled">
         <gr-icon-label gr-icon="crop">Crop full frame</gr-icon-label>

--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
@@ -9,7 +9,18 @@ batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
     function($scope, $rootScope, $state, mediaCropper) {
         let ctrl = this;
 
+        const checkForFullCrops = () => ctrl.images.every(
+            image => image.data.exports.some(
+              crop => crop.specification.type === 'full'
+            )
+        );
+
+        $scope.$watch('ctrl.images', () => {
+          ctrl.allHaveFullCrops = checkForFullCrops();
+        }, true);
+
         ctrl.callBatchCrop = function() {
+
 
             //Slightly backwards, if needsConfirmation is true, then this is second click
             if (ctrl.needsConfirmation) {

--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
@@ -21,7 +21,6 @@ batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
 
         ctrl.callBatchCrop = function() {
 
-
             //Slightly backwards, if needsConfirmation is true, then this is second click
             if (ctrl.needsConfirmation) {
               ctrl.confirmed = true;
@@ -53,6 +52,7 @@ batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
 
             Promise.all(cropImages).finally(() => {
               ctrl.cropping = false;
+              ctrl.allHaveFullCrops = true;
             });
         }
     }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -360,6 +360,10 @@ button[disabled],
     display: inline-block;
 }
 
+.inner-clickable--disabled {
+  opacity: 0.7;
+}
+
 .button-right-side {
     padding-left: 5px;
     margin-left: -4px


### PR DESCRIPTION
Adds better feedback for batch cropping. 

- Disable the crop button if all images in selection have full frame crops
- Tooltip explaining why button is disabled
- Crop icon spins when cropping is in progress

![screen shot 2019-02-06 at 11 46 19](https://user-images.githubusercontent.com/3066534/52352378-626cd680-2a24-11e9-8a6b-488dd8c2134f.png)
