### PR TITLE
Feature/configurable test properties

### DIFF
--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -13,11 +13,15 @@ import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 import scala.concurrent.duration._
+import scala.util.Properties
 
 trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with DockerKit with DockerTestKit with DockerKitSpotify {
 
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))
+
+  val useEsDocker = Properties.envOrElse("ES6_USE_DOCKER", "true").toBoolean
+  val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
 
   def esContainer: Option[DockerContainer]
 

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -32,19 +32,19 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
     "persistence.identifier" -> "picdarUrn")))
 
   private val mediaApiMetrics = new MediaApiMetrics(mediaApiConfig)
-  val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = "http://localhost:9200",
+  val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = es6TestUrl,
     cluster = "media-service-test", shards = 1, replicas = 0)
 
   private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig)
   val client = ES.client
 
-  def esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
+  def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9200))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
     )
-  )
+  ) else None
 
   private val expectedNumberOfImages = images.size
 

--- a/thrall/test/lib/ElasticSearch6Test.scala
+++ b/thrall/test/lib/ElasticSearch6Test.scala
@@ -8,14 +8,14 @@ import scala.concurrent.duration._
 
 class ElasticSearch6Test extends ElasticSearchTestBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "http://localhost:9200", "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", es6TestUrl, "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, None)
-  val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
+  val esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9200))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
     )
-  )
+  ) else None
 }

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -15,8 +15,12 @@ import play.api.libs.json.{JsDefined, JsLookupResult, Json}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.util.Properties
 
 trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with Eventually with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
+
+  val useEsDocker = Properties.envOrElse("ES6_USE_DOCKER", "true").toBoolean
+  val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
 
   val oneHundredMilliseconds = Duration(100, MILLISECONDS)
   val fiveSeconds = Duration(5, SECONDS)

--- a/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsElastic6Test.scala
@@ -8,14 +8,14 @@ import scala.concurrent.duration._
 
 class SyndicationRightsOpsElastic6Test extends SyndicationRightsOpsTestsBase {
 
-  val elasticSearchConfig = ElasticSearch6Config("writeAlias", "http://localhost:9200", "media-service-test", 1, 0)
+  val elasticSearchConfig = ElasticSearch6Config("writeAlias", es6TestUrl, "media-service-test", 1, 0)
 
   val ES = new ElasticSearch6(elasticSearchConfig, None)
-  val esContainer = Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
+  val esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
     .withPorts(9200 -> Some(9200))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
     )
-  )
+  ) else None
 }

--- a/thrall/test/syndication/SyndicationRightsOpsTestsBase.scala
+++ b/thrall/test/syndication/SyndicationRightsOpsTestsBase.scala
@@ -15,8 +15,12 @@ import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
+import scala.util.Properties
 
 trait SyndicationRightsOpsTestsBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
+
+  val useEsDocker = Properties.envOrElse("ES6_USE_DOCKER", "true").toBoolean
+  val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
 
   def ES: ElasticSearchVersion
   def esContainer: Option[DockerContainer]


### PR DESCRIPTION
Hi! I'm Felix a graduate software engineer working with Jamie Pitts on the grid for a few months. 

## What does this change?
Our CI process (jenkins pipeline) has limited memory and was failing to create the Elasticsearch docker image for Thrall and Media-Api tests. To work around this we have created a `test.properties` file that determines if Docker is used for the tests. 

The file is completely optional and values are defaulted if it's not present.

This file can be used for other configurable test properties in the future.

## How can success be measured?
To test locally, create a `/etc/gu/test.properties` files with the contents
```
es6.test.url=http://localhost:9200
es6.useDocker=false
```
run elasticsearch locally (or locally run an ES docker image) and then run thrall and Api tests.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
