### PR TITLE
Update SupplierProcessors.scala

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -174,7 +174,7 @@ trait GettyProcessor {
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
   def apply(image: Image): Image = {
     val excludedCredit = List(
-      "newspix international", "i-images", "photoshot", "Ian Jones", "Panoramic/Avalon", "Avalon", "INS News Agency Ltd", "Discovery.", "EPA"
+      "Replay Images", "newspix international", "i-images", "photoshot", "Ian Jones", "Panoramic/Avalon", "Avalon", "INS News Agency Ltd", "Discovery.", "EPA"
     )
 
     val excludedSource = List(


### PR DESCRIPTION
Exclude Replay Images from being identified as Getty due to presence of GettyGIFT XMP