### PR TITLE
Explicitly reduce batch size due to Kinesis rate limiting.

### DIFF
--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -49,6 +49,7 @@ class ThrallMessageConsumer(config: ThrallConfig,
       credentialsProvider,
       workerId
     ).withRegionName(config.awsRegion).
+      withMaxRecords(10).
       withIdleTimeBetweenReadsInMillis(250)
 
     from.fold(


### PR DESCRIPTION
Batch sizes of less than 100 are enough to trip the single shard rate limit. Not great.