### PR TITLE
Revert "Thrall kinesis message metrics"

### DIFF
--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -59,20 +59,20 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
     es6
   }
 
-  es1Opt.map { es1 =>
+  val messageConsumerForHealthCheck = es1Opt.map { es1 =>
     val thrallMessageConsumer = new ThrallMessageConsumer(config, es1, thrallMetrics, store, dynamoNotifications, new SyndicationRightsOps(es1))
     thrallMessageConsumer.startSchedule()
     context.lifecycle.addStopHook {
       () => thrallMessageConsumer.actorSystem.terminate()
     }
-  }
+    thrallMessageConsumer
+  }.get
 
-  var messageConsumerForHealthCheck = es6pot.map { es6 =>
+  es6pot.map { es6 =>
     val thrallKinesisMessageConsumer = new kinesis.ThrallMessageConsumer(config, es6, thrallMetrics,
       store, dynamoNotifications, new SyndicationRightsOps(es6), config.from)
     thrallKinesisMessageConsumer.start()
-    thrallKinesisMessageConsumer
-  }.get
+  }
 
   val thrallController = new ThrallController(controllerComponents)
   val healthCheckController = new HealthCheck(es1Opt.get, messageConsumerForHealthCheck, config, controllerComponents)

--- a/thrall/app/lib/ThrallMetrics.scala
+++ b/thrall/app/lib/ThrallMetrics.scala
@@ -28,6 +28,4 @@ class ThrallMetrics(config: ThrallConfig) extends CloudWatchMetrics(s"${config.s
 
   val snsMessage = new CountMetric("SNSMessage")
 
-  val kinesisMessage = new CountMetric("KinesisMessage")
-
 }

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -3,9 +3,7 @@ package lib.kinesis
 import java.nio.charset.StandardCharsets
 import java.util
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicReference
 
-import com.amazonaws.services.cloudwatch.model.Dimension
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor, IRecordProcessorCheckpointer}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
 import com.amazonaws.services.kinesis.model.Record
@@ -13,26 +11,22 @@ import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.json.PlayJsonHelpers
 import com.gu.mediaservice.model.usage.UsageNotice
 import lib._
-import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.{JodaReads, Json}
 
 import scala.concurrent.duration.{Duration, SECONDS}
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 class ThrallEventConsumer(es: ElasticSearchVersion,
                           thrallMetrics: ThrallMetrics,
                           store: ThrallStore,
                           metadataNotifications: MetadataNotifications,
-                          syndicationRightsOps: SyndicationRightsOps,
-                          timeMessageLastProcessed: AtomicReference[DateTime]
-                         ) extends IRecordProcessor with PlayJsonHelpers {
-
-  private val ThirtySeconds = Duration(30, SECONDS)
+                          syndicationRightsOps: SyndicationRightsOps) extends IRecordProcessor with PlayJsonHelpers {
 
   private val messageProcessor = new MessageProcessor(es, store, metadataNotifications, syndicationRightsOps)
 
-  private implicit val ctx: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
+  private implicit val ctx: ExecutionContext =
+    ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
 
   override def initialize(shardId: String): Unit = {
     Logger.info(s"Initialized an event processor for shard $shardId")
@@ -41,11 +35,6 @@ class ThrallEventConsumer(es: ElasticSearchVersion,
   override def processRecords(records: util.List[Record], checkpointer: IRecordProcessorCheckpointer): Unit = {
     import scala.collection.JavaConverters._
     Logger.info("Processing kinesis record batch of size: " + records.size)
-
-    def recordMessageCount(message: UpdateMessage) = {
-      val dimensions = List(new Dimension().withName("subject").withValue(message.subject))
-      thrallMetrics.kinesisMessage.runRecordOne(1L, dimensions)
-    }
 
     try {
       records.asScala.foreach { r =>
@@ -66,12 +55,11 @@ class ThrallEventConsumer(es: ElasticSearchVersion,
           val messageLogMessage = "(" + timestamp + "): " + updateMessage.subject + "/" + idForLogging.mkString(" ")
           Logger.info("Got update message: " + messageLogMessage)
 
-          messageProcessor.chooseProcessor(updateMessage).map { processor =>
-            val eventuallyAppliedUpdate = processor.apply(updateMessage).map { _ =>
+          messageProcessor.chooseProcessor(updateMessage).map { p =>
+            val ThirtySeconds = Duration(30, SECONDS)
+            val eventuallyAppliedUpdate: Future[Any] = p.apply(updateMessage)
+            eventuallyAppliedUpdate.map { _ =>
               Logger.info("Completed processing of update message: " + messageLogMessage)
-              recordMessageCount(updateMessage)
-              timeMessageLastProcessed.lazySet(DateTime.now)
-
             }.recover {
               case e: Throwable =>
                 Logger.error("Failed to process update message; message will be ignored: " + ("Got update message: " + messageLogMessage), e)
@@ -93,6 +81,7 @@ class ThrallEventConsumer(es: ElasticSearchVersion,
       case e: Throwable =>
         Logger.error("Exception during process records and checkpoint: ", e)
     }
+
 
   }
 


### PR DESCRIPTION
Reverts guardian/grid#2487.

The healthcheck refuses to pass because the new machines don't see any messages. I think this is because we only have one shard on the stream.