### PR TITLE
The metric been past to message consumer bu metadata editor is been u…

### DIFF
--- a/metadata-editor/app/lib/MetadataEditorMetrics.scala
+++ b/metadata-editor/app/lib/MetadataEditorMetrics.scala
@@ -4,6 +4,6 @@ import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 
 class MetadataEditorMetrics(config: EditsConfig) extends CloudWatchMetrics(s"${config.stage}/MetadataEditor", config) {
 
-  val processingLatency = new TimeMetric("ProcessingLatency")
+  val snsMessage = new CountMetric("SNSMessage")
 
 }

--- a/metadata-editor/app/lib/MetadataMessageConsumer.scala
+++ b/metadata-editor/app/lib/MetadataMessageConsumer.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class MetadataMessageConsumer(config: EditsConfig, metadataEditorMetrics: MetadataEditorMetrics, store: EditsStore) extends MessageConsumer(
-  config.queueUrl, config.awsEndpoint, config, metadataEditorMetrics.processingLatency) {
+  config.queueUrl, config.awsEndpoint, config, metadataEditorMetrics.snsMessage) {
 
   override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] =
     PartialFunction.condOpt(subject) {


### PR DESCRIPTION
…sed as a message counter not a latency timer; rename it as such.

Also move to a CountMetric; this was compiling because TimeMetric is also a Long CloudWatch type.