### PR TITLE
only set either local or session storage

### DIFF
--- a/kahuna/public/js/util/storage.js
+++ b/kahuna/public/js/util/storage.js
@@ -7,9 +7,9 @@ storage.factory('storage', ['$window', function($window) {
 
         if (toSessionStorage) {
             $window.sessionStorage.setItem(key, JSON.stringify(val));
+        } else {
+            $window.localStorage.setItem(key, JSON.stringify(val));
         }
-
-        $window.localStorage.setItem(key, JSON.stringify(val));
     }
 
     function getJs(key, fromSessionStorage) {


### PR DESCRIPTION
TL;DR only write to the location that is going to be read from.

We use local storage to store preferences such as which panels are locked open and what preset labels you've added on the upload screen.

We've recently extended this to idea to using session storage to restrict the crop type allowed. This is necessary for tools that embed Grid via an iframe. Session storage is useful in this scenario as its less persistent than local storage ([docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)).

This change updates the way we write to either of these stores. Previously we would write to both, however this makes debugging harder. Writing to one place brings `setJs` inline with [`getJs`](https://github.com/guardian/grid/blob/master/kahuna/public/js/util/storage.js#L16-L18) in that its writing to one location based on the `toSessionStorage` value.