### PR TITLE
switch node version in dev-start.sh

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -86,8 +86,24 @@ downloadApplicationConfig() {
     fi
 }
 
+fileExists() {
+  test -e "$1"
+}
+
+changeNodeVersion() {
+  if ! fileExists "$NVM_DIR/nvm.sh"; then
+    node_version=`cat .nvmrc`
+    echo -e "${red}nvm not found ${plain} NVM is required to run this project"
+    echo -e "Install it from https://github.com/creationix/nvm#installation"
+  else
+    source "$NVM_DIR/nvm.sh"
+    nvm install
+  fi
+}
+
 main() {
     checkRequirements
+    changeNodeVersion
     setupImgops
     downloadApplicationConfig
     startDockerContainers


### PR DESCRIPTION
to remove the pain of having to remember to run `nvm use` manually each time you want to run grid via the dev-start script