### PR TITLE
update kahuna is chip

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -64,7 +64,8 @@ const subjects = [
 const isSearch = [
   'GNM-owned-photo',
   'GNM-owned-illustration',
-  'GNM-owned'
+  'GNM-owned',
+  'under-quota'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {


### PR DESCRIPTION
# What does this change?
Adding `under-quota` option to Kahuna (added server side in #2607).

Eventually, we'll have a checkbox in the new search bar space created in https://github.com/guardian/grid/pull/2599.

Depends on https://github.com/guardian/grid/pull/2598

## How can success be measured?
We can use the search through the web UI (kahuna).

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
