### PR TITLE
Use imagemagick for tiff image operations

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -67,7 +67,7 @@ class ImageOperations(playPath: String) {
       cropped       = crop(profiled)(bounds)
       depthAdjusted = depth(cropped)(8)
       addOutput     = addDestImage(depthAdjusted)(outputFile)
-      _             <- runConvertCmd(addOutput, useImageMagick = fileType == "image/tiff")
+      _             <- runConvertCmd(addOutput, useImageMagick = fileType == "tif")
     }
     yield outputFile
   }
@@ -86,7 +86,7 @@ class ImageOperations(playPath: String) {
       qualified    = quality(resizeSource)(qual)
       resized      = scale(qualified)(dimensions)
       addOutput    = addDestImage(resized)(outputFile)
-      _           <- runConvertCmd(addOutput, useImageMagick = fileType == "image/tiff")
+      _           <- runConvertCmd(addOutput, useImageMagick = fileType == "tif")
     }
     yield outputFile
   }
@@ -121,7 +121,7 @@ class ImageOperations(playPath: String) {
       unsharpened = unsharp(profiled)(thumbUnsharpRadius, thumbUnsharpSigma, thumbUnsharpAmount)
       qualified   = quality(unsharpened)(qual)
       addOutput   = addDestImage(qualified)(outputFile)
-      _          <- runConvertCmd(addOutput, useImageMagick = fileType.contains("image/tiff"))
+      _          <- runConvertCmd(addOutput, useImageMagick = fileType.contains("tif"))
     } yield outputFile
   }
 
@@ -130,7 +130,7 @@ class ImageOperations(playPath: String) {
       outputFile  <- createTempFile(s"transformed-", ".png", tempDir)
       transformSource = addImage(sourceFile)
       addOutput    = addDestImage(transformSource)(outputFile)
-      _           <- runConvertCmd(addOutput, useImageMagick = fileType.contains("image/tiff"))
+      _           <- runConvertCmd(addOutput, useImageMagick = fileType.contains("tif"))
     }
       yield outputFile
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -162,7 +162,7 @@ object ImageOperations {
         val formatter = format(source)("%[JPEG-Colorspace-Name]")
 
         for {
-          output <- runIdentifyCmd(formatter, useImageMagick = true)
+          output <- runIdentifyCmd(formatter)
           colourModel = output.headOption
         } yield colourModel
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -1,17 +1,16 @@
 package com.gu.mediaservice.lib.imaging.im4jwrapper
 
 import java.util.concurrent.Executors
-
 import java.io.File
+
 import org.im4java.process.ArrayListOutputConsumer
 
 import scala.collection.JavaConverters._
-
-import scala.concurrent.{Future, ExecutionContext}
-import org.im4java.core.{IdentifyCmd, IMOperation, ConvertCmd}
+import scala.concurrent.{ExecutionContext, Future}
+import org.im4java.core.{ConvertCmd, IMOperation, IdentifyCmd}
 import scalaz.syntax.id._
-
-import com.gu.mediaservice.model.{Dimensions, Bounds}
+import com.gu.mediaservice.model.{Bounds, Dimensions}
+import play.api.Logger
 
 
 object ImageMagick {
@@ -32,9 +31,14 @@ object ImageMagick {
   def format(op: IMOperation)(definition: String): IMOperation = op <| (_.format(definition))
   def depth(op: IMOperation)(depth: Int): IMOperation = op <| (_.depth(depth))
 
-  def runConvertCmd(op: IMOperation, useImageMagick: Boolean): Future[Unit] = Future((new ConvertCmd(!useImageMagick)).run(op))
-  def runIdentifyCmd(op: IMOperation, useImageMagick: Boolean): Future[List[String]] = Future {
-    val cmd = new IdentifyCmd(!useImageMagick)
+  def runConvertCmd(op: IMOperation, useImageMagick: Boolean): Future[Unit] = {
+    // TODO MRB:
+    Logger.info(s"Using ${if(useImageMagick) { "imagemagick" } else { "graphicsmagick" }} for imaging operation")
+    Future((new ConvertCmd(!useImageMagick)).run(op))
+  }
+
+  def runIdentifyCmd(op: IMOperation): Future[List[String]] = Future {
+    val cmd = new IdentifyCmd(true)
     val output = new ArrayListOutputConsumer()
     cmd.setOutputConsumer(output)
     cmd.run(op)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -31,11 +31,10 @@ object ImageMagick {
   def scale(op: IMOperation)(dimensions: Dimensions): IMOperation = op <| (_.scale(dimensions.width, dimensions.height))
   def format(op: IMOperation)(definition: String): IMOperation = op <| (_.format(definition))
   def depth(op: IMOperation)(depth: Int): IMOperation = op <| (_.depth(depth))
-  val useGraphicsMagick = true
 
-  def runConvertCmd(op: IMOperation): Future[Unit] = Future((new ConvertCmd(useGraphicsMagick)).run(op))
-  def runIdentifyCmd(op: IMOperation): Future[List[String]] = Future {
-    val cmd = new IdentifyCmd(useGraphicsMagick)
+  def runConvertCmd(op: IMOperation, useImageMagick: Boolean): Future[Unit] = Future((new ConvertCmd(!useImageMagick)).run(op))
+  def runIdentifyCmd(op: IMOperation, useImageMagick: Boolean): Future[List[String]] = Future {
+    val cmd = new IdentifyCmd(!useImageMagick)
     val output = new ArrayListOutputConsumer()
     cmd.setOutputConsumer(output)
     cmd.run(op)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -32,7 +32,6 @@ object ImageMagick {
   def depth(op: IMOperation)(depth: Int): IMOperation = op <| (_.depth(depth))
 
   def runConvertCmd(op: IMOperation, useImageMagick: Boolean): Future[Unit] = {
-    // TODO MRB:
     Logger.info(s"Using ${if(useImageMagick) { "imagemagick" } else { "graphicsmagick" }} for imaging operation $op")
 
     Future((new ConvertCmd(!useImageMagick)).run(op))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -33,7 +33,8 @@ object ImageMagick {
 
   def runConvertCmd(op: IMOperation, useImageMagick: Boolean): Future[Unit] = {
     // TODO MRB:
-    Logger.info(s"Using ${if(useImageMagick) { "imagemagick" } else { "graphicsmagick" }} for imaging operation")
+    Logger.info(s"Using ${if(useImageMagick) { "imagemagick" } else { "graphicsmagick" }} for imaging operation $op")
+
     Future((new ConvertCmd(!useImageMagick)).run(op))
   }
 

--- a/cropper/app/lib/Crops.scala
+++ b/cropper/app/lib/Crops.scala
@@ -38,7 +38,7 @@ class Crops(config: CropperConfig, store: CropStore, imageOperations: ImageOpera
     val iccColourSpace = FileMetadataHelper.normalisedIccColourSpace(apiImage.fileMetadata)
 
     for {
-      strip <- imageOperations.cropImage(sourceFile, source.bounds, masterCropQuality, config.tempDir, iccColourSpace, colourModel, mediaType.extension)
+      strip <- imageOperations.cropImage(sourceFile, apiImage.source.mimeType, source.bounds, masterCropQuality, config.tempDir, iccColourSpace, colourModel, mediaType.extension)
       file: File <- imageOperations.appendMetadata(strip, metadata)
       dimensions  = Dimensions(source.bounds.width, source.bounds.height)
       filename    = outputFilename(apiImage, source.bounds, dimensions.width, mediaType.extension, true)
@@ -54,7 +54,7 @@ class Crops(config: CropperConfig, store: CropStore, imageOperations: ImageOpera
 
     Future.sequence[Asset, List](dimensionList.map { dimensions =>
       for {
-        file          <- imageOperations.resizeImage(sourceFile, dimensions, cropQuality, config.tempDir, mediaType.extension)
+        file          <- imageOperations.resizeImage(sourceFile, apiImage.source.mimeType, dimensions, cropQuality, config.tempDir, mediaType.extension)
         optimisedFile = imageOperations.optimiseImage(file, mediaType)
         filename      = outputFilename(apiImage, crop.specification.bounds, dimensions.width, mediaType.extension)
         sizing        <- store.storeCropSizing(optimisedFile, filename, mediaType.name, crop, dimensions)

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -170,7 +170,7 @@ object FileMetadataReader {
 
     val formatter = format(source)("%r")
 
-    runIdentifyCmd(formatter, useImageMagick = true).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
+    runIdentifyCmd(formatter).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
       .recover { case _ => getColourInformation(metadata, None, mimeType) }
   }
 

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -170,7 +170,7 @@ object FileMetadataReader {
 
     val formatter = format(source)("%r")
 
-    runIdentifyCmd(formatter).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
+    runIdentifyCmd(formatter, useImageMagick = true).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
       .recover { case _ => getColourInformation(metadata, None, mimeType) }
   }
 

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -119,7 +119,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
         fileMetadata <- fileMetadataFuture
         colourModel <- colourModelFuture
         iccColourSpace = FileMetadataHelper.normalisedIccColourSpace(fileMetadata)
-        thumb <- imageOps.createThumbnail(uploadedFile, config.thumbWidth, config.thumbQuality, config.tempDir, iccColourSpace, colourModel, uploadRequest.mimeType)
+        thumb <- imageOps.createThumbnail(uploadedFile, uploadRequest.mimeType, config.thumbWidth, config.thumbQuality, config.tempDir, iccColourSpace, colourModel)
       } yield thumb
 
       //Could potentially use this file as the source file if needed (to generate thumbnail etc from)
@@ -127,7 +127,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
         case Some(mime) => mime match {
           case transcodedMime if config.transcodedMimeTypes.contains(mime) =>
             for {
-            transformedImage <- imageOps.transformImage(uploadedFile, config.tempDir, uploadRequest.mimeType)
+            transformedImage <- imageOps.transformImage(uploadedFile, uploadRequest.mimeType, config.tempDir)
             } yield transformedImage
           case _ =>
             Future.apply(uploadedFile)

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -119,7 +119,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
         fileMetadata <- fileMetadataFuture
         colourModel <- colourModelFuture
         iccColourSpace = FileMetadataHelper.normalisedIccColourSpace(fileMetadata)
-        thumb <- imageOps.createThumbnail(uploadedFile, config.thumbWidth, config.thumbQuality, config.tempDir, iccColourSpace, colourModel)
+        thumb <- imageOps.createThumbnail(uploadedFile, config.thumbWidth, config.thumbQuality, config.tempDir, iccColourSpace, colourModel, uploadRequest.mimeType)
       } yield thumb
 
       //Could potentially use this file as the source file if needed (to generate thumbnail etc from)
@@ -127,7 +127,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
         case Some(mime) => mime match {
           case transcodedMime if config.transcodedMimeTypes.contains(mime) =>
             for {
-            transformedImage <- imageOps.transformImage(uploadedFile, config.tempDir)
+            transformedImage <- imageOps.transformImage(uploadedFile, config.tempDir, uploadRequest.mimeType)
             } yield transformedImage
           case _ =>
             Future.apply(uploadedFile)


### PR DESCRIPTION
Use imagemagick for calls to `convert` imaging operations. It produces correct colours in the resulting crops where graphicsmagick does not.