### PR TITLE
Show progress for batch operations

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -38,8 +38,7 @@ addLabel.controller('GrAddLabelCtrl', [
             ctrl.active = false;
 
             labelService.batchAdd(imageArray, label)
-                .then(images => {
-                    ctrl.images = images;
+                .then(() => {
                     reset();
                 })
                 .catch(saveFailed)

--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 
 import template from './gr-batch-export-original-images.html';
+import { trackAll } from '../../util/batch-tracking';
 
 export const batchExportOriginalImages = angular.module('gr.batchExportOriginalImages', []);
 
@@ -40,14 +41,15 @@ batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
         function cropImages() {
           ctrl.cropping = true;
           ctrl.needsConfirmation = false;
-          const cropImages = ctrl.images.map(image =>
+
+          const cropImages = trackAll($rootScope, "crop", ctrl.images, image =>
             mediaCropper.createFullCrop(image).then(crop => ({
               image,
               crop
             }))
           );
 
-          Promise.all(cropImages).then(specs => {
+          cropImages.then(specs => {
             $rootScope.$emit('events:crops-created', specs);
           }).finally(() => {
             ctrl.cropping = false;

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -37,11 +37,6 @@
                 </div>
             </li>
         </ul>
-        <ul class="batch_progress">
-            <li class="image-notice" ng-repeat="entry in ctrl.batchOperations">
-                Updating {{entry.key}}: {{entry.completed}}/{{entry.total}}
-            </li>
-        </ul>
     </div>
 
     <div ng:if="ctrl.selectedImages.size > 0">

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -37,9 +37,9 @@
                 </div>
             </li>
         </ul>
-        <ul class="batch_progress" ng:if="ctrl.completedBatchOperations > 0">
-            <li class="image-notice">
-                Updated {{ctrl.completedBatchOperations}} of {{ctrl.selectedImages.size}}
+        <ul class="batch_progress">
+            <li class="image-notice" ng-repeat="entry in ctrl.batchOperations">
+                {{entry.key}}: {{entry.completed}} of {{entry.total}}
             </li>
         </ul>
     </div>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -39,7 +39,7 @@
         </ul>
         <ul class="batch_progress">
             <li class="image-notice" ng-repeat="entry in ctrl.batchOperations">
-                {{entry.key}}: {{entry.completed}}/{{entry.total}}
+                Updating {{entry.key}}: {{entry.completed}}/{{entry.total}}
             </li>
         </ul>
     </div>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -39,7 +39,7 @@
         </ul>
         <ul class="batch_progress">
             <li class="image-notice" ng-repeat="entry in ctrl.batchOperations">
-                {{entry.key}}: {{entry.completed}} of {{entry.total}}
+                {{entry.key}}: {{entry.completed}}/{{entry.total}}
             </li>
         </ul>
     </div>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -37,6 +37,11 @@
                 </div>
             </li>
         </ul>
+        <ul class="batch_progress" ng:if="ctrl.completedBatchOperations > 0">
+            <li class="image-notice">
+                Updated {{ctrl.completedBatchOperations}} of {{ctrl.selectedImages.size}}
+            </li>
+        </ul>
     </div>
 
     <div ng:if="ctrl.selectedImages.size > 0">

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -62,6 +62,10 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     ctrl.batchOperations = [];
     $scope.$on("events:batch-operations:start", (e, entry) => {
       ctrl.batchOperations = [entry, ...ctrl.batchOperations];
+
+      window.onbeforeunload = function() {
+        return 'Batch update in progress, are you sure you want to leave?';
+      };
     });
     $scope.$on("events:batch-operations:progress", (e, { key, completed }) => {
       ctrl.batchOperations = ctrl.batchOperations.map(entry => {
@@ -74,6 +78,10 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     });
     $scope.$on("events:batch-operations:complete", (e, { key }) => {
       ctrl.batchOperations = ctrl.batchOperations.filter(entry => entry.key !== key);
+
+      if (ctrl.batchOperations.length === 0) {
+        window.onbeforeunload = null;
+      }
     });
 
     inject$($scope, selectedImagesList$, ctrl, 'selectedImages');

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -172,12 +172,20 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
 
     ctrl.updateMetadataField = function (field, value) {
       var imageArray = Array.from(ctrl.selectedImages);
+      ctrl.completedBatchOperations = 0;
+
       return editsService.batchUpdateMetadataField(
         imageArray,
         field,
         value,
-        ctrl.descriptionOption
-      );
+        ctrl.descriptionOption,
+        () => { ctrl.completedBatchOperations++ }
+      ).then(() => {
+        ctrl.completedBatchOperations = undefined;
+      }).catch(err => {
+        ctrl.completedBatchOperations = undefined;
+        throw err;
+      });
     };
 
     ctrl.addLabel = function (label) {

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -171,7 +171,7 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     };
 
     ctrl.updateMetadataField = function (field, value) {
-      const imageArray = Array.from(ctrl.selectedImages);
+      var imageArray = Array.from(ctrl.selectedImages);
 
       return editsService.batchUpdateMetadataField(
         imageArray,

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -58,14 +58,14 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     const ctrl = this;
 
     ctrl.showUsageRights = false;
-    
+
     ctrl.batchOperations = [];
     $scope.$on("events:batch-operations:start", (e, entry) => {
       ctrl.batchOperations = [entry, ...ctrl.batchOperations];
     });
     $scope.$on("events:batch-operations:progress", (e, { key, completed }) => {
       ctrl.batchOperations = ctrl.batchOperations.map(entry => {
-        if(entry.key === key) {
+        if (entry.key === key) {
           return Object.assign({}, entry, { completed });
         }
 
@@ -73,7 +73,7 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
       });
     });
     $scope.$on("events:batch-operations:complete", (e, { key }) => {
-      ctrl.batchOperations = ctrl.batchOperations.filter(entry => entry.key !== key)
+      ctrl.batchOperations = ctrl.batchOperations.filter(entry => entry.key !== key);
     });
 
     inject$($scope, selectedImagesList$, ctrl, 'selectedImages');

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -59,31 +59,6 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
 
     ctrl.showUsageRights = false;
 
-    ctrl.batchOperations = [];
-    $scope.$on("events:batch-operations:start", (e, entry) => {
-      ctrl.batchOperations = [entry, ...ctrl.batchOperations];
-
-      window.onbeforeunload = function() {
-        return 'Batch update in progress, are you sure you want to leave?';
-      };
-    });
-    $scope.$on("events:batch-operations:progress", (e, { key, completed }) => {
-      ctrl.batchOperations = ctrl.batchOperations.map(entry => {
-        if (entry.key === key) {
-          return Object.assign({}, entry, { completed });
-        }
-
-        return entry;
-      });
-    });
-    $scope.$on("events:batch-operations:complete", (e, { key }) => {
-      ctrl.batchOperations = ctrl.batchOperations.filter(entry => entry.key !== key);
-
-      if (ctrl.batchOperations.length === 0) {
-        window.onbeforeunload = null;
-      }
-    });
-
     inject$($scope, selectedImagesList$, ctrl, 'selectedImages');
 
     const selectedCosts$ = selectedImagesList$.

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
@@ -66,21 +66,11 @@ photoshoot.controller('GrPhotoshootCtrl', [
                 return ctrl.remove();
             }
 
-            return photoshootService.batchAdd({ images: ctrl.images, data: { title } })
-                .then(images => {
-                    // TODO be better! Pretty sure this isn't performant
-                    // reassign images to trigger a `refresh` by the `$watchCollection` below
-                    ctrl.images = images;
-                });
+            return photoshootService.batchAdd({ images: ctrl.images, data: { title } });
         };
 
         ctrl.remove = () => {
-            return photoshootService.batchRemove({ images: ctrl.images })
-                .then(images => {
-                    // TODO be better! Pretty sure this isn't performant
-                    // reassign images to trigger a `refresh` by the `$watchCollection` below
-                    ctrl.images = images;
-                });
+            return photoshootService.batchRemove({ images: ctrl.images });
         };
 
         if (Boolean(ctrl.withBatch)) {

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -300,7 +300,7 @@ service.factory('editsService',
 
 
     function batchUpdateMetadataField (images, field, value, editOption = overwrite.key) {
-        var completed = 0;
+        let completed = 0;
         $rootScope.$broadcast("events:batch-operations:start", { key: field, completed: 0, total: images.length });
 
         return $q.all(images.map(image => {

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -299,10 +299,10 @@ service.factory('editsService',
     }
 
 
-    function batchUpdateMetadataField (images, field, value, editOption = overwrite.key) {
+    function batchUpdateMetadataField (images, field, value, editOption = overwrite.key, callback = undefined) {
         return $q.all(images.map(image => {
           const newFieldValue = getNewFieldValue(image, field, value, editOption);
-          return updateMetadataField(image, field, newFieldValue);
+          return updateMetadataField(image, field, newFieldValue).then(() => callback());
         }));
     }
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -37,6 +37,14 @@
                     {{ctrl.selectionCount}} selected
                 </div>
 
+                <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static"
+                     ng:if="ctrl.batchOperations.length > 0">
+
+                    <span ng-repeat="entry in ctrl.batchOperations">
+                        Updating {{entry.key}}: {{entry.completed}}/{{entry.total}}
+                    </span>
+                </div>
+
                 <a class="results-toolbar-item results-toolbar-item--right"
                    ng:click="ctrl.clearSelection()"
                    ng:if="ctrl.selectionCount > 0">

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -37,8 +37,8 @@
                     {{ctrl.selectionCount}} selected
                 </div>
 
-                <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static"
-                     ng:if="ctrl.batchOperations.length > 0">
+                <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static results-toolbar-item__progress"
+                    ng-style="ctrl.buildBatchProgressGradient()" ng:if="ctrl.batchOperations.length > 0">
 
                     <span ng-repeat="entry in ctrl.batchOperations">
                         Updating {{entry.key}}: {{entry.completed}}/{{entry.total}}

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -470,6 +470,34 @@ results.controller('SearchResultsCtrl', [
         // FIXME: nicer (reactive?) way to do this?
         var scopeGone = false;
 
+        ctrl.batchOperations = [];
+
+        $scope.$on("events:batch-operations:start", (e, entry) => {
+            ctrl.batchOperations = [entry, ...ctrl.batchOperations];
+
+            window.onbeforeunload = function() {
+                return 'Batch update in progress, are you sure you want to leave?';
+            };
+        });
+
+        $scope.$on("events:batch-operations:progress", (e, { key, completed }) => {
+            ctrl.batchOperations = ctrl.batchOperations.map(entry => {
+                if (entry.key === key) {
+                return Object.assign({}, entry, { completed });
+                }
+
+                return entry;
+            });
+        });
+
+        $scope.$on("events:batch-operations:complete", (e, { key }) => {
+            ctrl.batchOperations = ctrl.batchOperations.filter(entry => entry.key !== key);
+
+            if (ctrl.batchOperations.length === 0) {
+                window.onbeforeunload = null;
+            }
+        });
+
         $scope.$on('$destroy', () => {
             scrollPosition.save($stateParams);
             freeUpdateListener();

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -472,6 +472,17 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.batchOperations = [];
 
+        ctrl.buildBatchProgressGradient = () => {
+            const completed = ctrl.batchOperations.map(({ completed }) => completed).reduce((acc, x) => acc + x, 0);
+            const total = ctrl.batchOperations.map(({ total }) => total).reduce((acc, x) => acc + x, 0);
+
+            const percentage = Math.round(((completed * 1.0) / total) * 100);
+            
+            return {
+                background: `linear-gradient(90deg, #00adee ${percentage}%, transparent ${percentage}%)`
+            };
+        }
+
         $scope.$on("events:batch-operations:start", (e, entry) => {
             ctrl.batchOperations = [entry, ...ctrl.batchOperations];
 
@@ -483,7 +494,7 @@ results.controller('SearchResultsCtrl', [
         $scope.$on("events:batch-operations:progress", (e, { key, completed }) => {
             ctrl.batchOperations = ctrl.batchOperations.map(entry => {
                 if (entry.key === key) {
-                return Object.assign({}, entry, { completed });
+                    return Object.assign({}, entry, { completed });
                 }
 
                 return entry;

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -473,15 +473,21 @@ results.controller('SearchResultsCtrl', [
         ctrl.batchOperations = [];
 
         ctrl.buildBatchProgressGradient = () => {
-            const completed = ctrl.batchOperations.map(({ completed }) => completed).reduce((acc, x) => acc + x, 0);
-            const total = ctrl.batchOperations.map(({ total }) => total).reduce((acc, x) => acc + x, 0);
+            const completed = ctrl.batchOperations
+                .map(({ completed }) => completed)
+                .reduce((acc, x) => acc + x, 0);
+
+            const total = ctrl.batchOperations
+                .map(({ total }) => total)
+                .reduce((acc, x) => acc + x, 0);
 
             const percentage = Math.round(((completed * 1.0) / total) * 100);
-            
+
             return {
-                background: `linear-gradient(90deg, #00adee ${percentage}%, transparent ${percentage}%)`
+                background:
+                    `linear-gradient(90deg, #00adee ${percentage}%, transparent ${percentage}%)`
             };
-        }
+        };
 
         $scope.$on("events:batch-operations:start", (e, entry) => {
             ctrl.batchOperations = [entry, ...ctrl.batchOperations];

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -4,6 +4,7 @@ import './media-api';
 import '../../services/image-list';
 
 import {service} from '../../edits/service';
+import { trackAll } from '../../util/batch-tracking';
 
 var leaseService = angular.module('kahuna.services.lease', [
   service.name
@@ -78,7 +79,7 @@ leaseService.factory('leaseService', [
     }
 
     function batchAdd(lease, images) {
-      return $q.all(images.map(image => add(image, lease))).then(() => {
+      return trackAll($rootScope, "leases", images, image => add(image, lease)).then(() => {
         pollLeases(images);
       });
     }

--- a/kahuna/public/js/services/label.js
+++ b/kahuna/public/js/services/label.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import { trackAll } from '../util/batch-tracking'
+import { trackAll } from '../util/batch-tracking';
 
 var labelService = angular.module('kahuna.services.label', []);
 

--- a/kahuna/public/js/services/label.js
+++ b/kahuna/public/js/services/label.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import { trackAll } from '../util/batch-tracking'
 
 var labelService = angular.module('kahuna.services.label', []);
 
@@ -59,11 +60,11 @@ labelService.factory('labelService',
     }
 
     function batchAdd (images, labels) {
-        return $q.all(images.map(image => add(image, labels)));
+        return trackAll($rootScope, "label", images, image => add(image, labels));
     }
 
     function batchRemove (images, label) {
-        return $q.all(images.map(image => remove(image, label)));
+        return trackAll($rootScope, "label", images, image => remove(image, label));
     }
 
     return {

--- a/kahuna/public/js/services/photoshoot.js
+++ b/kahuna/public/js/services/photoshoot.js
@@ -25,7 +25,8 @@ photoshootService.factory('photoshootService', [
             const key = "photoshoot-remove";
             let completed = 0;
 
-            $rootScope.$broadcast("events:batch-operations:start", { key, completed: 0, total: images.length });
+            $rootScope.$broadcast("events:batch-operations:start",
+                { key, completed: 0, total: images.length });
 
             return $q.all(images.map(image =>
                 deletePhotoshoot({ image }).then(r => {

--- a/kahuna/public/js/services/photoshoot.js
+++ b/kahuna/public/js/services/photoshoot.js
@@ -14,11 +14,45 @@ photoshootService.factory('photoshootService', [
         }
 
         function batchAdd({ data, images }) {
-            return $q.all(images.map(image => putPhotoshoot({data, image})));
+            const key = "photoshoot";
+            let completed = 0;
+
+            $rootScope.$broadcast("events:batch-operations:start", { key, completed: 0, total: images.size });
+
+            return $q.all(images.map(image =>
+                putPhotoshoot({data, image}).then(r => {
+                    completed++;
+                    $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
+                    return r;
+                })
+            )).then(r => {
+                $rootScope.$broadcast("events:batch-operations:complete", { key });
+                return r;
+            }).catch(err => {
+                $rootScope.$broadcast("events:batch-operations:complete", { key });
+                throw err;
+            });
         }
 
         function batchRemove({ images }) {
-            return $q.all(images.map(image => deletePhotoshoot({ image })));
+            const key = "photoshoot-remove";
+            let completed = 0;
+
+            $rootScope.$broadcast("events:batch-operations:start", { key, completed: 0, total: images.length });
+
+            return $q.all(images.map(image =>
+                deletePhotoshoot({ image }).then(r => {
+                    completed++;
+                    $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
+                    return r;
+                })
+            )).then(r => {
+                $rootScope.$broadcast("events:batch-operations:complete", { key });
+                return r;
+            }).catch(err => {
+                $rootScope.$broadcast("events:batch-operations:complete", { key });
+                throw err;
+            });
         }
 
         function putPhotoshoot({ data, image }) {

--- a/kahuna/public/js/services/photoshoot.js
+++ b/kahuna/public/js/services/photoshoot.js
@@ -22,25 +22,9 @@ photoshootService.factory('photoshootService', [
         }
 
         function batchRemove({ images }) {
-            const key = "photoshoot-remove";
-            let completed = 0;
-
-            $rootScope.$broadcast("events:batch-operations:start",
-                { key, completed: 0, total: images.length });
-
-            return $q.all(images.map(image =>
-                deletePhotoshoot({ image }).then(r => {
-                    completed++;
-                    $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
-                    return r;
-                })
-            )).then(r => {
-                $rootScope.$broadcast("events:batch-operations:complete", { key });
-                return r;
-            }).catch(err => {
-                $rootScope.$broadcast("events:batch-operations:complete", { key });
-                throw err;
-            });
+            return trackAll($rootScope, "photoshoot", images, image =>
+                deletePhotoshoot({ image })
+            );
         }
 
         function putPhotoshoot({ data, image }) {

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -12,6 +12,7 @@ import template from './usage-rights-editor.html';
 import './usage-rights-editor.css';
 
 import '../components/gr-confirm-delete/gr-confirm-delete.js';
+import { trackAll } from '../util/batch-tracking';
 
 export var usageRightsEditor = angular.module('kahuna.edits.usageRightsEditor', [
     'monospaced.elastic',
@@ -156,29 +157,12 @@ usageRightsEditor.controller(
     ctrl.cancel = () => ctrl.onCancel();
 
     function save(data) {
-        const key = "rights";
-        let completed = 0;
-
-        $rootScope.$broadcast("events:batch-operations:start", { key, completed: 0, total: ctrl.usageRights.length });
-
-        return $q.all(ctrl.usageRights.map(usageRights => {
+        return trackAll($rootScope, "rights", ctrl.usageRights, usageRights => {
             const image = usageRights.image;
             const resource = image.data.userMetadata.data.usageRights;
             return editsService.update(resource, data, image).
                 then(resource => resource.data).
-                then(() => setMetadataFromUsageRights(image)).
-                then(r => {
-                    completed++;
-
-                    $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
-                    return r;
-                });
-        })).then(r => {
-            $rootScope.$broadcast("events:batch-operations:complete", { key });
-            return r;
-        }).catch(err => {
-            $rootScope.$broadcast("events:batch-operations:complete", { key });
-            throw err;
+                then(() => setMetadataFromUsageRights(image));
         });
     }
 

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -1,0 +1,18 @@
+// TODO MRB: invoke function lazily, does it improve UI jank?
+export function trackAll($rootScope, key, input, fn) {
+    let completed = 0;
+    $rootScope.$broadcast("events:batch-operations:start", { key, completed: 0, total: input.size ? input.size : input.length });
+
+    return Promise.all(input.map(item => fn(item).then(intermediateResult => {
+        completed++;
+        $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
+
+        return intermediateResult;
+    }))).then(finalResult => {
+        $rootScope.$broadcast("events:batch-operations:complete", { key });
+        return finalResult;
+    }).catch(error => {
+        $rootScope.$broadcast("events:batch-operations:complete", { key });
+        throw error;
+    });
+}

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -1,7 +1,8 @@
 // TODO MRB: invoke function lazily, does it improve UI jank?
 export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
-    $rootScope.$broadcast("events:batch-operations:start", { key, completed: 0, total: input.size ? input.size : input.length });
+    $rootScope.$broadcast("events:batch-operations:start",
+        { key, completed: 0, total: input.size ? input.size : input.length });
 
     return Promise.all(input.map(item => fn(item).then(intermediateResult => {
         completed++;

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -4,16 +4,15 @@ export function trackAll($rootScope, key, input, fn) {
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
 
-    return Promise.all(input.map(item => fn(item).then(intermediateResult => {
-        completed++;
-        $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
+    const results = input.map(item => {
+        return fn(item).then(result => {
+            completed++;
+            $rootScope.$broadcast("events:batch-operations:progress", { key, completed });
+            return result;
+        });
+    });
 
-        return intermediateResult;
-    }))).then(finalResult => {
+    return Promise.all(results).finally(() => {
         $rootScope.$broadcast("events:batch-operations:complete", { key });
-        return finalResult;
-    }).catch(error => {
-        $rootScope.$broadcast("events:batch-operations:complete", { key });
-        throw error;
     });
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -984,6 +984,16 @@ textarea.ng-invalid {
     margin: 0 3px 3px 0;
 }
 
+.batch_progress {
+    position: absolute;
+    top: 5px;
+    z-index: 9999;
+}
+
+.batch_progress li {
+    background-color: #565656;
+}
+
 /* Hacky pointer to some element above */
 .validity--invalid--point-up {
     position: relative;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -984,16 +984,6 @@ textarea.ng-invalid {
     margin: 0 3px 3px 0;
 }
 
-.batch_progress {
-    position: absolute;
-    top: 5px;
-    z-index: 9999;
-}
-
-.batch_progress li {
-    background-color: #565656;
-}
-
 /* Hacky pointer to some element above */
 .validity--invalid--point-up {
     position: relative;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1079,6 +1079,12 @@ textarea.ng-invalid {
     padding: 0px;
 }
 
+.results-toolbar-item__progress {
+    /* updated in JS to show progress */
+    background: linear-gradient(90deg, #00adee 0%, transparent 0%);
+    text-shadow: 1px 1px 2px #333;
+}
+
 .image-results-count__new {
     font-family: inherit;
     background-color: #00adee;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1082,7 +1082,7 @@ textarea.ng-invalid {
 .results-toolbar-item__progress {
     /* updated in JS to show progress */
     background: linear-gradient(90deg, #00adee 0%, transparent 0%);
-    text-shadow: 1px 1px 2px #333;
+    color: white;
 }
 
 .image-results-count__new {


### PR DESCRIPTION
Show numerical progress in the top bar when batch operations are applied.

![2f3ebfd99d2daf5e94e656cbc45305d5](https://user-images.githubusercontent.com/395805/58566582-cf50ea00-8228-11e9-8405-d13636523b0a.gif)

This will give people more confidence that something is still happening during a long running batch operation and give us visibility on performance improvements if/when we move more batch operations to the server.

Since each component (and each service) implements batch as it sees fit, I have added the tracking using events on the root scope.

I also made the progress appear above the existing cost overview to avoid the controls below jumping up and down when you edit them.

It can track edits to more than one field at once, although the UI tends to lock up anyway when you try and do that.

TODO:
- [x] prompt when refreshing the page if an operation is still in progress
- [x] work out why sometimes the info panel disappears once operations complete
- [x] where to put progress (can't see during full frame crop)
- [x] change color to white (match buttons)
