### PR TITLE
Remove the SameSite restriction on the Play session cookie

### DIFF
--- a/auth/app/auth/AuthComponents.scala
+++ b/auth/app/auth/AuthComponents.scala
@@ -3,13 +3,25 @@ package auth
 import com.gu.mediaservice.lib.management.ManagementWithPermissions
 import com.gu.mediaservice.lib.play.GridComponents
 import play.api.ApplicationLoader.Context
+import play.api.{Configuration, Environment}
+import play.api.http.HttpConfiguration
 import router.Routes
 
 class AuthComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new AuthConfig(configuration)
+  final override lazy val httpConfiguration = AuthHttpConfig(configuration, context.environment)
 
   val controller = new AuthController(auth, config, controllerComponents)
   val permissionsAwareManagement = new ManagementWithPermissions(controllerComponents, controller)
 
   override val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement)
+}
+
+object AuthHttpConfig {
+  def apply(playConfig: Configuration, environment: Environment): HttpConfiguration = {
+    val base = HttpConfiguration.fromConfiguration(playConfig, environment)
+    base.copy(session =
+      base.session.copy(sameSite = None)
+    )
+  }
 }


### PR DESCRIPTION
Even post #2404, we are still seeing occasional big angry red login error boxes when running the Grid.

From analysing the network requests, we can see that the errors is "missing anti-forgery token", caused because the `PLAY_SESSION` cookie is not set when we are redirected back from the Google OAuth endpoint.

We think this is because the cookie has `SameSite=Lax`, which if you have a [pessismistic read of the specification](https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-4.1.1) should prevent the cookie from being included. [This Firefox blog post](https://blog.mozilla.org/security/2018/04/24/same-site-cookies-in-firefox-60/) also mentions the behaviour (at the bottom).

Chrome however does include it, Firefox does not. Since we require it to be included this PR disables the `SameSite` part of setting the cookie for `PLAY_SESSION` in the auth service.

This should have a limited security impact right now, since this cookie is only used during the auth dance with the seperate Panda cookie used to actually login. However it may impact us in the future if we decide to put more stuff in the session.

We were unable to reproduce locally but @RichieAHB made a [cool cut-down node app](https://glitch.com/edit/#!/receptive-brownie) that appears to prove our hypothesis. The intention is to throw this branch onto test after a night of inactivity to see if it makes a difference.