### PR TITLE
use nested query for Usages

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SearchFilters.scala
@@ -61,7 +61,7 @@ class SearchFilters(config: MediaApiConfig)  extends ImageFields {
   )
 
   val hasCrops = filters.bool.must(filters.existsOrMissing("exports", exists = true))
-  val usedInContent = filters.bool.must(filters.existsOrMissing("usages", exists = true))
+  val usedInContent = filters.nested("usages", filters.exists(NonEmptyList("usages")))
   val existedPreGrid = filters.exists(NonEmptyList(identifierField(config.persistenceIdentifier)))
   val addedToLibrary = filters.bool.must(filters.boolTerm(editsField("archived"), value = true))
   val hasUserEditsToImageMetadata = filters.exists(NonEmptyList(editsField("metadata")))

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/filters.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/filters.scala
@@ -3,7 +3,7 @@ package lib.elasticsearch.impls.elasticsearch6
 import com.gu.mediaservice.lib.formatting.printDateTime
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.searches.queries.{BoolQuery, Query}
+import com.sksamuel.elastic4s.searches.queries.{BoolQuery, NestedQuery, Query}
 import org.joda.time.DateTime
 import scalaz.NonEmptyList
 import scalaz.syntax.foldable1._
@@ -67,4 +67,5 @@ object filters {
     )
   }
 
+  def nested(path: String, query: Query) = NestedQuery(path, query)
 }

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -2,7 +2,7 @@ package lib.elasticsearch
 
 import java.util.UUID
 
-import com.gu.mediaservice.model.{Edits, FileMetadata, ImageMetadata, Handout, StaffPhotographer}
+import com.gu.mediaservice.model.{Edits, FileMetadata, Handout, ImageMetadata, StaffPhotographer}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures
@@ -20,8 +20,21 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
     createImage(UUID.randomUUID().toString, Handout(), usages = List(createDigitalUsage())),
 
     // with user metadata
-    createImage(id = "test-image-13-edited", Handout()).copy(userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author")))), uploadTime = DateTime.now.minusMonths(1)),
-    createImage(id = "test-image-14-unedited", Handout()).copy(uploadTime = DateTime.now.minusMonths(1)),
+    createImage(id = "persisted-because-edited", Handout()).copy(
+      userMetadata = Some(Edits(
+        metadata = ImageMetadata(credit = Some("author")))
+      ),
+      uploadTime = DateTime.now.minusMonths(1)
+    ),
+
+    createImage(id = "test-image-14-unedited", Handout()).copy(
+      uploadTime = DateTime.now.minusMonths(1)
+    ),
+
+    createImage(id = "persisted-because-usage", Handout()).copy(
+      uploadTime = DateTime.now.minusMonths(1),
+      usages = List(createPrintUsage())
+    ),
 
     // available for syndication
     createImageForSyndication(

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -19,20 +19,13 @@ class ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
     createImage(UUID.randomUUID().toString, StaffPhotographer("Yellow Giraffe", "The Guardian")),
     createImage(UUID.randomUUID().toString, Handout(), usages = List(createDigitalUsage())),
 
-    // with user metadata
-    createImage(id = "persisted-because-edited", Handout()).copy(
-      userMetadata = Some(Edits(
-        metadata = ImageMetadata(credit = Some("author")))
-      ),
-      uploadTime = DateTime.now.minusMonths(1)
+    createImageUploadedInThePast("persisted-because-edited").copy(
+      userMetadata = Some(Edits(metadata = ImageMetadata(credit = Some("author"))))
     ),
 
-    createImage(id = "test-image-14-unedited", Handout()).copy(
-      uploadTime = DateTime.now.minusMonths(1)
-    ),
+    createImageUploadedInThePast("test-image-14-unedited"),
 
-    createImage(id = "persisted-because-usage", Handout()).copy(
-      uploadTime = DateTime.now.minusMonths(1),
+    createImageUploadedInThePast("persisted-because-usage").copy(
       usages = List(createPrintUsage())
     ),
 

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -55,6 +55,10 @@ trait Fixtures {
     )
   }
 
+  def createImageUploadedInThePast(id: String): Image = createImage(id = id, Handout()).copy(
+    uploadTime = DateTime.now.minusMonths(1)
+  )
+
   def createImageForSyndication(
     id: String,
     rightsAcquired: Boolean,

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -98,6 +98,8 @@ trait Fixtures {
     createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, date)
   }
 
+  def createPrintUsage(date: DateTime = DateTime.now): Usage = createUsage(InDesignUsageReference, PrintUsage, PendingUsageStatus, date)
+
   def stringLongerThan(i: Int): String = {
     var out = ""
     while (out.trim.length < i) {


### PR DESCRIPTION
Usages is a [nested field](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/Mappings.scala#L245) in ES6, therefore we need to use a nested query against that field - https://www.elastic.co/guide/en/elasticsearch/guide/current/nested-query.html.

This PR fixes the persisted filter (including tests). `has:usages` is not fixed, however; we can do this as a separate PR.

This also fixes the recent spate of Media API 5XX alarms. This was caused by:
- reaper asking media-api for 100 images to delete
- media-api, incorrectly, returning images that have usages
- reaper issuing a DELETE request for each image
- media-api returns non 200 as the image cannot be deleted
- alarm rings

This PR addresses the issue as media-api will not return images that have usages in reaper's first request.