### PR TITLE
make elasticsearch metrics optional

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/FutureSyntax.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/FutureSyntax.scala
@@ -10,12 +10,6 @@ trait FutureSyntax {
 
   implicit class FutureOps[A](self: Future[A])(implicit ex: ExecutionContext) {
 
-    def thenIncrement[M, N](onSuccess: Metric[M], onFailure: Metric[N])
-                           (implicit M: Numeric[M], N: Numeric[N]): Future[A] = {
-      incrementOnSuccess(onSuccess)
-      incrementOnFailure(onFailure) { case _ => true }
-    }
-
     def incrementOnSuccess[N](metric: Metric[N])(implicit N: Numeric[N]): Future[A] =
       toMetric(metric)(_ => N.fromInt(1))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/FutureSyntax.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/FutureSyntax.scala
@@ -10,19 +10,19 @@ trait FutureSyntax {
 
   implicit class FutureOps[A](self: Future[A])(implicit ex: ExecutionContext) {
 
-    def incrementOnSuccess[N](metric: Metric[N])(implicit N: Numeric[N]): Future[A] =
+    def incrementOnSuccess[N](metric: Option[Metric[N]])(implicit N: Numeric[N]): Future[A] =
       toMetric(metric)(_ => N.fromInt(1))
 
-    def incrementOnFailure[B](metric: Metric[B])(pfn: PartialFunction[Throwable, Boolean])
+    def incrementOnFailure[B](metric: Option[Metric[B]])(pfn: PartialFunction[Throwable, Boolean])
                              (implicit B: Numeric[B]): Future[A] = {
       self.failed.foreach(pfn.andThen { b =>
-        if (b) metric.runRecordOne(B.fromInt(1))
+        if (b) metric.foreach(_.runRecordOne(B.fromInt(1)))
       })
       self
     }
 
-    def toMetric[B](metric: Metric[B], dims: List[Dimension] = List())(f: A => B): Future[A] = {
-      self.foreach { case a => metric.runRecordOne(f(a), dims) }
+    def toMetric[B](metric: Option[Metric[B]], dims: List[Dimension] = List())(f: A => B): Future[A] = {
+      self.foreach { case a => metric.foreach(_.runRecordOne(f(a), dims)) }
       self
     }
 

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch1/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch1/ElasticSearch.scala
@@ -113,7 +113,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
       .setFrom(params.offset)
       .setSize(params.length)
       .executeAndLog("image search")
-      .toMetric(mediaApiMetrics.searchQueries, List(mediaApiMetrics.searchTypeDimension("results")))(_.getTookInMillis)
+      .toMetric(Some(mediaApiMetrics.searchQueries), List(mediaApiMetrics.searchTypeDimension("results")))(_.getTookInMillis)
       .map(_.getHits)
       .map { results =>
         val hitsTuples = results.hits.toList flatMap (h => h.sourceOpt map (h.id -> _.as[Image]))
@@ -184,7 +184,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
     search
       .setSearchType(SearchType.COUNT)
       .executeAndLog(s"$name aggregate search")
-      .toMetric(mediaApiMetrics.searchQueries, List(mediaApiMetrics.searchTypeDimension("aggregate")))(_.getTookInMillis)
+      .toMetric(Some(mediaApiMetrics.searchQueries), List(mediaApiMetrics.searchTypeDimension("aggregate")))(_.getTookInMillis)
       .map(searchResultToAggregateResponse(_, name))
   }
 
@@ -194,7 +194,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
 
     search
       .executeAndLog("completion suggestion query")
-      .toMetric(mediaApiMetrics.searchQueries, List(mediaApiMetrics.searchTypeDimension("suggestion-completion")))(_.getTookInMillis)
+      .toMetric(Some(mediaApiMetrics.searchQueries), List(mediaApiMetrics.searchTypeDimension("suggestion-completion")))(_.getTookInMillis)
       .map { response =>
         val options =
           response.getSuggest

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -47,14 +47,14 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
 
   val es1Opt = es1Config.map { c =>
     Logger.info("Configuring ES1: " + c)
-    val es1 = new ElasticSearch(c, thrallMetrics)
+    val es1 = new ElasticSearch(c, Some(thrallMetrics))
     es1.ensureAliasAssigned()
     es1
   }
 
   val es6pot = es6Config.map { c =>
     Logger.info("Configuring ES6: " + c)
-    val es6 = new ElasticSearch6(c, thrallMetrics)
+    val es6 = new ElasticSearch6(c, Some(thrallMetrics))
     es6.ensureAliasAssigned()
     es6
   }

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -15,7 +15,7 @@ import play.api.libs.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) extends ElasticSearchVersion with ElasticSearchClient with ImageFields
+class ElasticSearch6(config: ElasticSearch6Config, metrics: Option[ThrallMetrics]) extends ElasticSearchVersion with ElasticSearchClient with ImageFields
   with ElasticSearch6Executions with ElasticImageUpdate {
 
   lazy val imagesAlias = config.alias
@@ -106,7 +106,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 updating usages on image $id")
-      .incrementOnFailure(metrics.failedUsagesUpdates){case _ => true}
+      .incrementOnFailure(metrics.map(_.failedUsagesUpdates)){case _ => true}
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -248,8 +248,8 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
         case _ => Future.failed(ImageNotDeletable)
       }
       deleteFuture
-        .incrementOnSuccess(metrics.deletedImages)
-        .incrementOnFailure(metrics.failedDeletedImages) { case ImageNotDeletable => true }
+        .incrementOnSuccess(metrics.map(_.deletedImages))
+        .incrementOnFailure(metrics.map(_.failedDeletedImages)) { case ImageNotDeletable => true }
     }
 
     List(eventualDeleteResponse.map { _ =>
@@ -265,7 +265,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 removing all usages on image $id")
-      .incrementOnFailure(metrics.failedUsagesUpdates){case _ => true}
+      .incrementOnFailure(metrics.map(_.failedUsagesUpdates)){case _ => true}
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -280,7 +280,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 removing syndication rights on image $id")
-      .incrementOnFailure(metrics.failedSyndicationRightsUpdates){case _ => true}
+      .incrementOnFailure(metrics.map(_.failedSyndicationRightsUpdates)){case _ => true}
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -308,7 +308,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 updating all leases on image $id with: ${leases.toString}")
-      .incrementOnFailure(metrics.failedSyndicationRightsUpdates){case _ => true}
+      .incrementOnFailure(metrics.map(_.failedSyndicationRightsUpdates)){case _ => true}
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -342,7 +342,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 adding lease on image $id with: $leaseParameter")
-      .incrementOnFailure(metrics.failedUsagesUpdates){case _ => true}
+      .incrementOnFailure(metrics.map(_.failedUsagesUpdates)){case _ => true}
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -377,7 +377,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 removing lease with id $leaseIdParameter from image $id")
-      .incrementOnFailure(metrics.failedUsagesUpdates) { case _ => true }
+      .incrementOnFailure(metrics.map(_.failedUsagesUpdates)) { case _ => true }
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -414,7 +414,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 updating exports on image $id")
-      .incrementOnFailure(metrics.failedExportsUpdates) { case _ => true }
+      .incrementOnFailure(metrics.map(_.failedExportsUpdates)) { case _ => true }
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -439,7 +439,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 removing exports from image $id")
-      .incrementOnFailure(metrics.failedExportsUpdates) { case _ => true }
+      .incrementOnFailure(metrics.map(_.failedExportsUpdates)) { case _ => true }
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
@@ -466,7 +466,7 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: ThrallMetrics) exten
     val updateRequest = updateById(imagesAlias, Mappings.dummyType, id).script(script)
 
     val eventualUpdateResponse = executeAndLog(updateRequest, s"ES6 setting collections on image $id")
-      .incrementOnFailure(metrics.failedCollectionsUpdates) { case _ => true }
+      .incrementOnFailure(metrics.map(_.failedCollectionsUpdates)) { case _ => true }
 
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }

--- a/thrall/test/lib/ElasticSearch1Test.scala
+++ b/thrall/test/lib/ElasticSearch1Test.scala
@@ -12,7 +12,7 @@ class ElasticSearch1Test extends ElasticSearchTestBase {
 
   val elasticSearchConfig = ElasticSearchConfig("writeAlias", "localhost", 9301, "media-service-test")
 
-  val ES = new ElasticSearch(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
+  val ES = new ElasticSearch(elasticSearchConfig, None)
 
   def findElasticsearchConfig(): Path = {
     // SBT does some monkey stuff and runs the test from the "thrall" folder compared to IntelliJ that runs it from the root

--- a/thrall/test/lib/ElasticSearch6Test.scala
+++ b/thrall/test/lib/ElasticSearch6Test.scala
@@ -10,7 +10,7 @@ class ElasticSearch6Test extends ElasticSearchTestBase {
 
   val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "media-service-test", 1, 0)
 
-  val ES = new ElasticSearch6(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
+  val ES = new ElasticSearch6(elasticSearchConfig, None)
   val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9206))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")

--- a/thrall/test/syndication/SyndicationRightsOpsElastic1Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic1Test.scala
@@ -13,7 +13,7 @@ class SyndicationRightsOpsElastic1Test extends SyndicationRightsOpsTestsBase {
 
   val elasticSearchConfig = ElasticSearchConfig("writeAlias", "localhost", 9301, "media-service-test")
 
-  val ES = new ElasticSearch(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
+  val ES = new ElasticSearch(elasticSearchConfig, None)
 
   def findElasticsearchConfig(): Path = {
     // SBT does some monkey stuff and runs the test from the "thrall" folder compared to IntelliJ that runs it from the root

--- a/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
@@ -10,7 +10,7 @@ class SyndicationRightsOpsElastic6Test extends SyndicationRightsOpsTestsBase {
 
   val elasticSearchConfig = ElasticSearch6Config("writeAlias", "localhost", 9206, "media-service-test", 1, 0)
 
-  val ES = new ElasticSearch6(elasticSearchConfig, new ThrallMetrics(new ThrallConfig(Configuration.empty)))
+  val ES = new ElasticSearch6(elasticSearchConfig, None)
   val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9206))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")


### PR DESCRIPTION
This is basically https://github.com/guardian/grid/commit/f10668ed521c2344c1fa627f15ed2a66e2998c8b but on top of a more up-to-date version of master. I couldn't cherry-pick that commit as master had evolved since and it was easier to copy/paste code rather than resolve conflicts!

## What does this change?
Optionally enable CloudWatch metrics for elasticsearch.

[`ThrallMetrics`](https://github.com/guardian/grid/blob/master/thrall/app/lib/ThrallMetrics.scala#L5), for example, takes in a [`ThrallConfig`](https://github.com/guardian/grid/blob/master/thrall/app/lib/ThrallConfig.scala#L10) which reads from [`/etc/gu/thrall.properties`](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala#L18). This file would never exist in CI and so the build log is littered with `FileNotFound` exceptions.

With this change, we can omit metrics in test and thus have a cleaner, saner more helpful build log.

## How can success be measured?
Simpler debugging of test failures.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [x] on TEST
