### PR TITLE
additional is searches

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -32,6 +32,10 @@ object UsageRights {
     Composite, PublicDomain
   )
 
+  val photographer = List(StaffPhotographer, ContractPhotographer, CommissionedPhotographer)
+  val illustrator = List(StaffIllustrator, ContractIllustrator, CommissionedIllustrator)
+  val whollyOwned = photographer ++ illustrator
+
   // this is a convenience method so that we use the same formatting for all subtypes
   // i.e. use the standard `Json.writes`. I still can't find a not have to pass the `f:Format[T]`
   // explicitly and inferring the type, but I think that has to do with the reflection that's used

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -62,6 +62,8 @@ const subjects = [
 ];
 
 const isSearch = [
+  'GNM-owned-photo',
+  'GNM-owned-illustration',
   'GNM-owned'
 ];
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -62,7 +62,7 @@ const subjects = [
 ];
 
 const isSearch = [
-  'staff'
+  'GNM-owned'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -33,8 +33,7 @@ object IsOwnedPhotograph extends IsQueryFilter {
 
 object IsOwnedIllustration extends IsQueryFilter {
   override def query: Query = filters.or(
-    filters.terms(usageRightsField("category"), UsageRights.illustrator.toNel.get.map(_.category)
-    )
+    filters.terms(usageRightsField("category"), UsageRights.illustrator.toNel.get.map(_.category))
   )
 }
 

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -3,46 +3,43 @@ package lib.elasticsearch.impls.elasticsearch6
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.model._
 import com.sksamuel.elastic4s.searches.queries.Query
+import scalaz.syntax.std.list._
 
 sealed trait IsQueryFilter extends Query with ImageFields {
   def query: Query
 
   override def toString: String = this match {
-    case IsGnmOwnedPhotographer => "gnm-owned-photo"
-    case IsGnmOwnedIllustration => "gnm-owned-illustration"
-    case IsGnmOwned => "gnm-owned"
+    case IsOwnedPhotograph => "gnm-owned-photo"
+    case IsOwnedIllustration => "gnm-owned-illustration"
+    case IsOwnedImage => "gnm-owned"
   }
 }
 
 object IsQueryFilter {
   // for readability, the client capitalises gnm, so `toLowerCase` it before matching
   def apply(value: String): Option[IsQueryFilter] = value.toLowerCase match {
-    case "gnm-owned-photo" => Some(IsGnmOwnedPhotographer)
-    case "gnm-owned-illustration" => Some(IsGnmOwnedIllustration)
-    case "gnm-owned" => Some(IsGnmOwned)
+    case "gnm-owned-photo" => Some(IsOwnedPhotograph)
+    case "gnm-owned-illustration" => Some(IsOwnedIllustration)
+    case "gnm-owned" => Some(IsOwnedImage)
     case _ => None
   }
 }
 
-object IsGnmOwnedPhotographer extends IsQueryFilter {
+object IsOwnedPhotograph extends IsQueryFilter {
   override def query: Query = filters.or(
-    filters.term(usageRightsField("category"), StaffPhotographer.category),
-    filters.term(usageRightsField("category"), CommissionedPhotographer.category),
-    filters.term(usageRightsField("category"), ContractPhotographer.category)
+    filters.terms(usageRightsField("category"), UsageRights.photographer.toNel.get.map(_.category))
   )
 }
 
-object IsGnmOwnedIllustration extends IsQueryFilter {
+object IsOwnedIllustration extends IsQueryFilter {
   override def query: Query = filters.or(
-    filters.term(usageRightsField("category"), StaffIllustrator.category),
-    filters.term(usageRightsField("category"), CommissionedIllustrator.category),
-    filters.term(usageRightsField("category"), ContractIllustrator.category)
+    filters.terms(usageRightsField("category"), UsageRights.illustrator.toNel.get.map(_.category)
+    )
   )
 }
 
-object IsGnmOwned extends IsQueryFilter {
+object IsOwnedImage extends IsQueryFilter {
   override def query: Query = filters.or(
-    IsGnmOwnedPhotographer.query,
-    IsGnmOwnedIllustration.query
+    filters.terms(usageRightsField("category"), UsageRights.whollyOwned.toNel.get.map(_.category))
   )
 }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -8,18 +8,19 @@ sealed trait IsQueryFilter extends Query with ImageFields {
   def query: Query
 
   override def toString: String = this match {
-    case IsStaffPhotographer => "staff"
+    case IsGnmOwnedPhotographer => "gnm-owned"
   }
 }
 
 object IsQueryFilter {
+  // for readability, the client capitalises gnm, so `toLowerCase` it before matching
   def apply(value: String): Option[IsQueryFilter] = value.toLowerCase match {
-    case "staff" => Some(IsStaffPhotographer)
+    case "gnm-owned" => Some(IsGnmOwnedPhotographer)
     case _ => None
   }
 }
 
-object IsStaffPhotographer extends IsQueryFilter {
+object IsGnmOwnedPhotographer extends IsQueryFilter {
   override def query: Query = filters.or(
     filters.term(usageRightsField("category"), StaffPhotographer.category),
     filters.term(usageRightsField("category"), CommissionedPhotographer.category),

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -1,21 +1,25 @@
 package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.ImageFields
-import com.gu.mediaservice.model.{CommissionedPhotographer, ContractPhotographer, StaffPhotographer}
+import com.gu.mediaservice.model._
 import com.sksamuel.elastic4s.searches.queries.Query
 
 sealed trait IsQueryFilter extends Query with ImageFields {
   def query: Query
 
   override def toString: String = this match {
-    case IsGnmOwnedPhotographer => "gnm-owned"
+    case IsGnmOwnedPhotographer => "gnm-owned-photo"
+    case IsGnmOwnedIllustration => "gnm-owned-illustration"
+    case IsGnmOwned => "gnm-owned"
   }
 }
 
 object IsQueryFilter {
   // for readability, the client capitalises gnm, so `toLowerCase` it before matching
   def apply(value: String): Option[IsQueryFilter] = value.toLowerCase match {
-    case "gnm-owned" => Some(IsGnmOwnedPhotographer)
+    case "gnm-owned-photo" => Some(IsGnmOwnedPhotographer)
+    case "gnm-owned-illustration" => Some(IsGnmOwnedIllustration)
+    case "gnm-owned" => Some(IsGnmOwned)
     case _ => None
   }
 }
@@ -25,5 +29,20 @@ object IsGnmOwnedPhotographer extends IsQueryFilter {
     filters.term(usageRightsField("category"), StaffPhotographer.category),
     filters.term(usageRightsField("category"), CommissionedPhotographer.category),
     filters.term(usageRightsField("category"), ContractPhotographer.category)
+  )
+}
+
+object IsGnmOwnedIllustration extends IsQueryFilter {
+  override def query: Query = filters.or(
+    filters.term(usageRightsField("category"), StaffIllustrator.category),
+    filters.term(usageRightsField("category"), CommissionedIllustrator.category),
+    filters.term(usageRightsField("category"), ContractIllustrator.category)
+  )
+}
+
+object IsGnmOwned extends IsQueryFilter {
+  override def query: Query = filters.or(
+    IsGnmOwnedPhotographer.query,
+    IsGnmOwnedIllustration.query
   )
 }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
@@ -53,7 +53,7 @@ class SyndicationFilter(config: MediaApiConfig) extends ImageFields {
     filters.date("syndicationRights.published", None, Some(DateTime.now)).get
   )
 
-  private val syndicatableCategory: Query = IsGnmOwnedPhotographer.query
+  private val syndicatableCategory: Query = IsOwnedPhotograph.query
 
   def statusFilter(status: SyndicationStatus): Query = status match {
     case SentForSyndication => filters.and(

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
@@ -53,7 +53,7 @@ class SyndicationFilter(config: MediaApiConfig) extends ImageFields {
     filters.date("syndicationRights.published", None, Some(DateTime.now)).get
   )
 
-  private val syndicatableCategory: Query = IsStaffPhotographer.query
+  private val syndicatableCategory: Query = IsGnmOwnedPhotographer.query
 
   def statusFilter(status: SyndicationStatus): Query = status match {
     case SentForSyndication => filters.and(

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -15,9 +15,11 @@ trait ConditionFixtures {
   val dateMatchCondition = Match(SingleField("adatefield"), DateRange(dateRangeStart, dateRangeEnd))
 
   val hasFieldCondition = Match(HasField, HasValue("foo"))
+
   val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph.toString))
   val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration.toString))
   val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage.toString))
+  val isInvalidCondition = Match(IsField, IsValue("a-random-string"))
 
   val hierarchyFieldPhraseCondition = Match(HierarchyField, Phrase("foo"))
   val anyFieldPhraseCondition = Match(AnyField, Phrase("cats and dogs"))

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -1,5 +1,6 @@
 package lib.elasticsearch
 
+import lib.elasticsearch.impls.elasticsearch6.{IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
 import lib.querysyntax.{Nested, _}
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -14,6 +15,10 @@ trait ConditionFixtures {
   val dateMatchCondition = Match(SingleField("adatefield"), DateRange(dateRangeStart, dateRangeEnd))
 
   val hasFieldCondition = Match(HasField, HasValue("foo"))
+  val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph.toString))
+  val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration.toString))
+  val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage.toString))
+
   val hierarchyFieldPhraseCondition = Match(HierarchyField, Phrase("foo"))
   val anyFieldPhraseCondition = Match(AnyField, Phrase("cats and dogs"))
   val anyFieldWordsCondition = Match(AnyField, Words("cats dogs"))

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -14,7 +14,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 import scala.concurrent.duration._
 
-trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with DockerKit with DockerTestKit with DockerKitSpotify {
+trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with DockerKit with DockerTestKit with DockerKitSpotify with ConditionFixtures {
 
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))
@@ -28,7 +28,10 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
 
   lazy val images = Seq(
     createImage(UUID.randomUUID().toString, Handout()),
-    createImage(UUID.randomUUID().toString, StaffPhotographer("Yellow Giraffe", "The Guardian")),
+    createImage("iron-suit", CommissionedPhotographer("Iron Man")),
+    createImage("green-giant", StaffIllustrator("Hulk")),
+    createImage("hammer-hammer-hammer", ContractIllustrator("Thor")),
+    createImage("green-leaf", StaffPhotographer("Yellow Giraffe", "The Guardian")),
     createImage(UUID.randomUUID().toString, Handout(), usages = List(createDigitalUsage())),
 
     createImageUploadedInThePast("persisted-because-edited").copy(
@@ -112,7 +115,7 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
     ),
 
     // no rights acquired, not available for syndication
-    createImageForSyndication(UUID.randomUUID().toString, rightsAcquired = false, None, None),
+    createImageForSyndication("test-image-13", rightsAcquired = false, None, None),
 
     // Agency image with published usage yesterday
     createImageForSyndication(

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -322,6 +322,79 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
     }
   }
 
+  describe("is field filter") {
+    it("should return no images with an invalid search") {
+      val search = SearchParams(tier = Internal, structuredQuery = List(isInvalidCondition))
+      whenReady(ES.search(search), timeout, interval) { result => {
+        result.total shouldBe 0
+      }}
+    }
+
+    it("should return owned photographs") {
+      val search = SearchParams(tier = Internal, structuredQuery = List(isOwnedPhotoCondition), length = 50)
+      whenReady(ES.search(search), timeout, interval) { result => {
+        val expected = List(
+          "iron-suit",
+          "green-leaf",
+          "test-image-1",
+          "test-image-2",
+          "test-image-3",
+          "test-image-4",
+          "test-image-5",
+          "test-image-6",
+          "test-image-7",
+          "test-image-8",
+          "test-image-12",
+          "test-image-13"
+        )
+
+        val imageIds = result.hits.map(_._1)
+        imageIds.size shouldBe expected.size
+        expected.foreach(imageIds.contains(_) shouldBe true)
+      }}
+    }
+
+    it("should return owned illustrations") {
+      val search = SearchParams(tier = Internal, structuredQuery = List(isOwnedIllustrationCondition))
+      whenReady(ES.search(search), timeout, interval) { result => {
+        val expected = List(
+          "green-giant",
+          "hammer-hammer-hammer"
+        )
+
+        val imageIds = result.hits.map(_._1)
+        imageIds.size shouldBe expected.size
+        expected.foreach(imageIds.contains(_) shouldBe true)
+      }}
+    }
+
+    it("should return all owned images") {
+      val search = SearchParams(tier = Internal, structuredQuery = List(isOwnedImageCondition), length = 50)
+      whenReady(ES.search(search), timeout, interval) { result => {
+        val expected = List(
+          "iron-suit",
+          "green-leaf",
+          "test-image-1",
+          "test-image-2",
+          "test-image-3",
+          "test-image-4",
+          "test-image-5",
+          "test-image-6",
+          "test-image-7",
+          "test-image-8",
+          "test-image-12",
+          "test-image-13",
+          "green-giant",
+          "hammer-hammer-hammer"
+        )
+
+        val imageIds = result.hits.map(_._1)
+        imageIds.size shouldBe expected.size
+        expected.foreach(imageIds.contains(_) shouldBe true)
+      }}
+    }
+  }
+
   private def saveImages(images: Seq[Image]) = {
     Future.sequence(images.map { i =>
       executeAndLog(indexInto(index, "_doc") id i.id source Json.stringify(Json.toJson(i)), s"Indexing test image")

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
@@ -1,11 +1,12 @@
 package lib.elasticsearch.impls.elasticsearch6
 
+import com.gu.mediaservice.model.UsageRights
 import com.sksamuel.elastic4s.Operator
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
 import com.sksamuel.elastic4s.searches.queries._
 import com.sksamuel.elastic4s.searches.queries.matches.{MatchPhrase, MatchQuery, MultiMatchQuery, MultiMatchQueryBuilderType}
-import com.sksamuel.elastic4s.searches.queries.term.TermQuery
+import com.sksamuel.elastic4s.searches.queries.term.{TermQuery, TermsQuery}
 import lib.elasticsearch.ConditionFixtures
 import lib.querysyntax.Negation
 import org.scalatest.{FunSpec, Matchers}
@@ -85,6 +86,54 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
       hasClause.filters.size shouldBe 1
       hasClause.filters.head.asInstanceOf[ExistsQuery].field shouldBe "foo"
      }
+
+    it("should correctly construct an is owned photo query") {
+      val query = queryBuilder.makeQuery(List(isOwnedPhotoCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.category"
+
+      val expected = UsageRights.photographer.map(_.category)
+
+      termQuery.values shouldEqual expected
+    }
+
+    it("should correctly construct an is owned illustration query") {
+      val query = queryBuilder.makeQuery(List(isOwnedIllustrationCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.category"
+
+      val expected = UsageRights.illustrator.map(_.category)
+
+      termQuery.values shouldEqual expected
+    }
+
+    it("should correctly construct an is owned image query") {
+      val query = queryBuilder.makeQuery(List(isOwnedImageCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.category"
+
+      val expected = UsageRights.whollyOwned.map(_.category)
+
+      termQuery.values shouldEqual expected
+    }
 
     it("hierarchy field phrase is expressed as a term query") {
       val query = queryBuilder.makeQuery(List(hierarchyFieldPhraseCondition)).asInstanceOf[BoolQuery]

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
@@ -87,54 +87,6 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
       hasClause.filters.head.asInstanceOf[ExistsQuery].field shouldBe "foo"
      }
 
-    it("should correctly construct an is owned photo query") {
-      val query = queryBuilder.makeQuery(List(isOwnedPhotoCondition)).asInstanceOf[BoolQuery]
-
-      query.must.size shouldBe 1
-
-      val isClause = query.must.head.asInstanceOf[BoolQuery]
-      isClause.should.size shouldBe 1
-
-      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
-      termQuery.field shouldBe "usageRights.category"
-
-      val expected = UsageRights.photographer.map(_.category)
-
-      termQuery.values shouldEqual expected
-    }
-
-    it("should correctly construct an is owned illustration query") {
-      val query = queryBuilder.makeQuery(List(isOwnedIllustrationCondition)).asInstanceOf[BoolQuery]
-
-      query.must.size shouldBe 1
-
-      val isClause = query.must.head.asInstanceOf[BoolQuery]
-      isClause.should.size shouldBe 1
-
-      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
-      termQuery.field shouldBe "usageRights.category"
-
-      val expected = UsageRights.illustrator.map(_.category)
-
-      termQuery.values shouldEqual expected
-    }
-
-    it("should correctly construct an is owned image query") {
-      val query = queryBuilder.makeQuery(List(isOwnedImageCondition)).asInstanceOf[BoolQuery]
-
-      query.must.size shouldBe 1
-
-      val isClause = query.must.head.asInstanceOf[BoolQuery]
-      isClause.should.size shouldBe 1
-
-      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
-      termQuery.field shouldBe "usageRights.category"
-
-      val expected = UsageRights.whollyOwned.map(_.category)
-
-      termQuery.values shouldEqual expected
-    }
-
     it("hierarchy field phrase is expressed as a term query") {
       val query = queryBuilder.makeQuery(List(hierarchyFieldPhraseCondition)).asInstanceOf[BoolQuery]
 
@@ -188,6 +140,63 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
       val query = queryBuilder.makeQuery(List(nestedCondition, anotherNestedCondition)).asInstanceOf[BoolQuery]
 
       query.must.size shouldBe 2
+    }
+  }
+
+  describe("is search filter") {
+    it("should correctly construct an is owned photo query") {
+      val query = queryBuilder.makeQuery(List(isOwnedPhotoCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.category"
+
+      val expected = UsageRights.photographer.map(_.category)
+
+      termQuery.values shouldEqual expected
+    }
+
+    it("should correctly construct an is owned illustration query") {
+      val query = queryBuilder.makeQuery(List(isOwnedIllustrationCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.category"
+
+      val expected = UsageRights.illustrator.map(_.category)
+
+      termQuery.values shouldEqual expected
+    }
+
+    it("should correctly construct an is owned image query") {
+      val query = queryBuilder.makeQuery(List(isOwnedImageCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.category"
+
+      val expected = UsageRights.whollyOwned.map(_.category)
+
+      termQuery.values shouldEqual expected
+    }
+
+    it("should return the match none query on an invalid is query") {
+      val query = queryBuilder.makeQuery(List(isInvalidCondition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+      query.must.head shouldBe ElasticDsl.matchNoneQuery()
     }
   }
 


### PR DESCRIPTION
## What does this change?
Per email thread with Jonny and Jo:
- renames `is:staff` to `is:gnm-owned-photo`
- adds two new `is` searches:
  - `is:gnm-owned-illustration`
  - `is:gnm-owned`

Ideally this would also take the form of a checkbox/select box...

## How can success be measured?
More useful search.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/60031538-de4a8100-969c-11e9-9d58-394b5043e948.png)

![img](https://media.giphy.com/media/D3OdaKTGlpTBC/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
