### PR TITLE
add `is` chip to kahuna

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -34,7 +34,8 @@ export const filterFields = [
     'croppedBy',
     'filename',
     'photoshoot',
-    'leasedBy'
+    'leasedBy',
+    'is'
 ].sort();
 // TODO: add date fields
 
@@ -58,6 +59,10 @@ const subjects = [
     'sport',
     'war',
     'weather'
+];
+
+const isSearch = [
+  'staff'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {
@@ -154,6 +159,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'illustrator': return listIllustrators().then(prefixFilter(value));
         case 'category': return listCategories().then(prefixFilter(value));
         case 'photoshoot': return suggestPhotoshoot(value);
+        case 'is': return isSearch;
         // No suggestions
         default:         return [];
         }

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -165,6 +165,14 @@
                 Checks for the existence of a field. For example crops, xmp metadata, location etc.
             </dd>
         </dl>
+        <dl class="advanced-search-example">
+          <dt class="advanced-search-example__field">
+            <gr-chip-example gr:filter-field="is" gr:example-search="staff"></gr-chip-example>
+          </dt>
+          <dd class="advanced-search-example__explanation">
+            Returns images that are staff.
+          </dd>
+        </dl>
     </div>
 
 


### PR DESCRIPTION
## What does this change?
Adds `is` chip to the chips.

Requires https://github.com/guardian/grid/pull/2592.

## How can success be measured?
We can perform more powerful search

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/59938955-5707ce00-944e-11e9-9e1a-d4b01a63334a.png)

If we can't serialise into a `IsQueryFilter`:
![image](https://user-images.githubusercontent.com/836140/59939087-c1207300-944e-11e9-9fa1-aded0205ecf9.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
