### PR TITLE
Tom Jenkins contract photographer for Observer

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -121,7 +121,8 @@ object MetadataConfig {
     "Katherine Anne Rose" -> "The Observer",
     "Richard Saker"       -> "The Observer",
     "Sophia Evans"        -> "The Observer",
-    "Suki Dhanda"         -> "The Observer"
+    "Suki Dhanda"         -> "The Observer".
+    "Tom Jenkins"         -> "The Observer"
   )
 
   val staffIllustrators = List(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -121,7 +121,7 @@ object MetadataConfig {
     "Katherine Anne Rose" -> "The Observer",
     "Richard Saker"       -> "The Observer",
     "Sophia Evans"        -> "The Observer",
-    "Suki Dhanda"         -> "The Observer".
+    "Suki Dhanda"         -> "The Observer",
     "Tom Jenkins"         -> "The Observer"
   )
 


### PR DESCRIPTION
Request from Daffydd.

NB Tom Jenkins is now listed under both [Guardian](https://github.com/guardian/grid/pull/2495/files#diff-b65ccb2c82ca02b1c6da58bdc8a978b2R111) and Observer.