### PR TITLE
add a failing test

### DIFF
--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -134,6 +134,30 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
       lease = None,
       usageRights = staffPhotographer,
       usages = List(createDigitalUsage(date = DateTime.now))
-    )
+    ),
+
+    // TODO this test image *should* be in `AwaitingReviewForSyndication` but instead its in `BlockedForSyndication`
+    // see https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html to understand why
+    //    createImageForSyndication(
+    //      id = "active-deny-syndication-with-expired-crop",
+    //      rightsAcquired = true,
+    //      Some(DateTime.parse("2018-01-01T00:00:00")),
+    //      None
+    //    ).copy(
+    //      leases =  LeasesByMedia(
+    //        lastModified = None,
+    //        leases = List(
+    //          createLease(
+    //            DenySyndicationLease,
+    //            imageId = "syndication-review-foo"
+    //          ),
+    //          createLease(
+    //            AllowUseLease,
+    //            imageId = "syndication-review-foo",
+    //            endDate = Some(DateTime.now().minusDays(100))
+    //          )
+    //        )
+    //      )
+    //    )
   )
 }


### PR DESCRIPTION
add a commented out test to document the scenario of "images getting stuck in the syndication review queue"

this is in place of https://github.com/guardian/grid/pull/2424