### PR TITLE
Add ability to batch add syndication leases when syndication leases are already present on images

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.model
 
 import com.gu.mediaservice.lib.formatting.printDateTime
 import org.joda.time.DateTime
-import play.api.libs.json._
+import play.api.libs.json.{JodaWrites, JsValue, Json, Writes}
 
 case class LeaseNotice(mediaId: String, leaseByMedia: JsValue) {
   def toJson = Json.obj(

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -82,8 +82,10 @@ leases.controller('LeasesCtrl', [
 
                 if (incomingLeaseIsSyndication && syndLeases.length > 0) {
                   const confirmText = ctrl.images.size > 1
-                    ? "One or more of the selected images have syndication leases. These will be overwritten. Do you wish to proceed?"
-                    : "This image already has syndication rights. They will be overwritten. Do you wish to proceed?";
+                    ? "One or more of the selected images have syndication leases. " +
+                      "These will be overwritten. Do you wish to proceed?"
+                    : "This image already has syndication rights. They will be overwritten. " +
+                      "Do you wish to proceed?";
                   const shouldApplyLeases = $window.confirm(confirmText);
                   if (!shouldApplyLeases) {
                     return;

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -79,10 +79,13 @@ leases.controller('LeasesCtrl', [
                 );
 
                 if (incomingLeaseIsSyndication && syndLeases.length > 0) {
-                    const shouldApplyLeases = $window.confirm("One or more of the selected images have syndication leases. These will be overwritten. Do you wish to proceed?");
-                    if (!shouldApplyLeases) {
-                      return;
-                    }
+                  const confirmText = ctrl.images.size > 1
+                    ? "One or more of the selected images have syndication leases. These will be overwritten. Do you wish to proceed?"
+                    : "This image already has syndication rights. They will be overwritten. Do you wish to proceed?";
+                  const shouldApplyLeases = $window.confirm(confirmText);
+                  if (!shouldApplyLeases) {
+                    return;
+                  }
                 }
                 const leasesToAdd = incomingLeaseIsSyndication
                   ? ctrl.leases.leases.filter(_ => !_.access.endsWith('-syndication'))

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -75,7 +75,7 @@ leases.controller('LeasesCtrl', [
                     ctrl.newLease.notes = noteWithClause.join(', ');
                 }
 
-                const incomingLeaseIsSyndication = ctrl.access.endsWith('-syndication');
+                const incomingLeaseIsSyndication = leaseService.isLeaseSyndication(ctrl);
                 const syndLeases = ctrl.leases.leases.filter((l) =>
                     l.access.endsWith('-syndication')
                 );
@@ -84,7 +84,7 @@ leases.controller('LeasesCtrl', [
                   const confirmText = ctrl.images.size > 1
                     ? "One or more of the selected images have syndication leases. " +
                       "These will be overwritten. Do you wish to proceed?"
-                    : "This image already has syndication rights. They will be overwritten. " +
+                    : "This image already has a syndication lease. It will be overwritten. " +
                       "Do you wish to proceed?";
                   const shouldApplyLeases = $window.confirm(confirmText);
                   if (!shouldApplyLeases) {

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -25,6 +25,7 @@ leases.controller('LeasesCtrl', [
     'inject$',
     'leaseService',
     'imageAccessor',
+    'imageList',
     '$rootScope',
     'onValChange',
     function(
@@ -35,6 +36,7 @@ leases.controller('LeasesCtrl', [
         inject$,
         leaseService,
         imageAccessor,
+        imageList,
         $rootScope,
         onValChange) {
 
@@ -87,10 +89,8 @@ leases.controller('LeasesCtrl', [
                     return;
                   }
                 }
-                const leasesToAdd = incomingLeaseIsSyndication
-                  ? ctrl.leases.leases.filter(_ => !_.access.endsWith('-syndication'))
-                  : ctrl.leases.leases;
-                leaseService.batchAdd(ctrl.newLease, leasesToAdd, ctrl.images)
+
+                leaseService.batchAdd(ctrl.newLease, ctrl.images)
                     .catch(() =>
                         alertFailed('Something went wrong when saving, please try again.')
                 )
@@ -144,7 +144,7 @@ leases.controller('LeasesCtrl', [
 
         ctrl.delete = (lease) => {
             ctrl.adding = true;
-            leaseService.deleteLease(lease, ctrl.leases, ctrl.images)
+            leaseService.deleteLease(lease, ctrl.images)
                 .catch(
                     () => alertFailed('Something when wrong when deleting, please try again!')
                 );

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -34,17 +34,6 @@ leaseService.factory('leaseService', [
           .then( (images) => imageList.getLeases(images) );
       }
 
-    function add(image, lease) {
-      const newLease = angular.copy(lease);
-      newLease.mediaId = image.data.id;
-
-      if (angular.isDefined(newLease.notes) && newLease.notes.trim().length === 0) {
-        newLease.notes = null;
-      }
-
-      return image.perform('add-lease', {body: newLease});
-    }
-
     function clear(image) {
         const images = [image];
         const currentLeases = getLeases(images);
@@ -94,8 +83,8 @@ leaseService.factory('leaseService', [
     }
 
     function batchAdd(lease, originalLeases, images) {
-      const originalLeaseCount = originalLeases.leases.length;
-      return $q.all(images.map(image => add(image, lease)))
+      const originalLeaseCount = originalLeases.length;
+      return $q.all(images.map(image => replace(image, originalLeases.concat(lease))))
         .then(pollLeases(images, originalLeaseCount));
     }
 
@@ -139,7 +128,6 @@ leaseService.factory('leaseService', [
     }
 
     return {
-        add,
         batchAdd,
         getLeases,
         canUserEdit,

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -124,6 +124,7 @@ leaseService.factory('leaseService', [
       })).then(results => {
         return results.map(result => {
           $rootScope.$emit('image-updated', result.image);
+          $rootScope.$emit('leases-updated');
           return result.leases;
         });
       });

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -31,27 +31,17 @@ leaseService.factory('leaseService', [
         images = images.toArray();
       }
       return $q.all(images.map(i => i.get()))
-          .then( (images) => imageList.getLeases(images) );
+          .then((images) => imageList.getLeases(images));
       }
 
     function clear(image) {
         const images = [image];
         const currentLeases = getLeases(images);
-
-        return currentLeases.then((originalLeases) => {
-
-            const originalLeaseCount = originalLeases[0].leases.length;
-
-            return image
-                .perform('delete-leases')
-                .then((op) => {
-                    return {
-                        op,
-                        originalLeaseCount
-                    };
-                });
-        }).then((op) => {
-            pollLeases(images, op.originalLeaseCount);
+        return currentLeases.then(() => {
+          return image
+              .perform('delete-leases').then(() => {
+              pollLeases(images, imageList.getLeases(images));
+          });
         });
     }
 
@@ -59,9 +49,7 @@ leaseService.factory('leaseService', [
         const images = [image];
         const currentLeases = getLeases(images);
 
-        return currentLeases.then((originalLeases) => {
-
-            const originalLeaseCount = originalLeases[0].leases.length;
+        return currentLeases.then(() => {
 
             const updatedLeases = leases.map((lease) => {
                 var newLease = angular.copy(lease);
@@ -70,54 +58,75 @@ leaseService.factory('leaseService', [
             });
 
             return image
-                .perform('replace-leases', {body: updatedLeases})
-                .then((op) => {
-                    return {
-                        op,
-                        originalLeaseCount
-                    };
-                });
-        }).then((op) => {
-            pollLeases(images, op.originalLeaseCount);
+              .perform('replace-leases', {body: updatedLeases})
+              .then(() => {
+                  pollLeases(images);
+              });
         });
     }
 
-    function batchAdd(lease, originalLeases, images) {
-      const originalLeaseCount = originalLeases.length;
-      return $q.all(images.map(image => replace(image, originalLeases.concat(lease))))
-        .then(pollLeases(images, originalLeaseCount));
+    /**
+     * Add a lease to the image. Overwrites any syndication leases
+     * if the incoming lease is itself a syndication lease.
+     *
+     * @param {Resource} image
+     * @param {Resource} newLease
+     */
+    function add(image, newLease) {
+      const originalLeases = imageAccessor.readLeases(image).leases;
+      const filteredLeases = isLeaseSyndication(newLease)
+        ? originalLeases.filter(_ => !_.access.endsWith('-syndication'))
+        : originalLeases;
+      const updatedLeases = filteredLeases.concat(newLease);
+      return replace(image, updatedLeases);
+    }
+
+    function batchAdd(lease, images) {
+      return $q.all(images.map(image => add(image, lease)));
     }
 
     function canUserEdit(image){
       return editsService.canUserEdit(image);
     }
 
-    function deleteLease(lease, originalLeases, images) {
-      const originalLeaseCount = originalLeases.leases.length;
+    /**
+     * Delete a lease by uuid from a collection of images.
+     * This method does not support batch deletion, because a
+     * uuid will only ever match one lease.
+     */
+    function deleteLease(lease, images) {
       return getLeasesRoot().follow('leases', {id: lease.id}).delete()
-        .then(pollLeases(images, originalLeaseCount));
+        .then(() => pollLeases(images));
     }
 
     function getByMediaId(image) {
       return getLeasesRoot().follow('by-media-id', {id: image.data.id}).get();
     }
 
-    function pollLeases(images, originalLeaseCount){
+    function pollLeases(images) {
       apiPoll(() => {
-        return untilLeasesChange(images, originalLeaseCount);
+        return untilLeasesChange(images);
       });
     }
 
-    function untilLeasesChange(images, originalLeaseCount){
-      return $q.all(images.map((image) => image.get().then( (apiImage) => {
-        const apiLeases = imageAccessor.readLeases(apiImage);
-        if (apiLeases.leases.length !== originalLeaseCount) {
-          $rootScope.$emit('leases-updated');
-          return apiLeases;
-        } else {
-          return $q.reject();
-        }
-      })));
+    function untilLeasesChange(images) {
+      const imagesArray = images.toArray ? images.toArray() : images;
+      return $q.all(imagesArray.map(image => {
+        return image.get().then(apiImage => {
+          const apiLeases = imageAccessor.readLeases(apiImage);
+          const leases = imageAccessor.readLeases(image);
+          if (apiLeases.lastModified !== leases.lastModified) {
+            return { image: apiImage, leases: apiLeases };
+          } else {
+            return $q.reject();
+          }
+        });
+      })).then(results => {
+        return results.map(result => {
+          $rootScope.$emit('image-updated', result.image);
+          return result.leases;
+        });
+      });
     }
 
     function flattenLeases(leaseByMedias) {
@@ -125,6 +134,10 @@ leaseService.factory('leaseService', [
         leases: leaseByMedias.map(l => l.leases).reduce((a, b) => a.concat(b)),
         lastModified: leaseByMedias.map(l => l.lastModified).sort()[0]
       };
+    }
+
+    function isLeaseSyndication(lease) {
+      return lease.access.endsWith('-syndication');
     }
 
     return {
@@ -135,7 +148,8 @@ leaseService.factory('leaseService', [
         getByMediaId,
         replace,
         clear,
-        flattenLeases
+        flattenLeases,
+        isLeaseSyndication
     };
 }]);
 

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import moment from 'moment';
 import './media-api';
 import '../../services/image-list';
 
@@ -112,7 +113,9 @@ leaseService.factory('leaseService', [
         return image.get().then(apiImage => {
           const apiLeases = imageAccessor.readLeases(apiImage);
           const leases = imageAccessor.readLeases(image);
-          if (apiLeases.lastModified !== leases.lastModified) {
+          const currentLastModified = moment(apiLeases.lastModified);
+          const previousLastModified = moment(leases.lastModified);
+          if (currentLastModified.isAfter(previousLastModified)) {
             return { image: apiImage, leases: apiLeases };
           } else {
             return $q.reject();

--- a/leases/app/controllers/MediaLeaseController.scala
+++ b/leases/app/controllers/MediaLeaseController.scala
@@ -49,16 +49,14 @@ class MediaLeaseController(auth: Authentication, store: LeaseStore, config: Leas
 
   private def addLease(mediaLease: MediaLease, userId: Option[String]) = {
     val lease = prepareLeaseForSave(mediaLease, userId)
-    lease.isSyndication match {
-      case true =>
-        val mediaId = mediaLease.mediaId
-        val leasesForMedia = store.getForMedia(mediaId)
-        val leasesWithoutSyndication = leasesForMedia.filter(!_.isSyndication)
-        replaceLeases(leasesWithoutSyndication :+ lease, mediaId, userId)
-      case false =>
-        store.put(lease).map { _ =>
-          notifications.sendAddLease(lease)
-        }
+    if (lease.isSyndication) {
+      val leasesForMedia = store.getForMedia(mediaLease.mediaId)
+      val leasesWithoutSyndication = leasesForMedia.filter(!_.isSyndication)
+      replaceLeases(leasesWithoutSyndication :+ lease, mediaLease.mediaId, userId)
+    } else {
+      store.put(lease).map { _ =>
+        notifications.sendAddLease(lease)
+      }
     }
   }
 

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -7,6 +7,31 @@ import com.gu.mediaservice.model.{LeaseNotice, LeasesByMedia, MediaLease}
 import org.joda.time.DateTime
 import play.api.libs.json._
 
+case class LeaseNotice(mediaId: String, leaseByMedia: JsValue) {
+  def toJson = Json.obj(
+    "id" -> mediaId,
+    "data" -> leaseByMedia,
+    "lastModified" -> printDateTime(DateTime.now())
+  )
+}
+
+object LeaseNotice {
+  import JodaWrites._
+
+  implicit val writer = new Writes[LeasesByMedia] {
+    def writes(leaseByMedia: LeasesByMedia) = {
+      LeasesByMedia.toJson(
+        Json.toJson(leaseByMedia.leases),
+        Json.toJson(leaseByMedia.lastModified)
+      )
+    }
+  }
+  def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
+    mediaLease.mediaId,
+    Json.toJson(LeasesByMedia(List(mediaLease), Some(mediaLease.createdAt)))
+  )
+}
+
 class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSender(config, config.topicArn) {
   private def build(mediaId: String, leases: List[MediaLease] ): LeaseNotice = {
     LeaseNotice(mediaId, Json.toJson(LeasesByMedia.build(leases)))

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -25,6 +25,10 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSend
     publish(MediaLease.toJson(mediaLease), addImageLease, updateMessage)
   }
 
+  def sendAddLeases(mediaLeases: List[MediaLease], mediaId: String) = {
+    publish(LeaseNotice(mediaId, Json.toJson(LeasesByMedia.build(mediaLeases))).toJson, "replace-image-leases")
+  }
+
   def sendRemoveLease(mediaId: String, leaseId: String) = {
     val removeImageLease = "remove-image-lease"
 

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -2,7 +2,7 @@ package lib
 
 import com.gu.mediaservice.lib.aws.{MessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting._
-import com.gu.mediaservice.model.{LeaseNotice, LeasesByMedia, MediaLease}
+import com.gu.mediaservice.model.{LeasesByMedia, MediaLease}
 
 import org.joda.time.DateTime
 import play.api.libs.json._

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -2,35 +2,9 @@ package lib
 
 import com.gu.mediaservice.lib.aws.{MessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting._
-import com.gu.mediaservice.model.{LeasesByMedia, MediaLease}
-
+import com.gu.mediaservice.model.{LeaseNotice, LeasesByMedia, MediaLease}
 import org.joda.time.DateTime
 import play.api.libs.json._
-
-case class LeaseNotice(mediaId: String, leaseByMedia: JsValue) {
-  def toJson = Json.obj(
-    "id" -> mediaId,
-    "data" -> leaseByMedia,
-    "lastModified" -> printDateTime(DateTime.now())
-  )
-}
-
-object LeaseNotice {
-  import JodaWrites._
-
-  implicit val writer = new Writes[LeasesByMedia] {
-    def writes(leaseByMedia: LeasesByMedia) = {
-      LeasesByMedia.toJson(
-        Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.lastModified)
-      )
-    }
-  }
-  def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
-    mediaLease.mediaId,
-    Json.toJson(LeasesByMedia(List(mediaLease), Some(mediaLease.createdAt)))
-  )
-}
 
 class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSender(config, config.topicArn) {
   private def build(mediaId: String, leases: List[MediaLease] ): LeaseNotice = {

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -3,6 +3,7 @@ package lib
 import com.gu.mediaservice.lib.aws.{MessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting._
 import com.gu.mediaservice.model.{LeaseNotice, LeasesByMedia, MediaLease}
+
 import org.joda.time.DateTime
 import play.api.libs.json._
 

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -26,7 +26,9 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSend
   }
 
   def sendAddLeases(mediaLeases: List[MediaLease], mediaId: String) = {
-    publish(LeaseNotice(mediaId, Json.toJson(LeasesByMedia.build(mediaLeases))).toJson, "replace-image-leases")
+    val replaceImageLeases = "replace-image-leases"
+    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(mediaLeases), id = Some(mediaId), lastModified = Some(DateTime.now()))
+    publish(LeaseNotice(mediaId, Json.toJson(LeasesByMedia.build(mediaLeases))).toJson, replaceImageLeases, updateMessage)
   }
 
   def sendRemoveLease(mediaId: String, leaseId: String) = {

--- a/leases/app/lib/LeaseStore.scala
+++ b/leases/app/lib/LeaseStore.scala
@@ -28,6 +28,10 @@ class LeaseStore(config: LeasesConfig) extends DynamoDB(config, config.leasesTab
     ScanamoAsync.exec(client)(leasesTable.put(lease))
   }
 
+  def putAll(leases: List[MediaLease])(implicit ec: ExecutionContext) = {
+    ScanamoAsync.exec(client)(leasesTable.putAll(leases.toSet))
+  }
+
   def delete(id: String)(implicit ec: ExecutionContext) = {
     ScanamoAsync.exec(client)(leasesTable.delete('id -> id))
   }

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -176,7 +176,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
     prepareImageUpdate(id) { request =>
       request.setScriptParams(Map(
         "lease" -> asGroovy(lease.getOrElse(JsNull)),
-        "lastModified" -> asGroovy(lastModified.getOrElse(JsNull))
+        "lastModified" -> asGroovy(Json.toJson(currentIsoDateString))
       ).asJava)
         .setScript(
           addLeaseScript + updateLastModifiedScript,
@@ -191,7 +191,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
     prepareImageUpdate(id) { request =>
       request.setScriptParams(Map(
         "leaseId" -> asGroovy(leaseId.getOrElse(JsNull)),
-        "lastModified" -> asGroovy(lastModified.getOrElse(JsNull))
+        "lastModified" -> asGroovy(Json.toJson(currentIsoDateString))
       ).asJava)
         .setScript(
           removeLeaseScript + updateLastModifiedScript,

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -287,8 +287,10 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
 
   def replaceImageLeases(id: String, leases: Seq[MediaLease])(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     val replaceLeasesScript = loadPainless(
-      """ | ctx._source.leases.lastModified = params.lastModified;
-          | ctx._source.leases.leases = params.leases;""".stripMargin
+      """
+        | ctx._source.leases.lastModified = params.lastModified;
+        | ctx._source.leases.leases = params.leases;
+        | """.stripMargin
     )
 
     val scriptSource = loadPainless(s"""
@@ -313,12 +315,14 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
 
   def addImageLease(id: String, lease: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
 
-    val addLeaseScript = loadPainless("""| if (ctx._source.leases == null || ctx._source.leases.leases == null) {
-       |   ctx._source.leases = ["leases": [params.lease]];
-       | } else {
-       |   ctx._source.leases.leases.add(params.lease);
-       | }
-    """)
+    val addLeaseScript = loadPainless(
+      """| if (ctx._source.leases == null || ctx._source.leases.leases == null) {
+         |   ctx._source.leases = ["leases": [params.lease], "lastModified": params.lastModified];
+         | } else {
+         |   ctx._source.leases.leases.add(params.lease);
+         |   ctx._source.leases.lastModified = params.lastModified;
+         | }
+    """.stripMargin)
 
     val scriptSource = loadPainless(s"""
                                        |   $addLeaseScript
@@ -326,11 +330,11 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
                                        | """)
 
     val leaseParameter = lease.toOption.map(_.as[MediaLease])
-    val lastModifiedParameter = lastModified.toOption.map(_.as[String])
+    val lastModifiedParameter = currentIsoDateString
 
     val params = Map(
       "lease" -> leaseParameter.map(i => asNestedMap(Json.toJson(i))).getOrElse(null),
-      "lastModified" -> lastModifiedParameter.getOrElse(null)
+      "lastModified" -> lastModifiedParameter
     )
 
     val script = Script(script = scriptSource).lang("painless").params(params)
@@ -345,9 +349,11 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
 
   def removeImageLease(id: String, leaseId: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     val removeLeaseScript = loadPainless(
-      """| for(int i = 0; i < ctx._source.leases.leases.size(); i++) {
-         |    if(ctx._source.leases.leases[i].id == params.leaseId) {
+      """|
+         | for(int i = 0; i < ctx._source.leases.leases.size(); i++) {
+         |    if (ctx._source.leases.leases[i].id == params.leaseId) {
          |      ctx._source.leases.leases.remove(i);
+         |      ctx._source.leases.lastModified = params.lastModified;
          |    }
          | }
       """)
@@ -359,11 +365,11 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
          | """)
 
     val leaseIdParameter = leaseId.toOption.map(_.as[String])
-    val lastModifiedParameter = lastModified.toOption.map(_.as[String])
+    val lastModifiedParameter = currentIsoDateString
 
     val params = Map(
       "leaseId" -> leaseIdParameter.getOrElse(null),
-      "lastModified" -> lastModifiedParameter.getOrElse(null)
+      "lastModified" -> lastModifiedParameter
     )
 
     val script = Script(script = scriptSource).lang("painless").params(params)

--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -57,7 +57,7 @@ trait Fixtures {
                                  lease: Option[MediaLease],
                                  usages: List[Usage] = Nil,
                                  fileMetadata: Option[FileMetadata] = None,
-                                 lastModified: Option[DateTime] = None
+                                 leasesLastModified: Option[DateTime] = None
                                ): Image = {
     val rights = List(
       Right("test", Some(rightsAcquired), Nil)
@@ -66,7 +66,7 @@ trait Fixtures {
     val syndicationRights = SyndicationRights(rcsPublishDate, Nil, rights)
 
     val leaseByMedia = lease.map(l => LeasesByMedia(
-      lastModified = lastModified,
+      lastModified = leasesLastModified,
       leases = List(l)
     ))
 

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -277,7 +277,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
         val id = UUID.randomUUID().toString
         val timeBeforeEdit = DateTime.now.minusMinutes(1)
         val image = createImageForSyndication(
-          id = UUID.randomUUID().toString,
+          id,
           true,
           Some(DateTime.now()),
           None,
@@ -303,7 +303,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
       "can remove image lease" in {
         val lease = model.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
         val id = UUID.randomUUID().toString
-        val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), lease = Some(lease))
+        val image = createImageForSyndication(id, true, Some(DateTime.now()), lease = Some(lease))
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
         reloadedImage(id).get.leases.leases.nonEmpty shouldBe true
 

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -281,7 +281,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
           true,
           Some(DateTime.now()),
           None,
-          lastModified = Some(timeBeforeEdit))
+          leasesLastModified = Some(timeBeforeEdit))
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
         reloadedImage(id).get.leases.leases.isEmpty shouldBe true
 
@@ -314,16 +314,23 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
       "removing a lease should update the leases last modified time" in {
         val lease = model.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
+        val timeBeforeEdit = DateTime.now
         val id = UUID.randomUUID().toString
-        val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), lease = Some(lease))
+        val image = createImageForSyndication(
+          id = UUID.randomUUID().toString,
+
+          true,
+          Some(DateTime.now()),
+          lease = Some(lease)
+        )
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
         reloadedImage(id).get.leases.leases.nonEmpty shouldBe true
 
-        val removalLastModified = DateTime.now.plusMinutes(1)
-        Await.result(Future.sequence(ES.removeImageLease(id, JsDefined(Json.toJson(lease.id)), asJsLookup(removalLastModified))), fiveSeconds)
+        Await.result(Future.sequence(ES.removeImageLease(id, JsDefined(Json.toJson(lease.id)), asJsLookup(timeBeforeEdit))), fiveSeconds)
 
-        reloadedImage(id).get.leases.leases.isEmpty shouldBe true
-        reloadedImage(id).get.lastModified.get.isEqual(removalLastModified) shouldBe true
+        val newLeases = reloadedImage(id).get.leases
+        newLeases.leases.isEmpty shouldBe true
+        newLeases.lastModified.get.isAfter(timeBeforeEdit) shouldBe true
       }
 
       "can replace leases" in {
@@ -335,7 +342,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
           true,
           Some(DateTime.now()),
           lease = Some(lease),
-          lastModified = Some(timeBeforeEdit)
+          leasesLastModified = Some(timeBeforeEdit)
         )
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
 
@@ -423,12 +430,18 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
       "updating syndication rights should update last modified date" in {
         val id = UUID.randomUUID().toString
-        val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), None)
+        val beforeUpdate = DateTime.now()
+        val image = createImageForSyndication(
+          id = UUID.randomUUID().toString,
+          true,
+          Some(DateTime.now()),
+          None,
+          leasesLastModified = Some(beforeUpdate)
+        )
         ES.indexImage(id, Json.toJson(image))
         eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(image.id))
 
         val newSyndicationRights = SyndicationRights(published = Some(DateTime.now().minusWeeks(1)), suppliers = Seq.empty, rights = Seq.empty)
-        val beforeUpdate = DateTime.now()
 
         Await.result(Future.sequence(ES.updateImageSyndicationRights(id, Some(newSyndicationRights))), fiveSeconds)
 


### PR DESCRIPTION
This allows users to batch add syndication to leases to collections of images when syndication leases are already present.

If a syndication is lease is present, the user is prompted with a warning, as continuing will remove any previous syndication leases with the incoming syndication lease.

This wasn't possible before -- the user would be confronted with a stern dialog.

![batch-lease](https://user-images.githubusercontent.com/7767575/52877343-9b5a2900-3151-11e9-8702-58c379066a1c.gif)