### PR TITLE
Rename the metadata notifications queue to better convey what it's for.

### DIFF
--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -1,6 +1,5 @@
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
-import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{HealthCheck, ThrallController}
 import lib._
@@ -12,7 +11,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new ThrallConfig(configuration)
 
   val store = new ThrallStore(config)
-  val dynamoNotifications = new DynamoNotifications(config)
+  val dynamoNotifications = new MetadataNotifications(config)
   val thrallMetrics = new ThrallMetrics(config)
 
   val es1Config = for {

--- a/thrall/app/lib/DynamoNotifications.scala
+++ b/thrall/app/lib/DynamoNotifications.scala
@@ -1,5 +1,0 @@
-package lib
-
-import com.gu.mediaservice.lib.aws.SNS
-
-class DynamoNotifications(config: ThrallConfig) extends SNS(config, config.dynamoTopicArn)

--- a/thrall/app/lib/MessageProcessor.scala
+++ b/thrall/app/lib/MessageProcessor.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MessageProcessor(es: ElasticSearchVersion,
                        store: ThrallStore,
-                       metadataNotifications: DynamoNotifications,
+                       metadataNotifications: MetadataNotifications,
                        syndicationRightsOps: SyndicationRightsOps,
                        kinesis: Kinesis
                       ) extends ImageId {

--- a/thrall/app/lib/MetadataNotifications.scala
+++ b/thrall/app/lib/MetadataNotifications.scala
@@ -1,0 +1,5 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.SNS
+
+class MetadataNotifications(config: ThrallConfig) extends SNS(config, config.metadataTopicArn)

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -48,7 +48,7 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
 
   lazy val healthyMessageRate: Int = properties("sqs.message.min.frequency").toInt
 
-  lazy val dynamoTopicArn: String = properties("indexed.image.sns.topic.arn")
+  lazy val metadataTopicArn: String = properties("indexed.image.sns.topic.arn")
 
   lazy val from: Option[DateTime] = properties.get("rewind.from").map(ISODateTimeFormat.dateTime.parseDateTime)
 

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -7,12 +7,12 @@ import play.api.libs.json.JsValue
 import scala.concurrent.{ExecutionContext, Future}
 
 class ThrallMessageConsumer(
-  config: ThrallConfig,
-  es: ElasticSearchVersion,
-  thrallMetrics: ThrallMetrics,
-  store: ThrallStore,
-  metadataNotifications: DynamoNotifications,
-  syndicationRightsOps: SyndicationRightsOps
+                             config: ThrallConfig,
+                             es: ElasticSearchVersion,
+                             thrallMetrics: ThrallMetrics,
+                             store: ThrallStore,
+                             metadataNotifications: MetadataNotifications,
+                             syndicationRightsOps: SyndicationRightsOps
 )(implicit ec: ExecutionContext) extends MessageConsumer (
   config.queueUrl,
   config.awsEndpoint,

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MessageProcessor(es: ElasticSearchVersion,
                        store: ThrallStore,
-                       metadataNotifications: DynamoNotifications,
+                       metadataNotifications: MetadataNotifications,
                        syndicationRightsOps: SyndicationRightsOps
                       ) {
 

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 class ThrallEventConsumer(es: ElasticSearchVersion,
                           thrallMetrics: ThrallMetrics,
                           store: ThrallStore,
-                          metadataNotifications: DynamoNotifications,
+                          metadataNotifications: MetadataNotifications,
                           syndicationRightsOps: SyndicationRightsOps) extends IRecordProcessor with PlayJsonHelpers {
 
   private val messageProcessor = new MessageProcessor(es, store, metadataNotifications, syndicationRightsOps)

--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -13,7 +13,7 @@ class ThrallMessageConsumer(config: ThrallConfig,
                             es: ElasticSearchVersion,
                             thrallMetrics: ThrallMetrics,
                             store: ThrallStore,
-                            metadataNotifications: DynamoNotifications,
+                            metadataNotifications: MetadataNotifications,
                             syndicationRightsOps: SyndicationRightsOps,
                             from: Option[DateTime]
                            ) extends MessageConsumerVersion {


### PR DESCRIPTION
ie. These notifications are intended for the metadata service (which then might update dynamo but that's none of our business).