### PR TITLE
add extra case to match rex images for BBC use

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -291,8 +291,9 @@ object RexParser extends ImageProcessor {
 
   def apply(image: Image): Image = (image.metadata.source, image.metadata.credit) match {
     // TODO: cleanup byline/credit
-    case (Some("Rex Features"), _) => image.copy(usageRights = rexAgency)
-    case (_, Some(SlashRex()))     => image.copy(usageRights = rexAgency)
+    case (Some("Rex Features"), _)      => image.copy(usageRights = rexAgency)
+    case (_, Some(SlashRex()))          => image.copy(usageRights = rexAgency)
+    case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = rexAgency)
     case _ => image
   }
 }


### PR DESCRIPTION
## What does this change?
We have just started ingesting images from all our suppliers (previously we just had PA). The Rex images we get are coming in with a source of `REX/Shutterstock`, which currently doesn't match with current cases so these images are being given no rights. This adds a match case so our images are assigned rights to REX Features. 

There will be several parts of this `SupplierProcessors.scala` that we will be looking to extract into configuration, but this seems like an easy fix for now.

## How can success be measured?
Rex images are correctly assigned to the Rex Features supplier.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
