### PR TITLE
update manifest endpoints to return buildinfo as json

### DIFF
--- a/auth/app/auth/AuthComponents.scala
+++ b/auth/app/auth/AuthComponents.scala
@@ -11,8 +11,10 @@ class AuthComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new AuthConfig(configuration)
   final override lazy val httpConfiguration = AuthHttpConfig(configuration, context.environment)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val controller = new AuthController(auth, config, controllerComponents)
-  val permissionsAwareManagement = new ManagementWithPermissions(controllerComponents, controller)
+  val permissionsAwareManagement = new ManagementWithPermissions(controllerComponents, controller, buildInfo)
 
   override val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -152,11 +152,27 @@ def project(projectName: String, path: Option[String] = None): Project =
   Project(projectName, file(path.getOrElse(projectName)))
     .settings(commonSettings)
 
+val buildInfo = Seq(
+  buildInfoKeys := Seq[BuildInfoKey](
+    name,
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse(try {
+      "git rev-parse HEAD".!!.trim
+    } catch {
+      case e: Exception => "unknown"
+    }))
+  ),
+  buildInfoPackage := "utils.buildinfo",
+  buildInfoOptions := Seq(
+    BuildInfoOption.Traits("com.gu.mediaservice.lib.management.BuildInfo"),
+    BuildInfoOption.ToJson
+  )
+)
+
 def playProject(projectName: String, port: Int): Project =
   project(projectName, None)
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
     .dependsOn(commonLib)
-    .settings(commonSettings ++ Seq(
+    .settings(commonSettings ++ buildInfo ++ Seq(
       playDefaultPort := port,
 
       debianPackageDependencies := Seq("openjdk-8-jre-headless"),

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -8,6 +8,8 @@ import store.CollectionsStore
 class CollectionsComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new CollectionsConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val store = new CollectionsStore(config)
   val metrics = new CollectionsMetrics(config)
   val notifications = new Notifications(config)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.lib.play
 
 import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.config.CommonConfig
-import com.gu.mediaservice.lib.management.Management
+import com.gu.mediaservice.lib.management.{BuildInfo, Management}
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -19,6 +19,8 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
 
   def config: CommonConfig
 
+  def buildInfo: BuildInfo
+
   implicit val ec: ExecutionContext = executionContext
 
   final override def httpFilters: Seq[EssentialFilter] = {
@@ -29,6 +31,6 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
     allowedOrigins = Origins.Matching(Set(config.services.kahunaBaseUri) ++ config.services.corsAllowedTools)
   )
 
-  val management = new Management(controllerComponents)
+  val management = new Management(controllerComponents, buildInfo)
   val auth = new Authentication(config, actorSystem, defaultBodyParser, wsClient, controllerComponents, executionContext)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -31,6 +31,6 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
     allowedOrigins = Origins.Matching(Set(config.services.kahunaBaseUri) ++ config.services.corsAllowedTools)
   )
 
-  val management = new Management(controllerComponents, buildInfo)
+  lazy val management = new Management(controllerComponents, buildInfo)
   val auth = new Authentication(config, actorSystem, defaultBodyParser, wsClient, controllerComponents, executionContext)
 }

--- a/cropper/app/CropperComponents.scala
+++ b/cropper/app/CropperComponents.scala
@@ -9,6 +9,8 @@ import router.Routes
 class CropperComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new CropperConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val store = new CropStore(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
@@ -16,7 +18,7 @@ class CropperComponents(context: Context) extends GridComponents(context) {
   val notifications = new Notifications(config)
 
   val controller = new CropperController(auth, crops, store, notifications, config, controllerComponents, wsClient)
-  val permissionsAwareManagement = new ManagementWithPermissions(controllerComponents, controller)
+  val permissionsAwareManagement = new ManagementWithPermissions(controllerComponents, controller, buildInfo)
 
   override lazy val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement)
 }

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -14,6 +14,8 @@ import router.Routes
 class ImageLoaderComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new ImageLoaderConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val store = new ImageLoaderStore(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -10,8 +10,11 @@ class KahunaComponents(context: Context) extends GridComponents(context) with As
   final override lazy val config = new KahunaConfig(configuration)
   final override lazy val securityHeadersConfig: SecurityHeadersConfig = KahunaSecurityConfig(config, context.initialConfiguration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val controller = new KahunaController(auth, config, controllerComponents)
   final override val router = new Routes(httpErrorHandler, controller, assets, management)
+
 }
 
 object KahunaSecurityConfig {

--- a/leases/app/LeasesComponents.scala
+++ b/leases/app/LeasesComponents.scala
@@ -7,6 +7,8 @@ import router.Routes
 class LeasesComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new LeasesConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val store = new LeaseStore(config)
   val notifications = new LeaseNotifier(config, store)
 

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -13,6 +13,8 @@ import router.Routes
 class MediaApiComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new MediaApiConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val messageSender = new ThrallMessageSender(config)
@@ -50,7 +52,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)
-  val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi)
+  val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi, buildInfo)
 
   override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, healthcheckController)
 }

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -8,6 +8,8 @@ import router.Routes
 class MetadataEditorComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new EditsConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val store = new EditsStore(config)
   val notifications = new Notifications(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", 
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -10,6 +10,8 @@ import router.Routes
 class ThrallComponents(context: Context) extends GridComponents(context) {
   final override lazy val config = new ThrallConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val store = new ThrallStore(config)
   val metadataEditorNotifications = new MetadataEditorNotifications(config)
   val thrallMetrics = new ThrallMetrics(config)

--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -11,6 +11,8 @@ class UsageComponents(context: Context) extends GridComponents(context) {
 
   final override lazy val config = new UsageConfig(configuration)
 
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
   val usageMetadataBuilder = new UsageMetadataBuilder(config)
   val mediaWrapper = new MediaWrapperOps(usageMetadataBuilder)
   val mediaUsage = new MediaUsageOps(usageMetadataBuilder)


### PR DESCRIPTION
## What does this change?
Updates `/management/manifest` to return the buildinfo as json using the [sbt-buildinfo plugin](https://github.com/sbt/sbt-buildinfo).

Somewhere in the Play upgrade we stopped using https://github.com/guardian/sbt-version-info-plugin which meant the `/management/manifest` endpoints are returning stale content. This PR replaces that stale content.

`/management/manifest` is a handy way to see what version of the app is running as it includes the last commit id. Hopefully helping to solve https://github.com/guardian/grid/pull/2556#issuecomment-490478097.

## How can success be measured?
Helping to solve https://github.com/guardian/grid/pull/2556#issuecomment-490478097.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/57472732-1b41ec00-7286-11e9-965a-0b84f038e1b0.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms 

## Tested?
- [x] locally
- [x] on TEST
