### PR TITLE
Deploy imgops alongside other services

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -68,6 +68,11 @@ deployments:
   usage-stream:
     template: usage-deploy
     app: usage-stream
+  
+  imgops:
+    template: autoscaling
+    actions:
+      - deploy
 
   ami-update:
     type: ami-cloudformation-parameter
@@ -84,3 +89,7 @@ deployments:
           BuiltBy: amigo
           AmigoStage: PROD
           Recipe: grid-xenial
+        ImgOpsAmiId:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: grid-imgops


### PR DESCRIPTION
## What does this change?

imgops is deployed at the same time as all the other services. In combination with https://github.com/guardian/editorial-tools-platform/pull/289 and AMIgo scheduled builds of the AMI, it will be automatically kept up to date with OS security patches etc.

## How can success be measured?

`imgops` is always green/yellow on [AMIable monitoring](https://amiable.gutools.co.uk/instanceAMIs?app=imgops)
