### PR TITLE
fix odd date issue

### DIFF
--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -20,8 +20,8 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
     createImage(UUID.randomUUID().toString, Handout(), usages = List(createDigitalUsage())),
 
     // with user metadata
-    createImage(id = "test-image-13-edited", Handout()).copy(userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author")))), uploadTime = DateTime.now.minusDays(25)),
-    createImage(id = "test-image-14-unedited", Handout()).copy(uploadTime = DateTime.now.minusDays(25)),
+    createImage(id = "test-image-13-edited", Handout()).copy(userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author")))), uploadTime = DateTime.now.minusMonths(1)),
+    createImage(id = "test-image-14-unedited", Handout()).copy(uploadTime = DateTime.now.minusMonths(1)),
 
     // available for syndication
     createImageForSyndication(


### PR DESCRIPTION
When performing ES date aggregations, we're using [the month as the interval](https://github.com/guardian/grid/blob/master/media-api/app/lib/elasticsearch/impls/elasticsearch1/ElasticSearch.scala#L154-L161).

Our test images would sometimes span two months and sometimes one month, this is because we were doing:
- Image A uploaded today
- [Image B uploaded 25 days ago](https://github.com/guardian/grid/blob/master/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala#L23-L24)

Between 26th and 31st of every month, [this test](https://github.com/guardian/grid/blob/master/media-api/test/lib/elasticsearch/impls/elasticsearch1/MediaApiElasticSearch1Test.scala#L100-L106) would fail because the number of monthly buckets would be one. However from 1st to 25th of every month, there would be two monthly buckets and the tests would pass.

Image B was a [fairly recent addition](https://github.com/guardian/grid/pull/2410), hence we've never seen this behaviour until now.