### PR TITLE
Fix replace leases action in ES6

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
@@ -1,0 +1,30 @@
+package com.gu.mediaservice.model
+
+import com.gu.mediaservice.lib.formatting.printDateTime
+import org.joda.time.DateTime
+import play.api.libs.json._
+
+case class LeaseNotice(mediaId: String, leaseByMedia: JsValue) {
+  def toJson = Json.obj(
+    "id" -> mediaId,
+    "data" -> leaseByMedia,
+    "lastModified" -> printDateTime(DateTime.now())
+  )
+}
+
+object LeaseNotice {
+  import JodaWrites._
+
+  implicit val writer = new Writes[LeasesByMedia] {
+    def writes(leaseByMedia: LeasesByMedia) = {
+      LeasesByMedia.toJson(
+        Json.toJson(leaseByMedia.leases),
+        Json.toJson(leaseByMedia.lastModified)
+      )
+    }
+  }
+  def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
+    mediaLease.mediaId,
+    Json.toJson(LeasesByMedia(List(mediaLease), Some(mediaLease.createdAt)))
+  )
+}

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -2,34 +2,9 @@ package lib
 
 import com.gu.mediaservice.lib.aws.{MessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting._
-import com.gu.mediaservice.model.{LeasesByMedia, MediaLease}
+import com.gu.mediaservice.model.{LeaseNotice, LeasesByMedia, MediaLease}
 import org.joda.time.DateTime
 import play.api.libs.json._
-
-case class LeaseNotice(mediaId: String, leaseByMedia: JsValue) {
-  def toJson = Json.obj(
-    "id" -> mediaId,
-    "data" -> leaseByMedia,
-    "lastModified" -> printDateTime(DateTime.now())
-  )
-}
-
-object LeaseNotice {
-  import JodaWrites._
-
-  implicit val writer = new Writes[LeasesByMedia] {
-    def writes(leaseByMedia: LeasesByMedia) = {
-      LeasesByMedia.toJson(
-        Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.lastModified)
-      )
-    }
-  }
-  def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
-    mediaLease.mediaId,
-    Json.toJson(LeasesByMedia(List(mediaLease), Some(mediaLease.createdAt)))
-  )
-}
 
 class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSender(config, config.topicArn) {
   private def build(mediaId: String, leases: List[MediaLease] ): LeaseNotice = {

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -14,7 +14,7 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSend
   def sendReindexLeases(mediaId: String) = {
     val replaceImageLeases = "replace-image-leases"
     val leases = store.getForMedia(mediaId)
-    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(leases) )
+    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(leases), id = Some(mediaId) )
     publish(build(mediaId, leases).toJson, replaceImageLeases, updateMessage)
   }
 

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -2,7 +2,7 @@ package lib
 
 import _root_.play.api.libs.json._
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, ElasticSearchConfig, ImageFields}
-import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.model.{Image, MediaLease, Photoshoot, SyndicationRights}
 import com.gu.mediaservice.syntax._
 import groovy.json.JsonSlurper
 import org.elasticsearch.action.update.{UpdateRequestBuilder, UpdateResponse}
@@ -156,17 +156,17 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
     }
   }
 
-  def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
+  def replaceImageLeases(id: String, leases: Seq[MediaLease])(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     prepareImageUpdate(id) { request =>
       request.setScriptParams(Map(
-        "leaseByMedia" -> asGroovy(leaseByMedia.getOrElse(JsNull)),
-        "lastModified" -> asGroovy(lastModified.getOrElse(JsNull))
+        "leaseByMedia" -> asGroovy(Json.toJson(leases)),
+        "lastModified" -> asGroovy(Json.toJson(DateTime.now.toString))
       ).asJava)
         .setScript(
           replaceLeasesScript +
             updateLastModifiedScript,
           scriptType)
-        .executeAndLog(s"updating all leases on image $id with: $leaseByMedia")
+        .executeAndLog(s"updating all leases on image $id with: ${leases.toString}")
         .recover { case e: DocumentMissingException => new UpdateResponse }
         .incrementOnFailure(metrics.failedUsagesUpdates) { case e: VersionConflictEngineException => true }
     }

--- a/thrall/app/lib/ElasticSearch.scala
+++ b/thrall/app/lib/ElasticSearch.scala
@@ -159,7 +159,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
   def replaceImageLeases(id: String, leases: Seq[MediaLease])(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     prepareImageUpdate(id) { request =>
       request.setScriptParams(Map(
-        "leaseByMedia" -> asGroovy(Json.toJson(leases)),
+        "leases" -> asGroovy(Json.toJson(leases)),
         "lastModified" -> asGroovy(Json.toJson(DateTime.now.toString))
       ).asJava)
         .setScript(
@@ -388,7 +388,9 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: ThrallMetrics) extends
     """.stripMargin
 
   private val replaceLeasesScript =
-    """ctx._source.leases = leaseByMedia;"""
+    """| ctx._source.leases.lastModified = lastModified;
+       | ctx._source.leases.leases = leases;
+    """.stripMargin
 
   private val removeLeaseScript =
     """| for(int i = 0; i < ctx._source.leases.leases.size(); i++) {

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -285,9 +285,10 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
 
-  def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
+  def replaceImageLeases(id: String, leases: Seq[MediaLease])(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     val replaceLeasesScript = loadPainless(
-    """ | ctx._source.leases = params.leaseByMedia;"""
+      """ | ctx._source.leases.lastModified = params.lastModified;
+        | ctx._source.leases.leases = params.leases;""".stripMargin
     )
 
     val scriptSource = loadPainless(s"""
@@ -295,19 +296,16 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
                                        |   $updateLastModifiedScript
                                        | """)
 
-    val lleaseByMediaParameter = leaseByMedia.toOption.map(asNestedMap)
-    val lastModifiedParameter = lastModified.toOption.map(_.as[String])
-
     val params = Map(
-      "leaseByMedia" -> lleaseByMediaParameter.getOrElse(null),
-      "lastModified" -> lastModifiedParameter.getOrElse(null)
+      "leases" -> Json.toJson(leases),
+      "lastModified" -> Json.toJson(DateTime.now.toString)
     )
 
     val script = Script(script = replaceLeasesScript).lang("painless").params(params)
 
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
-    val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 updating all leases on image $id with: $lleaseByMediaParameter")
+    val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 updating all leases on image $id with: ${leases.toString}")
       .incrementOnFailure(metrics.failedSyndicationRightsUpdates){case _ => true}
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))

--- a/thrall/app/lib/ElasticSearchRouter.scala
+++ b/thrall/app/lib/ElasticSearchRouter.scala
@@ -1,5 +1,5 @@
 package lib
-import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.model.{Image, MediaLease, Photoshoot, SyndicationRights}
 import play.api.libs.json.{JsLookupResult, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -23,8 +23,8 @@ class ElasticSearchRouter(versions: Seq[ElasticSearchVersion]) extends ElasticSe
 
   override def deleteSyndicationRights(id: String)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = versions.map(_.deleteSyndicationRights(id)).head
 
-  override def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] =
-    versions.map(_.replaceImageLeases(id, leaseByMedia, lastModified)).head
+  override def replaceImageLeases(id: String, leases: Seq[MediaLease])(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] =
+    versions.map(_.replaceImageLeases(id, leases)).head
 
   override def addImageLease(id: String, lease: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] =
     versions.map(_.addImageLease(id, lease, lastModified)).head

--- a/thrall/app/lib/ElasticSearchVersion.scala
+++ b/thrall/app/lib/ElasticSearchVersion.scala
@@ -1,6 +1,6 @@
 package lib
 
-import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.model.{Image, MediaLease, Photoshoot, SyndicationRights}
 import play.api.libs.json.{JsLookupResult, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,7 +19,7 @@ trait ElasticSearchVersion {
 
   def deleteSyndicationRights(id: String)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
 
-  def replaceImageLeases(id: String, leaseByMedia: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
+  def replaceImageLeases(id: String, leases: Seq[MediaLease])(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
 
   def addImageLease(id: String, lease: JsLookupResult, lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]]
 

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -82,7 +82,7 @@ class MessageProcessor(es: ElasticSearchVersion,
     withId(message) { id =>
       withLastModified(message) { lastModified =>
         withLeases(message) { leases =>
-          Future.sequence(es.replaceImageLeases(id, asJsLookup(leases), dateTimeAsJsLookup(lastModified)))
+          Future.sequence(es.replaceImageLeases(id, leases))
         }
       }
     }

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -80,10 +80,8 @@ class MessageProcessor(es: ElasticSearchVersion,
   def replaceImageLeases(message: UpdateMessage)(implicit ec: ExecutionContext) = {
     def asJsLookup(ls: Seq[MediaLease]): JsLookupResult = JsDefined(Json.toJson(ls))
     withId(message) { id =>
-      withLastModified(message) { lastModified =>
-        withLeases(message) { leases =>
-          Future.sequence(es.replaceImageLeases(id, leases))
-        }
+      withLeases(message) { leases =>
+        Future.sequence(es.replaceImageLeases(id, leases))
       }
     }
   }

--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -56,7 +56,8 @@ trait Fixtures {
                                  rcsPublishDate: Option[DateTime],
                                  lease: Option[MediaLease],
                                  usages: List[Usage] = Nil,
-                                 fileMetadata: Option[FileMetadata] = None
+                                 fileMetadata: Option[FileMetadata] = None,
+                                 lastModified: Option[DateTime] = None
                                ): Image = {
     val rights = List(
       Right("test", Some(rightsAcquired), Nil)
@@ -65,7 +66,7 @@ trait Fixtures {
     val syndicationRights = SyndicationRights(rcsPublishDate, Nil, rights)
 
     val leaseByMedia = lease.map(l => LeasesByMedia(
-      lastModified = None,
+      lastModified = lastModified,
       leases = List(l)
     ))
 

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -321,10 +321,10 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
         val updatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("An updated lease"), mediaId = UUID.randomUUID().toString)
         val anotherUpdatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("Another updated lease"), mediaId = UUID.randomUUID().toString)
-        val updatedLeases = LeasesByMedia.build(leases = List(updatedLease, anotherUpdatedLease))
-        updatedLeases.leases.size shouldBe 2
+        val updatedLeases = Seq(updatedLease, anotherUpdatedLease)
+        updatedLeases.size shouldBe 2
 
-        Await.result(Future.sequence(ES.replaceImageLeases(id, JsDefined(Json.toJson(updatedLeases)), asJsLookup(DateTime.now))), fiveSeconds)
+        Await.result(Future.sequence(ES.replaceImageLeases(id, updatedLeases)), fiveSeconds)
 
         reloadedImage(id).get.leases.leases.size shouldBe 2
         reloadedImage(id).get.leases.leases.head.notes shouldBe Some("An updated lease")

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.gu.mediaservice.model
 import com.gu.mediaservice.model._
 import helpers.Fixtures
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{DateTime, Duration => JodaDuration, DateTimeZone}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import play.api.libs.json.{JsDefined, JsLookupResult, Json, __}
@@ -316,7 +316,14 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
       "can replace leases" in {
         val lease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
         val id = UUID.randomUUID().toString
-        val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), lease = Some(lease))
+        val timeBeforeEdit = DateTime.now
+        val image = createImageForSyndication(
+          id = UUID.randomUUID().toString,
+          true,
+          Some(DateTime.now()),
+          lease = Some(lease),
+          lastModified = Some(timeBeforeEdit)
+        )
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
 
         val updatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("An updated lease"), mediaId = UUID.randomUUID().toString)
@@ -326,8 +333,10 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
         Await.result(Future.sequence(ES.replaceImageLeases(id, updatedLeases)), fiveSeconds)
 
-        reloadedImage(id).get.leases.leases.size shouldBe 2
-        reloadedImage(id).get.leases.leases.head.notes shouldBe Some("An updated lease")
+        val newLeases = reloadedImage(id).get.leases
+        newLeases.leases.size shouldBe 2
+        newLeases.leases.head.notes shouldBe Some("An updated lease")
+        newLeases.lastModified.get.isAfter(timeBeforeEdit) shouldBe true
       }
     }
 


### PR DESCRIPTION
The replace leases action in ES6 was broken. The type that eventually made it to the Painless script didn't align with what that script expected, and requests were failing as a result. This PR should fix that.

In addition to this, the lastModified value was being set incorrectly -- this is set as now() just before we run the ES script.

Finally, it also provides better type safety in ElasticSearchVersion, for comfort 🛏 