### PR TITLE
Few tweaks to info panel cost info

### DIFF
--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -22,7 +22,7 @@
 
                     <div ng:switch-when="pay"
                          class="image-notice image-info__group status cost cost--pay">
-                        {{cost.count}} pay
+                        {{cost.count}} paid
                     </div>
 
                     <div ng:switch-when="overquota"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -980,7 +980,7 @@ textarea.ng-invalid {
 }
 
 .costs .image-notice {
-    padding: 3px 6px;
+    padding: 6px 12px;
     margin: 0 3px 3px 0;
 }
 


### PR DESCRIPTION
## What does this change?
Large cost alerts and uses the same tense

## How can success be measured?
Easier to read / understand

## Screenshots (if applicable)
<img width="316" alt="Screenshot 2019-05-10 at 14 36 47" src="https://user-images.githubusercontent.com/1652187/57531337-15edab80-7331-11e9-82e5-514d321aa850.png">

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST

