### PR TITLE
Normalise new lines when read from database

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
@@ -5,6 +5,8 @@ import scala.util.Try
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.format.DateTimeFormatterBuilder
+import scalaz.Functor
+import scalaz.std.option._
 
 package object formatting {
 
@@ -39,4 +41,7 @@ package object formatting {
 
   def parseDuration(string: String): Option[Duration] =
     Try(Duration(string)).toOption
+
+  def normaliseNewLines(string: String): String = string.replaceAll("(\\r|\\n|\\r\\n)+", "\n")
+  def optNormaliseNewLines = Functor[Option].lift(normaliseNewLines)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -31,17 +31,17 @@ object ImageMetadata {
 
   implicit val ImageMetadataReads: Reads[ImageMetadata] = (
     (__ \ "dateTaken").readNullable[String].map(_.flatMap(parseDateTime)) ~
-      (__ \ "description").readNullable[String] ~
+      (__ \ "description").readNullable[String].map(optNormaliseNewLines) ~
       (__ \ "credit").readNullable[String] ~
       (__ \ "creditUri").readNullable[String] ~
       (__ \ "byline").readNullable[String] ~
       (__ \ "bylineTitle").readNullable[String] ~
       (__ \ "title").readNullable[String] ~
-      (__ \ "copyrightNotice").readNullable[String] ~
-      (__ \ "copyright").readNullable[String] ~
-      (__ \ "suppliersReference").readNullable[String] ~
+      (__ \ "copyrightNotice").readNullable[String].map(optNormaliseNewLines) ~
+      (__ \ "copyright").readNullable[String].map(optNormaliseNewLines) ~
+      (__ \ "suppliersReference").readNullable[String].map(optNormaliseNewLines) ~
       (__ \ "source").readNullable[String] ~
-      (__ \ "specialInstructions").readNullable[String] ~
+      (__ \ "specialInstructions").readNullable[String].map(optNormaliseNewLines) ~
       (__ \ "keywords").readNullable[List[String]].map(_ getOrElse Nil) ~
       (__ \ "subLocation").readNullable[String] ~
       (__ \ "city").readNullable[String] ~

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/formatting/NewLineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/formatting/NewLineTest.scala
@@ -1,0 +1,23 @@
+package com.gu.mediaservice.lib.formatting
+
+import org.scalatest.{FunSpec, Matchers}
+
+class NewLineTest extends FunSpec with Matchers {
+  it("should replace \\r linebreaks with \\n") {
+    val text = "Here is some text\rthat spans across\rmultiple lines\r"
+    val normalisedText = normaliseNewLines(text)
+    normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+
+  it("should replace \\r\\n linebreaks with \\n") {
+    val text = "Here is some text\r\nthat spans across\r\nmultiple lines\r\n"
+    val normalisedText = normaliseNewLines(text)
+    normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+
+  it("should not touch \\n linebreaks") {
+    val text = "Here is some text\nthat spans across\nmultiple lines\n"
+    val normalisedText = normaliseNewLines(text)
+    normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+}


### PR DESCRIPTION
The use of `\r` line endings instead of `\n` causes problems with presentation and behaviour of kahuna. The aim of this PR is to eliminate the issue of having different newline types stored in ES by normalising image metadata as it is retrieved from the database.

I've implemented this in the JSON reader implementation so as to be reasonably clean and normalise the data as soon as possible after leaving the DB layer. This is possibly contentious as it might be better to do this a little later and make the implementation clearer. As far as I'm aware there is no precedent for this but I'd be glad to be pointed to any examples.

This is an alternative approach to #2470 and only one should be merged (the one with the most approvals??)