### PR TITLE
Generic gr-radio-list component and example usage

### DIFF
--- a/kahuna/public/js/components/gr-radio-list/gr-radio-list.css
+++ b/kahuna/public/js/components/gr-radio-list/gr-radio-list.css
@@ -1,0 +1,41 @@
+gr-radio-list {
+  display: flex;
+}
+
+gr-radio-list > * {
+  flex-grow: 1;
+}
+
+gr-radio-list input[type="radio"] {
+  display: none;
+}
+
+gr-radio-list input[type="radio"]:checked + label {
+  background-color: #666;
+  border-bottom: 3px solid #00adee;
+}
+
+gr-radio-list input[type="radio"]:disabled + label {
+  color: #666;
+}
+
+gr-radio-list input[type="radio"]:disabled + label:hover {
+  background-color: #444;
+  color: #666;
+}
+
+gr-radio-list label {
+  background-color: #444;
+  border-bottom: 3px solid transparent;
+  color: #ccc;
+  width: calc(100% - 20px);
+  display: inline-block;
+  padding: 5px 10px;
+  cursor: pointer;
+  text-align: center;
+  user-select: none;
+}
+
+gr-radio-list label:hover {
+  background-color: #666;
+}

--- a/kahuna/public/js/components/gr-radio-list/gr-radio-list.html
+++ b/kahuna/public/js/components/gr-radio-list/gr-radio-list.html
@@ -1,0 +1,11 @@
+<span ng-repeat="option in options track by option.key">
+  <input type="radio"
+         id="{{listFor}}-{{option.key}}"
+         name="selected"
+         ng-disabled="option.disabled || false"
+         ng-value="option.key"
+         ng-model="$parent.selection"/>
+  <label for="{{listFor}}-{{option.key}}" gr-tooltip="{{option.tooltip}}">
+    <span ng-if="!option.icon">{{option.value || option.key}}</span>
+  </label>
+</span>

--- a/kahuna/public/js/components/gr-radio-list/gr-radio-list.js
+++ b/kahuna/public/js/components/gr-radio-list/gr-radio-list.js
@@ -1,0 +1,18 @@
+import angular from 'angular';
+
+import './gr-radio-list.css';
+import template from './gr-radio-list.html';
+
+export const radioList = angular.module('gr.radioList', []);
+
+radioList.directive('grRadioList', [function () {
+  return {
+    restrict: 'E',
+    template,
+    scope: {
+      listFor: '@grFor',
+      options: '=grOptions',
+      selection: '=grSelectedOption'
+    }
+  };
+}]);

--- a/kahuna/public/js/components/gr-tooltip/gr-tooltip.js
+++ b/kahuna/public/js/components/gr-tooltip/gr-tooltip.js
@@ -9,6 +9,10 @@ tooltip.directive('grTooltip', [
         return {
             restrict: 'A',
             link: function ($scope, element, attrs) {
+              if (!attrs.grTooltip) {
+                return;
+              }
+
                 const position = attrs.grTooltipPosition || 'bottom';
                 element.attr('data-title', attrs.grTooltip)
                     .addClass(`titip-default`)

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -21,216 +21,234 @@ import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
 import '../components/gr-metadata-validity/gr-metadata-validity';
 import '../components/gr-display-crops/gr-display-crops';
 import '../components/gu-date/gu-date';
+import {radioList} from '../components/gr-radio-list/gr-radio-list';
 
 
-var image = angular.module('kahuna.image.controller', [
-    'util.rx',
-    'kahuna.edits.service',
-    'gr.image.service',
-    'gr.image-usages.service',
+const image = angular.module('kahuna.image.controller', [
+  'util.rx',
+  'kahuna.edits.service',
+  'gr.image.service',
+  'gr.image-usages.service',
 
-    'gr.addLabel',
-    'gr.photoshoot',
-    'gr.syndicationRights',
-    'gr.archiver',
-    'gr.collectionOverlay',
-    'gr.cropImage',
-    'gr.deleteCrops',
-    'gr.deleteImage',
-    'gr.downloader',
-    'gr.exportOriginalImage',
-    'gr.imageCostMessage',
-    'gr.imageMetadata',
-    'gr.imageUsage',
-    'gr.keyboardShortcut',
-    'gr.metadataValidity',
-    'gr.displayCrops',
-    'gu.date'
+  'gr.addLabel',
+  'gr.photoshoot',
+  'gr.syndicationRights',
+  'gr.archiver',
+  'gr.collectionOverlay',
+  'gr.cropImage',
+  'gr.deleteCrops',
+  'gr.deleteImage',
+  'gr.downloader',
+  'gr.exportOriginalImage',
+  'gr.imageCostMessage',
+  'gr.imageMetadata',
+  'gr.imageUsage',
+  'gr.keyboardShortcut',
+  'gr.metadataValidity',
+  'gr.displayCrops',
+  'gu.date',
+  radioList.name
 ]);
 
 image.controller('ImageCtrl', [
-    '$rootScope',
-    '$scope',
-    '$element',
-    '$state',
-    '$stateParams',
-    '$window',
-    '$filter',
-    'inject$',
-    'image',
-    'mediaApi',
-    'optimisedImageUri',
-    'lowResImageUri',
-    'cropKey',
-    'mediaCropper',
-    'imageService',
-    'imageUsagesService',
-    'keyboardShortcut',
-    'storage',
+  '$rootScope',
+  '$scope',
+  '$element',
+  '$state',
+  '$stateParams',
+  '$window',
+  '$filter',
+  'inject$',
+  'image',
+  'mediaApi',
+  'optimisedImageUri',
+  'lowResImageUri',
+  'cropKey',
+  'mediaCropper',
+  'imageService',
+  'imageUsagesService',
+  'keyboardShortcut',
+  'storage',
 
-    function ($rootScope,
-              $scope,
-              $element,
-              $state,
-              $stateParams,
-              $window,
-              $filter,
-              inject$,
-              image,
-              mediaApi,
-              optimisedImageUri,
-              lowResImageUri,
-              cropKey,
-              mediaCropper,
-              imageService,
-              imageUsagesService,
-              keyboardShortcut,
-              storage) {
+  function ($rootScope,
+            $scope,
+            $element,
+            $state,
+            $stateParams,
+            $window,
+            $filter,
+            inject$,
+            image,
+            mediaApi,
+            optimisedImageUri,
+            lowResImageUri,
+            cropKey,
+            mediaCropper,
+            imageService,
+            imageUsagesService,
+            keyboardShortcut,
+            storage) {
 
-        let ctrl = this;
+    let ctrl = this;
 
-        keyboardShortcut.bindTo($scope)
-            .add({
-                combo: 'c',
-                description: 'Crop image',
-                callback: () => $state.go('crop', {imageId: ctrl.image.data.id})
-            })
-            .add({
-                combo: 'f',
-                description: 'Enter fullscreen',
-                callback: () => {
-                    const imageEl = $element[0].querySelector('.easel__image');
+    keyboardShortcut.bindTo($scope)
+      .add({
+        combo: 'c',
+        description: 'Crop image',
+        callback: () => $state.go('crop', {imageId: ctrl.image.data.id})
+      })
+      .add({
+        combo: 'f',
+        description: 'Enter fullscreen',
+        callback: () => {
+          const imageEl = $element[0].querySelector('.easel__image');
 
-                    // Fullscreen API has vendor prefixing https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API/Guide#Prefixing
-                    const fullscreenElement = (
-                        document.fullscreenElement ||
-                        document.webkitFullscreenElement ||
-                        document.mozFullScreenElement
-                    );
+          // Fullscreen API has vendor prefixing https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API/Guide#Prefixing
+          const fullscreenElement = (
+            document.fullscreenElement ||
+            document.webkitFullscreenElement ||
+            document.mozFullScreenElement
+          );
 
-                    const exitFullscreen = (
-                        document.exitFullscreen ||
-                        document.webkitExitFullscreen ||
-                        document.mozCancelFullScreen
-                    );
+          const exitFullscreen = (
+            document.exitFullscreen ||
+            document.webkitExitFullscreen ||
+            document.mozCancelFullScreen
+          );
 
-                    const requestFullscreen = (
-                        imageEl.requestFullscreen ||
-                        imageEl.webkitRequestFullscreen ||
-                        imageEl.mozRequestFullScreen
-                    );
+          const requestFullscreen = (
+            imageEl.requestFullscreen ||
+            imageEl.webkitRequestFullscreen ||
+            imageEl.mozRequestFullScreen
+          );
 
-                    // `.call` to ensure `this` is bound correctly.
-                    return fullscreenElement
-                        ? exitFullscreen.call(document)
-                        : requestFullscreen.call(imageEl);
-                }
-            });
-
-        ctrl.image = image;
-        ctrl.optimisedImageUri = optimisedImageUri;
-        ctrl.lowResImageUri = lowResImageUri;
-
-        const usages = imageUsagesService.getUsages(ctrl.image);
-        const usagesCount$ = usages.count$;
-
-        const recentUsages$ = usages.recentUsages$;
-
-        inject$($scope, usagesCount$, ctrl, 'usagesCount');
-        inject$($scope, recentUsages$, ctrl, 'recentUsages');
-
-        // TODO: we should be able to rely on ctrl.crop.id instead once
-        // all existing crops are migrated to have an id (they didn't
-        // initially)
-        ctrl.cropKey = cropKey;
-
-        ctrl.cropSelected = cropSelected;
-
-        ctrl.image.allCrops = [];
-
-        if ($stateParams.cropType) {
-            storage.setJs('cropType', $stateParams.cropType, true);
+          // `.call` to ensure `this` is bound correctly.
+          return fullscreenElement
+            ? exitFullscreen.call(document)
+            : requestFullscreen.call(imageEl);
         }
+      });
 
-        ctrl.cropType = storage.getJs('cropType', true);
-        ctrl.capitalisedCropType = ctrl.cropType ?
-            ctrl.cropType[0].toUpperCase() + ctrl.cropType.slice(1) :
-            '';
+    ctrl.tabs = [
+      {key: 'metadata', value: 'Metadata'},
+      {key: 'usages', value: `Usages`, disabled: true}
+    ];
 
-        imageService(ctrl.image).states.canDelete.then(deletable => {
-            ctrl.canBeDeleted = deletable;
-        });
+    ctrl.selectedTab = 'metadata';
 
-        ctrl.allowCropSelection = (crop) => {
-          return !ctrl.cropType ||
-            $filter('asAspectRatioWord')(crop.specification.aspectRatio) === ctrl.cropType;
-        };
+    ctrl.image = image;
+    ctrl.optimisedImageUri = optimisedImageUri;
+    ctrl.lowResImageUri = lowResImageUri;
 
-        ctrl.onCropsDeleted = () => {
-            // a bit nasty - but it updates the state of the page better than trying to do that in
-            // the client.
-            $state.go('image', {imageId: ctrl.image.data.id, crop: undefined}, {reload: true});
-        };
+    const usages = imageUsagesService.getUsages(ctrl.image);
+    const usagesCount$ = usages.count$;
 
-        // TODO: move this to a more sensible place.
-        function getCropDimensions() {
-            return {
-                width: ctrl.crop.specification.bounds.width,
-                height: ctrl.crop.specification.bounds.height
-            };
-        }
-        // TODO: move this to a more sensible place.
-        function getImageDimensions() {
-            return ctrl.image.data.source.dimensions;
-        }
+    const recentUsages$ = usages.recentUsages$;
 
-        mediaCropper.getCropsFor(image).then(crops => {
-            ctrl.crop = crops.find(crop => crop.id === cropKey);
-            ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');
-            ctrl.crops = crops.filter(crop => crop.specification.type === 'crop');
-            ctrl.image.allCrops = ctrl.fullCrop ? [ctrl.fullCrop].concat(ctrl.crops) : ctrl.crops;
-            //boolean version for use in template
-            ctrl.hasFullCrop = angular.isDefined(ctrl.fullCrop);
-            ctrl.hasCrops = ctrl.crops.length > 0;
-        }).finally(() => {
-            ctrl.dimensions = angular.isDefined(ctrl.crop) ?
-                getCropDimensions() : getImageDimensions();
+    inject$($scope, usagesCount$, ctrl, 'usagesCount');
+    inject$($scope, recentUsages$, ctrl, 'recentUsages');
 
-            if (angular.isDefined(ctrl.crop)) {
-                ctrl.originalDimensions = getImageDimensions();
-            }
-        });
+    const freeUsageCountWatch = $scope.$watch('ctrl.usagesCount', value => {
+      const usageTab = ctrl.tabs.find(_ => _.key === 'usages');
+      usageTab.value = `Usages (${value > 0 ? value : 'None'})`;
+      usageTab.disabled = value === 0;
 
-        function cropSelected(crop) {
-            $rootScope.$emit('events:crop-selected', {
-                image: ctrl.image,
-                crop: crop
-            });
-        }
+      // stop watching
+      freeUsageCountWatch();
+    });
 
-        const freeImageUpdateListener = $rootScope.$on('image-updated', (e, updatedImage) => {
-            if (ctrl.image.data.id === updatedImage.data.id) {
-                ctrl.image = updatedImage;
-            }
-        });
+    // TODO: we should be able to rely on ctrl.crop.id instead once
+    // all existing crops are migrated to have an id (they didn't
+    // initially)
+    ctrl.cropKey = cropKey;
 
-        const freeImageDeleteListener = $rootScope.$on('images-deleted', () => {
-            $state.go('search');
-        });
+    ctrl.cropSelected = cropSelected;
 
-        const freeImageDeleteFailListener = $rootScope.$on('image-delete-failure', (err, image) => {
-            if (err && err.body && err.body.errorMessage) {
-                $window.alert(err.body.errorMessage);
-            } else {
-                // Possibly not receiving a proper image object sometimes?
-                const imageId = image && image.data && image.data.id || 'Unknown ID';
-                $window.alert(`Failed to delete image ${imageId}`);
-            }
-        });
+    ctrl.image.allCrops = [];
 
-        $scope.$on('$destroy', function() {
-            freeImageUpdateListener();
-            freeImageDeleteListener();
-            freeImageDeleteFailListener();
-        });
-    }]);
+    if ($stateParams.cropType) {
+      storage.setJs('cropType', $stateParams.cropType, true);
+    }
+
+    ctrl.cropType = storage.getJs('cropType', true);
+    ctrl.capitalisedCropType = ctrl.cropType ?
+      ctrl.cropType[0].toUpperCase() + ctrl.cropType.slice(1) :
+      '';
+
+    imageService(ctrl.image).states.canDelete.then(deletable => {
+      ctrl.canBeDeleted = deletable;
+    });
+
+    ctrl.allowCropSelection = (crop) => {
+      return !ctrl.cropType ||
+        $filter('asAspectRatioWord')(crop.specification.aspectRatio) === ctrl.cropType;
+    };
+
+    ctrl.onCropsDeleted = () => {
+      // a bit nasty - but it updates the state of the page better than trying to do that in
+      // the client.
+      $state.go('image', {imageId: ctrl.image.data.id, crop: undefined}, {reload: true});
+    };
+
+    // TODO: move this to a more sensible place.
+    function getCropDimensions() {
+      return {
+        width: ctrl.crop.specification.bounds.width,
+        height: ctrl.crop.specification.bounds.height
+      };
+    }
+    // TODO: move this to a more sensible place.
+    function getImageDimensions() {
+      return ctrl.image.data.source.dimensions;
+    }
+
+    mediaCropper.getCropsFor(image).then(crops => {
+      ctrl.crop = crops.find(crop => crop.id === cropKey);
+      ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');
+      ctrl.crops = crops.filter(crop => crop.specification.type === 'crop');
+      ctrl.image.allCrops = ctrl.fullCrop ? [ctrl.fullCrop].concat(ctrl.crops) : ctrl.crops;
+      //boolean version for use in template
+      ctrl.hasFullCrop = angular.isDefined(ctrl.fullCrop);
+      ctrl.hasCrops = ctrl.crops.length > 0;
+    }).finally(() => {
+      ctrl.dimensions = angular.isDefined(ctrl.crop) ?
+        getCropDimensions() : getImageDimensions();
+
+      if (angular.isDefined(ctrl.crop)) {
+        ctrl.originalDimensions = getImageDimensions();
+      }
+    });
+
+    function cropSelected(crop) {
+      $rootScope.$emit('events:crop-selected', {
+        image: ctrl.image,
+        crop: crop
+      });
+    }
+
+    const freeImageUpdateListener = $rootScope.$on('image-updated', (e, updatedImage) => {
+      if (ctrl.image.data.id === updatedImage.data.id) {
+        ctrl.image = updatedImage;
+      }
+    });
+
+    const freeImageDeleteListener = $rootScope.$on('images-deleted', () => {
+      $state.go('search');
+    });
+
+    const freeImageDeleteFailListener = $rootScope.$on('image-delete-failure', (err, image) => {
+      if (err && err.body && err.body.errorMessage) {
+        $window.alert(err.body.errorMessage);
+      } else {
+        // Possibly not receiving a proper image object sometimes?
+        const imageId = image && image.data && image.data.id || 'Unknown ID';
+        $window.alert(`Failed to delete image ${imageId}`);
+      }
+    });
+
+    $scope.$on('$destroy', function() {
+      freeImageUpdateListener();
+      freeImageDeleteListener();
+      freeImageDeleteFailListener();
+    });
+  }]);

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -117,53 +117,14 @@
 </div>
 
 <div class="image-details image-details--full-image">
-    <gr-metadata-validity gr-image="ctrl.image"></gr-metadata-validity>
-    <gr-image-cost-message gr-image="ctrl.image"></gr-image-cost-message>
+  <gr-metadata-validity gr-image="ctrl.image"></gr-metadata-validity>
+  <gr-image-cost-message gr-image="ctrl.image"></gr-image-cost-message>
+  <gr-radio-list gr-for="tabs" gr-options="ctrl.tabs" gr-selected-option="ctrl.selectedTab"></gr-radio-list>
 
-    <div ng:init="showMetadata = true">
-        <div class="radio-list">
-            <input type="radio"
-                   id="show-metadata"
-                   class="radio-list__circle"
-                   name="show-metadata"/>
-            <label for="show-metadata"
-                   class="radio-list__label"
-                   ng:class="{'radio-list--selected': showMetadata}"
-                   ng:click="showMetadata = true"
-                   gr:track-click="Image panel tab"
-                   gr:track-click-data="{ tab: 'Metadata' }">
-                <div class="radio-list__selection-state"></div>
-                <div class="radio-list__label-value">Metadata</div>
-            </label>
-
-            <input type="radio"
-                   id="show-usage"
-                   class="radio-list__circle"
-                   name="show-usage"/>
-
-            <label for="show-usage"
-                   class="radio-list__label"
-                   ng:class="
-                   {
-                    'radio-list--disabled': ctrl.usagesCount < 1,
-                    'radio-list--selected': ! showMetadata
-                   }"
-                   ng:click="(ctrl.usagesCount < 1) || (showMetadata = false)"
-                   gr:track-click="Image panel tab"
-                   gr:track-click-data="{ tab: 'Usage' }">
-                <div class="radio-list__selection-state"></div>
-                <div class="radio-list__label-value">
-                    <gr-icon ng-if="ctrl.recentUsages.count()>0" class="icon-warning invert">info_outline</gr-icon>
-                    <span class="gr-icon" style="vertical-align: middle">Usages ({{ctrl.usagesCount == 0 ? "None" : ctrl.usagesCount}})</span>
-                </div>
-            </label>
-        </div>
-
-        <div class="image-details image-details--scroll">
-            <gr-image-metadata gr-image="ctrl.image" ng:if="showMetadata"></gr-image-metadata>
-            <gr-image-usage gr-image="ctrl.image" ng:if="! showMetadata"></gr-image-usage>
-        </div>
-    </div>
+  <div class="image-details image-details--scroll">
+    <gr-image-metadata gr-image="ctrl.image" ng:if="ctrl.selectedTab === 'metadata'"></gr-image-metadata>
+    <gr-image-usage gr-image="ctrl.image" ng:if="ctrl.selectedTab === 'usages'"></gr-image-usage>
+  </div>
 </div>
 
 <div class="image-holder">


### PR DESCRIPTION
Easiest to [review without whitespace changes](https://github.com/guardian/grid/pull/2471/files?w=1).

Creates a new `gr-radio-list` component to render a generic set of radios.

We have [styles for `radio-list`](https://github.com/guardian/grid/blob/master/kahuna/public/stylesheets/main.css#L2299-L2347) and some other elements around it, however its not especially semantic. This is the start of removing those styles.

This PR also contains an example usage of the new component by refactoring the image preview tabs.

Future PRs will refactor the following to use `gr-radio-list`:
- [ ] The sort order options
- [ ] The crop ratio selections
- [ ] The usage rights publication field
- [ ] The description edit options (overwrite, prepend, append)
- [ ] The date range field selection

# Before
![image](https://user-images.githubusercontent.com/836140/53455765-8750da00-3a23-11e9-9f68-0b03d8195a27.png)

# After
![image](https://user-images.githubusercontent.com/836140/53455774-9041ab80-3a23-11e9-8f5d-8785d3ff8b4e.png)
