### PR TITLE
Slow down kinesis updates to try to avoid Elastic version errors duri…

### DIFF
--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -73,6 +73,8 @@ class ThrallEventConsumer(es: ElasticSearchVersion,
             Logger.error("Exception during process record block", e)
         }
 
+        // Eventual consistency is an issue during migration
+        Thread.sleep(200)
       }
 
       checkpointer.checkpoint(records.asScala.last)


### PR DESCRIPTION
…ng rewind (and rapid usage updates from Composer).