### PR TITLE
Mirror RCS updates arriving via SQS onto Kinesis during migration work.

### DIFF
--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -1,6 +1,6 @@
 package lib
 
-import com.gu.mediaservice.lib.aws.MessageConsumer
+import com.gu.mediaservice.lib.aws.{Kinesis, MessageConsumer}
 import org.joda.time.DateTime
 import play.api.libs.json.JsValue
 
@@ -20,7 +20,9 @@ class ThrallMessageConsumer(
   thrallMetrics.snsMessage
 ) with MessageConsumerVersion {
 
-  val messageProcessor = new MessageProcessor(es, store, metadataNotifications, syndicationRightsOps)
+  val kinesis: Kinesis = new Kinesis(config, config.thrallKinesisStream)
+
+  val messageProcessor = new MessageProcessor(es, store, metadataNotifications, syndicationRightsOps, kinesis)
 
   override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] = {
     messageProcessor.chooseProcessor(subject)


### PR DESCRIPTION
Not possible to insert them from the RCS lambda at this time.