### PR TITLE
Use source field to figure out some more suppliers

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -69,7 +69,7 @@ object ActionImagesParser extends ImageProcessor {
 }
 
 object AlamyParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
+  def apply(image: Image): Image = (image.metadata.credit, image.metadata.source) match {
     case Some("Alamy") | Some("Alamy Stock Photo") => image.copy(
       usageRights = Agencies.get("alamy")
     )
@@ -255,9 +255,8 @@ object PaParser extends ImageProcessor {
     "Press Association Images"
   ).map(_.toLowerCase)
 
-  def apply(image: Image): Image = image.metadata.credit match {
+  def apply(image: Image): Image = (image.metadata.credit, image.metadata.source) match {
     case Some(credit) if paCredits.contains(credit.toLowerCase) => image.copy(
-      metadata = image.metadata.copy(credit = Some("PA")),
       usageRights = Agency("PA")
     )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -69,11 +69,13 @@ object ActionImagesParser extends ImageProcessor {
 }
 
 object AlamyParser extends ImageProcessor {
-  def apply(image: Image): Image = (image.metadata.credit, image.metadata.source) match {
-    case Some("Alamy") | Some("Alamy Stock Photo") => image.copy(
-      usageRights = Agencies.get("alamy")
-    )
-    case _ => image
+  def apply(image: Image): Image = {
+    val isAlamy = List(image.metadata.credit, image.metadata.source).flatten.exists { creditOrSource =>
+      creditOrSource == "Alamy" || creditOrSource == "Alamy Stock Photo"
+    }
+    if (isAlamy) {
+      image.copy(usageRights = Agencies.get("alamy"))
+    } else image
   }
 }
 
@@ -255,12 +257,13 @@ object PaParser extends ImageProcessor {
     "Press Association Images"
   ).map(_.toLowerCase)
 
-  def apply(image: Image): Image = (image.metadata.credit, image.metadata.source) match {
-    case Some(credit) if paCredits.contains(credit.toLowerCase) => image.copy(
-      usageRights = Agency("PA")
-    )
-
-    case _ => image
+  def apply(image: Image): Image = {
+    val isPa = List(image.metadata.credit, image.metadata.source).flatten.exists { creditOrSource =>
+      paCredits.contains(creditOrSource.toLowerCase)
+    }
+    if (isPa) {
+      image.copy(usageRights = Agency("PA"))
+    } else image
   }
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -69,13 +69,11 @@ object ActionImagesParser extends ImageProcessor {
 }
 
 object AlamyParser extends ImageProcessor {
-  def apply(image: Image): Image = {
-    val isAlamy = List(image.metadata.credit, image.metadata.source).flatten.exists { creditOrSource =>
-      creditOrSource == "Alamy" || creditOrSource == "Alamy Stock Photo"
-    }
-    if (isAlamy) {
-      image.copy(usageRights = Agencies.get("alamy"))
-    } else image
+  def apply(image: Image): Image = image.metadata.credit match {
+    case Some("Alamy") | Some("Alamy Stock Photo") => image.copy(
+      usageRights = Agencies.get("alamy")
+    )
+    case _ => image
   }
 }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -342,28 +342,30 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       val image = createImageFromMetadata("credit" -> "PA")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("PA"))
-      processedImage.metadata.credit should be(Some("PA"))
+    }
+
+    it("should match PA source if credit doesn't match") {
+      val image = createImageFromMetadata("credit" -> "BBC/PA", "source" -> "PA")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("PA"))
     }
 
     it("should match 'PA WIRE' images") {
       val image = createImageFromMetadata("credit" -> "PA WIRE")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("PA"))
-      processedImage.metadata.credit should be(Some("PA"))
     }
 
     it("should match 'Press Association Images' credit") {
       val image = createImageFromMetadata("credit" -> "Press Association Images")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("PA"))
-      processedImage.metadata.credit should be(Some("PA"))
     }
 
     it("should match archive images credit") {
       val image = createImageFromMetadata("credit" -> "PA Archive/PA Images")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("PA"))
-      processedImage.metadata.credit should be(Some("PA"))
     }
   }
 


### PR DESCRIPTION
After a [good change](https://github.com/guardian/grid/pull/2575) to cleaners we have been missing some images from ~[Alamy](https://media.gutools.co.uk/search?query=-%22alamy%20live%20news%22%20alamy%20-has:usageRights&since=2019-05-28T23:00:00.000Z&nonFree=true&until=2019-07-08T22:59:59.999Z)~ and [PA](https://media.gutools.co.uk/search?query=%22pa%20wire%22%20uploader:pa%20-has:usageRights&since=2019-05-28T23:00:00.000Z&nonFree=true&until=2019-07-08T22:59:59.999Z), because the whole cleaned `credit` can suddenly contain token(s) moved from `byline`.

~Here, for Alamy, we add matching by `source`.~ For PA, we do the same, but I had to remove the `credit` cleaner of `[different spellings]` > `PA`, because eg. cleaned `BBC/PA` could then be turned into just `PA`. There are no new pics with these `credit`s to clean, but would we ever re-ingest, we will suffer. This cleaner could be reinstated, if it would operate on just these tokens, instead of whole `credit`.

Ideally, we would not be cleaning in [several](https://github.com/guardian/grid/blob/a5ec2de3427f5fbf5f4e73f1e8b968f445e76a16/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala#L100) [places](https://github.com/guardian/grid/tree/master/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup) and matching half-blind.

- [x] tested on TEST

Opinions welcomed, @guardian/digital-cms. Thanks!