### PR TITLE
invert over-quota to under-quota

### DIFF
--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/IsQueryFilter.scala
@@ -2,7 +2,7 @@ package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.model._
-import com.sksamuel.elastic4s.http.ElasticDsl.matchNoneQuery
+import com.sksamuel.elastic4s.http.ElasticDsl.matchAllQuery
 import com.sksamuel.elastic4s.searches.queries.Query
 import scalaz.syntax.std.list._
 
@@ -13,7 +13,7 @@ sealed trait IsQueryFilter extends Query with ImageFields {
     case IsOwnedPhotograph => "gnm-owned-photo"
     case IsOwnedIllustration => "gnm-owned-illustration"
     case IsOwnedImage => "gnm-owned"
-    case _: IsOverQuota => "over-quota"
+    case _: IsUnderQuota => "under-quota"
   }
 }
 
@@ -23,7 +23,7 @@ object IsQueryFilter {
     case "gnm-owned-photo" => Some(IsOwnedPhotograph)
     case "gnm-owned-illustration" => Some(IsOwnedIllustration)
     case "gnm-owned" => Some(IsOwnedImage)
-    case "over-quota" => Some(IsOverQuota(overQuotaAgencies()))
+    case "under-quota" => Some(IsUnderQuota(overQuotaAgencies()))
     case _ => None
   }
 }
@@ -46,8 +46,8 @@ object IsOwnedImage extends IsQueryFilter {
   )
 }
 
-case class IsOverQuota(overQuotaAgencies: List[Agency]) extends IsQueryFilter {
+case class IsUnderQuota(overQuotaAgencies: List[Agency]) extends IsQueryFilter {
   override def query: Query = overQuotaAgencies.toNel
-    .map(agency => filters.or(filters.terms(usageRightsField("supplier"), agency.map(_.supplier))))
-    .getOrElse(matchNoneQuery)
+    .map(agency => filters.mustNot(filters.terms(usageRightsField("supplier"), agency.map(_.supplier))))
+    .getOrElse(matchAllQuery)
 }

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import lib.elasticsearch.impls.elasticsearch6.{IsOverQuota, IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
+import lib.elasticsearch.impls.elasticsearch6.{IsUnderQuota, IsOwnedIllustration, IsOwnedImage, IsOwnedPhotograph}
 import lib.querysyntax.{Nested, _}
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -19,7 +19,7 @@ trait ConditionFixtures {
   val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph.toString))
   val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration.toString))
   val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage.toString))
-  val isOverQuotaCondition = Match(IsField, IsValue(IsOverQuota(Nil).toString))
+  val isUnderQuotaCondition = Match(IsField, IsValue(IsUnderQuota(Nil).toString))
   val isInvalidCondition = Match(IsField, IsValue("a-random-string"))
 
   val hierarchyFieldPhraseCondition = Match(HierarchyField, Phrase("foo"))


### PR DESCRIPTION
## What does this change?
Simpler query language.

It is more common to ask "what images can I use (under-quota)" rather than "what images can I not use (over-quota)".

Whilst the former could be expressed as not(over-quota), it is by far the more common query so should be the default; to get over-quota we now do not(under-quota).

Relates to #2605.

## How can success be measured?
Less confusion?

## Screenshots (if applicable)
![img](https://media.giphy.com/media/m4aNskYL5oQqQ/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
