### PR TITLE
bump prout threshold

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,13 +1,13 @@
 {
   "checkpoints": {
-    "auth": { "url": "https://media-auth.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "collections": { "url": "https://media-collections.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "cropper": { "url": "https://cropper.media.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "image-loader": { "url": "https://loader.media.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "kahuna": { "url": "https://media.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "leases": { "url": "https://media-leases.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "media-api": { "url": "https://api.media.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "metadata-editor": { "url": "https://media-metadata.gutools.co.uk/management/manifest", "overdue": "12M" },
-    "usage": { "url": "https://media-usage.gutools.co.uk/management/manifest", "overdue": "12M" }
+    "auth": { "url": "https://media-auth.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "collections": { "url": "https://media-collections.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "cropper": { "url": "https://cropper.media.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "image-loader": { "url": "https://loader.media.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "kahuna": { "url": "https://media.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "leases": { "url": "https://media-leases.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "media-api": { "url": "https://api.media.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "metadata-editor": { "url": "https://media-metadata.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "usage": { "url": "https://media-usage.gutools.co.uk/management/manifest", "overdue": "30M" }
   }
 }


### PR DESCRIPTION
## What does this change?
12 minutes was a slightly arbitrary number taken from another prout config. As it turns out, it's slightly too short for Grid; this is perhaps the result of a long CI queue or it taking too long for the new instances in a deploy to report healthy. In any case, increasing the time to 30 minutes will have the effect of being more tolerant and less [chatty](https://github.com/guardian/grid/pull/2569) whilst still remaining useful.

## How can success be measured?
Fewer comments from @prout-bot to reduce the chance of us treating it as spam and ignoring any real issues that are being flagged.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

## Tested?
- [ ] locally
- [ ] on TEST
