### PR TITLE
renaming for clarity

### DIFF
--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -38,7 +38,7 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends SNS(config,
   }
 
   def sendReindexLeases(mediaId: String) = {
-    publish(build(mediaId).toJson, "update-image-leases")
+    publish(build(mediaId).toJson, "replace-image-leases")
   }
 
   def sendAddLease(mediaLease: MediaLease) = {

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -156,7 +156,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
     }
   }
 
-  def updateImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
+  def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     prepareImageUpdate(id) { request =>
       request.setScriptParams(Map(
         "leaseByMedia" -> asGroovy(leaseByMedia.getOrElse(JsNull)),

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -285,7 +285,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
 
-  def updateImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
+  def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     val replaceLeasesScript = loadPainless(
     """ | ctx._source.leases = params.leaseByMedia;"""
     )

--- a/thrall/app/lib/ElasticSearchRouter.scala
+++ b/thrall/app/lib/ElasticSearchRouter.scala
@@ -23,8 +23,8 @@ class ElasticSearchRouter(versions: Seq[ElasticSearchVersion]) extends ElasticSe
 
   override def deleteSyndicationRights(id: String)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = versions.map(_.deleteSyndicationRights(id)).head
 
-  override def updateImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] =
-    versions.map(_.updateImageLeases(id, leaseByMedia, lastModified)).head
+  override def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] =
+    versions.map(_.replaceImageLeases(id, leaseByMedia, lastModified)).head
 
   override def addImageLease(id: String, lease: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] =
     versions.map(_.addImageLease(id, lease, lastModified)).head

--- a/thrall/app/lib/ElasticSearchVersion.scala
+++ b/thrall/app/lib/ElasticSearchVersion.scala
@@ -19,7 +19,7 @@ trait ElasticSearchVersion {
 
   def deleteSyndicationRights(id: String)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
 
-  def updateImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
+  def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
 
   def addImageLease(id: String, lease: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
 

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -30,7 +30,7 @@ class ThrallMessageConsumer(
       case "update-image-exports"       => updateImageExports
       case "update-image-user-metadata" => updateImageUserMetadata
       case "update-image-usages"        => updateImageUsages
-      case "update-image-leases"        => updateImageLeases
+      case "replace-image-leases"       => replaceImageLeases
       case "add-image-lease"            => addImageLease
       case "remove-image-lease"         => removeImageLease
       case "set-image-collections"      => setImageCollections
@@ -63,8 +63,8 @@ class ThrallMessageConsumer(
     Future.sequence( withImageId(metadata)(id => es.applyImageMetadataOverride(id, data, lastModified)))
   }
 
-  def updateImageLeases(leaseByMedia: JsValue) =
-    Future.sequence( withImageId(leaseByMedia)(id => es.updateImageLeases(id, leaseByMedia \ "data", leaseByMedia \ "lastModified")) )
+  def replaceImageLeases(leaseByMedia: JsValue) =
+    Future.sequence( withImageId(leaseByMedia)(id => es.replaceImageLeases(id, leaseByMedia \ "data", leaseByMedia \ "lastModified")) )
 
   def addImageLease(lease: JsValue) =
     Future.sequence( withImageId(lease)(id => es.addImageLease(id, lease \ "data", lease \ "lastModified")) )

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -310,7 +310,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
         val updatedLeases = LeasesByMedia.build(leases = List(updatedLease, anotherUpdatedLease))
         updatedLeases.leases.size shouldBe 2
 
-        Await.result(Future.sequence(ES.updateImageLeases(id, JsDefined(Json.toJson(updatedLeases)), asJsLookup(DateTime.now))), fiveSeconds)
+        Await.result(Future.sequence(ES.replaceImageLeases(id, JsDefined(Json.toJson(updatedLeases)), asJsLookup(DateTime.now))), fiveSeconds)
 
         reloadedImage(id).get.leases.leases.size shouldBe 2
         reloadedImage(id).get.leases.leases.head.notes shouldBe Some("An updated lease")


### PR DESCRIPTION
If you look at the elasticsearch script, we're doing this `ctx._source.leases = params.leaseByMedia;` which is replacing the leases; updating function names to match.

It should be safe to change the message subject name as nothing is using the reindex endpoint.