### PR TITLE
Ensure aliases in thrall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ data
 kahuna/npm-debug.log
 imgops/dev/nginx.conf
 *.iml
+
+.bloop
+.metals

--- a/the_pingler.sh
+++ b/the_pingler.sh
@@ -3,7 +3,7 @@
 set -o shwordsplit
 
 API="http://localhost:9001/management/healthcheck"
-THRALL="http://localhost:9002/"
+THRALL="http://localhost:9002/management/healthcheck"
 IMAGE_LOADER="http://localhost:9003/management/healthcheck"
 KAHUNA="http://localhost:9005/management/healthcheck"
 CROPPER="http://localhost:9006/management/healthcheck"

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -32,6 +32,8 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   val es1 = new ElasticSearch(es1Config, Some(thrallMetrics))
   val es6 = new ElasticSearch6(es6Config, Some(thrallMetrics))
 
+  es6.ensureAliasAssigned()
+
   val messageConsumerForHealthCheck = new ThrallSqsMessageConsumer(config, es1, thrallMetrics, store, new SyndicationRightsOps(es1))
 
   messageConsumerForHealthCheck.startSchedule()


### PR DESCRIPTION
Also use thrall `/healthcheck` endpoint, which would have caught this

## What does this change?
Allows easier setup for fresh grid instances on local machine. I've also added a couple of lines to the `.gitignore` for Metals environments.

## How can success be measured?
Grid starts up! 🚀 

## Screenshots (if applicable)
N/A

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
