### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+# ISSUE
+
+## Steps to Reproduce
+
+## Actual Results (include screenshots)
+
+## Expected Results (include screenshots)
+
+## URL
+
+## OS and Browser details
+
+- Device:
+- Browser (inc version):
+- OS:
+
+*Please add relevant labels*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# My Awesome Pull Request
+
+## What does this change?
+
+## What is the value?
+
+## Screenshots
+
+## Requests for comments


### PR DESCRIPTION
GitHub have recently added issue and PR templates https://github.com/blog/2111-issue-and-pull-request-templates.

Although we follow Tackley's Law (TM) on creating issues, the template would act as a prompt for the details needed.