### PR TITLE
added configurable permissions bucket property

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/PermissionsHandler.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/PermissionsHandler.scala
@@ -11,7 +11,7 @@ trait PermissionsHandler {
   def config: CommonConfig
 
   private val permissionsStage = if(config.stage == "PROD") { "PROD" } else { "CODE" }
-  private val permissions = PermissionsProvider(PermissionsConfig(permissionsStage, config.awsRegion, config.awsCredentials))
+  private val permissions = PermissionsProvider(PermissionsConfig(permissionsStage, config.awsRegion, config.awsCredentials, config.permissionsBucket))
 
   def storeIsEmpty: Boolean = {
     permissions.storeIsEmpty

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -37,6 +37,8 @@ trait CommonConfig {
 
   lazy val authKeyStoreBucket = properties("auth.keystore.bucket")
 
+  lazy val permissionsBucket = properties.getOrElse("permissions.bucket", "permissions-cache")
+
   def withAWSCredentials[T, S <: AwsClientBuilder[S, T]](builder: AwsClientBuilder[S, T]): S = builder
     .withRegion(awsRegion)
     .withCredentials(awsCredentials)


### PR DESCRIPTION
Another property that was found to be missing, should be non-breaking as defaults to the original value. (Quite cool to see the permissions stuff working now, can delete other images/edit metadata :) )