### PR TITLE
introduce gr-top-bar-row

### DIFF
--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
@@ -1,9 +1,29 @@
 gr-top-bar {
-    display: block;
-    height: 50px; /* faking we're in the flow */
-    position: relative;
-    /* We do this as it should always be over `results-toolbar` */
-    z-index: 31;
+  display: block;
+  height: 50px; /* faking we're in the flow */
+  position: relative;
+  /* We do this as it should always be over `results-toolbar` */
+  z-index: 31;
+  font-size: 1.4rem;
+  font-family: "Guardian Agate Sans Web", Helvetica, Arial, sans-serif;
+}
+
+gr-top-bar-row {
+  display: flex;
+  width: 100%;
+  border-bottom: 1px solid #565656;
+  box-sizing: border-box;
+}
+
+gr-top-bar-row .gr-top-bar-row-inner {
+  height: 50px;
+  width: 100%;
+  display: flex;
+  padding-right: 10px;
+}
+
+gr-top-bar-row .gr-top-bar-row--small {
+  height: 25px;
 }
 
 gr-top-bar-nav {
@@ -21,17 +41,8 @@ gr-top-bar-actions {
 
 
 .gr-top-bar-inner {
-    background-color: #333;
-    padding-right: 10px;
-    font-family: "Guardian Agate Sans Web", Helvetica, Arial;
-    width: 100%;
-    height: 50px;
-    border-bottom: 1px solid #565656;
-    font-size: 1.4rem;
-    display: flex;
-    box-sizing: border-box;
-}
-
-.gr-top-bar-inner--fixed {
-    position: fixed;
+  background-color: #333;
+  width: 100%;
+  min-height: 50px;
+  position: fixed;
 }

--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
@@ -36,3 +36,16 @@ topBar.directive('grTopBarActions', [function() {
                    <ui-user-actions></ui-user-actions>`
     };
 }]);
+
+topBar.directive('grTopBarRow', [function () {
+  return {
+    restrict: 'E',
+    transclude: true,
+    scope: {
+      small: '='
+    },
+    template: `<ng:transclude class="gr-top-bar-row-inner"
+                              ng:class="{'gr-top-bar-row--small': small}">
+               </ng:transclude>`
+  };
+}]);

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -1,4 +1,5 @@
 <gr-top-bar>
+  <gr-top-bar-row>
     <gr-top-bar-nav>
         <a class="top-bar-item clickable side-padded"
            ui:sref="image({ imageId: ctrl.image.data.id })"
@@ -88,6 +89,7 @@
             </button>
         </div>
     </gr-top-bar-actions>
+  </gr-top-bar-row>
 </gr-top-bar>
 
 <div class="warning" ng:if="ctrl.cropSizeWarning()">

--- a/kahuna/public/js/image/image-error.html
+++ b/kahuna/public/js/image/image-error.html
@@ -1,4 +1,5 @@
 <gr-top-bar>
+  <gr-top-bar-row>
     <gr-top-bar-nav>
         <a class="top-bar-item side-padded clickable" ui:sref="search" title="Back to search">
             <gr-icon-label gr-icon="search">Search</gr-icon-label>
@@ -7,6 +8,7 @@
 
     <gr-top-bar-actions>
     </gr-top-bar-actions>
+  </gr-top-bar-row>
 </gr-top-bar>
 
 <div class="full-error">

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -1,4 +1,5 @@
 <gr-top-bar>
+  <gr-top-bar-row>
     <gr-top-bar-nav>
         <a class="top-bar-item side-padded clickable" ui:sref="search" title="Back to search">
             <gr-icon-label gr-icon="youtube_searched_for">Back to search</gr-icon-label>
@@ -22,6 +23,7 @@
         <gr-crop-image class="top-bar-item" image="ctrl.image" has-full-crop="ctrl.hasFullCrop" tracking-location="Top bar">
         </gr-crop-image>
     </gr-top-bar-actions>
+  </gr-top-bar-row>
 </gr-top-bar>
 
 

--- a/kahuna/public/js/search/query-shortcuts.html
+++ b/kahuna/public/js/search/query-shortcuts.html
@@ -1,0 +1,11 @@
+<form>
+  <label>
+    <input type="checkbox"
+           ng:model="searchQuery.filter.shortcuts.isUnderQuota"
+           ng:true-value="'true'"
+           ng:false-value="undefined" />
+    Under quota only
+  </label>
+
+  {{searchQuery.filter.shortcuts.isUnderQuota}}
+</form>

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -8,6 +8,7 @@ import moment from 'moment';
 import {eq} from '../util/eq';
 import {guDateRange} from '../components/gu-date-range/gu-date-range';
 import template from './query.html';
+import shortcutsTemplate from './query-shortcuts.html';
 import {syntax} from './syntax/syntax';
 import {grStructuredQuery} from './structured-query/structured-query';
 
@@ -36,7 +37,10 @@ query.controller('SearchQueryCtrl', [
     };
 
     ctrl.filter = {
-        uploadedByMe: false
+      uploadedByMe: false,
+      shortcuts: {
+        isUnderQuota: undefined
+      }
     };
 
     ctrl.dateFilter = {
@@ -138,10 +142,14 @@ query.controller('SearchQueryCtrl', [
 
 
     $scope.$watchCollection(() => ctrl.filter, onValChange(filter => {
-        filter.uploadedBy = filter.uploadedByMe ? ctrl.user.email : undefined;
-        ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
+      console.log(filter);
+        const updatedFilter = Object.assign({}, filter, {
+          uploadedBy: filter.uploadedByMe ? ctrl.user.email : undefined
+        });
 
-        $state.go('search.results', filter);
+        ctrl.collectionSearch = filter.query ? filter.query.indexOf('~') === 0 : false;
+
+        $state.go('search.results', updatedFilter);
     }));
 
     $scope.$watch(() => ctrl.ordering.orderBy, onValChange(newVal => {
@@ -185,4 +193,12 @@ query.directive('searchQuery', [function() {
         controller: 'SearchQueryCtrl as searchQuery',
         template: template
     };
+}]);
+
+query.directive('searchQueryShortcuts', [function () {
+  return {
+    restrict: 'E',
+    controller: 'SearchQueryCtrl as searchQuery',
+    template: shortcutsTemplate
+  }
 }]);

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -1,5 +1,6 @@
 <!-- TODO: rename this file and split it into it's components -->
-<gr-top-bar fixed="true">
+<gr-top-bar fixed="true" class="search-bar">
+  <gr-top-bar-row>
     <gr-top-bar-nav>
         <search-query></search-query>
     </gr-top-bar-nav>
@@ -14,6 +15,11 @@
         </a>
         <file-uploader class="top-bar-item side-padded"></file-uploader>
     </gr-top-bar-actions>
+  </gr-top-bar-row>
+
+  <gr-top-bar-row small="true">
+
+  </gr-top-bar-row>
 </gr-top-bar>
 
 <gr-panels class="search-panels">

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -17,8 +17,8 @@
     </gr-top-bar-actions>
   </gr-top-bar-row>
 
-  <gr-top-bar-row small="true">
-
+  <gr-top-bar-row small="true" class="search-bar-shortcuts">
+    <search-query-shortcuts></search-query-shortcuts>
   </gr-top-bar-row>
 </gr-top-bar>
 

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -1,10 +1,12 @@
 <gr-top-bar>
+  <gr-top-bar-row>
     <gr-top-bar-nav>
         <a class="top-bar-item side-padded"
            ui:sref="search"><gr-icon>search</gr-icon>
            <span class="top-bar-item__label">Search</span></a>
     </gr-top-bar-nav>
     <gr-top-bar-actions></gr-top-bar-actions>
+  </gr-top-bar-row>
 </gr-top-bar>
 
 <div class="page-wrapper">

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -113,7 +113,7 @@ input,
 option,
 textarea,
 button {
-    font-family: "Guardian Agate Sans Web", Helvetica, Arial;
+  font-family: "Guardian Agate Sans Web", Helvetica, Arial, sans-serif;
     font-size: 1.4rem;
 }
 
@@ -619,6 +619,10 @@ textarea.ng-invalid {
     display: flex;
     height: 30px;
     line-height: 12px;
+}
+
+.search-bar {
+  height: 75px; /* gr-top-bar with a gr-top-bar-row and gr-top-bar-row.small */
 }
 
 .search-query__magnifier {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -625,6 +625,11 @@ textarea.ng-invalid {
   height: 75px; /* gr-top-bar with a gr-top-bar-row and gr-top-bar-row.small */
 }
 
+.search-bar-shortcuts {
+  padding: 0 10px;
+  line-height: 25px;
+}
+
 .search-query__magnifier {
     /* Better vertical centering */
     align-self: center;


### PR DESCRIPTION
## What does this change?
As a way to introduce more search shortcuts to the search page's top bar, we need the idea of rows where the second row will house the shortcuts.

No shortcuts added in this PR, just adding the extra space.

## How can success be measured?
Provides more space to add search shortcuts.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/60341751-77341180-99a7-11e9-965f-f93ee8298062.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
