### PR TITLE
Remove cloudfront-signing feature toggle

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/FeatureToggle.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/FeatureToggle.scala
@@ -2,7 +2,6 @@ package com.gu.mediaservice.lib
 
 object FeatureToggle {
   val defaultSwitchMap: Map[String, Boolean] = Map(
-    "cloudfront-signing" -> true,
     "usage-quota-ui" -> true
   )
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -147,11 +147,9 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       .map(s3Client.signUrl(config.imageBucket, _, image))
 
     def s3SignedThumbUrl = s3Client.signUrl(config.thumbBucket, fileUri, image)
-    val thumbUrl = if(FeatureToggle.get("cloudfront-signing")) {
-      config.cloudFrontDomainThumbBucket
+    val thumbUrl = config.cloudFrontDomainThumbBucket
         .flatMap(s3Client.signedCloudFrontUrl(_, fileUri.getPath.drop(1)))
         .getOrElse(s3SignedThumbUrl)
-    } else { s3SignedThumbUrl }
 
     val validityMap       = ImageExtras.validityMap(image, withWritePermission)
     val valid             = ImageExtras.isValid(validityMap)


### PR DESCRIPTION
The feature is now enabled simply by adding the `cloudfront.domain.thumbbucket` configuration option in Media API