### PR TITLE
add cerebro

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,7 @@ services:
       - "9008:80"
     volumes:
       - "./imgops/dev/nginx.conf:/etc/nginx/nginx.conf"
+  cerebro:
+    image: lmenezes/cerebro
+    ports:
+    - "9000:9000"


### PR DESCRIPTION
## What does this change?
[Cerebro](https://github.com/lmenezes/cerebro) is a useful tool to manage an elasticsearch cluster. As its part of the docker-compose stack, we can go to http://localhost:9000/#/connect?host=http:%2F%2Felasticsearch6:9200 to open Cerebro against the ES6 cluster.

## How can success be measured?
An easier way to interact with the DEV ES cluster.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/57511097-5254e380-7300-11e9-980b-007bf55302cb.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@RichieAHB 

## Tested?
- [x] locally
- [ ] on TEST
