### PR TITLE
remove commented code

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/MessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/MessageSender.scala
@@ -18,16 +18,17 @@ class MessageSender(config: CommonConfig, snsTopicArn: String) {
   }
 }
 
-case class UpdateMessage(subject: String,
-                         image: Option[Image] = None,
-                         id: Option[String] = None,
-                         usageNotice: Option[UsageNotice] = None,
-                         edits: Option[Edits] = None,
-                         lastModified: Option[DateTime] = None,
-                         collections: Option[Seq[Collection]] = None,
-                         leaseId: Option[String] = None,
-                         crops: Option[Seq[Crop]] = None,
-                         mediaLease: Option[MediaLease] = None,
-                         leases: Option[Seq[MediaLease]] = None,
-                         syndicationRights: Option[SyndicationRights] = None
-                        )
+case class UpdateMessage(
+  subject: String,
+  image: Option[Image] = None,
+  id: Option[String] = None,
+  usageNotice: Option[UsageNotice] = None,
+  edits: Option[Edits] = None,
+  lastModified: Option[DateTime] = None,
+  collections: Option[Seq[Collection]] = None,
+  leaseId: Option[String] = None,
+  crops: Option[Seq[Crop]] = None,
+  mediaLease: Option[MediaLease] = None,
+  leases: Option[Seq[MediaLease]] = None,
+  syndicationRights: Option[SyndicationRights] = None
+)

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -11,7 +11,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new ThrallConfig(configuration)
 
   val store = new ThrallStore(config)
-  val dynamoNotifications = new MetadataNotifications(config)
+  val metadataEditorNotifications = new MetadataEditorNotifications(config)
   val thrallMetrics = new ThrallMetrics(config)
 
   val es1Config = for {
@@ -70,7 +70,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
 
   es6pot.map { es6 =>
     val thrallKinesisMessageConsumer = new kinesis.ThrallMessageConsumer(config, es6, thrallMetrics,
-      store, dynamoNotifications, new SyndicationRightsOps(es6), config.from)
+      store, metadataEditorNotifications, new SyndicationRightsOps(es6), config.from)
     thrallKinesisMessageConsumer.start()
   }
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -60,7 +60,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   }
 
   val messageConsumerForHealthCheck = es1Opt.map { es1 =>
-    val thrallMessageConsumer = new ThrallMessageConsumer(config, es1, thrallMetrics, store, dynamoNotifications, new SyndicationRightsOps(es1))
+    val thrallMessageConsumer = new ThrallMessageConsumer(config, es1, thrallMetrics, store, new SyndicationRightsOps(es1))
     thrallMessageConsumer.startSchedule()
     context.lifecycle.addStopHook {
       () => thrallMessageConsumer.actorSystem.terminate()

--- a/thrall/app/lib/MessageProcessor.scala
+++ b/thrall/app/lib/MessageProcessor.scala
@@ -10,7 +10,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MessageProcessor(es: ElasticSearchVersion,
                        store: ThrallStore,
-                       metadataNotifications: MetadataNotifications,
                        syndicationRightsOps: SyndicationRightsOps,
                        kinesis: Kinesis
                       ) extends ImageId {
@@ -83,10 +82,6 @@ class MessageProcessor(es: ElasticSearchVersion,
         es.deleteImage(id).map { requests =>
           requests.map {
             case _: ElasticSearchDeleteResponse =>
-              //store.deleteOriginal(id)
-              //store.deleteThumbnail(id)
-              //store.deletePng(id)
-              //metadataNotifications.publish(Json.obj("id" -> id), "image-deleted")
               EsResponse(s"Image deleted: $id")
           } recoverWith {
             case ImageNotDeletable =>

--- a/thrall/app/lib/MetadataEditorNotifications.scala
+++ b/thrall/app/lib/MetadataEditorNotifications.scala
@@ -1,0 +1,8 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.SNS
+import play.api.libs.json.Json
+
+class MetadataEditorNotifications(config: ThrallConfig) extends SNS(config, config.metadataTopicArn) {
+  def publishImageDeletion(id: String) = publish(Json.obj("id" -> id), "image-deleted")
+}

--- a/thrall/app/lib/MetadataNotifications.scala
+++ b/thrall/app/lib/MetadataNotifications.scala
@@ -1,5 +1,0 @@
-package lib
-
-import com.gu.mediaservice.lib.aws.SNS
-
-class MetadataNotifications(config: ThrallConfig) extends SNS(config, config.metadataTopicArn)

--- a/thrall/app/lib/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/ThrallMessageConsumer.scala
@@ -11,7 +11,6 @@ class ThrallMessageConsumer(
                              es: ElasticSearchVersion,
                              thrallMetrics: ThrallMetrics,
                              store: ThrallStore,
-                             metadataNotifications: MetadataNotifications,
                              syndicationRightsOps: SyndicationRightsOps
 )(implicit ec: ExecutionContext) extends MessageConsumer (
   config.queueUrl,
@@ -22,7 +21,7 @@ class ThrallMessageConsumer(
 
   val kinesis: Kinesis = new Kinesis(config, config.thrallKinesisStream)
 
-  val messageProcessor = new MessageProcessor(es, store, metadataNotifications, syndicationRightsOps, kinesis)
+  val messageProcessor = new MessageProcessor(es, store, syndicationRightsOps, kinesis)
 
   override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] = {
     messageProcessor.chooseProcessor(subject)

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MessageProcessor(es: ElasticSearchVersion,
                        store: ThrallStore,
-                       metadataNotifications: MetadataNotifications,
+                       metadataEditorNotifications: MetadataEditorNotifications,
                        syndicationRightsOps: SyndicationRightsOps
                       ) {
 
@@ -127,7 +127,7 @@ class MessageProcessor(es: ElasticSearchVersion,
               store.deleteOriginal(id)
               store.deleteThumbnail(id)
               store.deletePng(id)
-              metadataNotifications.publish(Json.obj("id" -> id), "image-deleted")
+              metadataEditorNotifications.publishImageDeletion(id)
               EsResponse(s"Image deleted: $id")
           } recoverWith {
             case ImageNotDeletable =>

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -20,10 +20,10 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 class ThrallEventConsumer(es: ElasticSearchVersion,
                           thrallMetrics: ThrallMetrics,
                           store: ThrallStore,
-                          metadataNotifications: MetadataNotifications,
+                          metadataEditorNotifications: MetadataEditorNotifications,
                           syndicationRightsOps: SyndicationRightsOps) extends IRecordProcessor with PlayJsonHelpers {
 
-  private val messageProcessor = new MessageProcessor(es, store, metadataNotifications, syndicationRightsOps)
+  private val messageProcessor = new MessageProcessor(es, store, metadataEditorNotifications, syndicationRightsOps)
 
   private implicit val ctx: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newCachedThreadPool)

--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -13,7 +13,7 @@ class ThrallMessageConsumer(config: ThrallConfig,
                             es: ElasticSearchVersion,
                             thrallMetrics: ThrallMetrics,
                             store: ThrallStore,
-                            metadataNotifications: MetadataNotifications,
+                            metadataEditorNotifications: MetadataEditorNotifications,
                             syndicationRightsOps: SyndicationRightsOps,
                             from: Option[DateTime]
                            ) extends MessageConsumerVersion {
@@ -21,7 +21,7 @@ class ThrallMessageConsumer(config: ThrallConfig,
   val workerId = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
   private val thrallEventProcessorFactory = new IRecordProcessorFactory {
-    override def createProcessor(): IRecordProcessor = new ThrallEventConsumer(es, thrallMetrics, store, metadataNotifications, syndicationRightsOps)
+    override def createProcessor(): IRecordProcessor = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, syndicationRightsOps)
   }
 
   private val builder: KinesisClientLibConfiguration => Worker = new Worker.Builder().recordProcessorFactory(thrallEventProcessorFactory).config(_).build()


### PR DESCRIPTION
When an image is deleted, Thrall writes to an SNS topic for metadata-editor to consume and then delete anything in dynamo for the image.

Within Thrall's SNS MessageConsumer, we had commented out the code to send these messages as we're sending them from the Kinesis MessageConsumer.

Commented out code isn't useful, so let's just remove it. This has also allowed us to remove the `MetadataNotifications` from that class too!

Rename `MetadataNotifications` to `MetadataEditorNotifications` and also add a `publishImageDeletion` function for explicitness.