### PR TITLE
tweak search placeholder

### DIFF
--- a/kahuna/public/js/components/gr-chips/gr-chips.css
+++ b/kahuna/public/js/components/gr-chips/gr-chips.css
@@ -84,3 +84,7 @@ gr-static-filter-chip,
 gr-filter-chip {
     margin-right: 5px;
 }
+
+gr-text-chip input::placeholder {
+  color: #888;
+}

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -1,6 +1,6 @@
 <input type="text"
        autocomplete="off"
-       placeholder="Search for images..."
+       placeholder="Search for images... (type + for advanced search)"
        ng:trim="false"
        gr-chip-input
        gr-chip-input-backspace-at-start="$grTextChipCtrl.removePrevious()"


### PR DESCRIPTION
## What does this change?
Adjust phrasing to suggest that chips are available (brilliant suggestion by @sihil)

Also adjusts the colour to make it more readable

Similar to https://github.com/guardian/grid/pull/2290

## How can success be measured?
making things more obvious

## Screenshots (if applicable)
Before
![image](https://user-images.githubusercontent.com/836140/60102881-75274400-9756-11e9-8a34-7995d89e6643.png)

After
![image](https://user-images.githubusercontent.com/836140/60102921-8b350480-9756-11e9-8ba1-3f578d7aee02.png)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
