### PR TITLE
Fixes persistence of images

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch1/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch1/SearchFilters.scala
@@ -64,6 +64,7 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
     filters.bool.must(filters.existsOrMissing("usages", exists = true)),
     filters.exists(NonEmptyList(identifierField(config.persistenceIdentifier))),
     filters.bool.must(filters.boolTerm(editsField("archived"), value = true)),
+    filters.exists(NonEmptyList(editsField("metadata"))),
     filters.bool.must(filters.terms(usageRightsField("category"), persistedCategories)),
     filters.bool.must(filters.terms(collectionsField("path"), config.persistedRootCollections.toNel.get)),
     filters.exists(NonEmptyList(editsField("photoshoot")))

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
@@ -65,6 +65,7 @@ class SearchFilters(config: MediaApiConfig)  extends ImageFields {
     filters.bool.must(filters.existsOrMissing("usages", exists = true)),
     filters.exists(NonEmptyList(identifierField(config.persistenceIdentifier))),
     filters.bool.must(filters.boolTerm(editsField("archived"), value = true)),
+    filters.exists(NonEmptyList(editsField("metadata"))),
     filters.bool.must(filters.terms(usageRightsField("category"), persistedCategories)),
     filters.bool.must(filters.terms(collectionsField("path"), config.persistedRootCollections.toNel.get)),
     filters.exists(NonEmptyList(editsField("photoshoot")))

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -2,7 +2,7 @@ package lib.elasticsearch
 
 import java.util.UUID
 
-import com.gu.mediaservice.model.{FileMetadata, Handout, StaffPhotographer}
+import com.gu.mediaservice.model.{Edits, FileMetadata, ImageMetadata, Handout, StaffPhotographer}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures
@@ -18,6 +18,10 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
     createImage(UUID.randomUUID().toString, Handout()),
     createImage(UUID.randomUUID().toString, StaffPhotographer("Yellow Giraffe", "The Guardian")),
     createImage(UUID.randomUUID().toString, Handout(), usages = List(createDigitalUsage())),
+
+    // with user metadata
+    createImage(id = "test-image-11-edited", Handout()).copy(userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author")))), uploadTime = DateTime.now.minusDays(25)),
+    createImage(id = "test-image-12-unedited", Handout()).copy(uploadTime = DateTime.now.minusDays(25)),
 
     // available for syndication
     createImageForSyndication(

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -20,8 +20,8 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
     createImage(UUID.randomUUID().toString, Handout(), usages = List(createDigitalUsage())),
 
     // with user metadata
-    createImage(id = "test-image-11-edited", Handout()).copy(userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author")))), uploadTime = DateTime.now.minusDays(25)),
-    createImage(id = "test-image-12-unedited", Handout()).copy(uploadTime = DateTime.now.minusDays(25)),
+    createImage(id = "test-image-13-edited", Handout()).copy(userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author")))), uploadTime = DateTime.now.minusDays(25)),
+    createImage(id = "test-image-14-unedited", Handout()).copy(uploadTime = DateTime.now.minusDays(25)),
 
     // available for syndication
     createImageForSyndication(

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -75,7 +75,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
 
         val imageId = result.hits.map(_._1)
         imageId.size shouldBe 1
-        imageId.contains("test-image-12-unedited") shouldBe true
+        imageId.contains("test-image-14-unedited") shouldBe true
       }
     }
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -102,7 +102,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
 
       val results = Await.result(ES.dateHistogramAggregate(aggregateSearchParams), fiveSeconds)
       results.total shouldBe 2
-      results.results.tail.head.count + results.results.head.count shouldBe images.size
+      results.results.foldLeft(0: Long)((a, b) => a + b.count) shouldBe images.size
     }
 
     it("can load metadata aggregations") {

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{Await, Future}
 
 class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually with MockitoSugar {
 
-  implicit val request  = mock[AuthenticatedRequest[AnyContent, Principal]]
+  implicit val request = mock[AuthenticatedRequest[AnyContent, Principal]]
 
   private val oneHundredMilliseconds = Duration(100, MILLISECONDS)
   private val fiveSeconds = Duration(5, SECONDS)
@@ -52,7 +52,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
     Thread.sleep(5000)
   }
 
-  override def afterAll  {
+  override def afterAll {
     purgeTestImages
   }
 
@@ -61,6 +61,21 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val expectedImage = images.head
       whenReady(ES.getImageById(expectedImage.id)) { r =>
         r.get.id shouldEqual expectedImage.id
+      }
+    }
+  }
+
+  describe("persistence") {
+    it("can persist any images older than 20 days that have edited user metadata") {
+      val searchParams = SearchParams(tier = Internal, length = 100, until = Some(DateTime.now.minusDays(20)), persisted = Some(false))
+
+      val searchResult = ES.search(searchParams)
+      whenReady(searchResult, timeout, interval) { result =>
+        result.total shouldBe 1
+
+        val imageId = result.hits.map(_._1)
+        imageId.size shouldBe 1
+        imageId.contains("test-image-12-unedited") shouldBe true
       }
     }
   }
@@ -86,9 +101,8 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val aggregateSearchParams = AggregateSearchParams(field = "uploadTime", q = None, structuredQuery = List.empty)
 
       val results = Await.result(ES.dateHistogramAggregate(aggregateSearchParams), fiveSeconds)
-
-      results.total shouldBe 1
-      results.results.head.count shouldBe images.size
+      results.total shouldBe 2
+      results.results.tail.head.count + results.results.head.count shouldBe images.size
     }
 
     it("can load metadata aggregations") {
@@ -261,6 +275,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
   private def purgeTestImages = {
     def deleteImages() = {
       val sixtySeconds = new TimeValue(60000)
+
       def scroll = ES.client.prepareSearch(imageAlias)
         .setScroll(sixtySeconds)
         .setQuery(QueryBuilders.matchAllQuery())
@@ -269,7 +284,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       var scrollResp = scroll
       while (scrollResp.getHits.getHits.length > 0) {
         scrollResp.getHits.getHits.map(h => ES.client.delete(new DeleteRequest(imageAlias, "image", h.getId)))
-        scrollResp =  ES.client.prepareSearchScroll(scrollResp.getScrollId()).setScroll(sixtySeconds).execute().actionGet()
+        scrollResp = ES.client.prepareSearchScroll(scrollResp.getScrollId()).setScroll(sixtySeconds).execute().actionGet()
       }
     }
 

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -94,7 +94,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
         val imageId = result.hits.map(_._1)
         imageId.size shouldBe 1
-        imageId.contains("test-image-12-unedited") shouldBe true
+        imageId.contains("test-image-14-unedited") shouldBe true
       }
     }
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -122,7 +122,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       val results = Await.result(ES.dateHistogramAggregate(aggregateSearchParams), fiveSeconds)
 
       results.total shouldBe 2
-      results.results.tail.head.count + results.results.head.count shouldBe images.size
+      results.results.foldLeft(0: Long)((a, b) => a + b.count) shouldBe images.size
     }
 
     it("can load metadata aggregations") {

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -84,6 +84,21 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
     }
   }
 
+  describe("persistence") {
+    it("can persist any images older than 20 days that have edited user metadata") {
+      val searchParams = SearchParams(tier = Internal, length = 100, until = Some(DateTime.now.minusDays(20)), persisted = Some(false))
+
+      val searchResult = ES.search(searchParams)
+      whenReady(searchResult, timeout, interval) { result =>
+        result.total shouldBe 1
+
+        val imageId = result.hits.map(_._1)
+        imageId.size shouldBe 1
+        imageId.contains("test-image-12-unedited") shouldBe true
+      }
+    }
+  }
+
   describe("usages for supplier") {
     it("can count published agency images within the last number of days") {
       val publishedAgencyImages = images.filter(i => i.usageRights.isInstanceOf[Agency] && i.usages.exists(_.status == PublishedUsageStatus))
@@ -106,8 +121,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
       val results = Await.result(ES.dateHistogramAggregate(aggregateSearchParams), fiveSeconds)
 
-      results.total shouldBe 1
-      results.results.head.count shouldBe images.size
+      results.total shouldBe 2
+      results.results.tail.head.count + results.results.head.count shouldBe images.size
     }
 
     it("can load metadata aggregations") {


### PR DESCRIPTION
Images that were uploaded more than 20 days ago and had user edits but were not used were not getting persisted. This fixes persistence filters such that any image with edit changes (userMetadata) will now also be persisted. 

Unit tests have been added