### PR TITLE
Remove cropper api key

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -46,7 +46,7 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
 
   override def invokeBlock[A](request: Request[A], block: Authentication.Request[A] => Future[Result]): Future[Result] = {
     // Try to auth by API key, and failing that, with Panda
-    request.headers.get(headerKey) match {
+    request.headers.get(Authentication.apiKeyHeaderName) match {
       case Some(key) =>
         keyStore.lookupIdentity(key) match {
           case Some(apiKey) =>
@@ -103,7 +103,8 @@ object Authentication {
   case class OnBehalfOfUser(override val principal: PandaUser, cookie: WSCookie) extends OnBehalfOfPrincipal
   case class OnBehalfOfService(override val principal: AuthenticatedService) extends OnBehalfOfPrincipal
 
-  val headerKey = "X-Gu-Media-Key"
+  val apiKeyHeaderName = "X-Gu-Media-Key"
+  val originalServiceHeaderName = "X-Gu-Original-Service"
 
   def getEmail(principal: Principal): String = principal match {
     case PandaUser(user) => user.email

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
@@ -40,7 +40,6 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
     val mandatoryMarkers = Map(
       "origin" -> originIp,
       "referrer" -> referer,
-      "originalService" -> originalService,
       "method" -> request.method,
       "status" -> response.header.status,
       "duration" -> duration
@@ -62,7 +61,6 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
     val mandatoryMarkers = Map(
       "origin" -> originIp,
       "referrer" -> referer,
-      "originalService" -> originalService,
       "method" -> request.method,
       "duration" -> duration
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.play
 
 import akka.stream.Materializer
+import com.gu.mediaservice.lib.auth.Authentication
 import net.logstash.logback.marker.Markers.appendEntries
 import play.api.mvc.{Filter, RequestHeader, Result}
 import play.api.{Logger, MarkerContext}
@@ -33,11 +34,13 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
   private def logSuccess(request: RequestHeader, response: Result, duration: Long): Unit = {
     val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
     val referer = request.headers.get("Referer").getOrElse("")
+    val originalService = request.headers.get(Authentication.originalServiceHeaderName).getOrElse("")
     val length = response.header.headers.getOrElse("Content-Length", 0)
 
     val markers = MarkerContext(appendEntries(Map(
       "origin" -> originIp,
       "referrer" -> referer,
+      "originalService" -> originalService,
       "method" -> request.method,
       "status" -> response.header.status,
       "duration" -> duration
@@ -49,10 +52,12 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
   private def logFailure(request: RequestHeader, throwable: Throwable, duration: Long): Unit = {
     val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
     val referer = request.headers.get("Referer").getOrElse("")
+    val originalService = request.headers.get(Authentication.originalServiceHeaderName).getOrElse("")
 
     val markers = MarkerContext(appendEntries(Map(
       "origin" -> originIp,
       "referrer" -> referer,
+      "originalService" -> originalService,
       "method" -> request.method,
       "duration" -> duration
     ).asJava))

--- a/cropper/app/controllers/CropperController.scala
+++ b/cropper/app/controllers/CropperController.scala
@@ -143,10 +143,13 @@ class CropperController(auth: Authentication, crops: Crops, store: CropStore, no
 
     case class HttpClientResponse(status: Int, statusText: String, json: JsValue)
 
-    val baseRequest = ws.url(uri).withQueryStringParameters("include" -> "fileMetadata")
+    val baseRequest = ws.url(uri)
+      .withQueryStringParameters("include" -> "fileMetadata")
+      .withHttpHeaders(Authentication.originalServiceHeaderName -> "cropper")
+
     val request = onBehalfOfPrincipal match {
       case OnBehalfOfService(service) =>
-        baseRequest.withHttpHeaders(Authentication.headerKey -> service.apiKey.name)
+        baseRequest.addHttpHeaders(Authentication.apiKeyHeaderName -> service.apiKey.name)
 
       case OnBehalfOfUser(_, cookie) =>
         baseRequest.addCookies(cookie)


### PR DESCRIPTION
Cropper uses an API key to access Media API - obtaining metadata about an image before cropping. It must be created before a new deployment of the Grid is used.

This PR removes the API key, passing through the credentials from the cropping request (API key or Panda cookie), removing the need for the API key.

I've added a new field to `RequestLoggingFilter`: `originalSystem`. This will allow us to distinguish between requests from a real client and inter-service requests done on behalf of a client.