### PR TITLE
Revert "Shonkily restrict batch editing photoshoots"

### DIFF
--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,13 +1,9 @@
 <section ng:if="! ctrl.editInline">
     <button class="image-info__edit"
             ng:click="photoshootEditForm.$show()"
-            ng:hide="photoshootEditForm.$visible || ctrl.editingDisabled">
+            ng:hide="photoshootEditForm.$visible">
         ✎
     </button>
-
-    <div ng:hide="!ctrl.editingDisabled">
-        Editing photoshoots is not possible for more than 10 images at a time. We are working to improve this, contact thegrid.dev@guardian.co.uk.
-    </div>
 
     <span editable-text="ctrl.photoshootData.title"
           ng:hide="photoshootEditForm.$visible"

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
@@ -24,8 +24,6 @@ photoshoot.controller('GrPhotoshootCtrl', [
     function($rootScope, $scope, imageService, mediaApi, imageAccessor, photoshootService) {
         const ctrl = this;
 
-        ctrl.editingDisabled = false;
-
         function refreshForOne() {
             const image = ctrl._images[0];
             const photoshootResource = imageAccessor.getPhotoshoot(image);
@@ -55,8 +53,6 @@ photoshoot.controller('GrPhotoshootCtrl', [
         function refresh() {
             // `ctrl.images` is a `Set` in multi-select mode, be safe and always have an array
             ctrl._images = Array.from(ctrl.images);
-            ctrl.editingDisabled = ctrl._images.length > 10;
-
             return ctrl._images.length === 1 ? refreshForOne() : refreshForMany();
         }
 


### PR DESCRIPTION
Reverts guardian/grid#2528.

We think #2533 will improve performance enough to be safely used in production.