### PR TITLE
remove heartbeat messages

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
@@ -35,8 +35,6 @@ abstract class SqsMessageConsumer(queueUrl: String, awsEndpoint: String, config:
 
   def chooseProcessor(subject: String): Option[JsValue => Future[Any]]
 
-  val timeMessageLastProcessed = new AtomicReference[DateTime](DateTime.now)
-
   @tailrec
   final def processMessages(): Unit = {
     // Pull 1 message at a time to avoid starvation
@@ -50,7 +48,6 @@ abstract class SqsMessageConsumer(queueUrl: String, awsEndpoint: String, config:
           sys.error(s"Unrecognised message subject ${message.subject}"))(
             _.apply(message.body))
         _ = recordMessageCount(message)
-        _ = timeMessageLastProcessed.lazySet(DateTime.now)
       } yield ()
       future |> deleteOnSuccess(msg)
     }

--- a/scripts/generate-dot-properties/config.json5
+++ b/scripts/generate-dot-properties/config.json5
@@ -9,9 +9,6 @@
   // Domain root of your site, e.g. foobar.co.uk
   domainRoot: '',
 
-  // The minimum number of messages to retrieve from SQS to be deemed healthy.
-  sqsMessageMinFrequency: 5,
-
   // An API key used to ingest images from the s3watcher.
   s3Watcher: {
     key: ''

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -123,7 +123,6 @@ function getThrallConfig(config) {
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |sqs.queue.url=${config.stackProps.SqsQueueUrl}
-        |sqs.message.min.frequency=${config.sqsMessageMinFrequency}
         |persistence.identifier=picdarUrn
         |es.index.aliases.write=writeAlias
         |es.index.aliases.read=readAlias

--- a/thrall/app/controllers/HealthCheck.scala
+++ b/thrall/app/controllers/HealthCheck.scala
@@ -12,7 +12,7 @@ class HealthCheck(elasticsearch: ElasticSearchVersion, messageConsumer: MessageC
 
   def healthCheck = Action.async {
     elasticHealth.map { esHealth =>
-      val problems = Seq(esHealth, actorSystemHealth, messageQueueHealth).flatten
+      val problems = Seq(esHealth, actorSystemHealth).flatten
       if (problems.nonEmpty) {
         val problemsMessage = problems.mkString(",")
         Logger.warn("Health check failed with problems: " + problemsMessage)
@@ -31,14 +31,6 @@ class HealthCheck(elasticsearch: ElasticSearchVersion, messageConsumer: MessageC
         None
       }
     }
-  }
-
-  private def messageQueueHealth: Option[String] = {
-    val timeLastMessage = messageConsumer.lastProcessed
-    if (timeLastMessage.plusMinutes(config.healthyMessageRate).isBeforeNow)
-      Some(s"Not received a message since $timeLastMessage")
-    else
-      None
   }
 
   private def actorSystemHealth: Option[String] = {

--- a/thrall/app/lib/MessageConsumerVersion.scala
+++ b/thrall/app/lib/MessageConsumerVersion.scala
@@ -1,8 +1,5 @@
 package lib
 
-import org.joda.time.DateTime
-
 trait MessageConsumerVersion {
-  def lastProcessed: DateTime
   def isStopped: Boolean
 }

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -38,8 +38,6 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   lazy val elasticsearch6Shards: Int = properties("es6.shards").toInt
   lazy val elasticsearch6Replicas: Int = properties("es6.replicas").toInt
 
-  lazy val healthyMessageRate: Int = properties("sqs.message.min.frequency").toInt
-
   lazy val metadataTopicArn: String = properties("indexed.image.sns.topic.arn")
 
   lazy val from: Option[DateTime] = properties.get("rewind.from").map(ISODateTimeFormat.dateTime.parseDateTime)

--- a/thrall/app/lib/ThrallSqsMessageConsumer.scala
+++ b/thrall/app/lib/ThrallSqsMessageConsumer.scala
@@ -30,7 +30,4 @@ class ThrallSqsMessageConsumer(
   override def isStopped: Boolean = {
     actorSystem.whenTerminated.isCompleted
   }
-
-  override def lastProcessed: DateTime = timeMessageLastProcessed.get
-
 }

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -29,15 +29,10 @@ class MessageProcessor(es: ElasticSearchVersion,
       case "add-image-lease" => addImageLease
       case "remove-image-lease" => removeImageLease
       case "set-image-collections" => setImageCollections
-      case "heartbeat" => heartbeat
       case "delete-usages" => deleteAllUsages
       case "upsert-rcs-rights" => upsertSyndicationRights
       case "update-image-photoshoot" => updateImagePhotoshoot
     }
-  }
-
-  def heartbeat(message: UpdateMessage)(implicit ec: ExecutionContext) = Future {
-    None
   }
 
   def updateImageUsages(message: UpdateMessage)(implicit ec: ExecutionContext) = {

--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -62,8 +62,6 @@ class ThrallMessageConsumer(config: ThrallConfig,
 
   private def makeThread(worker: Runnable) = new Thread(worker, s"${getClass.getSimpleName}-$workerId")
 
-  override def lastProcessed: DateTime = DateTime.now() // TODO implement
-
   override def isStopped: Boolean = !thrallKinesisWorkerThread.isAlive
 
 }


### PR DESCRIPTION
## What does this change?
Remove [`heartbeat`](https://www.youtube.com/watch?v=smKf_cQCdeo) messages. We introduced this message type to solve https://github.com/guardian/grid/issues/570; we've not implemented this for the Kinesis / ES6 world and, having discussed with the team, a heartbeat is probably the wrong solution to the problem.

`heartbeat`s are designed to ensure Thrall is alive and processing messages, however there are other characteristics that we can use to get a more accurate reading of this, such as size of queue or number of messages processed.

Also removes the `sqs.message.min.frequency` property from Thrall config as no longer needed.

## How can success be measured?
Less code = better code.

## Screenshots (if applicable)
![img](https://media.giphy.com/media/jd0pCZmSnK1bi/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

## Tested?
- [x] locally
- [ ] on TEST
