### PR TITLE
delete-image and update-image messages missing from the Kinesis messa…

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SNS.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SNS.scala
@@ -6,7 +6,6 @@ import com.gu.mediaservice.lib.config.CommonConfig
 import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
 
-
 class SNS(config: CommonConfig, topicArn: String) {
   lazy val client: AmazonSNS = config.withAWSCredentials(AmazonSNSClientBuilder.standard()).build()
 

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -75,7 +75,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
-  val usageController = new UsageController(auth, config, notifications, elasticSearch, usageQuota, controllerComponents)
+  val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)
   val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi)
 
   override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, healthcheckController)

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.aws.MessageSender
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.gu.mediaservice.lib.imaging.ImageOperations
@@ -15,7 +16,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
-  val notifications = new Notifications(config)
+  val messageSender = new MessageSender(config, config.topicArn)
   val mediaApiMetrics = new MediaApiMetrics(config)
 
   val es1Config: Option[ElasticSearchConfig] = for {
@@ -71,7 +72,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val mediaApi = new MediaApi(auth, notifications, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
+  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, notifications, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -10,7 +10,7 @@ import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class UsageController(auth: Authentication, config: MediaApiConfig, notifications: Notifications, elasticSearch: ElasticSearchVersion, usageQuota: UsageQuota,
+class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearch: ElasticSearchVersion, usageQuota: UsageQuota,
                       override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 

--- a/media-api/app/lib/Notifications.scala
+++ b/media-api/app/lib/Notifications.scala
@@ -1,5 +1,0 @@
-package lib
-
-import com.gu.mediaservice.lib.aws.SNS
-
-class Notifications(config: MediaApiConfig) extends SNS(config, config.topicArn)


### PR DESCRIPTION
…ge bus. Delete snowflake instance of Notifications to expose usages and then migrate to MessageSender.

Probably why deletes are not been applied to ES6 index.