### PR TITLE
Prune Illustrators list

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -133,11 +133,9 @@ object MetadataConfig {
   val contractIllustrators: Map[String, String] = Map(
     "Ben Lamb"              -> "The Guardian",
     "Andrzej Krauze"        -> "The Guardian",
-    "Chris Ware"            -> "The Guardian",
     "David Squires"         -> "The Guardian",
     "First Dog on the Moon" -> "The Guardian",
     "Harry Venning"         -> "The Guardian",
-    "Kipper Williams"       -> "The Guardian",
     "Martin Rowson"         -> "The Guardian",
     "Matt Kenyon"           -> "The Guardian",
     "Matthew Blease"        -> "The Guardian",
@@ -149,7 +147,6 @@ object MetadataConfig {
     "Chris Riddell"         -> "The Observer",
     "David Foldvari"        -> "The Observer",
     "David Simonds"         -> "The Observer",
-    "Ian Tovey"             -> "The Observer",
   )
 
   val allPhotographers = staffPhotographers ++ contractedPhotographers


### PR DESCRIPTION
Some no longer draw for us. Also, in preparation of applying them automatically to Usage Rights (like [we do](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala#L34) with photographers).