### PR TITLE
Feature/configurable hardcoded properties

### DIFF
--- a/cloud-formation/dev-template.yaml
+++ b/cloud-formation/dev-template.yaml
@@ -113,7 +113,6 @@ Resources:
   ThrallMessageQueue:
     Type: AWS::Kinesis::Stream
     Properties:
-      Name: media-service-thrall-DEV
       ShardCount: 1
       RetentionPeriodHours: 168
       Tags:
@@ -274,3 +273,5 @@ Outputs:
     Value: !Ref 'LiveContentPollTable'
   PreviewContentPollTable:
     Value: !Ref 'PreviewContentPollTable'
+  ThrallMessageQueue:
+    Value: !Ref 'ThrallMessageQueue'

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -46,7 +46,7 @@ trait CommonConfig {
   val isProd: Boolean = stage == "PROD"
   val isDev: Boolean = stage == "DEV"
 
-  final val thrallKinesisStream = s"$stackName-thrall-$stage"
+  final val thrallKinesisStream = properties.getOrElse("thrall.kinesis.stream.name", s"$stackName-thrall-$stage")
 
   // Note: had to make these lazy to avoid init order problems ;_;
   lazy val domainRoot: String = properties("domain.root")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -50,13 +50,27 @@ trait CommonConfig {
 
   // Note: had to make these lazy to avoid init order problems ;_;
   lazy val domainRoot: String = properties("domain.root")
-  lazy val services = new Services(domainRoot, isProd)
+  lazy val rootAppName: String = properties.getOrElse("app.name.root", "media")
+  lazy val serviceHosts = ServiceHosts(stringDefault("hosts.kahunaPrefix", s"$rootAppName."),
+                                       stringDefault("hosts.apiPrefix", s"api.$rootAppName."),
+                                       stringDefault("hosts.loaderPrefix", s"loader.$rootAppName."),
+                                       stringDefault("hosts.cropperPrefix", s"cropper.$rootAppName."),
+                                       stringDefault("hosts.metadataPrefix", s"$rootAppName-metadata."),
+                                       stringDefault("hosts.imgopsPrefix", s"$rootAppName-imgops."),
+                                       stringDefault("hosts.usagePrefix", s"$rootAppName-usage."),
+                                       stringDefault("hosts.collectionsPrefix", s"$rootAppName-collections."),
+                                       stringDefault("hosts.leasesPrefix", s"$rootAppName-leases."),
+                                       stringDefault("hosts.authPrefix", s"$rootAppName-auth."))
+  lazy val services = new Services(domainRoot, isProd, serviceHosts)
 
   final def apply(key: String): String =
     string(key)
 
   final def string(key: String): String =
     configuration.getOptional[String](key) getOrElse missing(key, "string")
+
+  final def stringDefault(key: String, default: String): String =
+    configuration.getOptional[String](key) getOrElse default
 
   final def stringOpt(key: String): Option[String] = configuration.getOptional[String](key)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -46,7 +46,7 @@ trait CommonConfig {
   val isProd: Boolean = stage == "PROD"
   val isDev: Boolean = stage == "DEV"
 
-  final val thrallKinesisStream = properties.getOrElse("thrall.kinesis.stream.name", s"$stackName-thrall-$stage")
+  final val thrallKinesisStream = properties("thrall.kinesis.stream.name")
 
   // Note: had to make these lazy to avoid init order problems ;_;
   lazy val domainRoot: String = properties("domain.root")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -1,18 +1,21 @@
 package com.gu.mediaservice.lib.config
 
-class Services(val domainRoot: String, isProd: Boolean) {
-  val appName = "media"
+case class ServiceHosts(kahunaPrefix: String, apiPrefix: String, loaderPrefix: String,
+                        cropperPrefix: String, metadataPrefix: String, imgopsPrefix: String,
+                        usagePrefix: String, collectionsPrefix: String, leasesPrefix: String,
+                        authPrefix: String)
 
-  val kahunaHost: String   = s"$appName.$domainRoot"
-  val apiHost: String      = s"api.$appName.$domainRoot"
-  val loaderHost: String   = s"loader.$appName.$domainRoot"
-  val cropperHost: String  = s"cropper.$appName.$domainRoot"
-  val metadataHost: String = s"$appName-metadata.$domainRoot"
-  val imgopsHost: String   = s"$appName-imgops.$domainRoot"
-  val usageHost: String    = s"$appName-usage.$domainRoot"
-  val collectionsHost: String = s"$appName-collections.$domainRoot"
-  val leasesHost: String   = s"$appName-leases.$domainRoot"
-  val authHost: String     = s"$appName-auth.$domainRoot"
+class Services(val domainRoot: String, isProd: Boolean, hosts: ServiceHosts) {
+  val kahunaHost: String      = s"${hosts.kahunaPrefix}$domainRoot"
+  val apiHost: String         = s"${hosts.apiPrefix}$domainRoot"
+  val loaderHost: String      = s"${hosts.loaderPrefix}$domainRoot"
+  val cropperHost: String     = s"${hosts.cropperPrefix}$domainRoot"
+  val metadataHost: String    = s"${hosts.metadataPrefix}$domainRoot"
+  val imgopsHost: String      = s"${hosts.imgopsPrefix}$domainRoot"
+  val usageHost: String       = s"${hosts.usagePrefix}$domainRoot"
+  val collectionsHost: String = s"${hosts.collectionsPrefix}$domainRoot"
+  val leasesHost: String      = s"${hosts.leasesPrefix}$domainRoot"
+  val authHost: String        = s"${hosts.authPrefix}$domainRoot"
 
   val kahunaBaseUri      = baseUri(kahunaHost)
   val apiBaseUri         = baseUri(apiHost)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearch6Config.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearch6Config.scala
@@ -1,3 +1,3 @@
 package com.gu.mediaservice.lib.elasticsearch6
 
-case class ElasticSearch6Config(alias: String, host: String, port: Int, protocol: String, cluster: String, shards: Int, replicas: Int)
+case class ElasticSearch6Config(alias: String, url: String, cluster: String, shards: Int, replicas: Int)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearch6Config.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearch6Config.scala
@@ -1,3 +1,3 @@
 package com.gu.mediaservice.lib.elasticsearch6
 
-case class ElasticSearch6Config(alias: String, host: String, port: Int, cluster: String, shards: Int, replicas: Int)
+case class ElasticSearch6Config(alias: String, host: String, port: Int, protocol: String, cluster: String, shards: Int, replicas: Int)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
@@ -16,11 +16,7 @@ trait ElasticSearchClient {
   private val tenSeconds = Duration(10, SECONDS)
   private val thirtySeconds = Duration(30, SECONDS)
 
-  def host: String
-
-  def port: Int
-
-  def protocol: String
+  def url: String
 
   def cluster: String
 
@@ -35,8 +31,8 @@ trait ElasticSearchClient {
   def replicas: Int
 
   lazy val client = {
-    Logger.info("Connecting to Elastic 6: " + host + " / " + port)
-    ElasticClient(ElasticProperties(protocol + "://" + host + ":" + port)) // TODO don't like this string config
+    Logger.info("Connecting to Elastic 6: " + url)
+    ElasticClient(ElasticProperties(url))
   }
 
   def ensureAliasAssigned() {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
@@ -20,6 +20,8 @@ trait ElasticSearchClient {
 
   def port: Int
 
+  def protocol: String
+
   def cluster: String
 
   def imagesAlias: String
@@ -34,7 +36,7 @@ trait ElasticSearchClient {
 
   lazy val client = {
     Logger.info("Connecting to Elastic 6: " + host + " / " + port)
-    ElasticClient(ElasticProperties("http://" + host + ":" + port)) // TODO don't like this string config
+    ElasticClient(ElasticProperties(protocol + "://" + host + ":" + port)) // TODO don't like this string config
   }
 
   def ensureAliasAssigned() {

--- a/docs/elasticsearch6.md
+++ b/docs/elasticsearch6.md
@@ -30,8 +30,7 @@ To turn off Elastic 1.7 the es.* config elements should be removed, with the exc
 ```
 es.index.aliases.write=writeAlias
 
-es6.host=elastic6.local
-es6.port=9200
+es6.url=http://elastic6.local:9200
 es6.cluster=media-service
 es6.shards=5
 es6.replicas=2
@@ -42,8 +41,7 @@ es6.replicas=2
 ```
 es.index.aliases.read=readAlias
 
-es6.host=elastic6.local
-es6.port=9200
+es6.url=http://elastic6.local:9200
 es6.cluster=media-service
 es6.shards=5
 es6.replicas=2

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -31,17 +31,14 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   }
 
   val es6Config: Option[ElasticSearch6Config] = for {
-    h <- config.elasticsearch6Host
-    p <- config.elasticsearch6Port
+    u <- config.elasticsearch6Url
     c <- config.elasticsearch6Cluster
     s <- config.elasticsearch6Shards
     r <- config.elasticsearch6Replicas
   } yield {
     ElasticSearch6Config(
       alias = config.imagesAlias,
-      host = h,
-      port = p,
-      protocol = config.elasticsearch6Protocol,
+      url = u,
       cluster = c,
       shards = s,
       replicas = r

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -41,6 +41,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
       alias = config.imagesAlias,
       host = h,
       port = p,
+      protocol = config.elasticsearch6Protocol,
       cluster = c,
       shards = s,
       replicas = r

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -52,6 +52,7 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
       properties.get("es6.host")
   }
   lazy val elasticsearch6Port: Option[Int] = properties.get("es6.port").map(_.toInt)
+  lazy val elasticsearch6Protocol: String = properties.getOrElse("es6.protocol", "http")
   lazy val elasticsearch6Cluster: Option[String] = properties.get("es6.cluster")
   lazy val elasticsearch6Shards = Some(if (isDev) 1 else properties("es6.shards").toInt)
   lazy val elasticsearch6Replicas = Some(if (isDev) 0 else properties("es6.replicas").toInt)

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -45,14 +45,12 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   lazy val elasticsearchPort: Option[Int] = properties.get("es.port").map(_.toInt)
   lazy val elasticsearchCluster: Option[String] = properties.get("es.cluster")
 
-  lazy val elasticsearch6Host: Option[String] =  {
+  lazy val elasticsearch6Url: Option[String] =  {
     if (isDev)
-      Some(properties.getOrElse("es6.host", "localhost"))
+      Some(properties.getOrElse("es6.url", "http://localhost:9200"))
     else
-      properties.get("es6.host")
+      properties.get("es6.url")
   }
-  lazy val elasticsearch6Port: Option[Int] = properties.get("es6.port").map(_.toInt)
-  lazy val elasticsearch6Protocol: String = properties.getOrElse("es6.protocol", "http")
   lazy val elasticsearch6Cluster: Option[String] = properties.get("es6.cluster")
   lazy val elasticsearch6Shards = Some(if (isDev) 1 else properties("es6.shards").toInt)
   lazy val elasticsearch6Replicas = Some(if (isDev) 0 else properties("es6.replicas").toInt)

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -26,9 +26,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
 
   lazy val imagesAlias = elasticConfig.alias
-  lazy val host = elasticConfig.host
-  lazy val port = elasticConfig.port
-  lazy val protocol = elasticConfig.protocol
+  lazy val url = elasticConfig.url
   lazy val cluster = elasticConfig.cluster
   lazy val shards = elasticConfig.shards
   lazy val replicas = elasticConfig.replicas

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -28,6 +28,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   lazy val imagesAlias = elasticConfig.alias
   lazy val host = elasticConfig.host
   lazy val port = elasticConfig.port
+  lazy val protocol = elasticConfig.protocol
   lazy val cluster = elasticConfig.cluster
   lazy val shards = elasticConfig.shards
   lazy val replicas = elasticConfig.replicas

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -32,7 +32,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
     "persistence.identifier" -> "picdarUrn")))
 
   private val mediaApiMetrics = new MediaApiMetrics(mediaApiConfig)
-  val elasticConfig = ElasticSearch6Config(alias = "readAlias", host = "localhost", port = 9206, protocol = "http",
+  val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = "http://localhost:9206",
     cluster = "media-service-test", shards = 1, replicas = 0)
 
   private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig)

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -32,7 +32,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
     "persistence.identifier" -> "picdarUrn")))
 
   private val mediaApiMetrics = new MediaApiMetrics(mediaApiConfig)
-  val elasticConfig = ElasticSearch6Config(alias = "readAlias", host = "localhost", port = 9206,
+  val elasticConfig = ElasticSearch6Config(alias = "readAlias", host = "localhost", port = 9206, protocol = "http",
     cluster = "media-service-test", shards = 1, replicas = 0)
 
   private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig)

--- a/migration/src/main/scala/Main.scala
+++ b/migration/src/main/scala/Main.scala
@@ -32,7 +32,7 @@ object Main extends App with JsonCleaners {
   val es6Alias= args(8)
 
   val es1Config = ElasticSearchConfig(alias = es1Alias, host = es1Host, port = es1Port, cluster = es1Cluster)
-  val es6Config = ElasticSearch6Config(alias = es6Alias, host = es6Host, port = es6Port, protocol = "http", cluster = es6Cluster, shards = 5, replicas = 0)
+  val es6Config = ElasticSearch6Config(alias = es6Alias, url = s"http://$es6Host:$es6Port", cluster = es6Cluster, shards = 5, replicas = 0)
 
   Logger.info("Configuring ES1: " + es1Config)
   val es1 = new com.gu.mediaservice.lib.elasticsearch.ElasticSearchClient {

--- a/migration/src/main/scala/Main.scala
+++ b/migration/src/main/scala/Main.scala
@@ -32,7 +32,7 @@ object Main extends App with JsonCleaners {
   val es6Alias= args(8)
 
   val es1Config = ElasticSearchConfig(alias = es1Alias, host = es1Host, port = es1Port, cluster = es1Cluster)
-  val es6Config = ElasticSearch6Config(alias = es6Alias, host = es6Host, port = es6Port, cluster = es6Cluster, shards = 5, replicas = 0)
+  val es6Config = ElasticSearch6Config(alias = es6Alias, host = es6Host, port = es6Port, protocol = "http", cluster = es6Cluster, shards = 5, replicas = 0)
 
   Logger.info("Configuring ES1: " + es1Config)
   val es1 = new com.gu.mediaservice.lib.elasticsearch.ElasticSearchClient {

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -21,6 +21,7 @@ function getCollectionsConfig(config) {
         |dynamo.table.collections=${config.stackProps.CollectionsDynamoTable}
         |dynamo.table.imageCollections=${config.stackProps.ImageCollectionsDynamoTable}
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |`;
 }
 
@@ -32,6 +33,7 @@ function getCropperConfig(config) {
         |publishing.image.bucket=${config.stackProps.ImageOriginBucket}
         |publishing.image.host=${config.stackProps.ImageOriginBucket}.s3.amazonaws.com
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |`;
 }
@@ -44,6 +46,7 @@ function getImageLoaderConfig(config) {
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |`;
 }
 
@@ -67,6 +70,7 @@ function getLeasesConfig(config) {
         |aws.region=${config.aws.region}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |dynamo.tablename.leasesTable=${config.stackProps.LeasesDynamoTable}
         |`;
 }
@@ -79,6 +83,7 @@ function getMediaApiConfig(config) {
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |s3.usagemail.bucket=${config.stackProps.UsageMailBucket}
         |persistence.identifier=picdarUrn
@@ -96,6 +101,7 @@ function getMetadataEditorConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.collections.bucket=${config.stackProps.CollectionsBucket}
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |dynamo.table.edits=${config.stackProps.EditsDynamoTable}
         |indexed.images.sqs.queue.url=${config.stackProps.IndexedImageMetadataQueueUrl}
         |`;
@@ -118,6 +124,7 @@ function getThrallConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
+        |sns.topic.arn=${config.stackProps.SnsTopicArn}
         |sqs.queue.url=${config.stackProps.SqsQueueUrl}
         |sqs.message.min.frequency=${config.sqsMessageMinFrequency}
         |persistence.identifier=picdarUrn
@@ -139,6 +146,7 @@ function getUsageConfig(config) {
         |dynamo.tablename.usageRecordTable=${config.stackProps.UsageRecordTable}
         |composer.baseUrl=${config.composer.url}
         |sns.topic.arn=${config.stackProps.SnsTopicArn}
+        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |crier.live.arn=${config.crier.live.roleArn}
         |crier.preview.arn=${config.crier.preview.roleArn}
         |crier.preview.name=${config.crier.preview.streamName}

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -39,6 +39,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
         alias = config.writeAlias,
         host = h,
         port = p,
+        protocol = config.elasticsearch6Protocol,
         cluster = c,
         shards = s,
         replicas = r

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -29,17 +29,14 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
 
   val es6Config =
     for {
-      h <- config.elasticsearch6Host
-      p <- config.elasticsearch6Port
+      u <- config.elasticsearch6Url
       c <- config.elasticsearch6Cluster
       s <- config.elasticsearch6Shards
       r <- config.elasticsearch6Replicas
     } yield {
       ElasticSearch6Config(
         alias = config.writeAlias,
-        host = h,
-        port = p,
-        protocol = config.elasticsearch6Protocol,
+        url = u,
         cluster = c,
         shards = s,
         replicas = r

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -21,6 +21,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
   lazy val imagesAlias = config.alias
   lazy val host = config.host
   lazy val port = config.port
+  lazy val protocol = config.protocol
   lazy val cluster = config.cluster
   lazy val shards = config.shards
   lazy val replicas = config.replicas

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -19,9 +19,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
   with ElasticSearch6Executions with ElasticImageUpdate {
 
   lazy val imagesAlias = config.alias
-  lazy val host = config.host
-  lazy val port = config.port
-  lazy val protocol = config.protocol
+  lazy val url = config.url
   lazy val cluster = config.cluster
   lazy val shards = config.shards
   lazy val replicas = config.replicas

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -34,15 +34,12 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   lazy val elasticsearchPort: Option[Int] = properties.get("es.port").map(_.toInt)
   lazy val elasticsearchCluster: Option[String] = properties.get("es.cluster")
 
-  lazy val elasticsearch6Host: Option[String] =  {
+  lazy val elasticsearch6Url: Option[String] =  {
     if (isDev)
-      Some(properties.getOrElse("es6.host", "localhost"))
+      Some(properties.getOrElse("es6.url", "http://localhost:9200"))
     else
-      properties.get("es6.host")
+      properties.get("es6.url")
   }
-
-  lazy val elasticsearch6Port: Option[Int] = properties.get("es6.port").map(_.toInt)
-  lazy val elasticsearch6Protocol: String = properties.getOrElse("es6.protocol", "http")
   lazy val elasticsearch6Cluster: Option[String] = properties.get("es6.cluster")
   lazy val elasticsearch6Shards = Some(if (isDev) 1 else properties("es6.shards").toInt)
   lazy val elasticsearch6Replicas = Some(if (isDev) 0 else properties("es6.replicas").toInt)

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -42,6 +42,7 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   }
 
   lazy val elasticsearch6Port: Option[Int] = properties.get("es6.port").map(_.toInt)
+  lazy val elasticsearch6Protocol: String = properties.getOrElse("es6.protocol", "http")
   lazy val elasticsearch6Cluster: Option[String] = properties.get("es6.cluster")
   lazy val elasticsearch6Shards = Some(if (isDev) 1 else properties("es6.shards").toInt)
   lazy val elasticsearch6Replicas = Some(if (isDev) 0 else properties("es6.replicas").toInt)

--- a/thrall/test/lib/ElasticSearch6Test.scala
+++ b/thrall/test/lib/ElasticSearch6Test.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 class ElasticSearch6Test extends ElasticSearchTestBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "http", "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "http://localhost:9206", "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
   val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")

--- a/thrall/test/lib/ElasticSearch6Test.scala
+++ b/thrall/test/lib/ElasticSearch6Test.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 class ElasticSearch6Test extends ElasticSearchTestBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "http", "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
   val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")

--- a/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 class SyndicationRightsOpsElastic6Test extends SyndicationRightsOpsTestsBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "http", "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "http://localhost:9206", "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
   val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")

--- a/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 class SyndicationRightsOpsElastic6Test extends SyndicationRightsOpsTestsBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "http", "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
   val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")


### PR DESCRIPTION
This should be non-breaking, all properties should default to what they previously were if they have not been set.

Three main properties have been made configurable:
- Thrall kinesis stream name, this can be set in the relevant /etc/gu/ props files with the property key `thrall.kinesis.stream.name`
- Elastic search protocol (i.e. http or https) this defaults to http, and can be set in the /etc/gu/ props files (thrall + api) with the property key `es6.protocol` 
- The host name prefix for the services. E.g. <prefix>domain-root. This is set in the .conf file (as it is required by all the components) an example configuration is as follows:
```
hosts {
  kahunaPrefix: ""
  apiPrefix: "api."
  loaderPrefix: "loader."
  cropperPrefix: "cropper."
  metadataPrefix: "metadata."
  imgopsPrefix: "imgops."
  usagePrefix: "usage."
  collectionsPrefix: "collections."
  leasesPrefix: "leases."
  authPrefix: "auth."
}
```