### PR TITLE
add is search

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -1,0 +1,28 @@
+package lib.elasticsearch.impls.elasticsearch6
+
+import com.gu.mediaservice.lib.ImageFields
+import com.gu.mediaservice.model.{CommissionedPhotographer, ContractPhotographer, StaffPhotographer}
+import com.sksamuel.elastic4s.searches.queries.Query
+
+sealed trait IsQueryFilter extends Query with ImageFields {
+  def query: Query
+
+  override def toString: String = this match {
+    case IsStaffPhotographer => "staff"
+  }
+}
+
+object IsQueryFilter {
+  def apply(value: String): Option[IsQueryFilter] = value.toLowerCase match {
+    case "staff" => Some(IsStaffPhotographer)
+    case _ => None
+  }
+}
+
+object IsStaffPhotographer extends IsQueryFilter {
+  override def query: Query = filters.or(
+    filters.term(usageRightsField("category"), StaffPhotographer.category),
+    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
+    filters.term(usageRightsField("category"), ContractPhotographer.category)
+  )
+}

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -44,6 +44,13 @@ class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
       case HasValue(value) => boolQuery().filter(existsQuery(getFieldPath(value)))
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
+    case IsField => condition.value match {
+      case IsValue(value) => IsQueryFilter.apply(value) match {
+        case Some(isQuery) => isQuery.query
+        case _ => throw InvalidQuery(s"Cannot perform is query on ${condition.value}")
+      }
+      case _ => throw InvalidQuery(s"Cannot perform is query on ${condition.value}")
+    }
   }
 
   def makeQuery(conditions: List[Condition]) = conditions match {

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -9,6 +9,7 @@ import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.searches.queries.Query
 import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQuery, MultiMatchQueryBuilderType}
 import lib.querysyntax._
+import play.api.Logger
 
 class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
 
@@ -47,9 +48,15 @@ class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
     case IsField => condition.value match {
       case IsValue(value) => IsQueryFilter.apply(value) match {
         case Some(isQuery) => isQuery.query
-        case _ => throw InvalidQuery(s"Cannot perform is query on ${condition.value}")
+        case _ => {
+          Logger.info(s"Cannot perform IS query on ${condition.value}")
+          matchNoneQuery
+        }
       }
-      case _ => throw InvalidQuery(s"Cannot perform is query on ${condition.value}")
+      case _ => {
+        Logger.info(s"Cannot perform IS query on ${condition.value}")
+        matchNoneQuery
+      }
     }
   }
 

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
@@ -53,11 +53,7 @@ class SyndicationFilter(config: MediaApiConfig) extends ImageFields {
     filters.date("syndicationRights.published", None, Some(DateTime.now)).get
   )
 
-  private val syndicatableCategory: Query = filters.or(
-    filters.term(usageRightsField("category"), StaffPhotographer.category),
-    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
-    filters.term(usageRightsField("category"), ContractPhotographer.category)
-  )
+  private val syndicatableCategory: Query = IsStaffPhotographer.query
 
   def statusFilter(status: SyndicationStatus): Query = status match {
     case SentForSyndication => filters.and(

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -29,6 +29,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
 
   def Filter = rule {
     HasMatch ~> Match |
+    IsMatch ~> Match |
     ScopedMatch ~> Match | HashMatch | CollectionRule |
     DateConstraintMatch |
     DateRangeMatch ~> Match | AtMatch |
@@ -39,6 +40,11 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   def HasMatchField = rule { capture(HasFieldName) ~> (_ => HasField) }
   def HasFieldName = rule { "has" }
   def HasMatchValue = rule { String ~> HasValue }
+
+  def IsMatch = rule { IsMatchField ~ ':' ~ IsMatchValue }
+  def IsMatchField = rule { capture(IsFieldName) ~> (_ => IsField) }
+  def IsFieldName = rule { "is" }
+  def IsMatchValue = rule { String ~> IsValue }
 
   def NestedMatch = rule { ParentField ~ "@" ~ NestedField ~ ':' ~ MatchValue }
   def NestedDateMatch = rule { ParentField ~ "@" ~ DateConstraintMatch ~> (

--- a/media-api/app/lib/querysyntax/model.scala
+++ b/media-api/app/lib/querysyntax/model.scala
@@ -13,6 +13,7 @@ final case object HierarchyField extends Field
 final case class SingleField(name: String) extends Field
 final case class MultipleField(names: List[String]) extends Field
 final case object HasField extends Field
+final case object IsField extends Field
 
 sealed trait Value
 final case class Words(string: String) extends Value
@@ -20,3 +21,4 @@ final case class Phrase(string: String) extends Value
 final case class Date(date: DateTime) extends Value
 final case class DateRange(startDate: DateTime, endDate: DateTime) extends Value
 final case class HasValue(string: String) extends Value
+final case class IsValue(string: String) extends Value


### PR DESCRIPTION
## What does this change?
As we cannot perform `or` searches, the `is` query is a handy shortcut for pre-saved queries. For example, `is:staff` represents a staff, commissioned or contract photographer.

## How can success be measured?
We can perform more complex queries with ease.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
