### PR TITLE
refactor SyndicationFilter

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch1/filters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch1/filters.scala
@@ -22,6 +22,10 @@ object filters {
     termFilter
   }
 
+  def dateBefore(field: String, date: DateTime): FilterBuilder = rangeFilter(field).to(printDateTime(date))
+
+  def dateAfter(field: String, date: DateTime): FilterBuilder = rangeFilter(field).from(printDateTime(date))
+
   def date(field: String, from: Option[DateTime], to: Option[DateTime]): Option[FilterBuilder] =
     if (from.isDefined || to.isDefined) {
       val builder = rangeFilter(field)

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/filters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/filters.scala
@@ -20,6 +20,10 @@ object filters {
 
   def boolTerm(field: String, value: Boolean): Query = termQuery(field, value)
 
+  def dateBefore(field: String, date: DateTime): Query = rangeQuery(field).lt(printDateTime(date))
+
+  def dateAfter(field: String, date: DateTime): Query = rangeQuery(field).gt(printDateTime(date))
+
   def date(field: String, from: Option[DateTime], to: Option[DateTime]): Option[Query] =
     if (from.isDefined || to.isDefined) {
       val builder = rangeQuery(field)

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -16,88 +16,87 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
 
   val imagesSentForSyndication: Seq[Image] = Seq(
     createImageForSyndication(
-      id = "test-image-3",
+      id = "syndication-sent-1",
       rightsAcquired = true,
       Some(DateTime.parse("2018-01-01T00:00:00")),
-      Some(createSyndicationLease(allowed = true, "test-image-3")),
+      Some(createSyndicationLease(allowed = true, "syndication-sent-1")),
       List(
         createDigitalUsage(),
         createSyndicationUsage()
       )
-    ),
+    )
   )
 
   val imagesQueuedForSyndication: Seq[Image] = Seq(
     createImageForSyndication(
-      id = "test-image-1",
+      id = "syndication-queued-1",
       rightsAcquired = true,
       Some(DateTime.parse("2018-01-01T00:00:00")),
-      Some(createSyndicationLease(allowed = true, "test-image-1"))
+      Some(createSyndicationLease(allowed = true, "syndication-queued-1"))
     ),
 
     // has a digital usage
     createImageForSyndication(
-      id = "test-image-2",
+      id = "syndication-queued-2",
       rightsAcquired = true,
       Some(DateTime.parse("2018-01-01T00:00:00")),
-      Some(createSyndicationLease(allowed = true, "test-image-2")),
+      Some(createSyndicationLease(allowed = true, "syndication-queued-2")),
       List(createDigitalUsage())
     ),
 
     // explicit allow syndication lease and unknown publish date
     createImageForSyndication(
-      id = "test-image-4",
+      id = "syndication-queued-3",
       rightsAcquired = true,
       None,
-      Some(createSyndicationLease(allowed = true, "test-image-4"))
+      Some(createSyndicationLease(allowed = true, "syndication-queued-3"))
     ),
 
-    // images published after "today", not available for syndication
+    // published after "today", not available on Syndication Tier
     createImageForSyndication(
-      id = "test-image-7",
+      id = "syndication-queued-4",
       rightsAcquired = true,
       Some(DateTime.parse("2018-07-02T00:00:00")),
-      Some(createSyndicationLease(allowed = false, "test-image-7"))
-    ),
+      Some(createSyndicationLease(allowed = false, "syndication-queued-4"))
+    )
   )
 
   val imagesForSyndicationReview: Seq[Image] = Seq(
-    // explicit deny syndication lease with end date before now, available for syndication
     createImageForSyndication(
-      id = "test-image-6",
-      rightsAcquired = true,
-      Some(DateTime.parse("2018-01-01T00:00:00")),
-      Some(createSyndicationLease(
-        allowed = false,
-        "test-image-6",
-        endDate = Some(DateTime.parse("2018-01-01T00:00:00")))
-      )
-    ),
-
-    // Staff photographer with rights acquired, eligible for syndication review
-    createImageForSyndication(
-      id = "test-image-12",
+      id = "syndication-review-1",
       rightsAcquired = true,
       rcsPublishDate = None,
       lease = None,
       usageRights = staffPhotographer,
       usages = List(createDigitalUsage(date = DateTime.now))
+    ),
+
+    // expired deny syndication lease
+    createImageForSyndication(
+      id = "syndication-review-2",
+      rightsAcquired = true,
+      Some(DateTime.parse("2018-01-01T00:00:00")),
+      Some(createSyndicationLease(
+        allowed = false,
+        "syndication-review-1",
+        endDate = Some(DateTime.parse("2018-01-01T00:00:00")))
+      )
     )
   )
 
   val imagesBlockedForSyndication: Seq[Image] = Seq(
     // explicit deny syndication lease with no end date, not available for syndication
     createImageForSyndication(
-      id = "test-image-5",
+      id = "syndication-blocked-1",
       rightsAcquired = true,
       None,
-      Some(createSyndicationLease(allowed = false, "test-image-5"))
+      Some(createSyndicationLease(allowed = false, "syndication-blocked-1"))
     ),
   )
 
   val imagesUnavailableForSyndication: Seq[Image] = Seq(
     createImageForSyndication(
-      UUID.randomUUID().toString,
+      id = "syndication-unavailable-1",
       rightsAcquired = false,
       None,
       None
@@ -105,7 +104,7 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
 
     // Agency image with published usage yesterday
     createImageForSyndication(
-      id = "test-image-9",
+      id = "syndication-unavailable-2",
       rightsAcquired = false,
       None,
       None,
@@ -115,17 +114,17 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
 
     // Agency image with published just now
     createImageForSyndication(
-      id = "test-image-10",
+      id = "syndication-unavailable-3",
       rightsAcquired = false,
       None,
-      Some(createSyndicationLease(allowed = true, "test-image-10")),
+      Some(createSyndicationLease(allowed = true, "syndication-unavailable-3")),
       usageRights = agency,
       usages = List(createDigitalUsage(date = DateTime.now))
     ),
 
     // Screen grab with rights acquired, not eligible for syndication review
     createImageForSyndication(
-      id = "test-image-11",
+      id = "syndication-unavailable-4",
       rightsAcquired = true,
       rcsPublishDate = None,
       lease = None,

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -198,7 +198,31 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
         "foo" -> "bar",
         "toolong" -> stringLongerThan(100000)
       )))
-    )
+    ),
+
+// TODO this test image *should* be in `AwaitingReviewForSyndication` but instead its in `BlockedForSyndication`
+// see https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html to understand why
+//    createImageForSyndication(
+//      id = "active-deny-syndication-with-expired-crop",
+//      rightsAcquired = true,
+//      Some(DateTime.parse("2018-01-01T00:00:00")),
+//      None
+//    ).copy(
+//      leases =  LeasesByMedia(
+//        lastModified = None,
+//        leases = List(
+//          createLease(
+//            DenySyndicationLease,
+//            imageId = "syndication-review-foo"
+//          ),
+//          createLease(
+//            AllowUseLease,
+//            imageId = "syndication-review-foo",
+//            endDate = Some(DateTime.now().minusDays(100))
+//          )
+//        )
+//      )
+//    )
   )
 
   val images: Seq[Image] =

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 
 import com.gu.mediaservice.model.usage.{UsageStatus => Status, _}
 import com.gu.mediaservice.model.{StaffPhotographer, _}
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeUtils}
 
 trait Fixtures {
 
@@ -78,13 +78,18 @@ trait Fixtures {
     createImage(id, usageRights, Some(syndicationRights), leaseByMedia, usages, fileMetadata)
   }
 
-  def createSyndicationLease(allowed: Boolean, imageId: String, startDate: Option[DateTime] = None, endDate: Option[DateTime] = None): MediaLease = {
+  def createLease(
+    leaseType: MediaLeaseType,
+    imageId: String,
+    startDate: Option[DateTime] = None,
+    endDate: Option[DateTime] = None
+  ): MediaLease = {
     MediaLease(
       id = None,
       leasedBy = None,
       startDate = startDate,
       endDate = endDate,
-      access = if (allowed) AllowSyndicationLease else DenySyndicationLease,
+      access = leaseType,
       notes = None,
       mediaId = imageId
     )

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -205,21 +205,28 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       }
     }
 
-    it("should return 3 images if an Internal tier queries for BlockedForSyndication images") {
+    it("should be able to show BlockedForSyndication images on the Internal tier") {
       val search = SearchParams(tier = Internal, syndicationStatus = Some(BlockedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.hits.forall(h => h._2.leases.leases.nonEmpty) shouldBe true
-        result.hits.forall(h => h._2.leases.leases.forall(l => l.access == DenySyndicationLease)) shouldBe true
-        result.total shouldBe 3
+        val imageIds = result.hits.map(_._1)
+        result.total shouldBe 2
+        imageIds.contains("syndication-blocked-forever") shouldBe true
+        imageIds.contains("syndication-blocked-for-10-days") shouldBe true
       }
     }
 
-    it("should return 3 images if an Internal tier queries for AwaitingReviewForSyndication images") {
+    it("should be able to show AwaitingReviewForSyndication images on the Internal tier") {
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 2
+        val imageIds = result.hits.map(_._1)
+        result.total shouldBe 5
+        imageIds.contains("syndication-review-1") shouldBe true
+        imageIds.contains("syndication-review-2") shouldBe true
+        imageIds.contains("syndication-review-3") shouldBe true
+        imageIds.contains("syndication-review-4") shouldBe true
+        imageIds.contains("syndication-review-5") shouldBe true
       }
     }
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -219,7 +219,7 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 3
+        result.total shouldBe 2
       }
     }
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala
@@ -125,9 +125,9 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
 
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe 3
-        imageIds.contains("test-image-1") shouldBe true
-        imageIds.contains("test-image-2") shouldBe true
-        imageIds.contains("test-image-4") shouldBe true
+        imageIds.contains("syndication-queued-1") shouldBe true
+        imageIds.contains("syndication-queued-2") shouldBe true
+        imageIds.contains("syndication-queued-3") shouldBe true
       }
     }
 
@@ -165,9 +165,9 @@ class MediaApiElasticSearch1Test extends ElasticSearchTestBase with Eventually w
 
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe 3
-        imageIds.contains("test-image-1") shouldBe true
-        imageIds.contains("test-image-2") shouldBe true
-        imageIds.contains("test-image-4") shouldBe true
+        imageIds.contains("syndication-queued-1") shouldBe true
+        imageIds.contains("syndication-queued-2") shouldBe true
+        imageIds.contains("syndication-queued-3") shouldBe true
       }
     }
 

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -145,9 +145,9 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe 3
-        imageIds.contains("test-image-1") shouldBe true
-        imageIds.contains("test-image-2") shouldBe true
-        imageIds.contains("test-image-4") shouldBe true
+        imageIds.contains("syndication-queued-1") shouldBe true
+        imageIds.contains("syndication-queued-2") shouldBe true
+        imageIds.contains("syndication-queued-3") shouldBe true
       }
     }
 
@@ -185,9 +185,9 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe 3
-        imageIds.contains("test-image-1") shouldBe true
-        imageIds.contains("test-image-2") shouldBe true
-        imageIds.contains("test-image-4") shouldBe true
+        imageIds.contains("syndication-queued-1") shouldBe true
+        imageIds.contains("syndication-queued-2") shouldBe true
+        imageIds.contains("syndication-queued-3") shouldBe true
       }
     }
 

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -240,7 +240,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 3
+        result.total shouldBe 2
       }
     }
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -225,22 +225,28 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       }
     }
 
-    it("should return 3 images if an Internal tier queries for BlockedForSyndication images") {
+    it("should be able to show BlockedForSyndication images on the Internal tier") {
       val search = SearchParams(tier = Internal, syndicationStatus = Some(BlockedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.hits.forall(h => h._2.leases.leases.nonEmpty) shouldBe true
-        result.hits.forall(h => h._2.leases.leases.forall(l => l.access == DenySyndicationLease)) shouldBe true
-        result.total shouldBe 3
+        val imageIds = result.hits.map(_._1)
+        result.total shouldBe 2
+        imageIds.contains("syndication-blocked-forever") shouldBe true
+        imageIds.contains("syndication-blocked-for-10-days") shouldBe true
       }
     }
 
-    it("should return 3 images if an Internal tier queries for AwaitingReviewForSyndication images") {
-      // Elastic1 implementation is returning the images with reviewed and blocked syndicationStatus
+    it("should be able to show AwaitingReviewForSyndication images on the Internal tier") {
       val search = SearchParams(tier = Internal, syndicationStatus = Some(AwaitingReviewForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.total shouldBe 2
+        val imageIds = result.hits.map(_._1)
+        result.total shouldBe 5
+        imageIds.contains("syndication-review-1") shouldBe true
+        imageIds.contains("syndication-review-2") shouldBe true
+        imageIds.contains("syndication-review-3") shouldBe true
+        imageIds.contains("syndication-review-4") shouldBe true
+        imageIds.contains("syndication-review-5") shouldBe true
       }
     }
   }


### PR DESCRIPTION
~~Refactors `SyndicationFilter` for brevity, clarity and correctness. Also adds more test images to exhaust the elasticsearch queries. This is after we've had some images returning in the review queue even though they've had a lease added to them. Looking at the previous queries, this is because the date ended query was a bit naive in that it was looking at any lease's end date rather than just a syndication lease.~~

So this doesn't do what's stated above. It's merely a refactor. To demonstrate this fact, I've commented out some test data that represents an image getting stuck in review: an image with two leases, an expired allowed use lease and an active deny syndication lease.