### PR TITLE
remove thrall's sns and sqs resources in DEV stack

### DIFF
--- a/cloud-formation/dev-template.yaml
+++ b/cloud-formation/dev-template.yaml
@@ -118,35 +118,6 @@ Resources:
       Tags:
       - { Key: Stack, Value: media-service }
       - { Key: Stage, Value: DEV }
-
-  # TODO MRB: remove this when we migrate to Kinesis
-  Topic:
-    Type: AWS::SNS::Topic
-    Properties:
-      Subscription:
-      - Endpoint: !GetAtt 'Queue.Arn'
-        Protocol: sqs
-  Queue:
-    Type: AWS::SQS::Queue
-    Properties: {}
-  QueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      PolicyDocument:
-        Id: MyQueuePolicy
-        Statement:
-        - Sid: Allow-SendMessage-To-Queue-From-Topic
-          Effect: Allow
-          Principal:
-            AWS: '*'
-          Action:
-          - sqs:SendMessage
-          Resource: '*'
-          Condition:
-            ArnEquals:
-              aws:SourceArn: !Ref 'Topic'
-      Queues:
-      - !Ref 'Queue'
   IndexedImageTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -259,10 +230,6 @@ Outputs:
     Value: !Ref 'ImageCollectionsDynamoTable'
   LeasesDynamoTable:
     Value: !Ref 'LeasesDynamoTable'
-  SnsTopicArn:
-    Value: !Ref 'Topic'
-  SqsQueueUrl:
-    Value: !Ref 'Queue'
   IndexedImageTopicArn:
     Value: !Ref 'IndexedImageTopic'
   IndexedImageMetadataQueueUrl:

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -120,7 +120,6 @@ function getThrallConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
-        |sqs.queue.url=${config.stackProps.SqsQueueUrl}
         |persistence.identifier=picdarUrn
         |es.index.aliases.write=writeAlias
         |es.index.aliases.read=readAlias


### PR DESCRIPTION
## What does this change?
they're no longer used (they were part of the ES1 infrastructure)

## How can success be measured?
Cost saving??

## Screenshots (if applicable)
![img](https://media.giphy.com/media/67ThRZlYBvibtdF9JH/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
