### PR TITLE
Make EPA processor not require an exact match on Credit

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -168,7 +168,7 @@ object CorbisParser extends ImageProcessor {
 
 object EpaParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
-    case Some("EPA") => image.copy(
+    case Some(x) if x.matches(".*\\bEPA\\b.*") => image.copy(
       usageRights = Agency("EPA")
     )
     case _ => image


### PR DESCRIPTION
## What does this change?
Turns out, we match suppliers on *cleaned* metadata fields. Because of recent (good!) [changes to the Credit cleaner](https://github.com/guardian/grid/pull/2576), we started missing a small amount of EPA imagery when we moved stuff from byline to credit (cos we also match the whole of the field). This change will match anything in Credit that contains a word `EPA` fixing some previously miscategorised images too (eg. `EPA-EFE`).

I will investigate if this change affected any other suppliers, to what degree, and copy and paste this code (obviously not mine, but @itsibitzi’s) to them if needed.

## How can success be measured?
Gee, why are you on about this _success_ thingie?! Seriously. Grow up. World is inherently a messy place, entropy is increasing, one can only do so much with their tiny corner of it. And most probably it’s all for nothing, anyway.

## Screenshots (if applicable)
Not this time, sorry.

## Who should look at this?
You asked for this yourself, Dear Template: @guardian/digital-cms.

## Tested?
- [x] on TEST
