### PR TITLE
only internal tiered services can do anything

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/PermissionsHandler.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/PermissionsHandler.scala
@@ -21,7 +21,7 @@ trait PermissionsHandler {
     user match {
       case PandaUser(u) => permissions.hasPermission(permission, u.email)
       // think about only allowing certain services i.e. on `service.name`?
-      case AuthenticatedService(_) => true
+      case service: AuthenticatedService if service.apiKey.tier == Internal => true
       case _ => false
     }
   }

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -97,7 +97,7 @@ class MediaApi(
         } else {
           hasPermission(user, permission)
         }
-      case _: AuthenticatedService => true
+      case service: AuthenticatedService if service.apiKey.tier == Internal => true
       case _ => false
     }
   }


### PR DESCRIPTION
Regarding permissions of API key access, only the `Internal` tier should be able to [writeMetadata](https://github.com/guardian/grid/pull/2501/files#diff-56cb21a41bb269d77a616e1f7a4f42e9L105) or [deleteImage](https://github.com/guardian/grid/pull/2501/files#diff-56cb21a41bb269d77a616e1f7a4f42e9L109).