### PR TITLE
Revert "Revert "Correctly identify Bloomberg uploads""

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -15,6 +15,7 @@ object SupplierProcessors {
     AllStarParser,
     ApParser,
     BarcroftParser,
+    BloombergParser,
     CorbisParser,
     EpaParser,
     GettyXmpParser,
@@ -145,6 +146,15 @@ object BarcroftParser extends ImageProcessor {
     if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
       List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
     }) image.copy(usageRights = Agency("Barcroft Media")) else image
+}
+
+object BloombergParser extends ImageProcessor {
+  def apply(image: Image): Image = image.metadata.credit match {
+    case Some("Bloomberg") => image.copy(
+      usageRights = Agencies.get("bloomberg")
+    )
+    case _ => image
+  }
 }
 
 object CorbisParser extends ImageProcessor {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -68,6 +68,7 @@ object UsageRightsConfig {
     "Allstar Picture Library",
     "AP",
     "Barcroft Media",
+    "Bloomberg",
     "EPA",
     "Getty Images",
     "PA",

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -160,7 +160,8 @@ object Agencies {
     "getty" -> Agency("Getty Images"),
     "rex" -> Agency("Rex Features"),
     "aap" -> Agency("AAP"),
-    "alamy" -> Agency("Alamy")
+    "alamy" -> Agency("Alamy"),
+    "bloomberg" -> Agency("Bloomberg")
   )
 
   def get(id: String) = all.getOrElse(id, Agency(id))

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -448,6 +448,25 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   }
 
 
+  describe("Bloomberg") {
+    it("should match Bloomberg credit") {
+      val image = createImageFromMetadata("credit" -> "Bloomberg")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Bloomberg"))
+      processedImage.metadata.credit should be(Some("Bloomberg"))
+    }
+    
+    it("should detect Bloomberg via Getty as Getty with suppliersCollection Bloomberg and not as Bloomberg") {
+      val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
+      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "atari.jpg")))
+      val processedImage = applyProcessors(gettyImage)
+      processedImage.usageRights should be(Agency("Getty Images", Some("Bloomberg")))
+      processedImage.metadata.credit should be(Some("Bloomberg via Getty Images"))
+      processedImage.metadata.source should be(Some("Bloomberg"))
+    }
+  }
+
+
   def applyProcessors(image: Image): Image =
     SupplierProcessors.process(image)
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -161,6 +161,7 @@ class UsageStore(
         case s if s.agency.supplier.contains("Getty Images") => copyAgency(s, "getty")
         case s if s.agency.supplier.contains("Australian Associated Press") => copyAgency(s, "aap")
         case s if s.agency.supplier.contains("Alamy") => copyAgency(s, "alamy")
+        case s if s.agency.supplier.contains("Bloomberg") => copyAgency(s, "bloomberg")
         case s => s
       }
 


### PR DESCRIPTION
Reverts guardian/grid#2519, because in the end _It wasn’t me_

![image](https://user-images.githubusercontent.com/6032869/56284163-9b53b680-610b-11e9-89a0-b3bba9582a91.png)

(which saddens me, if anything!)