### PR TITLE
Remove hard-coded name for the Thrall Kinesis stream

### DIFF
--- a/cloud-formation/dev-template.yaml
+++ b/cloud-formation/dev-template.yaml
@@ -113,7 +113,6 @@ Resources:
   ThrallMessageQueue:
     Type: AWS::Kinesis::Stream
     Properties:
-      Name: media-service-thrall-DEV
       ShardCount: 1
       RetentionPeriodHours: 168
       Tags:
@@ -274,3 +273,5 @@ Outputs:
     Value: !Ref 'LiveContentPollTable'
   PreviewContentPollTable:
     Value: !Ref 'PreviewContentPollTable'
+  ThrallMessageQueue:
+    Value: !Ref 'ThrallMessageQueue'


### PR DESCRIPTION
At the moment you can't have more than one stream per account which makes it hard to test setting up a new stack from scratch.

This change will remove/rename the existing stream and is thus dependent on #2510 before merging, as that PR allows us to inject the stream name in config.