### PR TITLE
Revert "is over quota"

### DIFF
--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -26,13 +26,13 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
     replicas = config.elasticsearch6Replicas
   )
 
+  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config)
+  elasticSearch.ensureAliasAssigned()
+
   val s3Client = new S3Client(config)
 
-  val usageQuota = new UsageQuota(config, actorSystem.scheduler)
+  val usageQuota = new UsageQuota(config, elasticSearch, actorSystem.scheduler)
   usageQuota.scheduleUpdates()
-
-  val elasticSearch = new lib.elasticsearch.impls.elasticsearch6.ElasticSearch(config, mediaApiMetrics, es6Config, () => usageQuota.usageStore.overQuotaAgencies)
-  elasticSearch.ensureAliasAssigned()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 

--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -2,11 +2,9 @@ package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.lib.auth.Authentication.Principal
-import com.gu.mediaservice.model.{Agencies, Image}
+import com.gu.mediaservice.model.Agencies
 import lib._
 import lib.elasticsearch.ElasticSearchVersion
-import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -41,21 +39,10 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
 
   }
 
-  def usageStatusForImage(id: String)(implicit request: AuthenticatedRequest[AnyContent, Principal]): Future[UsageStatus] = for {
-    imageOption <- elasticSearch.getImageById(id)
-
-    image <- Future { imageOption.get }
-      .recover { case _ => throw new ImageNotFound }
-
-    usageStatus <- usageQuota.usageStore.getUsageStatusForUsageRights(image.usageRights)
-
-  } yield usageStatus
-
-
   def quotaForImage(id: String) = auth.async { request =>
     implicit val r = request
 
-    usageStatusForImage(id)
+    usageQuota.usageStatusForImage(id)
       .map((u: UsageStatus) => respond(u))
       .recover {
         case e: ImageNotFound => respondError(NotFound, "image-not-found", e.toString)

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -138,10 +138,6 @@ class UsageStore(
       l <- lastUpdated
     } yield StoreAccess(s,l)).get())
 
-  def overQuotaAgencies: List[Agency] = store.get.collect {
-    case (_, status) if status.exceeded => status.usage.agency
-  }.toList
-
   def update() {
     lastUpdated.send(_ => DateTime.now())
     fetchUsage.foreach { usage => store.send(usage) }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -4,7 +4,7 @@ import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearch6Config, ElasticSearch6Executions, ElasticSearchClient, Mappings}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
-import com.gu.mediaservice.model.{Agencies, Agency, Image}
+import com.gu.mediaservice.model.{Agencies, Image}
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.search.{Aggregations, SearchHit, SearchResponse}
@@ -23,7 +23,7 @@ import scalaz.syntax.std.list._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, overQuotaAgencies: () => List[Agency]) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
+class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
 
   lazy val imagesAlias = elasticConfig.alias
   lazy val url = elasticConfig.url
@@ -34,7 +34,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   val searchFilters = new SearchFilters(config)
   val syndicationFilter = new SyndicationFilter(config)
 
-  val queryBuilder = new QueryBuilder(matchFields, overQuotaAgencies)
+  val queryBuilder = new QueryBuilder(matchFields)
 
   override def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] = {
     executeAndLog(get(imagesAlias, Mappings.dummyType, id), s"get image by id $id").map { r =>

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -2,7 +2,6 @@ package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.model._
-import com.sksamuel.elastic4s.http.ElasticDsl.matchNoneQuery
 import com.sksamuel.elastic4s.searches.queries.Query
 import scalaz.syntax.std.list._
 
@@ -13,17 +12,15 @@ sealed trait IsQueryFilter extends Query with ImageFields {
     case IsOwnedPhotograph => "gnm-owned-photo"
     case IsOwnedIllustration => "gnm-owned-illustration"
     case IsOwnedImage => "gnm-owned"
-    case _: IsOverQuota => "over-quota"
   }
 }
 
 object IsQueryFilter {
   // for readability, the client capitalises gnm, so `toLowerCase` it before matching
-  def apply(value: String, overQuotaAgencies: () => List[Agency]): Option[IsQueryFilter] = value.toLowerCase match {
+  def apply(value: String): Option[IsQueryFilter] = value.toLowerCase match {
     case "gnm-owned-photo" => Some(IsOwnedPhotograph)
     case "gnm-owned-illustration" => Some(IsOwnedIllustration)
     case "gnm-owned" => Some(IsOwnedImage)
-    case "over-quota" => Some(IsOverQuota(overQuotaAgencies()))
     case _ => None
   }
 }
@@ -44,10 +41,4 @@ object IsOwnedImage extends IsQueryFilter {
   override def query: Query = filters.or(
     filters.terms(usageRightsField("category"), UsageRights.whollyOwned.toNel.get.map(_.category))
   )
-}
-
-case class IsOverQuota(overQuotaAgencies: List[Agency]) extends IsQueryFilter {
-  override def query: Query = overQuotaAgencies.toNel
-    .map(agency => filters.or(filters.terms(usageRightsField("supplier"), agency.map(_.supplier))))
-    .getOrElse(matchNoneQuery)
 }

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/QueryBuilder.scala
@@ -3,7 +3,6 @@ package lib.elasticsearch.impls.elasticsearch6
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.elasticsearch6.IndexSettings
 import com.gu.mediaservice.lib.formatting.printDateTime
-import com.gu.mediaservice.model.Agency
 import com.sksamuel.elastic4s.Operator
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.ElasticDsl._
@@ -12,7 +11,7 @@ import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQuery, MultiMa
 import lib.querysyntax._
 import play.api.Logger
 
-class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agency]) extends ImageFields {
+class QueryBuilder(matchFields: Seq[String]) extends ImageFields {
 
   // For some sad reason, there was no helpful alias for this in the ES library
   private def multiMatchPhraseQuery(value: String, fields: Seq[String]): MultiMatchQuery =
@@ -47,7 +46,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies) match {
+      case IsValue(value) => IsQueryFilter.apply(value) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           Logger.info(s"Cannot perform IS query on ${condition.value}")

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import lib.elasticsearch.impls.elasticsearch6.{IsOverQuota, IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
+import lib.elasticsearch.impls.elasticsearch6.{IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
 import lib.querysyntax.{Nested, _}
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -19,7 +19,6 @@ trait ConditionFixtures {
   val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph.toString))
   val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration.toString))
   val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage.toString))
-  val isOverQuotaCondition = Match(IsField, IsValue(IsOverQuota(Nil).toString))
   val isInvalidCondition = Match(IsField, IsValue("a-random-string"))
 
   val hierarchyFieldPhraseCondition = Match(HierarchyField, Phrase("foo"))

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -31,10 +31,6 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
   final override val StartContainersTimeout = 1.minute
 
   lazy val images = Seq(
-    createImage("getty-image-1", Agency("Getty Images")),
-    createImage("getty-image-2", Agency("Getty Images")),
-    createImage("ap-image-1", Agency("AP")),
-    createImage("gnm-image-1", Agency("GNM")),
     createImage(UUID.randomUUID().toString, Handout()),
     createImage("iron-suit", CommissionedPhotographer("Iron Man")),
     createImage("green-giant", StaffIllustrator("Hulk")),

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -35,7 +35,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
   val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = es6TestUrl,
     cluster = "media-service-test", shards = 1, replicas = 0)
 
-  private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => List.empty)
+  private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig)
   val client = ES.client
 
   def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
@@ -386,33 +386,6 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
           "test-image-13",
           "green-giant",
           "hammer-hammer-hammer"
-        )
-
-        val imageIds = result.hits.map(_._1)
-        imageIds.size shouldBe expected.size
-        expected.foreach(imageIds.contains(_) shouldBe true)
-      }}
-    }
-
-    it("should return no images when no agencies are over quota") {
-      val search = SearchParams(tier = Internal, structuredQuery = List(isOverQuotaCondition))
-
-      whenReady(ES.search(search), timeout, interval) { result => {
-        result.total shouldBe 0
-      }}
-    }
-
-    it("should return images from agencies over quota") {
-      def overQuotaAgencies = List(Agency("Getty Images"), Agency("AP"))
-
-      val search = SearchParams(tier = Internal, structuredQuery = List(isOverQuotaCondition))
-      val elasticsearch = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => overQuotaAgencies)
-
-      whenReady(elasticsearch.search(search), timeout, interval) { result => {
-        val expected = List(
-          "getty-image-1",
-          "getty-image-2",
-          "ap-image-1"
         )
 
         val imageIds = result.hits.map(_._1)

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/QueryBuilderTest.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch.impls.elasticsearch6
 
-import com.gu.mediaservice.model.{Agency, UsageRights}
+import com.gu.mediaservice.model.UsageRights
 import com.sksamuel.elastic4s.Operator
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
@@ -15,7 +15,7 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
 
   val matchFields: Seq[String] = Seq("afield", "anothermatchfield")
 
-  val queryBuilder = new QueryBuilder(matchFields, () => Nil)
+  val queryBuilder = new QueryBuilder(matchFields)
 
   describe("Query builder") {
     it("Nil conditions parameter should give the match all query") {
@@ -197,30 +197,6 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
 
       query.must.size shouldBe 1
       query.must.head shouldBe ElasticDsl.matchNoneQuery()
-    }
-
-    it("should return the match none query when no over quota agencies") {
-      val qBuilder = new QueryBuilder(matchFields, () => List.empty)
-      val query = qBuilder.makeQuery(List(isOverQuotaCondition)).asInstanceOf[BoolQuery]
-      query.must.size shouldBe 1
-      query.must.head shouldBe ElasticDsl.matchNoneQuery()
-    }
-
-    it("should correctly construct an over quota query") {
-      def overQuotaAgencies = List(Agency("Getty Images"), Agency("AP"))
-
-      val qBuilder = new QueryBuilder(matchFields, () => overQuotaAgencies)
-      val query = qBuilder.makeQuery(List(isOverQuotaCondition)).asInstanceOf[BoolQuery]
-      query.must.size shouldBe 1
-
-      val isClause = query.must.head.asInstanceOf[BoolQuery]
-      isClause.should.size shouldBe 1
-
-      val termQuery = isClause.should.head.asInstanceOf[TermsQuery[String]]
-      termQuery.field shouldBe "usageRights.supplier"
-
-      val expected = overQuotaAgencies.map(_.supplier)
-      termQuery.values shouldEqual expected
     }
   }
 


### PR DESCRIPTION
Reverts guardian/grid#2598

This is breaking Quotas - one box is failing to retrieve them and so is saying there are no quotas 😱. Reverting whilst investigating. (Deploying via riffraff is also slow with this change, so I suspect the cause is in `MediaApiComponents`).