### PR TITLE
allow cropType to be cleared

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -15,7 +15,9 @@ crop.controller('ImageCropCtrl',
     const ctrl = this;
     const imageId = $stateParams.imageId;
     if ($stateParams.cropType) {
-        storage.setJs('cropType', $stateParams.cropType, true);
+        $stateParams.cropType === 'all'
+            ? storage.clearJs('cropType')
+            : storage.setJs('cropType', $stateParams.cropType, true);
     }
     ctrl.cropType = storage.getJs('cropType', true);
 

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -1,25 +1,26 @@
 import angular from 'angular';
 
 import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
+import {cropUtil} from '../util/crop';
 
-var crop = angular.module('kahuna.crop.controller', ['gr.keyboardShortcut']);
+var crop = angular.module('kahuna.crop.controller', ['gr.keyboardShortcut', cropUtil.name]);
 
 crop.controller('ImageCropCtrl',
                 ['$scope', '$rootScope', '$stateParams', '$state',
                  '$filter', '$document', 'mediaApi', 'mediaCropper',
-                 'image', 'optimisedImageUri', 'keyboardShortcut', 'storage',
+                 'image', 'optimisedImageUri', 'keyboardShortcut', 'cropType',
                  function($scope, $rootScope, $stateParams, $state,
                           $filter, $document, mediaApi, mediaCropper,
-                          image, optimisedImageUri, keyboardShortcut, storage) {
+                          image, optimisedImageUri, keyboardShortcut, cropType) {
 
     const ctrl = this;
     const imageId = $stateParams.imageId;
+
     if ($stateParams.cropType) {
-        $stateParams.cropType === 'all'
-            ? storage.clearJs('cropType')
-            : storage.setJs('cropType', $stateParams.cropType, true);
+        cropType.set($stateParams.cropType);
     }
-    ctrl.cropType = storage.getJs('cropType', true);
+
+    ctrl.cropType = cropType.get();
 
     keyboardShortcut.bindTo($scope)
         .add({

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -149,7 +149,9 @@ image.controller('ImageCtrl', [
         ctrl.image.allCrops = [];
 
         if ($stateParams.cropType) {
-            storage.setJs('cropType', $stateParams.cropType, true);
+            $stateParams.cropType === 'all'
+                ? storage.clearJs('cropType')
+                : storage.setJs('cropType', $stateParams.cropType, true);
         }
 
         ctrl.cropType = storage.getJs('cropType', true);

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 
 import '../util/rx';
+import {cropUtil} from '../util/crop';
 import '../services/image/usages';
 import '../image/service';
 
@@ -25,6 +26,7 @@ import '../components/gu-date/gu-date';
 
 var image = angular.module('kahuna.image.controller', [
     'util.rx',
+    cropUtil.name,
     'kahuna.edits.service',
     'gr.image.service',
     'gr.image-usages.service',
@@ -66,7 +68,7 @@ image.controller('ImageCtrl', [
     'imageService',
     'imageUsagesService',
     'keyboardShortcut',
-    'storage',
+    'cropType',
 
     function ($rootScope,
               $scope,
@@ -85,7 +87,7 @@ image.controller('ImageCtrl', [
               imageService,
               imageUsagesService,
               keyboardShortcut,
-              storage) {
+              cropType) {
 
         let ctrl = this;
 
@@ -149,12 +151,10 @@ image.controller('ImageCtrl', [
         ctrl.image.allCrops = [];
 
         if ($stateParams.cropType) {
-            $stateParams.cropType === 'all'
-                ? storage.clearJs('cropType')
-                : storage.setJs('cropType', $stateParams.cropType, true);
+            cropType.set($stateParams.cropType);
         }
 
-        ctrl.cropType = storage.getJs('cropType', true);
+        ctrl.cropType = cropType.get();
         ctrl.capitalisedCropType = ctrl.cropType ?
             ctrl.cropType[0].toUpperCase() + ctrl.cropType.slice(1) :
             '';

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -4,7 +4,7 @@ import Rx from 'rx';
 import 'rx-dom';
 import Immutable from 'immutable';
 import {getCollectionsFromQuery} from '../search-query/query-syntax';
-
+import {cropUtil} from '../util/crop';
 import './query';
 import './results';
 import '../preview/image';
@@ -36,7 +36,8 @@ export var search = angular.module('kahuna.search', [
     'gr.keyboardShortcut',
     'grInfoPanel',
     'grCollectionsPanel',
-    'ui.router'
+    'ui.router',
+    cropUtil.name
 ]);
 
 // TODO: add a resolver here so that if we error (e.g. 401) we don't keep trying
@@ -75,16 +76,14 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         controllerAs: 'ctrl',
         controller: [
             '$scope', '$window', '$stateParams', 'panels', 'shortcutKeys', 'keyboardShortcut',
-            'panelService', 'storage',
+            'panelService', 'cropType',
             function($scope, $window, $stateParams, panels, shortcutKeys, keyboardShortcut,
-                     panelService, storage) {
+                     panelService, cropType) {
 
             const ctrl = this;
 
             if ($stateParams.cropType) {
-                $stateParams.cropType === 'all'
-                    ? storage.clearJs('cropType')
-                    : storage.setJs('cropType', $stateParams.cropType, true);
+                cropType.set($stateParams.cropType);
             }
 
             ctrl.collectionsPanel = panels.collectionsPanel;

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -82,7 +82,9 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             const ctrl = this;
 
             if ($stateParams.cropType) {
-                storage.setJs('cropType', $stateParams.cropType, true);
+                $stateParams.cropType === 'all'
+                    ? storage.clearJs('cropType')
+                    : storage.setJs('cropType', $stateParams.cropType, true);
             }
 
             ctrl.collectionsPanel = panels.collectionsPanel;

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -1,0 +1,28 @@
+import angular from 'angular';
+
+const STORAGE_KEY = 'cropType';
+
+export const cropUtil = angular.module('util.crop', ['util.storage']);
+
+// freeze available crop types based on `cropType` query string
+cropUtil.factory('cropType', ['storage', function(storage) {
+    function set(cropType) {
+        if (!cropType) {
+            return;
+        }
+
+        // TODO validate input, if invalid crop name, clear storage?
+        cropType === 'all'
+            ? storage.clearJs(STORAGE_KEY)
+            : storage.setJs(STORAGE_KEY, cropType, true);
+    }
+
+    function get() {
+        return storage.getJs(STORAGE_KEY, true);
+    }
+
+    return {
+        set,
+        get
+    };
+}]);

--- a/kahuna/public/js/util/storage.js
+++ b/kahuna/public/js/util/storage.js
@@ -23,8 +23,14 @@ storage.factory('storage', ['$window', function($window) {
         }
     }
 
+    function clearJs(key) {
+        $window.sessionStorage.removeItem(key);
+        $window.localStorage.removeItem(key);
+    }
+
     return {
         setJs,
-        getJs
+        getJs,
+        clearJs
     };
 }]);


### PR DESCRIPTION
Setting the `cropType` query string will set a value in session storage, which is later read to freeze the crop type available. This is useful in embedded Grid when the ratio matters, for example a video thumbnail should be a 16:9 ratio.

Allow session storage to be cleared if `cropType === 'all'`. That is, we're happy to crop to any ratio.