### PR TITLE
Rename Witness to Readers Photos

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -261,7 +261,7 @@ final case class GuardianWitness(restrictions: Option[String] = None) extends Us
   val defaultCost = GuardianWitness.defaultCost
 }
 object GuardianWitness extends UsageRightsSpec {
-  val category = "guardian-readers-photos"
+  val category = "guardian-witness"
   val defaultCost = Some(Free)
   val name = "Guardian Readers Photos"
   val description =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -261,12 +261,15 @@ final case class GuardianWitness(restrictions: Option[String] = None) extends Us
   val defaultCost = GuardianWitness.defaultCost
 }
 object GuardianWitness extends UsageRightsSpec {
-  val category = "guardian-witness"
+  val category = "guardian-readers-photos"
   val defaultCost = Some(Free)
-  val name = "GuardianWitness"
+  val name = "Guardian Readers Photos"
   val description =
-    "Images provided by readers in response to callouts and assignments on GuardianWitness."
+    "Images provided by readers in response to community callouts and assignments."
 
+  override val caution =
+    Some("Please coordinate use with community team by emailing community@theguardian.com.")
+  
   implicit val formats: Format[GuardianWitness] =
     UsageRights.subtypeFormat(GuardianWitness.category)(Json.format[GuardianWitness])
 }

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -47,7 +47,7 @@ dndUploader.controller('DndUploaderCtrl',
                       update(userMetadata, metadata, fullImage);
 
             const rights = {
-                category: 'guardian-readers-photos'
+                category: 'guardian-witness'
             };
             const userRights = fullImage.data.userMetadata.data.usageRights;
             const rightsUpdate = editsService.

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -47,7 +47,7 @@ dndUploader.controller('DndUploaderCtrl',
                       update(userMetadata, metadata, fullImage);
 
             const rights = {
-                category: 'guardian-witness'
+                category: 'guardian-readers-photos'
             };
             const userRights = fullImage.data.userMetadata.data.usageRights;
             const rightsUpdate = editsService.


### PR DESCRIPTION
There is plenty of code we could remove since the death of n0tice, instead here is just cosmetics. 

![image](https://user-images.githubusercontent.com/6032869/56596349-538bce00-65e8-11e9-9fd6-268a37744ca7.png)

![image](https://user-images.githubusercontent.com/6032869/56596394-630b1700-65e8-11e9-9505-b3bdc0101c98.png)

Yeah, I know it should be `Readers’ Photos`, but wouldn’t play nice with the URL and stuff.

- [x] tested on TEST