### PR TITLE
Revert "Tom Jenkins contract photographer for Observer"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -121,8 +121,7 @@ object MetadataConfig {
     "Katherine Anne Rose" -> "The Observer",
     "Richard Saker"       -> "The Observer",
     "Sophia Evans"        -> "The Observer",
-    "Suki Dhanda"         -> "The Observer",
-    "Tom Jenkins"         -> "The Observer"
+    "Suki Dhanda"         -> "The Observer"
   )
 
   val staffIllustrators = List(


### PR DESCRIPTION
Reverts guardian/grid#2495

`contractedPhotographers` is a `Map[String, String]` so this change isn't doing what I thought... Tom Jenkins is only listed under The Observer rather than both.