### PR TITLE
update how cropper config is generated

### DIFF
--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -30,7 +30,7 @@ function getCropperConfig(config) {
         |aws.region=${config.aws.region}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |publishing.image.bucket=${config.stackProps.ImageOriginBucket}
-        |publishing.image.host=${config.stackProps.ImageOriginWebsite}
+        |publishing.image.host=${config.stackProps.ImageOriginBucket}.s3.amazonaws.com
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |`;


### PR DESCRIPTION
[`ImageOriginWebsite`](https://github.com/guardian/grid/blob/master/cloud-formation/dev-template.yaml#L232-L233) includes the protocol which we don't need as we're adding `https` already - https://github.com/guardian/grid/blob/master/cropper/app/lib/CropStore.scala#L101. That is, using `ImageOriginWebsite` results in us storing the url to a crop as `https://http://s3.bucket.com` which isn't a valid URI.