### PR TITLE
Extract hardcoded links in HTML to API

### DIFF
--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -6,7 +6,7 @@
     </button>
     <ul class="drop-menu__items drop-menu__items--right" ng:if="showUserActions">
         <li><a href="/quotas" target="_blank">Quotas</a></li>
-        <li><a href="https://goo.gl/forms/OO7CrMt9BRobi1j63" target="_blank" rel="noopener noreferrer">Feedback</a></li>
+        <li><a href="{{ctrl.feedbackForm}}" target="_blank" rel="noopener noreferrer">Feedback</a></li>
         <li><a href="/logout" target="_self">Logout</a></li>
     </ul>
 </nav>

--- a/kahuna/public/js/common/user-actions.js
+++ b/kahuna/public/js/common/user-actions.js
@@ -3,9 +3,21 @@ import template from './user-actions.html';
 
 export var userActions = angular.module('kahuna.common.userActions', []);
 
+userActions.controller('userActionCtrl',
+  ['mediaApi',
+    function(mediaApi) {
+      var ctrl = this
+      mediaApi.getHelpLinks().then(links => ctrl.setFeedbackForm(links));
+      ctrl.setFeedbackForm = ({feedbackForm}) => ctrl.feedbackForm = feedbackForm;
+    }]);
+
 userActions.directive('uiUserActions', [function() {
-    return {
-        restrict: 'E',
-        template: template
-    };
+  return {
+    restrict: 'E',
+    controller: 'userActionCtrl',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    template: template,
+    scope: {} // ensure isolated scope
+  };
 }]);

--- a/kahuna/public/js/errors/global.html
+++ b/kahuna/public/js/errors/global.html
@@ -6,7 +6,7 @@
 
         <p>
             If you can see this icon <img src="/assets/images/blocked-cookies.png" alt="blocked third party cookies" class="side-padded"/> in the address bar,
-            please follow <a href="https://docs.google.com/a/guardian.co.uk/document/d/1qlQhHM2NX3xWBIREB2O8D7S4ZtN0sYb7IDV2leE4Ubc/edit?usp=sharing" class="coloured-link" target="_blank">these instructions</a>.
+            please follow <a href="{{ctrl.invalidSessionHelp}}" class="coloured-link" target="_blank">these instructions</a>.
         </p>
     </div>
 
@@ -16,7 +16,7 @@
 
         <div>
             We are looking into this but if the problem persists please
-            <a href="mailto:thegrid.dev@theguardian.com"
+            <a href="{{ctrl.supportEmail}}"
             class="coloured-link">email the Grid team</a>.
         </div>
 
@@ -29,13 +29,13 @@
 
         <p>
             If you can see this icon <img src="/assets/images/blocked-cookies.png" alt="blocked third party cookies" class="side-padded"/> in the address bar,
-            please follow <a href="https://docs.google.com/a/guardian.co.uk/document/d/1qlQhHM2NX3xWBIREB2O8D7S4ZtN0sYb7IDV2leE4Ubc/edit?usp=sharing" class="coloured-link" target="_blank">these instructions</a>.
+            please follow <a href="{{ctrl.invalidSessionHelp}}" class="coloured-link" target="_blank">these instructions</a>.
         </p>
     </div>
 
     <div class="global-error warning" ng:message="unknown">
         An unknown error has occurred.
-        If the problem persists please <a href="mailto:thegrid.dev@theguardian.com" class="coloured-link">email the Grid team</a>.
+        If the problem persists please <a href="{{ctrl.supportEmail}}" class="coloured-link">email the Grid team</a>.
 
         <gr-icon class="global-error__close"
                  title="Close"
@@ -44,6 +44,6 @@
 
     <div class="global-error error" ng:message="server">
         A server error has occurred; the Grid may not be fully functional at this time.
-        If the problem persists please <a href="mailto:thegrid.dev@theguardian.com" class="coloured-link">email the Grid team</a>.
+        If the problem persists please <a href="{{ctrl.supportEmail}}" class="coloured-link">email the Grid team</a>.
     </div>
 </ng:messages>

--- a/kahuna/public/js/errors/global.js
+++ b/kahuna/public/js/errors/global.js
@@ -35,11 +35,19 @@ globalErrors.factory('globalErrors', [function() {
 
 
 globalErrors.controller('GlobalErrorsCtrl',
-                  ['$location', 'globalErrors',
-                   function($location, globalErrors) {
+                  ['$location', 'globalErrors', 'mediaApi',
+                   function($location, globalErrors, mediaApi) {
 
     var ctrl = this;
     ctrl.errors = globalErrors.getErrors();
+
+    mediaApi.getHelpLinks().then(links => {
+      ctrl.setInvalidSessionHelpLink(links);
+      ctrl.setSupportEmail(links);
+    });
+
+    ctrl.setInvalidSessionHelpLink = ({invalidSessionHelp}) => ctrl.invalidSessionHelp = invalidSessionHelp;
+    ctrl.setSupportEmail = ({supportEmail}) => ctrl.supportEmail = supportEmail;
 
     // handy as these can happen anywhere
     ctrl.getCurrentLocation = () => $location.url();

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -12,6 +12,7 @@ mediaApi.factory('mediaApi',
 
     var root = client.resource(mediaApiUri);
     var session;
+    var helpLinks;
 
     function search(query = '', {ids, since, until, archived, valid, free,
                                  payType, uploadedBy, offset, length, orderBy,
@@ -50,6 +51,10 @@ mediaApi.factory('mediaApi',
         }
 
         return undefined;
+    }
+
+    function getHelpLinks() {
+      return helpLinks || (helpLinks = root.follow('helpLinks').get());
     }
 
     function getOrder(orderBy) {
@@ -96,6 +101,7 @@ mediaApi.factory('mediaApi',
         metadataSearch,
         labelSearch,
         labelsSuggest,
+        getHelpLinks,
         delete: delete_
     };
 }]);

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -5,7 +5,7 @@
       ng:submit="usageRights.$valid && ctrl.save()">
 
     <div class="ure__description">
-        <a target="_blank" href="https://docs.google.com/a/guardian.co.uk/document/d/1owx57raHRncnSU-voyg1b21yZBcrkM1ttka7CDQLYOs/pub">
+        <a target="_blank" href="{{ctrl.usageRightsHelp}}">
             <gr-icon title="Rights Guide">
                 info_outline
             </gr-icon>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -23,8 +23,8 @@ export var usageRightsEditor = angular.module('kahuna.edits.usageRightsEditor', 
 
 usageRightsEditor.controller(
     'UsageRightsEditorCtrl',
-    ['$q', '$rootScope', '$scope', 'inject$', 'observe$', 'editsService', 'editsApi', 'imageList',
-    function($q, $rootScope, $scope, inject$, observe$, editsService, editsApi, imageList) {
+    ['$q', '$rootScope', '$scope', 'inject$', 'observe$', 'editsService', 'editsApi', 'imageList', 'mediaApi',
+    function($q, $rootScope, $scope, inject$, observe$, editsService, editsApi, imageList, mediaApi) {
 
     var ctrl = this;
     const multiCat = { name: 'Multiple categories', value: 'multi-cat', properties: [] };
@@ -112,6 +112,9 @@ usageRightsEditor.controller(
     inject$($scope, forceRestrictions$, ctrl, 'forceRestrictions');
     inject$($scope, showRestrictions$, ctrl, 'showRestrictions');
     inject$($scope, categoryInvalid$, ctrl, 'categoryInvalid');
+
+    mediaApi.getHelpLinks().then(links => ctrl.setUsageRightsHelpLink(links));
+    ctrl.setUsageRightsHelpLink = ({usageRightsHelp}) => ctrl.usageRightsHelp = usageRightsHelp;
 
     // TODO: Some of these could be streams
     ctrl.saving = false;

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -66,7 +66,8 @@ class MediaApi(
       Link("witness-report",  s"${config.services.guardianWitnessBaseUri}/2/report/{id}"),
       Link("collections",     config.collectionsUri),
       Link("permissions",     s"${config.rootUri}/permissions"),
-      Link("leases",          config.leasesUri)
+      Link("leases",          config.leasesUri),
+      Link("helpLinks",       s"${config.rootUri}/helpLinks")
     )
     respond(indexData, indexLinks)
   }
@@ -306,6 +307,16 @@ class MediaApi(
       params => respondSuccess(params)
     )
   }
+  
+  def helpLinks() = auth { request =>
+    implicit val r = request
+    Ok(Json.obj(
+      "feedbackForm" -> "https://goo.gl/forms/OO7CrMt9BRobi1j63",
+      "usageRightsHelp" -> "https://docs.google.com/a/guardian.co.uk/document/d/1owx57raHRncnSU-voyg1b21yZBcrkM1ttka7CDQLYOs/pub",
+      "invalidSessionHelp"-> "https://docs.google.com/a/guardian.co.uk/document/d/1qlQhHM2NX3xWBIREB2O8D7S4ZtN0sYb7IDV2leE4Ubc/edit?usp=sharing",
+      "supportEmail"-> "mailto:thegrid.dev@theguardian.com"
+    ))
+  }
 
   private def getSearchUrl(searchParams: SearchParams, updatedOffset: Int, length: Int): String = {
     // Enforce a toDate to exclude new images since the current request
@@ -341,5 +352,4 @@ class MediaApi(
       None
     }
   }
-
 }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -21,6 +21,9 @@ POST    /images/:id/reindex                           controllers.MediaApi.reind
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
 GET     /images                                       controllers.MediaApi.imageSearch
 
+# Help links
+GET     /helpLinks                                    controllers.MediaApi.helpLinks
+
 # completion
 GET     /suggest/metadata/credit                      controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
 GET     /suggest/metadata/photoshoot                  controllers.SuggestionController.suggestPhotoshoot(q: Option[String], size: Option[Int])


### PR DESCRIPTION
## What does this change?
Makes some guardian specific hardcoded links in HTML now come from media-api.

Currently some guardian specific links to google docs and forms are hardcoded into HTML, namely: 
- 'Having trouble picking usage rights?' link
- The feedback form from the menu option in the top right 
- The 'email grid team' in the invalid session error message
- The invalid session help doc

We would like these to be configurable for use in the BBC. This is a non breaking change which hard codes the links into media-api, which are then requested by the front end and placed into the HTML. 

The next stage would be to make the links come into media-api from a config file, which would be a breaking change so thought it best to make this PR first before progressing. 

## How can success be measured?
The links listed above are still making their way to the ui.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
