### PR TITLE
Updated display crops to use the file url from media api instead of secureUri

### DIFF
--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -19,7 +19,7 @@
                     </div>
                     <ul>
                         <li ng:repeat="asset in crop.assets">
-                            <a href="{{asset.secureUrl}}">{{asset.dimensions.width}} x {{asset.dimensions.height}}</a>
+                            <a href="{{asset.file}}">{{asset.dimensions.width}} x {{asset.dimensions.height}}</a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
`exports` (ie public crops) in the media api response has both a `file` and `secureUrl`. The secure field is redundant for a crop that is already public so the UI should not depend on it