### PR TITLE
Disallow edits in the UI whilst batch operations in progress

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -302,7 +302,7 @@ service.factory('editsService',
     function batchUpdateMetadataField (images, field, value, editOption = overwrite.key) {
         return $q.all(images.map(image => {
           const newFieldValue = getNewFieldValue(image, field, value, editOption);
-          updateMetadataField(image, field, newFieldValue);
+          return updateMetadataField(image, field, newFieldValue);
         }));
     }
 


### PR DESCRIPTION
## What does this change?

Before:

![0b099abecfeac2a8af5fd077a3a16f79](https://user-images.githubusercontent.com/395805/58479512-5716f580-8150-11e9-95f8-d867cb4480dc.gif)

After:

![e7826525741681b79ef887bcfba777b5](https://user-images.githubusercontent.com/395805/58479546-6a29c580-8150-11e9-83b7-c79a1779a4f1.gif)

## How can success be measured?

Slightly more confidence from users that their batch operation is proceeding. There's still a lot more we can do to make the operations more reliable but this is a quick win.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
