### PR TITLE
Add source: as a chip

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -21,6 +21,7 @@ export const filterFields = [
     'keyword',
     'label',
     'location',
+    'source',
     'state',
     'subject',
     'supplier',
@@ -124,6 +125,11 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
             then(results => results.data.map(res => res.key));
     }
 
+    function suggestSource(prefix) {
+        return mediaApi.metadataSearch('source', {q: prefix}).
+            then(results => results.data.map(res => res.key));
+    }
+
     function suggestLabels(prefix) {
         return mediaApi.labelsSuggest({q: prefix}).
             then(labels => labels.data);
@@ -141,6 +147,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'subject':  return prefixFilter(value)(subjects);
         case 'label':    return suggestLabels(value);
         case 'credit':   return suggestCredit(value);
+        case 'source':   return suggestSource(value);
         case 'supplier': return listSuppliers().then(prefixFilter(value));
         // TODO: list all known bylines, not just our photographers
         case 'by':       return listPhotographers().then(prefixFilter(value));

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -87,6 +87,14 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
+                <gr-chip-example gr:filter-field="source" gr:example-search="WireImage"></gr-chip-example>
+            </dt>
+            <dd class="advanced-search-example__explanation">
+                Currently case-sensitive. Has a suggestion list.
+            </dd>
+        </dl>
+        <dl class="advanced-search-example">
+            <dt class="advanced-search-example__field">
                 <gr-chip-example gr:filter-field="supplier" gr:example-search="AAP"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">


### PR DESCRIPTION
It’s already possible to search `source` _via_ URL. This adds it as a chip and updates Search Help panel.

- [ ] tested on TEST