### PR TITLE
is over quota

### DIFF
--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -26,13 +26,13 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
     replicas = config.elasticsearch6Replicas
   )
 
-  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config)
-  elasticSearch.ensureAliasAssigned()
-
   val s3Client = new S3Client(config)
 
   val usageQuota = new UsageQuota(config, actorSystem.scheduler)
   usageQuota.scheduleUpdates()
+
+  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config, usageQuota.usageStore)
+  elasticSearch.ensureAliasAssigned()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -31,7 +31,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val usageQuota = new UsageQuota(config, actorSystem.scheduler)
   usageQuota.scheduleUpdates()
 
-  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config, () => usageQuota.usageStore.exceededAgencies)
+  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config, () => usageQuota.usageStore.overQuotaAgencies)
   elasticSearch.ensureAliasAssigned()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -31,7 +31,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val s3Client = new S3Client(config)
 
-  val usageQuota = new UsageQuota(config, elasticSearch, actorSystem.scheduler)
+  val usageQuota = new UsageQuota(config, actorSystem.scheduler)
   usageQuota.scheduleUpdates()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -31,7 +31,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val usageQuota = new UsageQuota(config, actorSystem.scheduler)
   usageQuota.scheduleUpdates()
 
-  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config, usageQuota.usageStore)
+  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config, () => usageQuota.usageStore.exceededAgencies)
   elasticSearch.ensureAliasAssigned()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)

--- a/media-api/app/lib/UsageQuota.scala
+++ b/media-api/app/lib/UsageQuota.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 case class ImageNotFound() extends Exception("Image not found")
 case class NoUsageQuota() extends Exception("No usage found for this image")
 
-class UsageQuota(config: MediaApiConfig, elasticSearch: ElasticSearchVersion, scheduler: Scheduler) {
+class UsageQuota(config: MediaApiConfig, scheduler: Scheduler) {
   val quotaStore = new QuotaStore(
     config.quotaStoreConfig.storeKey,
     config.quotaStoreConfig.storeBucket,
@@ -39,16 +39,5 @@ class UsageQuota(config: MediaApiConfig, elasticSearch: ElasticSearchVersion, sc
       usageStore.getUsageStatusForUsageRights(rights),
       waitMillis.millis)
   }.toOption.exists(_.exceeded) && FeatureToggle.get("usage-quota-ui")
-
-  def usageStatusForImage(id: String)(implicit request: AuthenticatedRequest[AnyContent, Principal]): Future[UsageStatus] = for {
-    imageOption <- elasticSearch.getImageById(id)
-
-    image <- Future { imageOption.get }
-      .recover { case _ => throw new ImageNotFound }
-
-    usageStatus <- usageStore.getUsageStatusForUsageRights(image.usageRights)
-
-  } yield usageStatus
-
 }
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -138,7 +138,7 @@ class UsageStore(
       l <- lastUpdated
     } yield StoreAccess(s,l)).get())
 
-  def exceededAgencies: List[Agency] = store.get.collect {
+  def overQuotaAgencies: List[Agency] = store.get.collect {
     case (_, status) if status.exceeded => status.usage.agency
   }.toList
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -138,6 +138,10 @@ class UsageStore(
       l <- lastUpdated
     } yield StoreAccess(s,l)).get())
 
+  def exceededAgencies: List[Agency] = store.get.collect {
+    case (_, status) if status.exceeded => status.usage.agency
+  }.toList
+
   def update() {
     lastUpdated.send(_ => DateTime.now())
     fetchUsage.foreach { usage => store.send(usage) }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -4,7 +4,7 @@ import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearch6Config, ElasticSearch6Executions, ElasticSearchClient, Mappings}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
-import com.gu.mediaservice.model.{Agencies, Image}
+import com.gu.mediaservice.model.{Agencies, Agency, Image}
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.search.{Aggregations, SearchHit, SearchResponse}
@@ -13,7 +13,7 @@ import com.sksamuel.elastic4s.searches.aggs.Aggregation
 import com.sksamuel.elastic4s.searches.queries.Query
 import lib.elasticsearch._
 import lib.querysyntax.{HierarchyField, Match, Phrase}
-import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary, UsageStore}
+import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary}
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.AnyContent
@@ -23,7 +23,7 @@ import scalaz.syntax.std.list._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, usageStore: UsageStore) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
+class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, exceededAgencies: () =>  List[Agency]) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
 
   lazy val imagesAlias = elasticConfig.alias
   lazy val url = elasticConfig.url
@@ -34,7 +34,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   val searchFilters = new SearchFilters(config)
   val syndicationFilter = new SyndicationFilter(config)
 
-  val queryBuilder = new QueryBuilder(matchFields, usageStore)
+  val queryBuilder = new QueryBuilder(matchFields, exceededAgencies)
 
   override def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] = {
     executeAndLog(get(imagesAlias, Mappings.dummyType, id), s"get image by id $id").map { r =>

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -23,7 +23,7 @@ import scalaz.syntax.std.list._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, exceededAgencies: () =>  List[Agency]) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
+class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, overQuotaAgencies: () => List[Agency]) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
 
   lazy val imagesAlias = elasticConfig.alias
   lazy val url = elasticConfig.url
@@ -34,7 +34,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   val searchFilters = new SearchFilters(config)
   val syndicationFilter = new SyndicationFilter(config)
 
-  val queryBuilder = new QueryBuilder(matchFields, exceededAgencies)
+  val queryBuilder = new QueryBuilder(matchFields, overQuotaAgencies)
 
   override def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] = {
     executeAndLog(get(imagesAlias, Mappings.dummyType, id), s"get image by id $id").map { r =>

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -13,7 +13,7 @@ import com.sksamuel.elastic4s.searches.aggs.Aggregation
 import com.sksamuel.elastic4s.searches.queries.Query
 import lib.elasticsearch._
 import lib.querysyntax.{HierarchyField, Match, Phrase}
-import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary}
+import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary, UsageStore}
 import play.api.Logger
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.AnyContent
@@ -23,7 +23,7 @@ import scalaz.syntax.std.list._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
+class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, usageStore: UsageStore) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
 
   lazy val imagesAlias = elasticConfig.alias
   lazy val url = elasticConfig.url
@@ -34,7 +34,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   val searchFilters = new SearchFilters(config)
   val syndicationFilter = new SyndicationFilter(config)
 
-  val queryBuilder = new QueryBuilder(matchFields)
+  val queryBuilder = new QueryBuilder(matchFields, usageStore)
 
   override def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] = {
     executeAndLog(get(imagesAlias, Mappings.dummyType, id), s"get image by id $id").map { r =>

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -19,11 +19,11 @@ sealed trait IsQueryFilter extends Query with ImageFields {
 
 object IsQueryFilter {
   // for readability, the client capitalises gnm, so `toLowerCase` it before matching
-  def apply(value: String, exceededAgencies: () =>  List[Agency]): Option[IsQueryFilter] = value.toLowerCase match {
+  def apply(value: String, overQuotaAgencies: () => List[Agency]): Option[IsQueryFilter] = value.toLowerCase match {
     case "gnm-owned-photo" => Some(IsOwnedPhotograph)
     case "gnm-owned-illustration" => Some(IsOwnedIllustration)
     case "gnm-owned" => Some(IsOwnedImage)
-    case "over-quota" => Some(IsOverQuota(exceededAgencies()))
+    case "over-quota" => Some(IsOverQuota(overQuotaAgencies()))
     case _ => None
   }
 }
@@ -46,8 +46,8 @@ object IsOwnedImage extends IsQueryFilter {
   )
 }
 
-case class IsOverQuota(exceededAgencies: List[Agency]) extends IsQueryFilter {
-  override def query: Query = exceededAgencies.toNel
-    .map(agency => filters.not(filters.terms(usageRightsField("supplier"), agency.map(_.supplier))))
+case class IsOverQuota(overQuotaAgencies: List[Agency]) extends IsQueryFilter {
+  override def query: Query = overQuotaAgencies.toNel
+    .map(agency => filters.or(filters.terms(usageRightsField("supplier"), agency.map(_.supplier))))
     .getOrElse(matchNoneQuery)
 }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -2,7 +2,9 @@ package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.model._
+import com.sksamuel.elastic4s.http.ElasticDsl.matchNoneQuery
 import com.sksamuel.elastic4s.searches.queries.Query
+import lib.UsageStore
 import scalaz.syntax.std.list._
 
 sealed trait IsQueryFilter extends Query with ImageFields {
@@ -12,15 +14,17 @@ sealed trait IsQueryFilter extends Query with ImageFields {
     case IsOwnedPhotograph => "gnm-owned-photo"
     case IsOwnedIllustration => "gnm-owned-illustration"
     case IsOwnedImage => "gnm-owned"
+    case _: IsOverQuota => "over-quota"
   }
 }
 
 object IsQueryFilter {
   // for readability, the client capitalises gnm, so `toLowerCase` it before matching
-  def apply(value: String): Option[IsQueryFilter] = value.toLowerCase match {
+  def apply(value: String, usageStore: UsageStore): Option[IsQueryFilter] = value.toLowerCase match {
     case "gnm-owned-photo" => Some(IsOwnedPhotograph)
     case "gnm-owned-illustration" => Some(IsOwnedIllustration)
     case "gnm-owned" => Some(IsOwnedImage)
+    case "over-quota" => Some(IsOverQuota(usageStore.exceededAgencies))
     case _ => None
   }
 }
@@ -41,4 +45,10 @@ object IsOwnedImage extends IsQueryFilter {
   override def query: Query = filters.or(
     filters.terms(usageRightsField("category"), UsageRights.whollyOwned.toNel.get.map(_.category))
   )
+}
+
+case class IsOverQuota(exceededAgencies: List[Agency]) extends IsQueryFilter {
+  override def query: Query = exceededAgencies.toNel
+    .map(i => filters.not(filters.terms(usageRightsField("supplier"), i.map(_.supplier))))
+    .getOrElse(matchNoneQuery)
 }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -12,7 +12,7 @@ import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQuery, MultiMa
 import lib.querysyntax._
 import play.api.Logger
 
-class QueryBuilder(matchFields: Seq[String], exceededAgencies: () =>  List[Agency]) extends ImageFields {
+class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agency]) extends ImageFields {
 
   // For some sad reason, there was no helpful alias for this in the ES library
   private def multiMatchPhraseQuery(value: String, fields: Seq[String]): MultiMatchQuery =
@@ -47,7 +47,7 @@ class QueryBuilder(matchFields: Seq[String], exceededAgencies: () =>  List[Agenc
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value, exceededAgencies) match {
+      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           Logger.info(s"Cannot perform IS query on ${condition.value}")

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -3,16 +3,16 @@ package lib.elasticsearch.impls.elasticsearch6
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.elasticsearch6.IndexSettings
 import com.gu.mediaservice.lib.formatting.printDateTime
+import com.gu.mediaservice.model.Agency
 import com.sksamuel.elastic4s.Operator
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.searches.queries.Query
 import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQuery, MultiMatchQueryBuilderType}
-import lib.UsageStore
 import lib.querysyntax._
 import play.api.Logger
 
-class QueryBuilder(matchFields: Seq[String], usageStore: UsageStore) extends ImageFields {
+class QueryBuilder(matchFields: Seq[String], exceededAgencies: () =>  List[Agency]) extends ImageFields {
 
   // For some sad reason, there was no helpful alias for this in the ES library
   private def multiMatchPhraseQuery(value: String, fields: Seq[String]): MultiMatchQuery =
@@ -47,7 +47,7 @@ class QueryBuilder(matchFields: Seq[String], usageStore: UsageStore) extends Ima
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value, usageStore) match {
+      case IsValue(value) => IsQueryFilter.apply(value, exceededAgencies) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           Logger.info(s"Cannot perform IS query on ${condition.value}")

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -8,10 +8,11 @@ import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.searches.queries.Query
 import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQuery, MultiMatchQueryBuilderType}
+import lib.UsageStore
 import lib.querysyntax._
 import play.api.Logger
 
-class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
+class QueryBuilder(matchFields: Seq[String], usageStore: UsageStore) extends ImageFields {
 
   // For some sad reason, there was no helpful alias for this in the ES library
   private def multiMatchPhraseQuery(value: String, fields: Seq[String]): MultiMatchQuery =
@@ -46,7 +47,7 @@ class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value) match {
+      case IsValue(value) => IsQueryFilter.apply(value, usageStore) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           Logger.info(s"Cannot perform IS query on ${condition.value}")

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import lib.elasticsearch.impls.elasticsearch6.{IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
+import lib.elasticsearch.impls.elasticsearch6.{IsOverQuota, IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
 import lib.querysyntax.{Nested, _}
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -19,6 +19,7 @@ trait ConditionFixtures {
   val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph.toString))
   val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration.toString))
   val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage.toString))
+  val isOverQuotaCondition = Match(IsField, IsValue(IsOverQuota(Nil).toString))
   val isInvalidCondition = Match(IsField, IsValue("a-random-string"))
 
   val hierarchyFieldPhraseCondition = Match(HierarchyField, Phrase("foo"))

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -27,6 +27,10 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
   final override val StartContainersTimeout = 1.minute
 
   lazy val images = Seq(
+    createImage("getty-image-1", Agency("Getty Images")),
+    createImage("getty-image-2", Agency("Getty Images")),
+    createImage("ap-image-1", Agency("AP")),
+    createImage("gnm-image-1", Agency("GNM")),
     createImage(UUID.randomUUID().toString, Handout()),
     createImage("iron-suit", CommissionedPhotographer("Iron Man")),
     createImage("green-giant", StaffIllustrator("Hulk")),

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch.impls.elasticsearch6
 
-import com.gu.mediaservice.model.UsageRights
+import com.gu.mediaservice.model.{Agency, UsageRights}
 import com.sksamuel.elastic4s.Operator
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
@@ -15,7 +15,7 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
 
   val matchFields: Seq[String] = Seq("afield", "anothermatchfield")
 
-  val queryBuilder = new QueryBuilder(matchFields)
+  val queryBuilder = new QueryBuilder(matchFields, () => Nil)
 
   describe("Query builder") {
     it("Nil conditions parameter should give the match all query") {
@@ -197,6 +197,30 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
 
       query.must.size shouldBe 1
       query.must.head shouldBe ElasticDsl.matchNoneQuery()
+    }
+
+    it("should return the match none query when no over quota agencies") {
+      val qBuilder = new QueryBuilder(matchFields, () => List.empty)
+      val query = qBuilder.makeQuery(List(isOverQuotaCondition)).asInstanceOf[BoolQuery]
+      query.must.size shouldBe 1
+      query.must.head shouldBe ElasticDsl.matchNoneQuery()
+    }
+
+    it("should correctly construct an over quota query") {
+      def overQuotaAgencies = List(Agency("Getty Images"), Agency("AP"))
+
+      val qBuilder = new QueryBuilder(matchFields, () => overQuotaAgencies)
+      val query = qBuilder.makeQuery(List(isOverQuotaCondition)).asInstanceOf[BoolQuery]
+      query.must.size shouldBe 1
+
+      val isClause = query.must.head.asInstanceOf[BoolQuery]
+      isClause.should.size shouldBe 1
+
+      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
+      termQuery.field shouldBe "usageRights.supplier"
+
+      val expected = overQuotaAgencies.map(_.supplier)
+      termQuery.values shouldEqual expected
     }
   }
 


### PR DESCRIPTION
## What does this change?
Adds is:over-quota search. Unfortunately this means passing a `UsageStore` really far down in order to get store updates, which isn't especially clean... if only scala could pass by reference! (`IsQueryFilter`'s apply could take an anonymous function rather than a `UsageStore`).

UPDATE: it's a lot cleaner with anonymous function and the tests are easier to write too!

https://github.com/guardian/grid/pull/2475 take II.

## How can success be measured?
We can search for images that are over/under quota.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
