### PR TITLE
fix issues with apostrophised names in bylines

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerByline.scala
@@ -6,7 +6,7 @@ object InitialJoinerByline extends MetadataCleaner {
   // Squish together pairs of dangling initials. For example: "C P Scott" -> "CP Scott"
   override def clean(metadata: ImageMetadata): ImageMetadata = {
     metadata.copy(
-      byline = metadata.byline.map(_.replaceAll("\\b(\\p{Lu})\\s(\\p{Lu})\\b", "$1$2"))
+      byline = metadata.byline.map(_.replaceAll("\\b(\\p{Lu})\\s(\\p{Lu}(\\s|$))", "$1$2"))
     )
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerBylineTest.scala
@@ -24,4 +24,17 @@ class InitialJoinerBylineTest extends FunSpec with Matchers with MetadataHelper 
     cleanedMetadata.byline should be(Some("First AB"))
   }
 
+  it("should not squish together if it's actually part of a name, with straight quote") {
+    val metadata = createImageMetadata("byline" -> "First A D'Last")
+    val cleanedMetadata = InitialJoinerByline.clean(metadata)
+
+    cleanedMetadata.byline should be(Some("First A D'Last"))
+  }
+
+  it("should not squish together if it's actually part of a name, with curly quote") {
+    val metadata = createImageMetadata("byline" -> "First A D’Last")
+    val cleanedMetadata = InitialJoinerByline.clean(metadata)
+
+    cleanedMetadata.byline should be(Some("First A D’Last"))
+  }
 }


### PR DESCRIPTION
The Guardian style guide prefers `C. P. Scott` to be written as `CP Scott`, but this causes issues with names such as `Stefania M. D'Alessandro` becoming `Stefania MD’Alessandro`.

This is because the apostrophes count as word boundaries so the previous regex assumed they were a loose character.

Instead of using a word boundary we now use a group of either a white space or an end of line.

Added new tests to check this is ok!