### PR TITLE
Don't require credit to process bylines

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -18,11 +18,9 @@ object BylineCreditReorganise extends MetadataCleaner {
     )
   }
 
-  def bothExist(byline: Field, credit: Field): Option[(String, String)] =
-    for(b <- byline; c <- credit) yield (b, c)
-
   def removeBylineFromCredit(bylineField: Field, creditField: Field) =
-    bothExist(bylineField, creditField).map { case (byline, credit) =>
+    bylineField.map { byline =>
+      val credit = creditField.getOrElse("")
       val bylineParts = byline.split("/").filter(!_.isEmpty)
       val creditParts = credit.split("/").filter(!_.isEmpty)
 
@@ -41,7 +39,7 @@ object BylineCreditReorganise extends MetadataCleaner {
       }
     }
     // Convert the strings back to `Option`s
-    .map{ case (b, c) => (Some(b), Some(c)) }
+    .map{ case (b, c) => (Some(b), Some(c).filter(!_.isEmpty)) }
     // return the defaults if they both didn't exist
     .getOrElse((bylineField, creditField))
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -56,7 +56,7 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
 
   it ("should handle empty credit") {
     CreditByline("John Doe", "")
-      .whenCleaned("John Doe", "")
+      .whenCleaned("John Doe", None)
   }
 
   it ("should handle empty credit when byline has organisation names") {
@@ -65,6 +65,18 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
   }
 
   case class CreditByline(byline: String, credit: String) {
+    def whenCleaned(cByline: String, cCredit: Option[String]) = {
+      val metadata = createImageMetadata(
+        "byline" -> byline,
+        "credit" -> credit
+      )
+
+      val cleanMetadata = BylineCreditReorganise.clean(metadata)
+
+      cleanMetadata.byline should be (Some(cByline))
+      cleanMetadata.credit should be (cCredit)
+    }
+
     def whenCleaned(cByline: String, cCredit: String) = {
       val metadata = createImageMetadata(
         "byline" -> byline,


### PR DESCRIPTION
We can handle a missing credit but not a missing byline so we shouldn't require both of them in the metadata cleaner

Also had to modify how the tests are run to deal with the fact there might not be a credit after the processor has run (e.g. when there's a byline such as `Sam Cutler` and no credit)

Hopefully the tests make sense?