### PR TITLE
es6 config is no longer optional

### DIFF
--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -42,18 +42,13 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
         "App"   -> Seq(elasticsearchApp)
       ))
 
-  lazy val elasticsearchPort: Option[Int] = properties.get("es.port").map(_.toInt)
-  lazy val elasticsearchCluster: Option[String] = properties.get("es.cluster")
+  lazy val elasticsearchPort: Int = properties("es.port").toInt
+  lazy val elasticsearchCluster: String = properties("es.cluster")
 
-  lazy val elasticsearch6Url: Option[String] =  {
-    if (isDev)
-      Some(properties.getOrElse("es6.url", "http://localhost:9200"))
-    else
-      properties.get("es6.url")
-  }
-  lazy val elasticsearch6Cluster: Option[String] = properties.get("es6.cluster")
-  lazy val elasticsearch6Shards = Some(if (isDev) 1 else properties("es6.shards").toInt)
-  lazy val elasticsearch6Replicas = Some(if (isDev) 0 else properties("es6.replicas").toInt)
+  lazy val elasticsearch6Url: String =  properties("es6.url")
+  lazy val elasticsearch6Cluster: String = properties("es6.cluster")
+  lazy val elasticsearch6Shards: Int = properties("es6.shards").toInt
+  lazy val elasticsearch6Replicas: Int = properties("es6.replicas").toInt
 
   lazy val imageBucket: String = properties("s3.image.bucket")
   lazy val thumbBucket: String = properties("s3.thumb.bucket")

--- a/scripts/generate-dot-properties/config.json5
+++ b/scripts/generate-dot-properties/config.json5
@@ -17,6 +17,13 @@
     key: ''
   },
 
+  es6: {
+    cluster: 'media-service',
+    url: 'http://localhost:9206',
+    shards: 1,
+    replicas: 0
+  },
+
   // Guardian specific properties for the Usage service
   capi: {
     poll:  5,

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -90,6 +90,10 @@ function getMediaApiConfig(config) {
         |es.index.aliases.read=readAlias
         |es.port=9300
         |es.cluster=media-service
+        |es6.url=${config.es6.url}
+        |es6.cluster=${config.es6.cluster}
+        |es6.shards=${config.es6.shards}
+        |es6.replicas=${config.es6.replicas}
         |quota.store.key=rcs-quota.json
         |`;
 }
@@ -133,6 +137,10 @@ function getThrallConfig(config) {
         |indexed.image.sns.topic.arn=${config.stackProps.IndexedImageTopicArn}
         |es.port=9300
         |es.cluster=media-service
+        |es6.url=${config.es6.url}
+        |es6.cluster=${config.es6.cluster}
+        |es6.shards=${config.es6.shards}
+        |es6.replicas=${config.es6.replicas}
         |`;
 }
 

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -20,7 +20,7 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
 
   lazy val thumbnailBucket: String = properties("s3.thumb.bucket")
 
-  lazy val elasticsearchHost: Option[String] = Some {
+  lazy val elasticsearchHost: String =
     if (isDev)
       properties.getOrElse("es.host", "localhost")
     else
@@ -29,20 +29,14 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
         "Stack" -> Seq(elasticsearchStack),
         "App" -> Seq(elasticsearchApp)
       ))
-  }
 
-  lazy val elasticsearchPort: Option[Int] = properties.get("es.port").map(_.toInt)
-  lazy val elasticsearchCluster: Option[String] = properties.get("es.cluster")
+  lazy val elasticsearchPort: Int = properties("es.port").toInt
+  lazy val elasticsearchCluster: String = properties("es.cluster")
 
-  lazy val elasticsearch6Url: Option[String] =  {
-    if (isDev)
-      Some(properties.getOrElse("es6.url", "http://localhost:9200"))
-    else
-      properties.get("es6.url")
-  }
-  lazy val elasticsearch6Cluster: Option[String] = properties.get("es6.cluster")
-  lazy val elasticsearch6Shards = Some(if (isDev) 1 else properties("es6.shards").toInt)
-  lazy val elasticsearch6Replicas = Some(if (isDev) 0 else properties("es6.replicas").toInt)
+  lazy val elasticsearch6Url: String =  properties("es6.url")
+  lazy val elasticsearch6Cluster: String = properties("es6.cluster")
+  lazy val elasticsearch6Shards: Int = properties("es6.shards").toInt
+  lazy val elasticsearch6Replicas: Int = properties("es6.replicas").toInt
 
   lazy val healthyMessageRate: Int = properties("sqs.message.min.frequency").toInt
 


### PR DESCRIPTION
## What does this change?
This PR makes the ES* config easier to reason about by removing Option types.

We've been running both clusters for a while and there is no scenario where we would only be running es1.

Update the config generator to add es6 config to the .properties files too.

Ultimately, this is to make the removal of the ES1 cluster easier.

## How can success be measured?
Fewer headaches!

## Screenshots (if applicable)
n/a

## Who should look at this?
**YOU**

## Tested?
- [x] locally
- [x] on TEST