### PR TITLE
update rules for syndication review queue

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch1/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch1/SyndicationFilter.scala
@@ -66,10 +66,10 @@ object SyndicationFilter extends ImageFields {
     filters.date("uploadTime", Some(startDate), None).get
   }
 
-  private val isPhotographer: FilterBuilder = filters.or(
+  private val syndicatableCategory: FilterBuilder = filters.or(
     filters.term(usageRightsField("category"), StaffPhotographer.category),
-    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
-    filters.term(usageRightsField("category"), ContractPhotographer.category)
+    filters.term(usageRightsField("category"), StaffIllustrator.category),
+    filters.term(usageRightsField("category"), CommissionedPhotographer.category)
   )
 
   def statusFilter(status: SyndicationStatus, config: MediaApiConfig): FilterBuilder = status match {
@@ -94,7 +94,7 @@ object SyndicationFilter extends ImageFields {
     case AwaitingReviewForSyndication => {
       val rightsAcquiredNoLeaseFilter = filters.and(
         hasRightsAcquired,
-        isPhotographer,
+        syndicatableCategory,
         filters.bool.mustNot(
           hasAllowLease,
           filters.and(

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch1/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch1/SyndicationFilter.scala
@@ -66,10 +66,10 @@ object SyndicationFilter extends ImageFields {
     filters.date("uploadTime", Some(startDate), None).get
   }
 
-  private val illustratorFilter: FilterBuilder = filters.or(
-    filters.term(usageRightsField("category"), ContractIllustrator.category),
-    filters.term(usageRightsField("category"), StaffIllustrator.category),
-    filters.term(usageRightsField("category"), CommissionedIllustrator.category)
+  private val isPhotographer: FilterBuilder = filters.or(
+    filters.term(usageRightsField("category"), StaffPhotographer.category),
+    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
+    filters.term(usageRightsField("category"), ContractPhotographer.category)
   )
 
   def statusFilter(status: SyndicationStatus, config: MediaApiConfig): FilterBuilder = status match {
@@ -94,8 +94,8 @@ object SyndicationFilter extends ImageFields {
     case AwaitingReviewForSyndication => {
       val rightsAcquiredNoLeaseFilter = filters.and(
         hasRightsAcquired,
+        isPhotographer,
         filters.bool.mustNot(
-          illustratorFilter,
           hasAllowLease,
           filters.and(
             hasDenyLease,

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
@@ -67,10 +67,10 @@ class SyndicationFilter(config: MediaApiConfig) {
     filters.date("uploadTime", Some(startDate), None).get
   }
 
-  private val illustratorFilter: Query = filters.or(
-    filters.term(usageRightsField("category"), ContractIllustrator.category),
-    filters.term(usageRightsField("category"), StaffIllustrator.category),
-    filters.term(usageRightsField("category"), CommissionedIllustrator.category)
+  private val isPhotographer: Query = filters.or(
+    filters.term(usageRightsField("category"), StaffPhotographer.category),
+    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
+    filters.term(usageRightsField("category"), ContractPhotographer.category)
   )
 
   def statusFilter(status: SyndicationStatus): Query = status match {
@@ -95,8 +95,8 @@ class SyndicationFilter(config: MediaApiConfig) {
     case AwaitingReviewForSyndication => {
       val rightsAcquiredNoLeaseFilter = filters.and(
         hasRightsAcquired,
+        isPhotographer,
         filters.mustNot(
-          illustratorFilter,
           hasAllowLease,
           filters.and(
             hasDenyLease,

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
@@ -67,10 +67,10 @@ class SyndicationFilter(config: MediaApiConfig) {
     filters.date("uploadTime", Some(startDate), None).get
   }
 
-  private val isPhotographer: Query = filters.or(
+  private val syndicatableCategory: Query = filters.or(
     filters.term(usageRightsField("category"), StaffPhotographer.category),
-    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
-    filters.term(usageRightsField("category"), ContractPhotographer.category)
+    filters.term(usageRightsField("category"), StaffIllustrator.category),
+    filters.term(usageRightsField("category"), CommissionedPhotographer.category)
   )
 
   def statusFilter(status: SyndicationStatus): Query = status match {
@@ -95,7 +95,7 @@ class SyndicationFilter(config: MediaApiConfig) {
     case AwaitingReviewForSyndication => {
       val rightsAcquiredNoLeaseFilter = filters.and(
         hasRightsAcquired,
-        isPhotographer,
+        syndicatableCategory,
         filters.mustNot(
           hasAllowLease,
           filters.and(

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -112,7 +112,7 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
       id = "test-image-11",
       rightsAcquired = true,
       None,
-      Some(createSyndicationLease(allowed = true, "test-image-11")),
+      None,
       usageRights = screengrab,
       usages = List(createDigitalUsage(date = DateTime.now))
     )

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -105,6 +105,16 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
       Some(createSyndicationLease(allowed = true, "test-image-10")),
       usageRights = agency,
       usages = List(createDigitalUsage(date = DateTime.now))
+    ),
+
+    // Screen grab with published just now with rights acquired
+    createImageForSyndication(
+      id = "test-image-11",
+      rightsAcquired = true,
+      None,
+      Some(createSyndicationLease(allowed = true, "test-image-11")),
+      usageRights = screengrab,
+      usages = List(createDigitalUsage(date = DateTime.now))
     )
   )
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -107,15 +107,24 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
       usages = List(createDigitalUsage(date = DateTime.now))
     ),
 
-    // Screen grab with published just now with rights acquired
+    // Screen grab with rights acquired, not eligible for syndication review
     createImageForSyndication(
       id = "test-image-11",
       rightsAcquired = true,
-      None,
-      None,
+      rcsPublishDate = None,
+      lease = None,
       usageRights = screengrab,
+      usages = List(createDigitalUsage(date = DateTime.now))
+    ),
+
+    // Staff photographer with rights acquired, eligible for syndication review
+    createImageForSyndication(
+      id = "test-image-12",
+      rightsAcquired = true,
+      rcsPublishDate = None,
+      lease = None,
+      usageRights = staffPhotographer,
       usages = List(createDigitalUsage(date = DateTime.now))
     )
   )
-
 }

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -12,6 +12,7 @@ trait Fixtures {
   val testUser = "yellow-giraffe@theguardian.com"
   val staffPhotographer = StaffPhotographer("Tom Jenkins", "The Guardian")
   val agency = Agency("ACME")
+  val screengrab = Screengrab(None, None)
 
   def createImage(
                    id: String,

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -104,14 +104,13 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val searchParams = SearchParams(tier = Syndication)
       val searchResult = ES.search(searchParams)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 4
+        result.total shouldBe 3
 
         val imageIds = result.hits.map(_._1)
-        imageIds.size shouldBe 4
+        imageIds.size shouldBe 3
         imageIds.contains("test-image-1") shouldBe true
         imageIds.contains("test-image-2") shouldBe true
         imageIds.contains("test-image-4") shouldBe true
-        imageIds.contains("test-image-11") shouldBe true
       }
     }
 
@@ -145,14 +144,13 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Syndication, syndicationStatus = Some(QueuedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 4
+        result.total shouldBe 3
 
         val imageIds = result.hits.map(_._1)
-        imageIds.size shouldBe 4
+        imageIds.size shouldBe 3
         imageIds.contains("test-image-1") shouldBe true
         imageIds.contains("test-image-2") shouldBe true
         imageIds.contains("test-image-4") shouldBe true
-        imageIds.contains("test-image-11") shouldBe true
       }
     }
 
@@ -186,7 +184,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Internal, syndicationStatus = Some(QueuedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 4
+        result.total shouldBe 3
       }
     }
 
@@ -200,12 +198,11 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       }
     }
 
-    it("should return 2 images if an Internal tier queries for AwaitingReviewForSyndication images") {
+    it("should return 3 images if an Internal tier queries for AwaitingReviewForSyndication images") {
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.hits.foreach(println)
-        result.total shouldBe 2
+        result.total shouldBe 3
       }
     }
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -104,13 +104,14 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val searchParams = SearchParams(tier = Syndication)
       val searchResult = ES.search(searchParams)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 3
+        result.total shouldBe 4
 
         val imageIds = result.hits.map(_._1)
-        imageIds.size shouldBe 3
+        imageIds.size shouldBe 4
         imageIds.contains("test-image-1") shouldBe true
         imageIds.contains("test-image-2") shouldBe true
         imageIds.contains("test-image-4") shouldBe true
+        imageIds.contains("test-image-11") shouldBe true
       }
     }
 
@@ -144,13 +145,14 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Syndication, syndicationStatus = Some(QueuedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 3
+        result.total shouldBe 4
 
         val imageIds = result.hits.map(_._1)
-        imageIds.size shouldBe 3
+        imageIds.size shouldBe 4
         imageIds.contains("test-image-1") shouldBe true
         imageIds.contains("test-image-2") shouldBe true
         imageIds.contains("test-image-4") shouldBe true
+        imageIds.contains("test-image-11") shouldBe true
       }
     }
 
@@ -184,7 +186,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Internal, syndicationStatus = Some(QueuedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 3
+        result.total shouldBe 4
       }
     }
 
@@ -202,6 +204,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
+        result.hits.foreach(println)
         result.total shouldBe 2
       }
     }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -224,12 +224,12 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       }
     }
 
-    it("should return 2 images if an Internal tier queries for AwaitingReviewForSyndication images") {
+    it("should return 3 images if an Internal tier queries for AwaitingReviewForSyndication images") {
       // Elastic1 implementation is returning the images with reviewed and blocked syndicationStatus
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 2
+        result.total shouldBe 3
       }
     }
   }


### PR DESCRIPTION
Update the rules used to determine which images should enter the review queue for the picture desk to add leases to. This is in response to Joanna's request:

> Preventing certain images entering the review queue. Basically the easiest way to say is that from the rights and restriction list only staff or photographer - commissioned should enter the review queue. Currently we are getting these among others:
bylines
handout 
composite
glabs
some agency images Rex mainly
screengrab
pr image 
etc etc