### PR TITLE
Remove kinesis workaround for RCS-poller-lambda

### DIFF
--- a/thrall/app/lib/MessageProcessor.scala
+++ b/thrall/app/lib/MessageProcessor.scala
@@ -115,12 +115,6 @@ class MessageProcessor(es: ElasticSearchVersion,
             )
           case _ => GridLogger.info(s"Image $id not found")
         }
-
-        Future.successful {
-          // Mirror RCS messages onto Kinesis for migration. It was not possible to write to Kinesis from the RCS lambda
-          val updateMessage = UpdateMessage(subject = "upsert-rcs-rights", id = Some(id), syndicationRights = Some(syndicationRights))
-          kinesis.publish(updateMessage)
-        }
       }
     }
   }


### PR DESCRIPTION
This is no longer needed, as lambda can talk to Kinesis directly.