### PR TITLE
Bump sbt-riff-raff-artifact plugin to use latest buildinfo

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 


### PR DESCRIPTION
With #2516 we broke the version picked up by riff-raff (switching from the SBT build runner means that the system properties are no longer exposed). The latest riffraff artifact plugin has improved semantics around this and will figure it out from environment variables that are always there (see https://github.com/guardian/sbt-riffraff-artifact/pull/50).