### PR TITLE
Update SupplierProcessors.scala

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -178,7 +178,7 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
     )
 
     val excludedSource = List(
-      "UKTV", "Pinnacle Photo Agency Ltd"
+      "Replay Images", "UKTV", "Pinnacle Photo Agency Ltd"
     )
 
     val isExcludedByCredit = image.metadata.credit.exists(isExcluded(_, excludedCredit))


### PR DESCRIPTION
Excludes source of "Replay Images" being categorised as Getty.