### PR TITLE
Send messages for multiple crops

### DIFF
--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
@@ -38,22 +38,21 @@ batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
         };
 
         function cropImages() {
-            ctrl.cropping = true;
-            ctrl.needsConfirmation = false;
-            const cropImages = ctrl.images.map(image => {
-              mediaCropper.createFullCrop(image).then(crop => {
-                  //Global notification of action
-                  $rootScope.$emit('events:crop-created', {
-                      image: image,
-                      crop: crop
-                  });
-              });
-            });
+          ctrl.cropping = true;
+          ctrl.needsConfirmation = false;
+          const cropImages = ctrl.images.map(image =>
+            mediaCropper.createFullCrop(image).then(crop => ({
+              image,
+              crop
+            }))
+          );
 
-            Promise.all(cropImages).finally(() => {
-              ctrl.cropping = false;
-              ctrl.allHaveFullCrops = true;
-            });
+          Promise.all(cropImages).then(specs => {
+            $rootScope.$emit('events:crops-created', specs);
+          }).finally(() => {
+            ctrl.cropping = false;
+            ctrl.allHaveFullCrops = true;
+          });
         }
     }
 ]);

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -287,6 +287,21 @@ kahuna.run(['$rootScope', '$window', '$q', 'getEntity',
             postMessage(message);
         });
     });
+
+    // used for batched crops
+    $rootScope.$on('events:crops-created', (_, params) => {
+      const specsPromise = params.map(({ image, crop }) => $q.all([
+        getEntity(image),
+        getEntity(crop)
+      ]).then(([image, crop]) => ({
+        image,
+        crop
+      })));
+
+      $q.all(specsPromise).then(images => postMessage({
+        images
+      }));
+    });
 }]);
 
 


### PR DESCRIPTION
Prior to this PR, when batch cropping an image in an iframe, the parent window would receive a `message` that contained the `image` and `crop` of the first image where `createFullCrop` resolved first.

This doesn't _seem_ useful, you can't guarantee which of these images which actually come through and the assumption is that if you're batch cropping you probably want _all_ of them.

This PR changes batch cropping to post a different type of `message` when batch cropping happens, posting an array of `{ image, crop }` rather than just an `{ image, crop }`.

Unfortunately, our messages don't have any form of `type` property added to discriminate between them but given consumers could (and do) receive all sorts of messages in the `message` event listener we can be pretty that they discriminate somehow and that this change won't break any consumers.

From the tools I can find (Media Atom Maker, Fronts, Composer and others) they all seems to validate a grid message by doing something like `message.image && message.crops && message.image.data` or similar.

The new message has a different shape so these checks should now fail meaning batch cropping won't randomly insert one image and instead consumers will have to add more code to handle batching explicitly.