### PR TITLE
Attempting to account for nested query usage.dateAdded.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ImageFields.scala
@@ -34,7 +34,7 @@ trait ImageFields {
 
   val editsFields = List("archived", "labels")
   val collectionsFields = List("path", "pathId", "pathHierarchy")
-  val usagesFields = List("status", "platform")
+  val usagesFields = List("status", "platform", "dateAdded")
 
   def identifierField(field: String)  = s"identifiers.$field"
   def metadataField(field: String)    = s"metadata.$field"

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -30,9 +30,9 @@ class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
       // Force AND operator else it will only require *any* of the words, not *all*
-      case Words(value) => matchQuery(field, value).operator(Operator.AND)
-      case Phrase(value) => matchPhraseQuery(field, value)
-      case DateRange(start, end) => rangeQuery(field).gte(printDateTime(start)).lte(printDateTime(end))
+      case Words(value) => matchQuery(getFieldPath(field), value).operator(Operator.AND)
+      case Phrase(value) => matchPhraseQuery(getFieldPath(field), value)
+      case DateRange(start, end) => rangeQuery(getFieldPath(field)).gte(printDateTime(start)).lte(printDateTime(end))
       case e => throw InvalidQuery(s"Cannot do single field query on $e")
     }
     case HierarchyField => condition.value match {


### PR DESCRIPTION
All previous nested types where copied to the root in Elastic1, possibly to make the index match the query DSL?