### PR TITLE
refactor UpdateMessage

### DIFF
--- a/collections/app/controllers/ImageCollectionsController.scala
+++ b/collections/app/controllers/ImageCollectionsController.scala
@@ -68,7 +68,7 @@ class ImageCollectionsController(authenticated: Authentication, config: Collecti
       "data" -> Json.toJson(onlyLatestCollections)
     )
 
-    val updateMessage = UpdateMessage(subject = "set-image-collections", id = Some(id), collections = Some(onlyLatestCollections))
+    val updateMessage = UpdateMessage(subject = "set-image-collections", id = id, collections = Some(onlyLatestCollections))
     notifications.publish(message, "set-image-collections", updateMessage)
     onlyLatestCollections
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/MessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/MessageSender.scala
@@ -19,8 +19,8 @@ class MessageSender(config: CommonConfig, snsTopicArn: String) {
 }
 
 case class UpdateMessage(subject: String,
+                         id: String,
                          image: Option[Image] = None,
-                         id: Option[String] = None,
                          usageNotice: Option[UsageNotice] = None,
                          edits: Option[Edits] = None,
                          lastModified: Option[DateTime] = None,

--- a/cropper/app/controllers/CropperController.scala
+++ b/cropper/app/controllers/CropperController.scala
@@ -59,7 +59,7 @@ class CropperController(auth: Authentication, crops: Crops, store: CropStore, no
         )
 
         val updateImageExports = "update-image-exports"
-        val updateMessage = UpdateMessage(subject = updateImageExports, id = Some(imageId), crops = Some(Seq(export)))
+        val updateMessage = UpdateMessage(subject = updateImageExports, id = imageId, crops = Some(Seq(export)))
         notifications.publish(exports, updateImageExports, updateMessage)
 
         Ok(cropJson).as(ArgoMediaType)
@@ -109,7 +109,7 @@ class CropperController(auth: Authentication, crops: Crops, store: CropStore, no
 
     if(canDeleteCrops) {
       store.deleteCrops(id).map { _ =>
-        val updateMessage = UpdateMessage(subject = "delete-image-exports", id = Some(id))
+        val updateMessage = UpdateMessage(subject = "delete-image-exports", id = id)
         notifications.publish(Json.obj("id" -> id), "delete-image-exports", updateMessage)
         Accepted
       } recover {

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -141,7 +141,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
       imageUpload <- imageUploadOps.fromUploadRequest(uploadRequest)
       image = imageUpload.image
     } yield {
-      val updateMessage = UpdateMessage(subject = "image", image = Some(image))
+      val updateMessage = UpdateMessage(subject = "image", image = Some(image), id = image.id)
       notifications.publish(Json.toJson(image), "image", updateMessage)
 
       // TODO: centralise where all these URLs are constructed

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -39,13 +39,13 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSend
   def sendReindexLeases(mediaId: String) = {
     val replaceImageLeases = "replace-image-leases"
     val leases = store.getForMedia(mediaId)
-    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(leases) )
+    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(leases), id = mediaId)
     publish(build(mediaId, leases).toJson, replaceImageLeases, updateMessage)
   }
 
   def sendAddLease(mediaLease: MediaLease) = {
     val addImageLease = "add-image-lease"
-    val updateMessage = UpdateMessage(subject = addImageLease, mediaLease = Some(mediaLease), id = Some(mediaLease.mediaId), lastModified = Some(DateTime.now()))
+    val updateMessage = UpdateMessage(subject = addImageLease, mediaLease = Some(mediaLease), id = mediaLease.mediaId, lastModified = Some(DateTime.now()))
     publish(MediaLease.toJson(mediaLease), addImageLease, updateMessage)
   }
 
@@ -57,7 +57,7 @@ class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends MessageSend
       "id" -> mediaId,
       "lastModified" -> printDateTime(DateTime.now())
     )
-    val updateMessage = UpdateMessage(subject = removeImageLease, id = Some(mediaId),
+    val updateMessage = UpdateMessage(subject = removeImageLease, id = mediaId,
       leaseId = Some(leaseId), lastModified = Some(DateTime.now())
     )
     publish(leaseInfo, removeImageLease, updateMessage)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -196,7 +196,7 @@ class MediaApi(
 
           if (canDelete) {
             val deleteImage = "delete-image"
-            val updateMessage = UpdateMessage(subject = deleteImage, id = Some(id))
+            val updateMessage = UpdateMessage(subject = deleteImage, id = id)
             messageSender.publish(Json.obj("id" -> id), deleteImage, updateMessage)
             Accepted
           } else {
@@ -254,7 +254,7 @@ class MediaApi(
           val notification = Json.toJson(finalImage)
 
           val updateImage = "update-image"
-          val updateMessage = UpdateMessage(subject = updateImage, id = Some(finalImage.id), image = Some(finalImage))
+          val updateMessage = UpdateMessage(subject = updateImage, id = finalImage.id, image = Some(finalImage))
           messageSender.publish(notification, updateImage, updateMessage)
 
           Ok(Json.obj(

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -223,7 +223,7 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
       "lastModified" -> printDateTime(new DateTime())
     )
 
-    val updateMessage = UpdateMessage(subject = subject, id = Some(id), edits = Some(edits), lastModified = Some(new DateTime()))
+    val updateMessage = UpdateMessage(subject = subject, id = id, edits = Some(edits), lastModified = Some(new DateTime()))
     notifications.publish(message, subject, updateMessage)
     edits
   }

--- a/thrall/app/lib/MessageProcessor.scala
+++ b/thrall/app/lib/MessageProcessor.scala
@@ -112,7 +112,7 @@ class MessageProcessor(es: ElasticSearchVersion,
 
         Future.successful {
           // Mirror RCS messages onto Kinesis for migration. It was not possible to write to Kinesis from the RCS lambda
-          val updateMessage = UpdateMessage(subject = "upsert-rcs-rights", id = Some(id), syndicationRights = Some(syndicationRights))
+          val updateMessage = UpdateMessage(subject = "upsert-rcs-rights", id = id, syndicationRights = Some(syndicationRights))
           kinesis.publish(updateMessage)
         }
       }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -192,7 +192,7 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
         respondError(InternalServerError, "image-usage-delete-failed", error.getMessage)
     }
 
-    val updateMessage = UpdateMessage(subject = " delete-usages", id = Some(mediaId))
+    val updateMessage = UpdateMessage(subject = " delete-usages", id = mediaId)
     notifications.publish(Json.obj("id" -> mediaId), "delete-usages", updateMessage)
     Future.successful(Ok)
   }

--- a/usage/app/lib/UsageNotifier.scala
+++ b/usage/app/lib/UsageNotifier.scala
@@ -19,7 +19,7 @@ class UsageNotifier(config: UsageConfig, usageTable: UsageTable) extends Message
 
   def send(usageNotice: UsageNotice) = {
     Logger.info(s"Sending usage notice for ${usageNotice.mediaId}")
-    val updateMessage = UpdateMessage(subject = "update-image-usages", id = Some(usageNotice.mediaId), usageNotice = Some(usageNotice), lastModified = Some(DateTime.now()))
+    val updateMessage = UpdateMessage(subject = "update-image-usages", id = usageNotice.mediaId, usageNotice = Some(usageNotice), lastModified = Some(DateTime.now()))
     publish(usageNotice.toJson, "update-image-usages", updateMessage)
   }
 }


### PR DESCRIPTION
Make `id` required as it should always be present. Also remove `withImageId` as a result too.

Easier to review here - https://github.com/guardian/grid/pull/2491/files?w=1