### PR TITLE
Add cost messages to image page

### DIFF
--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
@@ -1,4 +1,12 @@
-<div ng:switch="image.data.cost">
+<div ng:switch="messageState">
+    <div ng:switch-when="no_rights"
+        class="image-notice image-info__group status cost cost--pay">
+        No rights to use this image
+    </div>
+    <div ng:switch-when="overquota"
+        class="image-notice image-info__group status cost cost--pay">
+        Quota exceeded for this supplier
+    </div>
     <div ng:switch-when="pay"
          class="image-notice image-info__group status cost cost--pay">
         Pay to use

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
@@ -5,11 +5,15 @@ import './gr-image-cost-message.css';
 
 export const module = angular.module('gr.imageCostMessage', []);
 
-module.directive('grImageCostMessage', [function () {
+module.directive('grImageCostMessage', ['imageService', function (imageService) {
     return {
         restrict: 'E',
         template: template,
         transclude: true,
+        link: scope => {
+            const { states } = imageService(scope.image);
+            scope.messageState = states.costState;
+        },
         scope: {
             image: '=grImage'
         }

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -15,9 +15,19 @@
                         {{cost.count}} free
                     </div>
 
+                    <div ng:switch-when="no_rights"
+                         class="image-notice image-info__group status cost cost--pay">
+                        {{cost.count}} no rights
+                    </div>
+
                     <div ng:switch-when="pay"
                          class="image-notice image-info__group status cost cost--pay">
                         {{cost.count}} pay
+                    </div>
+
+                    <div ng:switch-when="overquota"
+                         class="image-notice image-info__group status cost cost--pay">
+                        {{cost.count}} over quota
                     </div>
 
                     <div ng:switch-when="conditional"

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -62,7 +62,7 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     inject$($scope, selectedImagesList$, ctrl, 'selectedImages');
 
     const selectedCosts$ = selectedImagesList$.
-    map(imageList.getCost).
+    map(imageList.getCostState).
     map(imageList.getOccurrences);
     inject$($scope, selectedCosts$, ctrl, 'selectedCosts');
 

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -62,6 +62,11 @@
                 Pay to use
             </div>
 
+            <div ng:switch-when="overquota"
+                 class="cost cost--pay">
+                Quota exceeded for this supplier
+            </div>
+
             <div ng:switch-when="conditional"
                  class="cost cost--conditional"
                  title="restricted use: {{ctrl.image.data.usageRights.restrictions}}">

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -51,6 +51,9 @@
                 <span class="result-editor__status status status--invalid"
                       ng:switch-when="pay">Pay to use</span>
 
+                <span class="result-editor__status status status--invalid"
+                      ng:switch-when="overquota">Quota exceeded for this supplier</span>
+
                 <span class="result-editor__status status status--valid"
                       ng:switch-when="free">Free to use</span>
 

--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -22,10 +22,13 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
     }
 
     function getStates(image) {
+      const hasRights = !(Object.keys(image.data.usageRights).length === 0);
+      const cost = image.data.cost;
         return {
-            cost: image.data.cost,
+            cost,
             hasCrops: image.data.exports && image.data.exports.length > 0,
-            hasRights: !Boolean(Object.keys(image.data.usageRights).length === 0),
+            hasRights,
+            costState: hasRights ? cost : "no_rights",
             isValid: image.data.valid,
             canDelete: imageLogic.canBeDeleted(image),
             canArchive: imageLogic.canBeArchived(image),

--- a/kahuna/public/js/preview/image-large.html
+++ b/kahuna/public/js/preview/image-large.html
@@ -126,12 +126,24 @@
                 </gr-archiver-status>
 
                 <div class="bottom-bar__action bottom-bar__action--cost preview__cost"
-                     ng:if="ctrl.states.cost !== 'free'"
-                     ng:switch="ctrl.states.cost">
+                     ng:if="ctrl.states.costState !== 'free'"
+                     ng:switch="ctrl.states.costState">
                     <div ng:switch-when="pay"
                          class="cost cost--pay">
                         <!-- material icons doesn't have a £ icon -->
                         <span title="pay to use">£</span>
+                    </div>
+
+                    <div ng:switch-when="no_rights"
+                        class="cost cost--no_rights">
+
+                        <!-- material icons doesn't have a £ icon -->
+                        <gr-icon>warning</gr-icon>
+                    </div>
+
+                    <div ng:switch-when="overquota"
+                         class="cost cost--pay">
+                        <gr-icon>trending_up</gr-icon>
                     </div>
 
                     <div ng:switch-when="conditional"

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -52,9 +52,7 @@ image.controller('uiPreviewImageCtrl', [
         `Staff Image: ${ctrl.image.data.metadata.description}` :
         ctrl.image.data.metadata.description;
 
-    const hasRights = ctrl.states.hasRights;
-
-    ctrl.flagState = hasRights ? ctrl.states.cost : 'no_rights';
+    ctrl.flagState = ctrl.states.costState;
 
     const hasPrintUsages$ =
         imageUsagesService.getUsages(ctrl.image).hasPrintUsages$;

--- a/kahuna/public/js/services/image-list.js
+++ b/kahuna/public/js/services/image-list.js
@@ -6,7 +6,10 @@ const imageList = angular.module('kahuna.services.image-list', []);
 /**
  * Helper functions to operate on list of images.
  */
-imageList.factory('imageList', ['imageAccessor', function(imageAccessor) {
+imageList.factory("imageList", [
+  "imageAccessor",
+  "imageService",
+  function(imageAccessor, imageService) {
 
     function countOccurrences(collection) {
         return collection.reduce((counts, item) => {
@@ -27,8 +30,8 @@ imageList.factory('imageList', ['imageAccessor', function(imageAccessor) {
         return images.filter(imageAccessor.isArchived).size;
     }
 
-    function getCost(images) {
-        return images.map(imageAccessor.readCost);
+    function getCostState(images) {
+        return images.map(img => imageService(img).states.costState);
     }
 
     function getLabels(images) {
@@ -66,7 +69,7 @@ imageList.factory('imageList', ['imageAccessor', function(imageAccessor) {
 
     return {
         archivedCount,
-        getCost,
+        getCostState,
         getLabels,
         getLeases,
         getMetadata,

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -975,17 +975,13 @@ textarea.ng-invalid {
     background-color: green;
 }
 
-.costs {
-    display: flex;
-}
-
 .costs li {
-    flex-grow: 1;
-    flex-basis: 0;
+    display: inline-block;
 }
 
 .costs .image-notice {
-    padding: 3px;
+    padding: 3px 6px;
+    margin: 0 3px 3px 0;
 }
 
 /* Hacky pointer to some element above */


### PR DESCRIPTION
## What does this change?
Adds two extra messages for the image preview page:
- An _over quota_ message which corresponds to the upwards moving graph icon that appears on the search page for over quota images

<img width="392" alt="Screenshot 2019-05-10 at 09 08 55" src="https://user-images.githubusercontent.com/1652187/57512354-4caccd00-7303-11e9-9afb-1b3bfda0795a.png">

- A _no rights_ messages which corresponds to the warning icon that appears on the search page for images with no rights

<img width="414" alt="Screenshot 2019-05-10 at 09 08 40" src="https://user-images.githubusercontent.com/1652187/57512356-4caccd00-7303-11e9-8455-3806be1a7301.png">

These additions have also been reflected in the info panel:

<img width="349" alt="Screenshot 2019-05-10 at 12 56 08" src="https://user-images.githubusercontent.com/1652187/57525599-12ebbe80-7323-11e9-84a5-aca8155533a2.png">

## How can success be measured?
N/A

## Screenshots (if applicable)
Added above

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
