### PR TITLE
move Thrall's healthcheck to ES6 / kinesis

### DIFF
--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -46,7 +46,7 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   thrallKinesisMessageConsumer.start()
 
   val thrallController = new ThrallController(controllerComponents)
-  val healthCheckController = new HealthCheck(es1, messageConsumerForHealthCheck, config, controllerComponents)
+  val healthCheckController = new HealthCheck(es6, thrallKinesisMessageConsumer, config, controllerComponents)
 
   override lazy val router = new Routes(httpErrorHandler, thrallController, healthCheckController, management)
 }


### PR DESCRIPTION
## What does this change?
Update Thrall's healthcheck to use ES6 and Kinesis queue processor.

## How can success be measured?
ES1 stack becomes easier to remove.

## Screenshots (if applicable)
![img](https://media.giphy.com/media/eltlIJQ3gWNDGGAYgs/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
