### PR TITLE
add delete usages component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,11 +3,8 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-*.{scala,yml,yaml}
-indent_size = 2

--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.css
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.css
@@ -1,20 +1,21 @@
 gr-confirm-delete {
-    width: inherit;
+  width: inherit;
 }
 
 .gr-confirm-delete {
-    line-height: inherit;
+  line-height: inherit;
+  width: 100%
 }
 .gr-confirm-delete:hover {
-    color: white;
-    background-color: #666666;
+  color: white;
+  background-color: #666666;
 }
 
 .gr-confirm-delete--confirm {
-    color: white;
-    background: red;
+  color: white;
+  background: red;
 }
 
 .gr-confirm-delete--confirm:hover {
-    background-color: #960000;
+  background-color: #960000;
 }

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.css
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.css
@@ -1,0 +1,3 @@
+gr-delete-usages {
+  display: block;
+}

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.html
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.html
@@ -1,0 +1,5 @@
+<gr-confirm-delete
+  ng:if="ctrl.active"
+  gr:label="Delete ALL usages"
+  gr:on-confirm="ctrl.delete()">
+</gr-confirm-delete>

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.html
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.html
@@ -1,5 +1,5 @@
 <gr-confirm-delete
-  ng:if="ctrl.active"
+  ng:if="ctrl.userHasPermission"
   gr:label="Delete ALL usages"
   gr:on-confirm="ctrl.delete()">
 </gr-confirm-delete>

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
@@ -1,0 +1,60 @@
+import angular from 'angular';
+
+import template from './gr-delete-usages.html';
+import './gr-delete-usages.css';
+
+import {confirmDelete} from '../gr-confirm-delete/gr-confirm-delete';
+import {imageUsagesService} from '../../services/image/usages';
+
+export const deleteUsages = angular.module('gr.deleteUsages', [
+  confirmDelete.name,
+  imageUsagesService.name
+]);
+
+deleteUsages.controller('grDeleteUsagesCtrl', [
+  '$window',
+  'imageUsagesService',
+  function($window, imageUsagesService) {
+    const ctrl = this;
+
+    ctrl.active = false;
+
+    imageUsagesService.canDeleteUsages(ctrl.image).then(deleteUsages => {
+      if (!deleteUsages) {
+        ctrl.active = false;
+        return;
+      }
+
+      ctrl.active = true;
+
+      ctrl.delete = () => {
+        const deleteConfirmText = 'DELETE';
+
+        const superSure = $window.prompt(
+          `You're about to delete the ALL USAGES for this image. 
+          This will NOT remove the image from content, 
+          however it will remove it from Grid's database.
+          Type ${deleteConfirmText} below to confirm.`
+        );
+
+        if (superSure === deleteConfirmText) {
+          deleteUsages().then(ctrl.onDelete);
+        }
+      };
+    });
+  }
+]);
+
+deleteUsages.directive('grDeleteUsages', [function () {
+  return {
+    restrict: 'E',
+    controller: 'grDeleteUsagesCtrl',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    template: template,
+    scope: {
+      image: '=grImage',
+      onDelete: '&grOnDelete'
+    }
+  };
+}]);

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
@@ -6,15 +6,19 @@ import './gr-delete-usages.css';
 import {confirmDelete} from '../gr-confirm-delete/gr-confirm-delete';
 import {imageUsagesService} from '../../services/image/usages';
 
+import {string} from '../../util/string';
+
 export const deleteUsages = angular.module('gr.deleteUsages', [
   confirmDelete.name,
-  imageUsagesService.name
+  imageUsagesService.name,
+  string.name
 ]);
 
 deleteUsages.controller('grDeleteUsagesCtrl', [
   '$window',
   'imageUsagesService',
-  function($window, imageUsagesService) {
+  'stripMargin',
+  function($window, imageUsagesService, stripMargin) {
     const ctrl = this;
 
     ctrl.active = false;
@@ -31,10 +35,13 @@ deleteUsages.controller('grDeleteUsagesCtrl', [
         const deleteConfirmText = 'DELETE';
 
         const superSure = $window.prompt(
-          `You're about to delete the ALL USAGES for this image. 
-          This will NOT remove the image from content, 
-          however it will remove it from Grid's database.
-          Type ${deleteConfirmText} below to confirm.`
+          stripMargin`
+            |You're about to delete the ALL USAGES for this image.
+            |This will NOT remove the image from content,
+            |however it will remove it from Grid's database.
+            |
+            |Enter ${deleteConfirmText} below to confirm.
+            |`
         );
 
         if (superSure === deleteConfirmText) {

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
@@ -21,15 +21,15 @@ deleteUsages.controller('grDeleteUsagesCtrl', [
   function($window, imageUsagesService, stripMargin) {
     const ctrl = this;
 
-    ctrl.active = false;
+    ctrl.userHasPermission = false;
 
     imageUsagesService.canDeleteUsages(ctrl.image).then(deleteUsages => {
       if (!deleteUsages) {
-        ctrl.active = false;
+        ctrl.userHasPermission = false;
         return;
       }
 
-      ctrl.active = true;
+      ctrl.userHasPermission = true;
 
       ctrl.delete = () => {
         const deleteConfirmText = 'DELETE';

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
@@ -1,3 +1,9 @@
 <div ng-repeat="(type, usages) in ctrl.usages">
-    <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages"></gr-image-usage-list>
+  <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages"></gr-image-usage-list>
 </div>
+
+<gr-delete-usages
+  ng:if="ctrl.usagesCount > 0"
+  gr:image="ctrl.image"
+  gr:on-delete="ctrl.onUsagesDeleted()">
+</gr-delete-usages>

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
@@ -8,86 +8,95 @@ import usageTemplate from './gr-image-usage-list.html';
 import './gr-image-usage.css';
 
 import '../../services/image/usages';
+import {deleteUsages} from '../gr-delete-usages/gr-delete-usages';
 
 export const module = angular.module('gr.imageUsage', [
-    'gr.image-usages.service',
-    'util.rx'
+  'gr.image-usages.service',
+  'util.rx',
+  deleteUsages.name
 ]);
 
 module.controller('grImageUsageCtrl', [
-    '$scope',
-    'inject$',
-    'imageUsagesService',
+  '$scope',
+  '$state',
+  'inject$',
+  'imageUsagesService',
 
-    function ($scope, inject$, imageUsagesService) {
+  function ($scope, $state, inject$, imageUsagesService) {
 
-        const ctrl = this;
+    const ctrl = this;
 
-        const usages = imageUsagesService.getUsages(ctrl.image);
+    const usages = imageUsagesService.getUsages(ctrl.image);
 
-        const usages$ = usages.groupedByState$.map((u) => u.toJS());
-        const usagesCount$ = usages.count$;
+    const usages$ = usages.groupedByState$.map((u) => u.toJS());
+    const usagesCount$ = usages.count$;
 
-      // TODO match on `platform` rather than `type` as `platform` includes more detail
-        ctrl.usageTypeToName = (usageType) => {
-            switch (usageType) {
-                case 'removed':
-                    return 'Taken down';
-                case 'pending':
-                    return 'Pending publication';
-                case 'published':
-                    return 'Published';
-                case 'unknown':
-                    return 'Front'; // currently only fronts have an `unknown` type, see TODO above
-                default:
-                    return usageType;
-            }
-        };
+    // TODO match on `platform` rather than `type` as `platform` includes more detail
+    ctrl.usageTypeToName = (usageType) => {
+      switch (usageType) {
+        case 'removed':
+          return 'Taken down';
+        case 'pending':
+          return 'Pending publication';
+        case 'published':
+          return 'Published';
+        case 'unknown':
+          return 'Front'; // currently only fronts have an `unknown` type, see TODO above
+        default:
+          return usageType;
+      }
+    };
 
-        inject$($scope, usages$, ctrl, 'usages');
-        inject$($scope, usagesCount$, ctrl, 'usagesCount');
-}]);
+    ctrl.onUsagesDeleted = () => {
+      // a bit nasty - but it updates the state of the page better than trying to do that in
+      // the client.
+      $state.go('image', {imageId: ctrl.image.data.id, crop: undefined}, {reload: true});
+    };
+
+    inject$($scope, usages$, ctrl, 'usages');
+    inject$($scope, usagesCount$, ctrl, 'usagesCount');
+  }]);
 
 module.directive('grImageUsage', [function() {
-    return {
-        restrict: 'E',
-        template: template,
-        controller: 'grImageUsageCtrl',
-        controllerAs: 'ctrl',
-        bindToController: true,
-        scope: {
-            image: '=grImage'
-        }
-    };
+  return {
+    restrict: 'E',
+    template: template,
+    controller: 'grImageUsageCtrl',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      image: '=grImage'
+    }
+  };
 }]);
 
 module.controller('grImageUsageListCtrl', [
-    'imageUsagesService',
-    function (imageUsagesService) {
+  'imageUsagesService',
+  function (imageUsagesService) {
     const ctrl = this;
 
     ctrl.formatTimestamp = (timestamp) => {
-        return moment(timestamp).fromNow();
+      return moment(timestamp).fromNow();
     };
 
     ctrl.isRecent = (timestamp) => {
-        const nowtime = new Date();
-        return moment(timestamp)
-            .isAfter(moment(nowtime).subtract(imageUsagesService.recentTime, 'days'));
+      const nowtime = new Date();
+      return moment(timestamp)
+        .isAfter(moment(nowtime).subtract(imageUsagesService.recentTime, 'days'));
     };
-}]);
+  }]);
 
 
 module.directive('grImageUsageList', [function () {
-    return {
-        restrict: 'E',
-        template: usageTemplate,
-        controller: 'grImageUsageListCtrl',
-        controllerAs: 'ctrl',
-        bindToController: true,
-        scope: {
-            type: '=',
-            usages: '='
-        }
-    };
+  return {
+    restrict: 'E',
+    template: usageTemplate,
+    controller: 'grImageUsageListCtrl',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      type: '=',
+      usages: '='
+    }
+  };
 }]);

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -5,84 +5,94 @@ import moment from 'moment';
 import Rx from 'rx';
 
 export const imageUsagesService = angular.module('gr.image-usages.service', [
-        'kahuna.edits.service'
+  'kahuna.edits.service'
 ]);
 
 
 imageUsagesService.factory('imageUsagesService', [function() {
+  const recentDays = 7;
 
-    const recentDays = 7;
+  function canDeleteUsages(image) {
+    const actionName = 'delete-usages';
+    return image.getAction(actionName).then(action => {
+      if (action) {
+        // return a function that performs the action
+        return () => image.perform(actionName);
+      }
+    });
+  }
 
-    return {
-        getUsages: (imageResource) => {
+  return {
+    canDeleteUsages,
+    getUsages: (imageResource) => {
 
-            function frontsUsageTitle(usage) {
-              const metadata = usage.get('frontUsageMetadata');
-              return `${metadata.get('front')}, ${metadata.get('addedBy')}`;
-            }
+      function frontsUsageTitle(usage) {
+        const metadata = usage.get('frontUsageMetadata');
+        return `${metadata.get('front')}, ${metadata.get('addedBy')}`;
+      }
 
-            function usageTitle(usage) {
-                if (usage.has('frontUsageMetadata')) {
-                  return frontsUsageTitle(usage);
-                }
-                const referenceType =
-                    usage.get('platform') == 'print' ? 'indesign' : 'frontend';
+      function usageTitle(usage) {
+        if (usage.has('frontUsageMetadata')) {
+          return frontsUsageTitle(usage);
+        }
+        const referenceType =
+          usage.get('platform') === 'print' ? 'indesign' : 'frontend';
 
-                const reference = usage.get('references').find(u =>
-                        u.get('type') == referenceType);
+        const reference = usage.get('references').find(u =>
+          u.get('type') === referenceType);
 
-                return (reference && reference.get('name')) ?
-                    reference.get('name') : 'No title found.';
-            }
+        return (reference && reference.get('name')) ?
+          reference.get('name') : 'No title found.';
+      }
 
-            const image$ = Rx.Observable.fromPromise(imageResource.getData());
+      const image$ = Rx.Observable.fromPromise(imageResource.getData());
 
-            const usages$ = image$
-                .flatMap((image) =>
-                    Rx.Observable.fromPromise(image.usages.getData()))
-                .flatMap((usages) => usages.map(usage => usage.getData()))
-                .flatMap(Rx.Observable.fromPromise)
-                .toArray()
-                .map((usages) =>
-                    Immutable.fromJS(usages).map(usage =>
-                        usage.set('title', usageTitle(usage))));
+      const usages$ = image$
+        .flatMap((image) =>
+          Rx.Observable.fromPromise(image.usages.getData()))
+        .flatMap((usages) => usages.map(usage => usage.getData()))
+        .flatMap(Rx.Observable.fromPromise)
+        .toArray()
+        .map((usages) =>
+          Immutable.fromJS(usages).map(usage =>
+            usage.set('title', usageTitle(usage))));
 
-            const filterByPlatform = (platform) => usages$.map((usagesList) =>
-                usagesList.filter(usage => usage.get('platform') == platform));
+      const filterByPlatform = (platform) => usages$.map((usagesList) =>
+        usagesList.filter(usage => usage.get('platform') === platform));
 
-            const hasPlatformUsages = (platform) =>
-                filterByPlatform(platform).every((group) => !group.isEmpty());
+      const hasPlatformUsages = (platform) =>
+        filterByPlatform(platform).every((group) => !group.isEmpty());
 
-            const recentUsages$ = usages$.map((usagesList) => {
-                    return usagesList.filter(item=> {
-                        const timestamp = item.get('dateAdded');
-                        const recentIfAfter = moment().subtract(recentDays, 'days');
-                        return moment(timestamp).isAfter(recentIfAfter);
-                    });
-                });
+      const recentUsages$ = usages$.map((usagesList) => {
+        return usagesList.filter(item=> {
+          const timestamp = item.get('dateAdded');
+          const recentIfAfter = moment().subtract(recentDays, 'days');
+          return moment(timestamp).isAfter(recentIfAfter);
+        });
+      });
 
 
-            const groupedByState$ = usages$
-                .map((usagesList) => usagesList.groupBy(usage => usage.get('status')));
+      const groupedByState$ = usages$
+        .map((usagesList) => usagesList.groupBy(usage => usage.get('status')));
 
-            const hasPrintUsages$ = hasPlatformUsages('print');
-            const hasDigitalUsages$ = hasPlatformUsages('digital');
-            const count$ = usages$.map((usages) => usages.size);
+      const hasPrintUsages$ = hasPlatformUsages('print');
+      const hasDigitalUsages$ = hasPlatformUsages('digital');
+      const count$ = usages$.map((usages) => usages.size);
 
-            return {
-                usages$,
-                groupedByState$,
-                hasPrintUsages$,
-                hasDigitalUsages$,
-                count$,
-                recentUsages$
-            };
-        },
-        /*
-         //If a usage is newer than this number of days,
-          then consider it as "recent" and show a warning
-         */
-        recentTime: recentDays
-    };
+      return {
+        usages$,
+        groupedByState$,
+        hasPrintUsages$,
+        hasDigitalUsages$,
+        count$,
+        recentUsages$
+      };
+    },
+    /*
+     //If a usage is newer than this number of days,
+      then consider it as "recent" and show a warning
+     */
+    recentTime: recentDays
+  };
 
 }]);

--- a/kahuna/public/js/util/string.js
+++ b/kahuna/public/js/util/string.js
@@ -8,3 +8,8 @@ string.value('humanJoin', function humanJoin(list, joiner) {
     const lastTwo = list.slice(-2).join(` ${joiner} `);
     return allButLastTwo.concat(lastTwo).join(', ');
 });
+
+string.value('stripMargin', function(template, ...args) {
+  const result = template.reduce((acc, part, i) => acc + args[i - 1] + part);
+  return result.replace(/\r?(\n)\s*\|/g, '$1');
+});

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -218,6 +218,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val addLeasesUri = URI.create(s"${config.leasesUri}/leases")
     val replaceLeasesUri = URI.create(s"${config.leasesUri}/leases/media/$id")
     val deleteLeasesUri = URI.create(s"${config.leasesUri}/leases/media/$id")
+    val deleteUsagesUri = URI.create(s"${config.usageUri}/usages/media/$id")
 
     val deleteAction = Action("delete", imageUri, "DELETE")
     val reindexAction = Action("reindex", reindexUri, "POST")
@@ -227,6 +228,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val addLeasesAction = Action("add-lease", addLeasesUri, "POST")
     val replaceLeasesAction = Action("replace-leases", replaceLeasesUri, "POST")
     val deleteLeasesAction = Action("delete-leases", deleteLeasesUri, "DELETE")
+    val deleteUsagesAction = Action("delete-usages", deleteUsagesUri, "DELETE")
 
     List(
       deleteAction        -> isDeletable,
@@ -234,6 +236,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       addLeasesAction     -> withWritePermission,
       replaceLeasesAction -> withWritePermission,
       deleteLeasesAction  -> withWritePermission,
+      deleteUsagesAction  -> withWritePermission,
       addCollectionAction -> true
     )
     .filter{ case (action, active) => active }


### PR DESCRIPTION
We have an endpoint in the usages app to delete all usages for an image. This creates a button to expose the endpoint to users via Kahuna.

The component will only appear if you have `delete_crops` permission.

![delete-usages](https://user-images.githubusercontent.com/836140/53414834-92761c80-39c7-11e9-876f-60f9637ecba3.gif)
