### PR TITLE
Improve byline metadata cleaning logic

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
-object ByLineCreditReorganise extends MetadataCleaner {
+object BylineCreditReorganise extends MetadataCleaner {
   type Field = Option[String]
 
   val SpaceySlashes = """\s*\/\s*""".r
@@ -23,14 +23,17 @@ object ByLineCreditReorganise extends MetadataCleaner {
 
   def removeBylineFromCredit(bylineField: Field, creditField: Field) =
     bothExist(bylineField, creditField).map { case (byline, credit) =>
-      (byline.split("/", 2).toList, credit.split("/", 2).toList) match {
-        // if no split, business as usual
-        case (b1 :: Nil, c1 :: Nil) => (b1, c1)
+      val bylineParts = byline.split("/").filter(!_.isEmpty)
+      val creditParts = credit.split("/").filter(!_.isEmpty)
 
-        // if we have a split, and the first split is the same, remove if from credit
-        // and use it as byline, the rest is the credit
-        case (b1 :: bTail, c1 :: cTail)if b1 == c1 => (b1, cTail.head)
-        case _ => (byline, credit)
+      if (bylineParts.length == 0 || (bylineParts.length == 1 && creditParts.length == 1)) {
+        (byline, credit)
+      } else {
+        val outputByline = bylineParts.head
+
+        val outputCredit = (bylineParts.tail.filter(!creditParts.contains(_)) ++ creditParts.filter(_ != outputByline)).distinct.mkString("/")
+
+        (outputByline, outputCredit)
       }
     }
     // Convert the strings back to `Option`s

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -26,7 +26,11 @@ object BylineCreditReorganise extends MetadataCleaner {
       val bylineParts = byline.split("/").filter(!_.isEmpty)
       val creditParts = credit.split("/").filter(!_.isEmpty)
 
-      if (bylineParts.length == 0 || (bylineParts.length == 1 && creditParts.length == 1)) {
+      // It's very difficult to decide how to reorganise the byline or credits if they're both single tokens
+      // since we'd need to know what's likely to be a name and what's likely to be an organisation.
+      val ambiguousBylineCredit = bylineParts.length == 0 || (bylineParts.length == 1 && creditParts.length == 1)
+
+      if (ambiguousBylineCredit) {
         (byline, credit)
       } else {
         val outputByline = bylineParts.head

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -15,7 +15,7 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
   val allCleaners: List[MetadataCleaner] = List(
     CleanRubbishLocation,
     StripCopyrightPrefix,
-    ByLineCreditReorganise,
+    BylineCreditReorganise,
     UseCanonicalGuardianCredit,
     ExtractGuardianCreditFromByline
   ) ++ attrCreditFromBylineCleaners ++ List(

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -11,12 +11,12 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
 
   it ("should remove spaces between slashes") {
     CreditByline("Man /In /Suit", "Presseye/ INPHO /REX")
-    .whenCleaned("Man/In/Suit"  , "Presseye/INPHO/REX")
+    .whenCleaned("Man"  , "In/Suit/Presseye/INPHO/REX")
   }
 
-  it ("should leave non matching byline and credit") {
+  it ("should clean credits from byline but leave non-matching name") {
     CreditByline("Ella/BPI/REX", "Ella Ling/BPI/REX")
-    .whenCleaned("Ella/BPI/REX", "Ella Ling/BPI/REX")
+    .whenCleaned("Ella", "Ella Ling/BPI/REX")
   }
 
   it ("should remove matching byline from credit in triple slash") {
@@ -44,13 +44,33 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
       .whenCleaned("Barcroft Media", "Philip Glass")
   }
 
+  it ("should remove organisation from byline") {
+    CreditByline("Philip Glass/Barcroft Media", "Barcroft Media")
+      .whenCleaned("Philip Glass", "Barcroft Media")
+  }
+
+  it ("should handle empty byline") {
+    CreditByline("", "Barcroft Media")
+      .whenCleaned("", "Barcroft Media")
+  }
+
+  it ("should handle empty credit") {
+    CreditByline("John Doe", "")
+      .whenCleaned("John Doe", "")
+  }
+
+  it ("should handle empty credit when byline has organisation names") {
+    CreditByline("John Doe/BPI/REX", "")
+      .whenCleaned("John Doe", "BPI/REX")
+  }
+
   case class CreditByline(byline: String, credit: String) {
     def whenCleaned(cByline: String, cCredit: String) = {
       val metadata = createImageMetadata(
         "byline" -> byline,
         "credit" -> credit
       )
-      val cleanMetadata = ByLineCreditReorganise.clean(metadata)
+      val cleanMetadata = BylineCreditReorganise.clean(metadata)
 
       cleanMetadata.byline should be (Some(cByline))
       cleanMetadata.credit should be (Some(cCredit))


### PR DESCRIPTION
Closes #2318 

And fixes two Trello cards!!!

https://trello.com/c/jcuM36Fa/612-byline-capitalisation-should-work-even-if-there-is-a-in-the-byline-thishttps-githubcom-guardian-grid-blob-master-common-lib-src

https://trello.com/c/iTvsjo9t/786-grid-fix-head-of-empty-list-on-upload