### PR TITLE
Correctly set last modified date when leases are ... modified

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -24,7 +24,7 @@ case class Image(
   originalUsageRights: UsageRights,
   exports:             List[Crop]       = Nil,
   usages:              List[Usage]      = Nil,
-  leases:              LeasesByMedia     = LeasesByMedia.build(Nil),
+  leases:              LeasesByMedia    = LeasesByMedia.empty,
   collections:         List[Collection] = Nil,
   syndicationRights:   Option[SyndicationRights] = None,
   userMetadataLastModified: Option[DateTime] = None) {
@@ -80,7 +80,7 @@ object Image {
       (__ \ "originalUsageRights").readNullable[UsageRights].map(_ getOrElse NoRights) ~
       (__ \ "exports").readNullable[List[Crop]].map(_ getOrElse List()) ~
       (__ \ "usages").readNullable[List[Usage]].map(_ getOrElse List()) ~
-      (__ \ "leases").readNullable[LeasesByMedia].map(_ getOrElse LeasesByMedia.build(Nil)) ~
+      (__ \ "leases").readNullable[LeasesByMedia].map(_ getOrElse LeasesByMedia.empty) ~
       (__ \ "collections").readNullable[List[Collection]].map(_ getOrElse Nil) ~
       (__ \ "syndicationRights").readNullable[SyndicationRights] ~
       (__ \ "userMetadataLastModified").readNullable[String].map(parseOptDateTime)

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -21,13 +21,13 @@ object LeaseNotice {
     def writes(leaseByMedia: LeasesByMedia) = {
       LeasesByMedia.toJson(
         Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.lastModified.map(lm => Json.toJson(lm)))
+        Json.toJson(leaseByMedia.lastModified)
       )
     }
   }
   def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
     mediaLease.mediaId,
-    Json.toJson(LeasesByMedia.build(List(mediaLease)))
+    Json.toJson(LeasesByMedia(List(mediaLease), Some(mediaLease.createdAt)))
   )
 }
 

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -394,6 +394,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
     """| for(int i = 0; i < ctx._source.leases.leases.size(); i++) {
        |    if(ctx._source.leases.leases[i].id == leaseId) {
        |      ctx._source.leases.leases.remove(i);
+       |      ctx._source.leases.lastModified = lastModified;
        |    }
        | }
     """.stripMargin


### PR DESCRIPTION
Previously, the leases last modified date was the most recent creation date of the image's leases. This PR corrects that behaviour to set lastModified when leases are added or removed.