### PR TITLE
persist an image if its got a label

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch1/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch1/SearchFilters.scala
@@ -67,6 +67,7 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
   val hasPersistedUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), persistedCategories))
   val addedGNMArchiveOrPersistedCollections = filters.bool.must(filters.terms(collectionsField("path"), config.persistedRootCollections.toNel.get))
   val addedToPhotoshoot = filters.exists(NonEmptyList(editsField("photoshoot")))
+  val hasLabels = filters.exists(NonEmptyList(editsField("labels")))
 
   val persistedFilter: FilterBuilder = filters.or(
     hasCrops,
@@ -76,7 +77,8 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
     hasUserEditsToImageMetadata,
     hasPersistedUsageRights,
     addedGNMArchiveOrPersistedCollections,
-    addedToPhotoshoot
+    addedToPhotoshoot,
+    hasLabels
   )
 
   val nonPersistedFilter: FilterBuilder = filters.not(persistedFilter)

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
@@ -68,6 +68,7 @@ class SearchFilters(config: MediaApiConfig)  extends ImageFields {
   val hasPersistedUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), persistedCategories))
   val addedGNMArchiveOrPersistedCollections = filters.bool.must(filters.terms(collectionsField("path"), config.persistedRootCollections.toNel.get))
   val addedToPhotoshoot = filters.exists(NonEmptyList(editsField("photoshoot")))
+  val hasLabels = filters.exists(NonEmptyList(editsField("labels")))
 
   val persistedFilter: Query = filters.or(
     hasCrops,
@@ -77,7 +78,8 @@ class SearchFilters(config: MediaApiConfig)  extends ImageFields {
     hasUserEditsToImageMetadata,
     hasPersistedUsageRights,
     addedGNMArchiveOrPersistedCollections,
-    addedToPhotoshoot
+    addedToPhotoshoot,
+    hasLabels
   )
 
   val nonPersistedFilter: Query = filters.not(persistedFilter)


### PR DESCRIPTION
A bit difficult to write a test for this. We're currently testing what is [not kept](https://github.com/guardian/grid/blob/master/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala#L70).

We could test what is kept, however there are lots of test images such as [this one](https://github.com/guardian/grid/blob/master/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala#L130-L137) which'll get picked up which is a bit annoying.