### PR TITLE
Refactor; pull up auth keystore bucket name config.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -30,11 +30,10 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
   )
 
   // API key errors
-  val invalidApiKeyResult    = respondError(Unauthorized, "invalid-api-key", "Invalid API key provided", loginLinks)
+  val invalidApiKeyResult = respondError(Unauthorized, "invalid-api-key", "Invalid API key provided", loginLinks)
 
   private val headerKey = "X-Gu-Media-Key"
-  private val keyStoreBucket: String = config.properties("auth.keystore.bucket")
-  val keyStore = new KeyStore(keyStoreBucket, config)
+  val keyStore = new KeyStore(config.authKeyStoreBucket, config)
 
   keyStore.scheduleUpdates(actorSystem.scheduler)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -35,6 +35,8 @@ trait CommonConfig {
 
   lazy val awsRegion = properties.getOrElse("aws.region", "eu-west-1")
 
+  lazy val authKeyStoreBucket = properties("auth.keystore.bucket")
+
   def withAWSCredentials[T, S <: AwsClientBuilder[S, T]](builder: AwsClientBuilder[S, T]): S = builder
     .withRegion(awsRegion)
     .withCredentials(awsCredentials)


### PR DESCRIPTION
2 motives. The native properties implementation should be private to the configuration provider; pushing up to a named field in the config class documents it as a thing you need to run the grid.