### PR TITLE
Fix hang removing labels

### DIFF
--- a/kahuna/public/js/services/label.js
+++ b/kahuna/public/js/services/label.js
@@ -67,7 +67,11 @@ labelService.factory('labelService',
     }
 
     function batchRemove (images, label) {
-        return trackAll($rootScope, "label", images, image => remove(image, label));
+        const affectedImages = images.filter(image =>
+            imageAccessor.readLabels(image).some(({ data }) => data === label)
+        );
+
+        return trackAll($rootScope, "label", affectedImages, image => remove(image, label));
     }
 
     return {

--- a/kahuna/public/js/services/label.js
+++ b/kahuna/public/js/services/label.js
@@ -45,6 +45,9 @@ labelService.factory('labelService',
                     return newImage;
                 });
         }
+
+        // no-op
+        return Promise.resolve(image);
     }
 
     function add (image, labels) {


### PR DESCRIPTION
Fixes a regression introduced in #2574 (progress bar for batch operations) where the UI would hang when removing a label if the selection contained a mix of different labels.

The problem was caused due to `labelService.remove` returning `undefined` if the label did not exist on the image, since the entire selection was passed to `labelService.batchRemove`.

As well as fixing this, I've also filtered out the images without the label from the call. This means the progress bar now correctly reflects the number of images that will have the label removed, rather than showing the total number of images in the selection.
