### PR TITLE
Deletion from image buckets and notification of metadata moves from E…

### DIFF
--- a/thrall/app/lib/MessageProcessor.scala
+++ b/thrall/app/lib/MessageProcessor.scala
@@ -77,10 +77,10 @@ class MessageProcessor(es: ElasticSearchVersion,
         es.deleteImage(id).map { requests =>
           requests.map {
             case _: ElasticSearchDeleteResponse =>
-              store.deleteOriginal(id)
-              store.deleteThumbnail(id)
-              store.deletePng(id)
-              metadataNotifications.publish(Json.obj("id" -> id), "image-deleted")
+              //store.deleteOriginal(id)
+              //store.deleteThumbnail(id)
+              //store.deletePng(id)
+              //metadataNotifications.publish(Json.obj("id" -> id), "image-deleted")
               EsResponse(s"Image deleted: $id")
           } recoverWith {
             case ImageNotDeletable =>

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -126,9 +126,9 @@ class MessageProcessor(es: ElasticSearchVersion,
         es.deleteImage(id).map { requests =>
           requests.map {
             case _: ElasticSearchDeleteResponse =>
-              //store.deleteOriginal(id)
-              //store.deleteThumbnail(id)
-              //store.deletePng(id)
+              store.deleteOriginal(id)
+              store.deleteThumbnail(id)
+              store.deletePng(id)
               metadataNotifications.publish(Json.obj("id" -> id), "image-deleted")
               EsResponse(s"Image deleted: $id")
           } recoverWith {


### PR DESCRIPTION
…S1 to ES6 based message processor.

This duplication can be resolved by moving the SQS queue to the UpdateMessage format and merging the 2 MessageProcessor implementations.