### PR TITLE
rename for clarity

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class MessageConsumer(queueUrl: String, awsEndpoint: String, config: CommonConfig, metric: Metric[Long]) extends ImageId {
+abstract class SqsMessageConsumer(queueUrl: String, awsEndpoint: String, config: CommonConfig, metric: Metric[Long]) extends ImageId {
   val actorSystem = ActorSystem("MessageConsumer")
 
   private implicit val ctx: ExecutionContext =

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -13,7 +13,7 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val metrics = new MetadataEditorMetrics(config)
-  val messageConsumer = new MetadataMessageConsumer(config, metrics, store)
+  val messageConsumer = new MetadataSqsMessageConsumer(config, metrics, store)
 
   messageConsumer.startSchedule()
   context.lifecycle.addStopHook {

--- a/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala
+++ b/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala
@@ -1,12 +1,12 @@
 package lib
 
-import com.gu.mediaservice.lib.aws.MessageConsumer
+import com.gu.mediaservice.lib.aws.SqsMessageConsumer
 import play.api.libs.json._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class MetadataMessageConsumer(config: EditsConfig, metadataEditorMetrics: MetadataEditorMetrics, store: EditsStore) extends MessageConsumer(
+class MetadataSqsMessageConsumer(config: EditsConfig, metadataEditorMetrics: MetadataEditorMetrics, store: EditsStore) extends SqsMessageConsumer(
   config.queueUrl, config.awsEndpoint, config, metadataEditorMetrics.snsMessage) {
 
   override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] =

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -32,7 +32,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   val es1 = new ElasticSearch(es1Config, Some(thrallMetrics))
   val es6 = new ElasticSearch6(es6Config, Some(thrallMetrics))
 
-  val messageConsumerForHealthCheck = new ThrallMessageConsumer(config, es1, thrallMetrics, store, new SyndicationRightsOps(es1))
+  val messageConsumerForHealthCheck = new ThrallSqsMessageConsumer(config, es1, thrallMetrics, store, new SyndicationRightsOps(es1))
 
   messageConsumerForHealthCheck.startSchedule()
 

--- a/thrall/app/lib/ThrallSqsMessageConsumer.scala
+++ b/thrall/app/lib/ThrallSqsMessageConsumer.scala
@@ -1,18 +1,18 @@
 package lib
 
-import com.gu.mediaservice.lib.aws.{Kinesis, MessageConsumer}
+import com.gu.mediaservice.lib.aws.{Kinesis, SqsMessageConsumer}
 import org.joda.time.DateTime
 import play.api.libs.json.JsValue
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ThrallMessageConsumer(
+class ThrallSqsMessageConsumer(
                              config: ThrallConfig,
                              es: ElasticSearchVersion,
                              thrallMetrics: ThrallMetrics,
                              store: ThrallStore,
                              syndicationRightsOps: SyndicationRightsOps
-)(implicit ec: ExecutionContext) extends MessageConsumer (
+)(implicit ec: ExecutionContext) extends SqsMessageConsumer (
   config.queueUrl,
   config.awsEndpoint,
   config,


### PR DESCRIPTION
## What does this change?
Not much. `MessageConsumer` has been renamed `SqsMessageConsumer ` to be more intention revealing and thus make it easier to remove the ES1 resources.

## How can success be measured?
n/a

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
Eminem?

## Tested?
- [ ] locally
- [ ] on TEST

![img](https://media.giphy.com/media/tLQSYnrLCGcKY/giphy.gif)