### PR TITLE
Normalise newlines when preparing image responses for API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,8 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
     "org.apache.commons" % "commons-email" % "1.5",
     "org.parboiled" %% "parboiled" % "2.1.5",
     "org.http4s" %% "http4s-core" % "0.18.7",
-    "org.mockito" % "mockito-core" % "2.18.0"
+    "org.mockito" % "mockito-core" % "2.18.0",
+    "com.softwaremill.quicklens" %% "quicklens" % "1.4.11"
   )
 ).settings(testSettings)
 

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -1,0 +1,23 @@
+package lib
+
+import org.scalatest.{FunSpec, Matchers}
+
+class ImageResponseTest extends FunSpec with Matchers {
+  it("should replace \\r linebreaks with \\n") {
+    val text = "Here is some text\rthat spans across\rmultiple lines\r"
+    val normalisedText = ImageResponse.normaliseNewLines(text)
+    normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+
+  it("should replace \\r\\n linebreaks with \\n") {
+    val text = "Here is some text\r\nthat spans across\r\nmultiple lines\r\n"
+    val normalisedText = ImageResponse.normaliseNewLines(text)
+    normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+
+  it("should not touch \\n linebreaks") {
+    val text = "Here is some text\nthat spans across\nmultiple lines\n"
+    val normalisedText = ImageResponse.normaliseNewLines(text)
+    normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+}


### PR DESCRIPTION
The use of `\r` line endings instead of `\n` causes problems with presentation and behaviour of kahuna. The aim of this PR is to eliminate the issue of having different newline types stored in ES by normalising image metadata as it is prepared to be sent to the client.

I've implemented this in `ImageResponse` class so as to leave the change until it's about to leave the server. This localises the change and should reduce the possibility of introducing any unintended consequences. As far as I'm aware there is no precedent for this but I'd be glad to be pointed to any examples.

This is an alternative approach to #2468 and only one should be merged (the one with the most approvals??)