### PR TITLE
cropping refactor

### DIFF
--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -14,7 +14,7 @@
                 <li class="image-info__group--dl gr-display-crops__crop"
                     ng:repeat="crop in ctrl.crops">
                     <div class="gr-display-crops__crop__list image-info__group--dl__key image-info__heading">
-                        <div>{{crop.specification.aspectRatio | asAspectRatioWord}}</div>
+                        <div>{{crop.specification.aspectRatio | asCropType}}</div>
                         <div>{{crop.master.dimensions.width}} x {{crop.master.dimensions.height}}</div>
                     </div>
                     <ul>

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.js
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.js
@@ -2,7 +2,9 @@ import angular from 'angular';
 import template from './gr-display-crops.html';
 import './gr-display-crops.css';
 
-export var displayCrops = angular.module('gr.displayCrops', []);
+import {cropUtil} from '../../util/crop';
+
+export const displayCrops = angular.module('gr.displayCrops', [cropUtil.name]);
 
 displayCrops.controller('GrDisplayCrops', [function() {
 

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -1,236 +1,209 @@
 import angular from 'angular';
 
 import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
+import {radioList} from '../components/gr-radio-list/gr-radio-list';
+import {cropUtil} from "../util/crop";
 
-var crop = angular.module('kahuna.crop.controller', ['gr.keyboardShortcut']);
+const crop = angular.module('kahuna.crop.controller', [
+  'gr.keyboardShortcut',
+  radioList.name,
+  cropUtil.name
+]);
 
-crop.controller('ImageCropCtrl',
-                ['$scope', '$rootScope', '$stateParams', '$state',
-                 '$filter', '$document', 'mediaApi', 'mediaCropper',
-                 'image', 'optimisedImageUri', 'keyboardShortcut', 'storage',
-                 function($scope, $rootScope, $stateParams, $state,
-                          $filter, $document, mediaApi, mediaCropper,
-                          image, optimisedImageUri, keyboardShortcut, storage) {
+crop.controller('ImageCropCtrl', [
+  '$scope',
+  '$rootScope',
+  '$stateParams',
+  '$state',
+  'mediaApi',
+  'mediaCropper',
+  'image',
+  'optimisedImageUri',
+  'keyboardShortcut',
+  'defaultCrop',
+  'cropOptions',
+  'cropTypeUtil',
+  'square',
+  'freeform',
+  function(
+    $scope,
+    $rootScope,
+    $stateParams,
+    $state,
+    mediaApi,
+    mediaCropper,
+    image,
+    optimisedImageUri,
+    keyboardShortcut,
+    defaultCrop,
+    cropOptions,
+    cropTypeUtil,
+    square,
+    freeform) {
 
-    const ctrl = this;
-    const imageId = $stateParams.imageId;
-    if ($stateParams.cropType) {
-        storage.setJs('cropType', $stateParams.cropType, true);
-    }
-    ctrl.cropType = storage.getJs('cropType', true);
+      const ctrl = this;
+      const imageId = $stateParams.imageId;
 
-    keyboardShortcut.bindTo($scope)
-        .add({
-            combo: 'esc',
-            description: 'Cancel crop and return to image',
-            callback: () => $state.go('image', {imageId: ctrl.image.data.id})
-        })
-        .add({
-            combo: 'enter',
-            description: 'Create crop',
-            callback: () => ctrl.callCrop()
-        })
-        .add({
-            combo: 'l',
-            description: 'Start landscape crop',
-            callback: () => {
-                ctrl.aspect = ctrl.landscapeRatio;
-            }
-        })
-        .add({
-            combo: 's',
-            description: 'Start square crop',
-            callback: () => {
-                ctrl.aspect = ctrl.squareRatio;
-            }
-        })
-        .add({
-            combo: 'p',
-            description: 'Start portrait crop',
-            callback: () => {
-                ctrl.aspect = ctrl.portraitRatio;
-            }
-        })
-        .add({
-            combo: 'v',
-            description: 'Start video crop',
-            callback: () => {
-                ctrl.aspect = ctrl.videoRatio;
-            }
-        })
-        .add({
-            combo: 'f',
-            description: 'Start free-form crop',
-            callback: () => {
-                // freeRatio's 'null' gets converted to empty string somehow, meh
-                ctrl.aspect = '';
-            }
-        });
+      cropTypeUtil.set($stateParams);
 
-    ctrl.image = image;
-    ctrl.optimisedImageUri = optimisedImageUri;
+      const storageCropType = cropTypeUtil.get();
 
-    ctrl.cropping = false;
+      const cropOptionDisplayValue = cropOption => cropOption.ratioString
+        ? `${cropOption.key} (${cropOption.ratioString})`
+        : cropOption.key;
 
-    // Standard ratios
-    ctrl.squareRatio = 1;
-    ctrl.landscapeRatio = 5 / 3;
-    ctrl.portraitRatio = 4 / 5;
-    ctrl.videoRatio = 16 / 9;
-    ctrl.freeRatio = null;
+      ctrl.cropOptions = cropOptions.map(option => Object.assign(option, {
+        value: cropOptionDisplayValue(option),
+        tooltip: `${option.key} [${option.key.charAt(0)}]`,
+        disabled: storageCropType && storageCropType !== option.key
+      }));
 
-    const originalDimensions = image.data.source.dimensions;
-    ctrl.originalWidth  = originalDimensions.width;
-    ctrl.originalHeight = originalDimensions.height;
+      ctrl.cropType = storageCropType || defaultCrop.key;
 
-    ctrl.maxInputX = () =>
+      ctrl.image = image;
+      ctrl.optimisedImageUri = optimisedImageUri;
+
+      ctrl.cropping = false;
+
+      const originalDimensions = image.data.source.dimensions;
+      ctrl.originalWidth  = originalDimensions.width;
+      ctrl.originalHeight = originalDimensions.height;
+
+      ctrl.maxInputX = () =>
         ctrl.originalWidth - ctrl.cropWidth();
 
-    ctrl.maxInputY = () =>
+      ctrl.maxInputY = () =>
         ctrl.originalHeight - ctrl.cropHeight();
 
-    if (ctrl.cropType === 'video') {
-        ctrl.aspect = ctrl.videoRatio;
-    } else if (ctrl.cropType === 'landscape') {
-        ctrl.aspect = ctrl.landscapeRatio;
-    } else {
-        ctrl.aspect = ctrl.landscapeRatio;
-        ctrl.landscapeChecked = true;
-    }
-
-    ctrl.coords = {
+      ctrl.coords = {
         x1: ctrl.inputX,
         y1: ctrl.inputY,
         // fill the image with the selection
         x2: ctrl.originalWidth,
         y2: ctrl.originalHeight
-    };
+      };
 
-    $scope.$watch('ctrl.aspect', (newAspect) => {
-        // freeRatio's 'null' gets converted to empty string somehow, meh
-        const isFreeRatio = newAspect === '';
-        if (isFreeRatio) {
-            ctrl.coords = {
-                x1: ctrl.inputX,
-                y1: ctrl.inputY,
-                // fill the image with the selection
-                x2: ctrl.originalWidth,
-                y2: ctrl.originalHeight
-            };
-        }
-    });
-
-
-    const ratioString = (aspect) => {
-        if (Number(aspect) === ctrl.landscapeRatio) {
-            return '5:3';
-        } else if (Number(aspect) === ctrl.portraitRatio) {
-            return '4:5';
-        } else if (Number(aspect) === ctrl.squareRatio) {
-            return '1:1';
-        } else if (Number(aspect) === ctrl.videoRatio) {
-            return '16:9';
-        }
-        // else undefined is fine
-    };
-
-    ctrl.getRatioString = ratioString;
-
-    // If we have a square crop, remove any jitter introduced by client lib by using only one side
-    if (ratioString === '1:1') {
+      // If we have a square crop, remove any jitter introduced by client lib by using only one side
+      if (ctrl.cropType === square.key) {
         const sideLength = () => Math.round(ctrl.coords.x2 - ctrl.coords.x1);
         ctrl.cropWidth = sideLength;
         ctrl.cropHeight = sideLength;
-    } else {
+      } else {
         ctrl.cropWidth = () => Math.round(ctrl.coords.x2 - ctrl.coords.x1);
         ctrl.cropHeight = () => Math.round(ctrl.coords.y2 - ctrl.coords.y1);
-    }
+      }
 
-    ctrl.cropX = () => Math.round(ctrl.coords.x1);
-    ctrl.cropY = () => Math.round(ctrl.coords.y1);
 
-    ctrl.inputX = parseInt(ctrl.cropX());
-    ctrl.inputY = parseInt(ctrl.cropY());
+      ctrl.cropX = () => Math.round(ctrl.coords.x1);
+      ctrl.cropY = () => Math.round(ctrl.coords.y1);
 
-    ctrl.inputWidth = parseInt(ctrl.cropWidth());
-    ctrl.inputHeight = parseInt(ctrl.cropHeight());
+      ctrl.inputX = parseInt(ctrl.cropX());
+      ctrl.inputY = parseInt(ctrl.cropY());
 
-    ctrl.broadcastHeightChange = function (){
+      ctrl.inputWidth = parseInt(ctrl.cropWidth());
+      ctrl.inputHeight = parseInt(ctrl.cropHeight());
+
+      ctrl.broadcastHeightChange = function (){
         $scope.$broadcast('user-height-change', ctrl.inputHeight);
-    };
-    ctrl.broadcastWidthChange = function (){
+      };
+      ctrl.broadcastWidthChange = function (){
         $scope.$broadcast('user-width-change', ctrl.inputWidth);
-    };
-    ctrl.broadcastXChange = function (){
+      };
+      ctrl.broadcastXChange = function (){
         $scope.$broadcast('user-x-change', ctrl.inputX);
-    };
-    ctrl.broadcastYChange = function (){
+      };
+      ctrl.broadcastYChange = function (){
         $scope.$broadcast('user-y-change', ctrl.inputY);
-    };
+      };
 
-    //make the view match the ctrl value
-    $scope.$watch(function(){ return ctrl.cropWidth(); }, function(){
+      //make the view match the ctrl value
+      $scope.$watch(function(){ return ctrl.cropWidth(); }, function(){
         ctrl.inputWidth = ctrl.cropWidth();
-    });
-    $scope.$watch(function(){ return ctrl.cropHeight(); }, function(){
+      });
+      $scope.$watch(function(){ return ctrl.cropHeight(); }, function(){
         ctrl.inputHeight = ctrl.cropHeight();
-    });
-    $scope.$watch(function(){ return ctrl.cropX(); }, function(){
+      });
+      $scope.$watch(function(){ return ctrl.cropX(); }, function(){
         ctrl.inputX = ctrl.cropX();
-    });
-    $scope.$watch(function(){ return ctrl.cropY(); }, function(){
+      });
+      $scope.$watch(function(){ return ctrl.cropY(); }, function(){
         ctrl.inputY = ctrl.cropY();
-    });
+      });
 
-    ctrl.cropSizeWarning = () => ctrl.cropWidth() < 500;
+      ctrl.cropSizeWarning = () => ctrl.cropWidth() < 500;
 
-    ctrl.getRatioString = (aspect) => {
-        if (Number(aspect) === ctrl.landscapeRatio) {
-            return '5:3';
-        } else if (Number(aspect) === ctrl.portraitRatio) {
-            return '4:5';
-        } else if (Number(aspect) === ctrl.squareRatio) {
-            return '1:1';
-        } else if (Number(aspect) === ctrl.videoRatio) {
-            return '16:9';
+      function crop() {
+        // TODO: show crop
+        const coords = {
+          x: Math.round(ctrl.coords.x1),
+          y: Math.round(ctrl.coords.y1),
+          width:  ctrl.cropWidth(),
+          height: ctrl.cropHeight()
+        };
+
+        const ratioString = ctrl.cropOptions.find(_ => _.key === ctrl.cropType).ratioString;
+
+        ctrl.cropping = true;
+
+        mediaCropper.createCrop(ctrl.image, coords, ratioString).then(crop => {
+          // Global notification of action
+          $rootScope.$emit('events:crop-created', {
+            image: ctrl.image,
+            crop: crop
+          });
+
+          $state.go('image', {
+            imageId: imageId,
+            crop: crop.data.id
+          });
+        }).finally(() => {
+          ctrl.cropping = false;
+        });
+      }
+
+      ctrl.callCrop = function() {
+        //prevents return keypress on the crop button posting crop twice
+        if (!ctrl.cropping) {
+          crop();
         }
-        // else undefined is fine
-    };
+      };
 
-     function crop() {
-         // TODO: show crop
-         var coords = {
-             x: Math.round(ctrl.coords.x1),
-             y: Math.round(ctrl.coords.y1),
-             width:  ctrl.cropWidth(),
-             height: ctrl.cropHeight()
-         };
+      $scope.$watch('ctrl.cropType', (newCropType, oldCropType) => {
+        const isCropTypeDisabled = ctrl.cropOptions.find(_ => _.key === newCropType).disabled;
 
-         var ratio = ctrl.getRatioString(ctrl.aspect);
+        if (isCropTypeDisabled) {
+          ctrl.cropType = oldCropType;
+        } else {
+          if (newCropType === freeform.key) {
+            ctrl.coords = {
+              x1: ctrl.inputX,
+              y1: ctrl.inputY,
+              // fill the image with the selection
+              x2: ctrl.originalWidth,
+              y2: ctrl.originalHeight
+            };
+          }
+        }
+      });
 
-         ctrl.cropping = true;
+      keyboardShortcut.bindTo($scope)
+        .add({
+          combo: 'esc',
+          description: 'Cancel crop and return to image',
+          callback: () => $state.go('image', {imageId: ctrl.image.data.id})
+        })
+        .add({
+          combo: 'enter',
+          description: 'Create crop',
+          callback: () => ctrl.callCrop()
+        });
 
-         mediaCropper.createCrop(ctrl.image, coords, ratio).then(crop => {
-             // Global notification of action
-             $rootScope.$emit('events:crop-created', {
-                 image: ctrl.image,
-                 crop: crop
-             });
-
-             $state.go('image', {
-                 imageId: imageId,
-                 crop: crop.data.id
-             });
-         }).finally(() => {
-             ctrl.cropping = false;
-         });
-     }
-
-     ctrl.callCrop = function() {
-         //prevents return keypress on the crop button posting crop twice
-         if (!ctrl.cropping) {
-             crop();
-         }
-     };
-}]);
+      cropOptions.forEach(option => {
+        keyboardShortcut.bindTo($scope).add({
+          combo: option.key.charAt(0),
+          description: `Start ${option.key} crop`,
+          callback: () => ctrl.cropType = option.key
+        });
+      });
+    }]);
 

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -52,30 +52,9 @@
             </form>
         </div>
 
-        <label class="top-bar-item clickable side-padded" gr-tooltip="landscape [l]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.landscapeRatio}}" ng-checked="ctrl.landscapeChecked || ctrl.cropType === 'landscape'" ng-disabled="ctrl.cropType" name="aspect" />
-            <gr-icon-label gr-icon="crop_landscape">Landscape</gr-icon-label> ({{::ctrl.getRatioString(ctrl.landscapeRatio)}})
-        </label>
-
-        <label class="top-bar-item clickable side-padded" gr-tooltip="portrait [p]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.portraitRatio}}" ng-disabled="ctrl.cropType" name="portrait ratio" />
-            <gr-icon-label gr-icon="crop_portrait">Portrait</gr-icon-label> ({{::ctrl.getRatioString(ctrl.portraitRatio)}})
-        </label>
-
-        <label class="top-bar-item clickable side-padded" gr-tooltip="video [v]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.videoRatio}}" ng-checked="ctrl.cropType === 'video'" ng-disabled="ctrl.cropType" name="video ratio" />
-            <gr-icon-label gr-icon="crop_16_9">Video</gr-icon-label> ({{::ctrl.getRatioString(ctrl.videoRatio)}})
-        </label>
-
-        <label class="top-bar-item clickable side-padded" gr-tooltip="square [s]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.squareRatio}}" ng-disabled="ctrl.cropType" name="square ratio" />
-            <gr-icon-label gr-icon="crop_square">Square</gr-icon-label> ({{::ctrl.getRatioString(ctrl.squareRatio)}})
-        </label>
-
-        <label class="top-bar-item clickable side-padded" gr-tooltip="free-form [F]">
-            <input type="radio" ng:model="ctrl.aspect" value="{{ctrl.freeRatio}}" ng-disabled="ctrl.cropType" name="free ratio" />
-            <gr-icon-label gr-icon="crop_free">Free-form</gr-icon-label>
-        </label>
+        <div class="inline-block side-padded">
+          <gr-radio-list gr-for="crop" gr-options="ctrl.cropOptions" gr-selected-option="ctrl.cropType"></gr-radio-list>
+        </div>
 
         <div class="top-bar-item" ng:switch="ctrl.image.data.cost">
             <div ng:switch-when="pay"
@@ -120,7 +99,7 @@
                  ui:crop-box="ctrl.coords"
                  ui:crop-box-original-width="ctrl.originalWidth"
                  ui:crop-box-original-height="ctrl.originalHeight"
-                 ui:crop-box-aspect="ctrl.aspect"
+                 ui:crop-box-crop-type="ctrl.cropType"
 
                  grid:track-image="ctrl.image"
                  grid:track-image-location="original-cropping"

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -4,16 +4,24 @@ import 'cropperjs/dist/cropper.css';
 
 import './cropper-override.css';
 
-export var cropBox = angular.module('ui.cropBox', []);
+import {cropUtil} from '../../util/crop';
 
-cropBox.directive('uiCropBox', ['$timeout', '$parse', 'safeApply', 'nextTick', 'delay',
-                                function($timeout, $parse, safeApply, nextTick, delay) {
+export var cropBox = angular.module('ui.cropBox', [cropUtil.name]);
+
+cropBox.directive('uiCropBox', [
+  '$timeout',
+  '$parse',
+  'safeApply',
+  'nextTick',
+  'delay',
+  'cropOptions',
+  function($timeout, $parse, safeApply, nextTick, delay, cropOptions) {
 
     return {
         restrict: 'A',
         scope: {
             coords:         '=uiCropBox',
-            aspectRatio:    '=uiCropBoxAspect',
+            cropType:       '=uiCropBoxCropType',
             originalWidth:  '=uiCropBoxOriginalWidth',
             originalHeight: '=uiCropBoxOriginalHeight'
         },
@@ -84,11 +92,11 @@ cropBox.directive('uiCropBox', ['$timeout', '$parse', 'safeApply', 'nextTick', '
                 });
             }
 
-
             // Once initialised, sync all options to cropperjs
             function postInit(cropper) {
-                scope.$watch('aspectRatio', function(aspectRatio) {
-                    cropper.setAspectRatio(aspectRatio);
+                scope.$watch('cropType', function(cropType) {
+                    const cropSpec = cropOptions.find(_ => _.key === cropType);
+                    cropper.setAspectRatio(cropSpec.ratio);
                 });
 
                 scope.$on('user-width-change', function(event, width){

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -22,6 +22,7 @@ import '../components/gr-metadata-validity/gr-metadata-validity';
 import '../components/gr-display-crops/gr-display-crops';
 import '../components/gu-date/gu-date';
 import {radioList} from '../components/gr-radio-list/gr-radio-list';
+import {cropUtil} from '../util/crop';
 
 
 const image = angular.module('kahuna.image.controller', [
@@ -47,7 +48,8 @@ const image = angular.module('kahuna.image.controller', [
   'gr.metadataValidity',
   'gr.displayCrops',
   'gu.date',
-  radioList.name
+  radioList.name,
+  cropUtil.name
 ]);
 
 image.controller('ImageCtrl', [
@@ -68,7 +70,7 @@ image.controller('ImageCtrl', [
   'imageService',
   'imageUsagesService',
   'keyboardShortcut',
-  'storage',
+  'cropTypeUtil',
 
   function ($rootScope,
             $scope,
@@ -87,7 +89,7 @@ image.controller('ImageCtrl', [
             imageService,
             imageUsagesService,
             keyboardShortcut,
-            storage) {
+            cropTypeUtil) {
 
     let ctrl = this;
 
@@ -166,11 +168,8 @@ image.controller('ImageCtrl', [
 
     ctrl.image.allCrops = [];
 
-    if ($stateParams.cropType) {
-      storage.setJs('cropType', $stateParams.cropType, true);
-    }
-
-    ctrl.cropType = storage.getJs('cropType', true);
+    cropTypeUtil.set($stateParams);
+    ctrl.cropType = cropTypeUtil.get();
     ctrl.capitalisedCropType = ctrl.cropType ?
       ctrl.cropType[0].toUpperCase() + ctrl.cropType.slice(1) :
       '';

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -71,6 +71,7 @@ image.controller('ImageCtrl', [
   'imageUsagesService',
   'keyboardShortcut',
   'cropTypeUtil',
+  'cropOptions',
 
   function ($rootScope,
             $scope,
@@ -89,7 +90,8 @@ image.controller('ImageCtrl', [
             imageService,
             imageUsagesService,
             keyboardShortcut,
-            cropTypeUtil) {
+            cropTypeUtil,
+            cropOptions) {
 
     let ctrl = this;
 
@@ -179,8 +181,12 @@ image.controller('ImageCtrl', [
     });
 
     ctrl.allowCropSelection = (crop) => {
-      return !ctrl.cropType ||
-        $filter('asAspectRatioWord')(crop.specification.aspectRatio) === ctrl.cropType;
+      if (ctrl.cropType) {
+        const cropSpec = cropOptions.find(_ => _.key === ctrl.cropType);
+        return crop.specification.aspectRatio === cropSpec.ratioString;
+      }
+
+      return true;
     };
 
     ctrl.onCropsDeleted = () => {

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -5,7 +5,7 @@
 <div class="image-crop__info"
      ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
   <div class="flex-container">
-    {{:: crop.specification.aspectRatio | asAspectRatioWord}}
+    {{:: crop.specification.aspectRatio | asCropType}}
     <span class="flex-spacer"></span>
     <span ng:if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
   </div>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -53,8 +53,10 @@
             <dd>
                 <div class="image-crop"
                      ng:init="crop = ctrl.fullCrop"
-                     ng:class="{'image-crop--selected': crop == ctrl.crop}">
-                    <a draggable="true"
+                     ng:class="{'image-crop--selected': crop == ctrl.crop}"
+                     ng-switch="ctrl.allowCropSelection(crop)">
+                    <a ng:switch-when="true"
+                       draggable="true"
                        ng:init="extremeAssets = (crop | getExtremeAssets)"
                        ng:click="ctrl.cropSelected(crop)"
                        ui:sref="{ crop: crop.id }"
@@ -62,7 +64,8 @@
                        ui:drag-image="extremeAssets.smallest | assetFile">
                         <img class="image-crop__image"
                              alt="full frame image thumbnail"
-                             ng:src="{{:: extremeAssets.smallest | assetFile }}" />
+                             ng:src="{{:: extremeAssets.smallest | assetFile }}"
+                             ng:class="{'image-crop__image--disabled': !ctrl.allowCropSelection(crop) }"/>
 
                         <div class="flex-container image-crop__info image-crop__more-info"
                              ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
@@ -71,6 +74,14 @@
                             <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
                         </div>
                     </a>
+                    <div ng-switch-when="false"
+                         draggable="false"
+                         class="image-crop--disabled"
+                         ng:init="extremeAssets = (crop | getExtremeAssets)"
+                         gr-tooltip="{{:: ctrl.capitalisedCropType}} crops only"
+                         gr-tooltip-position="top">
+                      <ng-include src="'/assets/js/image/crop.html'"></ng-include>
+                    </div>
                 </div>
             </dd>
         </div>

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -32,7 +32,6 @@ import {globalErrors} from './errors/global';
 import {icon}    from './components/gr-icon/gr-icon';
 import {tooltip} from './components/gr-tooltip/gr-tooltip';
 
-
 // TODO: move to an async config to remove deps on play
 var apiLink = document.querySelector('link[rel="media-api-uri"]');
 var reauthLink = document.querySelector('link[rel="reauth-uri"]');
@@ -381,19 +380,6 @@ kahuna.filter('asImageAndCropsDragData', ['$filter',
             $filter('asCropsDragData')(crops));
     };
 }]);
-
-kahuna.filter('asAspectRatioWord', function() {
-    // FIXME: Try to find one place to store these mappings
-    var aspectToName = {
-        '5:3': 'landscape',
-        '2:3': 'portrait',
-        '16:9': 'video',
-        '1:1': 'square'
-    };
-    var defaultName = 'freeform';
-
-    return aspectRatio => aspectToName[aspectRatio] || defaultName;
-});
 
 kahuna.filter('asFileSize', function() {
     return bytes => {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -22,6 +22,7 @@ import searchResultsTemplate from './results.html';
 import panelTemplate        from '../components/gr-info-panel/gr-info-panel.html';
 import collectionsPanelTemplate from
     '../components/gr-collections-panel/gr-collections-panel.html';
+import {cropUtil} from '../util/crop';
 
 
 export var search = angular.module('kahuna.search', [
@@ -36,7 +37,8 @@ export var search = angular.module('kahuna.search', [
     'gr.keyboardShortcut',
     'grInfoPanel',
     'grCollectionsPanel',
-    'ui.router'
+    'ui.router',
+  cropUtil.name
 ]);
 
 // TODO: add a resolver here so that if we error (e.g. 401) we don't keep trying
@@ -75,15 +77,13 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         controllerAs: 'ctrl',
         controller: [
             '$scope', '$window', '$stateParams', 'panels', 'shortcutKeys', 'keyboardShortcut',
-            'panelService', 'storage',
+            'panelService', 'cropTypeUtil',
             function($scope, $window, $stateParams, panels, shortcutKeys, keyboardShortcut,
-                     panelService, storage) {
+                     panelService, cropTypeUtil) {
 
             const ctrl = this;
 
-            if ($stateParams.cropType) {
-                storage.setJs('cropType', $stateParams.cropType, true);
-            }
+            cropTypeUtil.set($stateParams);
 
             ctrl.collectionsPanel = panels.collectionsPanel;
             ctrl.metadataPanel = panels.metadataPanel;

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -1,0 +1,48 @@
+import angular from 'angular';
+
+const STORAGE_KEY = 'cropType';
+
+// `ratioString` is sent to the server, being `undefined` for `freeform` is expected 🙈
+const landscape = {key: 'landscape', ratio: 5 / 3, ratioString: '5:3'};
+const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
+const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
+const square = {key: 'square', ratio: 1, ratioString: '1:1'};
+const freeform = {key: 'freeform', ratio: null};
+
+const cropOptions = [landscape, portrait, video, square, freeform];
+
+export const cropUtil = angular.module('util.crop', ['util.storage']);
+
+cropUtil.constant('landscape', landscape);
+cropUtil.constant('portrait', portrait);
+cropUtil.constant('video', video);
+cropUtil.constant('square', square);
+cropUtil.constant('freeform', freeform);
+cropUtil.constant('cropOptions', cropOptions);
+cropUtil.constant('defaultCrop', landscape);
+
+cropUtil.factory('cropTypeUtil', ['storage', function(storage) {
+  const isValidCropType = cropType => cropOptions.some(_ => _.key === cropType);
+
+  function set({cropType}) {
+    if (!cropType) {
+      return;
+    }
+
+    if (isValidCropType(cropType)) {
+      storage.setJs(STORAGE_KEY, cropType, true);
+    } else {
+      storage.clearJs(STORAGE_KEY);
+    }
+  }
+
+  function get() {
+    const cropType = storage.getJs(STORAGE_KEY, true);
+
+    if (isValidCropType(cropType)) {
+      return cropType;
+    }
+  }
+
+  return { set, get };
+}]);

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -46,3 +46,10 @@ cropUtil.factory('cropTypeUtil', ['storage', function(storage) {
 
   return { set, get };
 }]);
+
+cropUtil.filter('asCropType', function() {
+  return ratioString => {
+    const cropSpec = cropOptions.find(_ => _.ratioString === ratioString) || freeform;
+    return cropSpec.key;
+  };
+});

--- a/kahuna/public/js/util/storage.js
+++ b/kahuna/public/js/util/storage.js
@@ -3,28 +3,34 @@ import angular from 'angular';
 export const storage  = angular.module('util.storage', []);
 
 storage.factory('storage', ['$window', function($window) {
-    function setJs(key, val, toSessionStorage = false) {
+  function setJs(key, val, toSessionStorage = false) {
 
-        if (toSessionStorage) {
-            $window.sessionStorage.setItem(key, JSON.stringify(val));
-        } else {
-            $window.localStorage.setItem(key, JSON.stringify(val));
-        }
+    if (toSessionStorage) {
+      $window.sessionStorage.setItem(key, JSON.stringify(val));
+    } else {
+      $window.localStorage.setItem(key, JSON.stringify(val));
     }
+  }
 
-    function getJs(key, fromSessionStorage) {
-        const val = fromSessionStorage ?
-            $window.sessionStorage.getItem(key) :
-            $window.localStorage.getItem(key);
-        try {
-            return JSON.parse(val);
-        } catch (_) {
-            throw new Error(`Could not parse JSON: ${val} for: ${key}`);
-        }
+  function getJs(key, fromSessionStorage) {
+    const val = fromSessionStorage ?
+      $window.sessionStorage.getItem(key) :
+      $window.localStorage.getItem(key);
+    try {
+      return JSON.parse(val);
+    } catch (_) {
+      throw new Error(`Could not parse JSON: ${val} for: ${key}`);
     }
+  }
 
-    return {
-        setJs,
-        getJs
-    };
+  function clearJs(key) {
+    $window.sessionStorage.removeItem(key);
+    $window.localStorage.removeItem(key);
+  }
+
+  return {
+    setJs,
+    getJs,
+    clearJs
+  };
 }]);


### PR DESCRIPTION
Best reviewed [w/out whitespace](https://github.com/guardian/grid/pull/2479/files?w=1) as I've changed the indentation of a couple of files 😄 

This PR is slightly more than a refactor, but for short titles are good, right?

- Creates a `util.crop` factory to house crop definitions and helper functions for `cropType`*
- Validate the value of `cropType` on the query string. If its invalid, ignore it and additionally clear the store.
  - This means we can freeze crop types in Composer again
    - Embed Grid with `?cropType=landscape` for trail pics
    - Embed Grid with `?cropType=all` for other elements (`all` is invalid, so the storage will clear, enabling all types)
- Keeps the crop view DRY by using the `gr-radio-list` component

*`cropType` is used to restrict the type of crop you can make or select

This is https://github.com/guardian/grid/pull/2463 take 2.