### PR TITLE
Correctly identify Bloomberg uploads

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -15,6 +15,7 @@ object SupplierProcessors {
     AllStarParser,
     ApParser,
     BarcroftParser,
+    BloombergParser,
     CorbisParser,
     EpaParser,
     GettyXmpParser,
@@ -145,6 +146,16 @@ object BarcroftParser extends ImageProcessor {
     if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
       List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
     }) image.copy(usageRights = Agency("Barcroft Media")) else image
+}
+
+object BloombergParser extends ImageProcessor {
+  def apply(image: Image): Image = image.metadata.credit match {
+    case Some("Bloomberg") => image.copy(
+      usageRights = Agency("Bloomberg"),
+      metadata    = image.metadata.copy(credit = Some("Bloomberg"))
+    )
+    case _ => image
+  }
 }
 
 object CorbisParser extends ImageProcessor {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -151,8 +151,7 @@ object BarcroftParser extends ImageProcessor {
 object BloombergParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     case Some("Bloomberg") => image.copy(
-      usageRights = Agency("Bloomberg"),
-      metadata    = image.metadata.copy(credit = Some("Bloomberg"))
+      usageRights = Agencies.get("bloomberg")
     )
     case _ => image
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -68,6 +68,7 @@ object UsageRightsConfig {
     "Allstar Picture Library",
     "AP",
     "Barcroft Media",
+    "Bloomberg",
     "EPA",
     "Getty Images",
     "PA",

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -160,7 +160,8 @@ object Agencies {
     "getty" -> Agency("Getty Images"),
     "rex" -> Agency("Rex Features"),
     "aap" -> Agency("AAP"),
-    "alamy" -> Agency("Alamy")
+    "alamy" -> Agency("Alamy"),
+    "bloomberg" -> Agency("Bloomberg")
   )
 
   def get(id: String) = all.getOrElse(id, Agency(id))

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -448,6 +448,25 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   }
 
 
+  describe("Bloomberg") {
+    it("should match Bloomberg credit") {
+      val image = createImageFromMetadata("credit" -> "Bloomberg")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Bloomberg"))
+      processedImage.metadata.credit should be(Some("Bloomberg"))
+    }
+    
+    it("should detect Bloomberg via Getty as Getty with suppliersCollection Bloomberg and not as Bloomberg") {
+      val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
+      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "atari.jpg")))
+      val processedImage = applyProcessors(gettyImage)
+      processedImage.usageRights should be(Agency("Getty Images", Some("Bloomberg")))
+      processedImage.metadata.credit should be(Some("Bloomberg via Getty Images"))
+      processedImage.metadata.source should be(Some("Bloomberg"))
+    }
+  }
+
+
   def applyProcessors(image: Image): Image =
     SupplierProcessors.process(image)
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -161,6 +161,7 @@ class UsageStore(
         case s if s.agency.supplier.contains("Getty Images") => copyAgency(s, "getty")
         case s if s.agency.supplier.contains("Australian Associated Press") => copyAgency(s, "aap")
         case s if s.agency.supplier.contains("Alamy") => copyAgency(s, "alamy")
+        case s if s.agency.supplier.contains("Bloomberg") => copyAgency(s, "bloomberg")
         case s => s
       }
 


### PR DESCRIPTION
Not sure about the second test as order of things may be such – it won’t work. In which case, we will have to remove [this line](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala#L16). Then, the end result would be a tad less correct (old `Bloomberg via Getty` would just be unrecognised as opposed to be recognised as paid Getty collection), but practically – almost the same (pics red).