### PR TITLE
Feature/extract config usage rights

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -1,15 +1,16 @@
 package com.gu.mediaservice.lib.cleanup
 
+import com.gu.mediaservice.lib.config.Company
 import com.gu.mediaservice.model.ImageMetadata
 
 trait MetadataCleaner {
   def clean(metadata: ImageMetadata): ImageMetadata
 }
 
-class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
+class MetadataCleaners(companies: List[Company]) {
 
-  val attrCreditFromBylineCleaners = creditBylineMap.map { case (credit, bylines) =>
-    AttributeCreditFromByline(bylines, credit)
+  val attrCreditFromBylineCleaners = companies.map { company =>
+    AttributeCreditFromByline(company.photographers, company.name)
   }
 
   val allCleaners: List[MetadataCleaner] = List(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -1,13 +1,13 @@
 package com.gu.mediaservice.lib.cleanup
 
-import com.gu.mediaservice.model.{NoRights, Agencies, Agency, Image, StaffPhotographer, ContractPhotographer}
-import com.gu.mediaservice.lib.config.PhotographersList
+import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.model._
 
 trait ImageProcessor {
   def apply(image: Image): Image
 }
 
-object SupplierProcessors {
+class SupplierProcessors(metadataConfig: MetadataConfig) {
   val all: List[ImageProcessor] = List(
     GettyXmpParser,
     GettyCreditParser,
@@ -23,17 +23,17 @@ object SupplierProcessors {
     ReutersParser,
     RexParser,
     RonaldGrantParser,
-    PhotographerParser
+    new PhotographerParser(metadataConfig)
   )
 
   def process(image: Image): Image =
     all.foldLeft(image) { case (im, processor) => processor(im) }
 }
 
-object PhotographerParser extends ImageProcessor {
+class PhotographerParser(metadataConfig: MetadataConfig) extends ImageProcessor {
   def apply(image: Image): Image = {
     image.metadata.byline.flatMap { byline =>
-      PhotographersList.getPhotographer(byline).map{
+      metadataConfig.getPhotographer(byline).map {
         case p: StaffPhotographer => image.copy(
           usageRights = p,
           metadata    = image.metadata.copy(credit = Some(p.publication), byline = Some(p.photographer))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -1,32 +1,26 @@
 package com.gu.mediaservice.lib.config
 
-// TODO: Only import the semigroup syntax, but can't find out what to import
-import scalaz._
-import Scalaz._
+import com.gu.mediaservice.model.{ContractPhotographer, Photographer, StaffPhotographer}
+import play.api.libs.json._
 
+case class MetadataConfig(
+  staffIllustrators: List[String],
+  creativeCommonsLicense: List[String],
+  externalStaffPhotographers: List[Company],
+  internalStaffPhotographers: List[Company],
+  contractedPhotographers: List[Company],
+  contractIllustrators: List[Company]) {
+  val staffPhotographers: List[Company] = MetadataConfig.flattenCompanyList(
+    internalStaffPhotographers ++ externalStaffPhotographers)
+  val allPhotographers: List[Company] = MetadataConfig.flattenCompanyList(
+    internalStaffPhotographers ++ externalStaffPhotographers ++ contractedPhotographers)
 
-
-import com.gu.mediaservice.model.{StaffPhotographer, ContractPhotographer, Photographer}
-
-object PhotographersList {
-  type Store = Map[String, String]
-  type CreditBylineMap = Map[String, List[String]]
-
-  import MetadataConfig.{ staffPhotographers, contractedPhotographers }
-
-  def creditBylineMap(store: Store): CreditBylineMap = store
-      .groupBy{ case (photographer, publication) => publication }
-      .map{ case (publication, photographers) => publication -> photographers.keys.toList.sortWith(_.toLowerCase < _.toLowerCase) }
-
-  def creditBylineMap(stores: List[Store]): CreditBylineMap =
-    stores.map(creditBylineMap).reduceLeft(_ |+| _)
-
-  def list(store: Store) = store.keys.toList.sortWith(_.toLowerCase < _.toLowerCase)
-
-  def getPublication(store: Store, name: String): Option[String] = store.get(name)
-
-  def caseInsensitiveLookup(store: Store, lookup: String) =
-    store.find{case (name, pub) => name.toLowerCase == lookup.toLowerCase}
+  def caseInsensitiveLookup(store: List[Company], lookup: String) = {
+    store.map {
+      case Company(name, photographers) if photographers.map(_.toLowerCase) contains lookup.toLowerCase() => Some(lookup, name)
+      case _ => None
+    }.find(_.isDefined).flatten
+  }
 
   def getPhotographer(photographer: String): Option[Photographer] = {
     caseInsensitiveLookup(staffPhotographers, photographer).map {
@@ -37,128 +31,19 @@ object PhotographersList {
   }
 }
 
+case class Company(name: String, photographers: List[String])
+
+object Company {
+  implicit val companyClassFormats = Json.format[Company]
+}
+
 object MetadataConfig {
+  implicit val metadataConfigClassFormats = Json.format[MetadataConfig]
 
-  val externalStaffPhotographers: Map[String, String] = Map(
-    // Current
-    "Ben Doherty"     -> "The Guardian",
-    "Bill Code"       -> "The Guardian",
-    "Calla Wahlquist" -> "The Guardian",
-    "David Sillitoe"  -> "The Guardian",
-    "Graham Turner"   -> "The Guardian",
-    "Helen Davidson"  -> "The Guardian",
-    "Jill Mead"       -> "The Guardian",
-    "Jonny Weeks"     -> "The Guardian",
-    "Joshua Robertson" -> "The Guardian",
-    "Rachel Vere"     -> "The Guardian",
-    "Roger Tooth"     -> "The Guardian",
-    "Sean Smith"      -> "The Guardian",
-    "Melissa Davey"   -> "The Guardian",
-    "Michael Safi"    -> "The Guardian",
-    "Michael Slezak"  -> "The Guardian",
-    "Sean Smith"      -> "The Guardian",
-    "Carly Earl"      -> "The Guardian",
-
-    // Past
-    "Dan Chung"             -> "The Guardian",
-    "Denis Thorpe"          -> "The Guardian",
-    "Don McPhee"            -> "The Guardian",
-    "Frank Baron"           -> "The Guardian",
-    "Frank Martin"          -> "The Guardian",
-    "Garry Weaser"          -> "The Guardian",
-    "Graham Finlayson"      -> "The Guardian",
-    "Martin Argles"         -> "The Guardian",
-    "Peter Johns"           -> "The Guardian",
-    "Robert Smithies"       -> "The Guardian",
-    "Tom Stuttard"          -> "The Guardian",
-    "Tricia De Courcy Ling" -> "The Guardian",
-    "Walter Doughty"        -> "The Guardian",
-    "David Newell Smith"    -> "The Observer",
-    "Tony McGrath"          -> "The Observer",
-    "Catherine Shaw"        -> "The Observer",
-    "John Reardon"          -> "The Observer",
-    "Sean Gibson"           -> "The Observer"
-  )
-
-  // these are people who aren't photographers by trade, but have taken photographs for us.
-  // This is mainly used so when we ingest photos from Picdar, we make sure we categorise
-  // them correctly.
-  // TODO: Think about removin these once Picdar is dead.
-  val internalStaffPhotographers = List(
-    "E Hamilton West"       -> "The Guardian",
-    "Harriet St Johnston"   -> "The Guardian",
-    "Lorna Roach"           -> "The Guardian",
-    "Rachel Vere"           -> "The Guardian",
-    "Ken Saunders"          -> "The Guardian"
-  )
-
-  val staffPhotographers = externalStaffPhotographers ++ internalStaffPhotographers
-
-  val contractedPhotographers: Map[String, String] = Map(
-    "Alicia Canter"       -> "The Guardian",
-    "Antonio Zazueta"     -> "The Guardian",
-    "Christopher Thomond" -> "The Guardian",
-    "David Levene"        -> "The Guardian",
-    "Eamonn McCabe"       -> "The Guardian",
-    "Graeme Robertson"    -> "The Guardian",
-    "Johanna Parkin"      -> "The Guardian",
-    "Linda Nylind"        -> "The Guardian",
-    "Louise Hagger"       -> "The Guardian",
-    "Martin Godwin"       -> "The Guardian",
-    "Mike Bowers"         -> "The Guardian",
-    "Murdo MacLeod"       -> "The Guardian",
-    "Sarah Lee"           -> "The Guardian",
-    "Tom Jenkins"         -> "The Guardian",
-    "Tristram Kenton"     -> "The Guardian",
-    "Jill Mead"           -> "The Guardian",
-
-    "Andy Hall"           -> "The Observer",
-    "Antonio Olmos"       -> "The Observer",
-    "Gary Calton"         -> "The Observer",
-    "Jane Bown"           -> "The Observer",
-    "Jonathan Lovekin"    -> "The Observer",
-    "Karen Robinson"      -> "The Observer",
-    "Katherine Anne Rose" -> "The Observer",
-    "Richard Saker"       -> "The Observer",
-    "Sophia Evans"        -> "The Observer",
-    "Suki Dhanda"         -> "The Observer"
-  )
-
-  val staffIllustrators = List(
-    "Mona Chalabi",
-    "Sam Morris",
-    "Guardian Design"
-  )
-
-  val contractIllustrators: Map[String, String] = Map(
-    "Ben Lamb"              -> "The Guardian",
-    "Andrzej Krauze"        -> "The Guardian",
-    "David Squires"         -> "The Guardian",
-    "First Dog on the Moon" -> "The Guardian",
-    "Harry Venning"         -> "The Guardian",
-    "Martin Rowson"         -> "The Guardian",
-    "Matt Kenyon"           -> "The Guardian",
-    "Matthew Blease"        -> "The Guardian",
-    "Nicola Jennings"       -> "The Guardian",
-    "Rosalind Asquith"      -> "The Guardian",
-    "Steve Bell"            -> "The Guardian",
-    "Steven Appleby"        -> "The Guardian",
-    "Ben Jennings"          -> "The Guardian",
-    "Chris Riddell"         -> "The Observer",
-    "David Foldvari"        -> "The Observer",
-    "David Simonds"         -> "The Observer",
-  )
-
-  val allPhotographers = staffPhotographers ++ contractedPhotographers
-
-  val externalPhotographersMap = PhotographersList.creditBylineMap(externalStaffPhotographers)
-  val staffPhotographersMap = PhotographersList.creditBylineMap(staffPhotographers)
-  val contractPhotographersMap = PhotographersList.creditBylineMap(contractedPhotographers)
-  val allPhotographersMap = PhotographersList.creditBylineMap(allPhotographers)
-  val contractIllustratorsMap = PhotographersList.creditBylineMap(contractIllustrators)
-
-  val creativeCommonsLicense = List(
-    "CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0"
-  )
+  def flattenCompanyList(companies: List[Company]): List[Company] = companies
+    .groupBy(_.name)
+    .map { case (group, companies) => Company(group, companies.flatMap(company => company.photographers)) }
+    .toList
 
 }
+

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataStore.scala
@@ -1,0 +1,54 @@
+package com.gu.mediaservice.lib.config
+
+import com.gu.mediaservice.lib.BaseStore
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+class MetadataStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext)
+  extends BaseStore[String, MetadataConfig](bucket, config)(ec) {
+
+  val metadataMapKey = "metadataConfig"
+  val metadataStoreKey = "photographers.json"
+
+  def apply() = fetchAll match {
+    case Some(_) => Logger.info("Metadata config read in from config bucket")
+    case None => throw FailedToLoadMetadataConfigJson
+  }
+
+  def update() {
+    lastUpdated.send(_ => DateTime.now())
+    fetchAll match {
+      case Some(config) => store.send(_ => config)
+      case None => Logger.warn("Could not parse metadata config JSON into MetadataConfig class")
+    }
+  }
+
+  private def fetchAll: Option[Map[String, MetadataConfig]] = {
+    getS3Object(metadataStoreKey) match {
+      case Some(fileContents) => Try(Json.parse(fileContents).as[MetadataConfig]) match {
+          case Success(metadataConfigClass) => Some(Map(metadataMapKey -> metadataConfigClass))
+          case Failure(_) => None
+        }
+      case None => None
+      }
+    }
+
+  def get: MetadataConfig = store.get()(metadataMapKey)
+}
+
+object MetadataStore {
+  def apply(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext): MetadataStore = {
+    val store = new MetadataStore(bucket, config)(ec)
+    store.fetchAll match {
+      case Some(_) => Logger.info("Metadata config read in from config bucket")
+      case None => throw FailedToLoadMetadataConfigJson
+    }
+    store
+  }
+}
+
+case object FailedToLoadMetadataConfigJson extends Exception("Failed to load metadataConfig from S3 config bucket on start up")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -1,91 +1,15 @@
 package com.gu.mediaservice.lib.config
 
+import play.api.libs.json._
+
+case class UsageRightsConfig(usageRights: List[String], freeSuppliers: List[String], suppliersCollectionExcl: Map[String, List[String]]) {
+
+  def isFreeSupplier(supplier: String) = freeSuppliers.contains(supplier)
+
+  def isExcludedColl(supplier: String, supplierColl: String) =
+    suppliersCollectionExcl.get(supplier).exists(_.contains(supplierColl))
+}
+
 object UsageRightsConfig {
-
-  val payGettySourceList = List(
-    "Arnold Newman Collection",
-    "360cities.net Editorial",
-    "360cities.net RM",
-    "age fotostock RM",
-    "Alinari",
-    "Arnold Newman Collection",
-    "ASAblanca",
-    // Note: Even though we have a deal directly with Barcroft, it
-    // does not apply to images sourced through Getty. Silly, I know.
-    "Barcroft Media",
-    "Bob Thomas Sports Photography",
-    "Carnegie Museum of Art",
-    "Catwalking",
-    "Contour",
-    "Contour RA",
-    "Corbis Premium Historical",
-    "Editorial Specials",
-    "Reportage Archive",
-    "Gamma-Legends",
-    "Genuine Japan Editorial Stills",
-    "Genuine Japan Creative Stills",
-    "George Steinmetz",
-    "Getty Images Sport Classic",
-    "Iconic Images",
-    "Iconica",
-    "Icon Sport",
-    "Kyodo News Stills",
-    "Lichfield Studios Limited",
-    "Lonely Planet Images",
-    "Lonely Planet RF",
-    "Masters",
-    "Major League Baseball Platinum",
-    "Moment Select",
-    "Mondadori Portfolio Premium",
-    "National Geographic",
-    "National Geographic RF",
-    "National Geographic Creative",
-    "National Geographic Magazines",
-    "NBA Classic",
-    "Neil Leifer Collection",
-    "Newspix",
-    "PA Images",
-    "Papixs",
-    "Paris Match Archive",
-    "Paris Match Collection",
-    "Pele 10",
-    "Photonica",
-    "Photonica World",
-    "Popperfoto",
-    "Popperfoto Creative",
-    "Premium Archive",
-    "Reportage Archive",
-    "SAMURAI JAPAN",
-    "Sports Illustrated",
-    "Sports Illustrated Classic",
-    "Sygma Premium",
-    "Terry O'Neill",
-    "The Asahi Shimbun Premium",
-    "The LIFE Premium Collection",
-    "ullstein bild Premium",
-    "Ulrich Baumgarten",
-    "VII Premium",
-    "Vision Media",
-    "Xinhua News Agency"
-  )
-
-  val freeSuppliers = List(
-    "AAP",
-    "Alamy",
-    "Allstar Picture Library",
-    "AP",
-    "Barcroft Media",
-    "EPA",
-    "Getty Images",
-    "PA",
-    "Reuters",
-    "Rex Features",
-    "Ronald Grant Archive",
-    "Action Images",
-    "Action Images via Reuters"
-  )
-
-  val suppliersCollectionExcl = Map(
-    "Getty Images" -> payGettySourceList
-  )
+  implicit val metadataConfigClassFormats = Json.format[UsageRightsConfig]
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsStore.scala
@@ -1,0 +1,57 @@
+package com.gu.mediaservice.lib.config
+
+import com.gu.mediaservice.lib.BaseStore
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+class UsageRightsStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext)
+  extends BaseStore[String, UsageRightsConfig](bucket, config)(ec) {
+
+  val usageRightsMapKey = "usageRights"
+  val usageRightsStoreKey = "usage_rights.json"
+
+  def apply() = fetchAll match {
+    case Some(_) => Logger.info("Usage Rights config read in from config bucket")
+    case None => throw FailedToLoadUsageRightsConfigJson
+  }
+
+  def update() {
+    lastUpdated.send(_ => DateTime.now())
+    fetchAll match {
+      case Some(config) => store.send(_ => config)
+      case None => Logger.warn("Could not parse usage rights config JSON into UsageRightsConfig class")
+    }
+  }
+
+  private def fetchAll: Option[Map[String, UsageRightsConfig]] = {
+    getS3Object(usageRightsStoreKey) match {
+      case Some(fileContents) => {
+        Try(Json.parse(fileContents).as[UsageRightsConfig]) match {
+          case Success(usageRightsConfigClass) => Some(Map(usageRightsMapKey -> usageRightsConfigClass))
+          case Failure(e) => None
+        }
+      }
+      case None => None
+    }
+  }
+
+  def get: UsageRightsConfig = store.get()(usageRightsMapKey)
+
+}
+
+object UsageRightsStore {
+  def apply(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext): UsageRightsStore = {
+    val store = new UsageRightsStore(bucket, config)(ec)
+    store.fetchAll match {
+      case Some(_) => Logger.info("Usage rights config read in from config bucket")
+      case None => throw FailedToLoadMetadataConfigJson
+    }
+    store
+  }
+}
+
+case object FailedToLoadUsageRightsConfigJson extends Exception("Failed to load UsageRightsConfig from S3 config bucket on start up")

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -23,14 +23,37 @@ sealed trait UsageRightsSpec {
 }
 
 object UsageRights {
-  val all = List(
-    NoRights, Handout, PrImage, Screengrab, SocialMedia,
-    Agency, CommissionedAgency, Chargeable, Bylines,
-    StaffPhotographer, ContractPhotographer, CommissionedPhotographer,
-    CreativeCommons, GuardianWitness, Pool, CrownCopyright, Obituary,
-    ContractIllustrator, CommissionedIllustrator, StaffIllustrator,
-    Composite, PublicDomain
+
+  val usageRightsMap: Map[String, UsageRightsSpec] = Map(
+    "NoRights"                -> NoRights,
+    "Handout"                 -> Handout,
+    "PrImage"                 -> PrImage,
+    "Screengrab"              -> Screengrab,
+    "SocialMedia"             -> SocialMedia,
+    "Agency"                  -> Agency,
+    "CommissionedAgency"      -> CommissionedAgency,
+    "Chargeable"              -> Chargeable,
+    "Bylines"                 -> Bylines,
+    "StaffPhotographer"       -> StaffPhotographer,
+    "ContractPhotographer"    -> ContractPhotographer,
+    "CommissionedPhotographer"-> CommissionedPhotographer,
+    "CreativeCommons"         -> CreativeCommons,
+    "GuardianWitness"         -> GuardianWitness,
+    "Pool"                    -> Pool,
+    "CrownCopyright"          -> CrownCopyright,
+    "Obituary"                -> Obituary,
+    "ContractIllustrator"     -> ContractIllustrator,
+    "CommissionedIllustrator" -> CommissionedIllustrator,
+    "StaffIllustrator"        -> StaffIllustrator,
+    "Composite"               -> Composite,
+    "PublicDomain"            -> PublicDomain
   )
+
+  def getAll(usageRights: List[String]): List[UsageRightsSpec] =
+    usageRights
+      .map(usageRightsMap.get)
+      .collect { case Some(spec) => spec }
+  
 
   val photographer = List(StaffPhotographer, ContractPhotographer, CommissionedPhotographer)
   val illustrator = List(StaffIllustrator, ContractIllustrator, CommissionedIllustrator)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -1,5 +1,6 @@
 package com.gu.mediaservice.lib.cleanup
 
+import com.gu.mediaservice.lib.config.{Company, MetadataConfig}
 import com.gu.mediaservice.model._
 import org.scalatest.{Matchers, FunSpec}
 
@@ -450,8 +451,14 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   }
 
 
-  def applyProcessors(image: Image): Image =
-    SupplierProcessors.process(image)
-
-
+  def applyProcessors(image: Image): Image = {
+    val metadataConfig =
+      MetadataConfig(List(), List(),
+        List(Company("The Guardian", List("Graham Turner"))),
+        List(),
+        List(Company("The Guardian", List("Linda Nylind", "Murdo MacLeod"))),
+        List()
+      )
+    new SupplierProcessors(metadataConfig).process(image)
+  }
 }

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -1,14 +1,11 @@
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.imaging.ImageOperations
-import com.gu.mediaservice.lib.play.{GridComponents, RequestLoggingFilter}
+import com.gu.mediaservice.lib.play.GridComponents
 import controllers.ImageLoaderController
 import lib._
 import lib.storage.ImageLoaderStore
 import model.{ImageUploadOps, OptimisedPngOps}
 import play.api.ApplicationLoader.Context
-import play.api.mvc.EssentialFilter
-import play.filters.HttpFiltersComponents
-import play.filters.cors.CORSComponents
-import play.filters.gzip.GzipFilterComponents
 import router.Routes
 
 class ImageLoaderComponents(context: Context) extends GridComponents(context) {
@@ -16,15 +13,19 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context) {
 
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val store = new ImageLoaderStore(config)
+  val loaderStore = new ImageLoaderStore(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val notifications = new Notifications(config)
   val downloader = new Downloader()
-  val optimisedPngOps = new OptimisedPngOps(store, config)
-  val imageUploadOps = new ImageUploadOps(store, config, imageOperations, optimisedPngOps)
+  val optimisedPngOps = new OptimisedPngOps(loaderStore, config)
 
-  val controller = new ImageLoaderController(auth, downloader, store, notifications, config, imageUploadOps, controllerComponents, wsClient)
+  val metaDataConfigStore = MetadataStore(config.configBucket, config)
+  metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
+
+  val imageUploadOps = new ImageUploadOps(metaDataConfigStore, loaderStore, config, imageOperations, optimisedPngOps)
+
+  val controller = new ImageLoaderController(auth, downloader, loaderStore, notifications, config, imageUploadOps, controllerComponents, wsClient)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management)
 }

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -13,6 +13,8 @@ class ImageLoaderConfig(override val configuration: Configuration) extends Commo
 
   val thumbnailBucket: String = properties("s3.thumb.bucket")
 
+  val configBucket: String = properties("s3.config.bucket")
+
   val tempDir: File = new File(properties.getOrElse("upload.tmp.dir", "/tmp"))
 
   val thumbWidth: Int = 256

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.management.ManagementWithPermissions
@@ -37,7 +38,10 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
+  val metaDataConfigStore = MetadataStore(config.configBucket, config)
+  metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
+
+  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, metaDataConfigStore)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -37,7 +37,7 @@ object ImageExtras {
   def hasCurrentDenyLease(leases: LeasesByMedia): Boolean = leases.leases.exists(lease => lease.access == DenyUseLease && isCurrent(lease))
 
   def validityMap(image: Image, withWritePermission: Boolean)(
-    implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
+    implicit cost: CostCalculator): ValidMap = {
 
     val shouldOverride = validityOverrides(image, withWritePermission).exists(_._2 == true)
 
@@ -51,7 +51,7 @@ object ImageExtras {
       "missing_credit"       -> createCheck(!hasCredit(image.metadata), overrideable = false),
       "missing_description"  -> createCheck(!hasDescription(image.metadata), overrideable = false),
       "current_deny_lease"   -> createCheck(hasCurrentDenyLease(image.leases)),
-      "over_quota"           -> createCheck(quotas.isOverQuota(image.usageRights))
+      "over_quota"           -> createCheck(cost.quotas.isOverQuota(image.usageRights))
     )
   }
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -17,16 +17,8 @@ import play.utils.UriEncoding
 
 import scala.util.{Failure, Try}
 
-class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: UsageQuota) extends EditsResponse {
-  //  implicit val dateTimeFormat = DateFormat
-  implicit val usageQuotas = usageQuota
-
-  object Costing extends CostCalculator {
-    val quotas = usageQuotas
-  }
-
-  implicit val costing = Costing
-
+class ImageResponse(config: MediaApiConfig, s3Client: S3Client, implicit val costCalculator: CostCalculator) extends EditsResponse {
+//  implicit val dateTimeFormat = DateFormat
   val metadataBaseUri: String = config.services.metadataBaseUri
 
   type FileMetadataEntity = EmbeddedEntity[FileMetadata]
@@ -177,7 +169,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       (source \ "userMetadata" \ "usageRights").asOpt[JsObject]
     ).flatten.foldLeft(Json.obj())(_ ++ _).as[UsageRights]
 
-    val cost = Costing.getCost(usageRights)
+    val cost = costCalculator.getCost(usageRights)
 
     __.json.update(__.read[JsObject].map(_ ++ Json.obj("cost" -> cost.toString)))
   }

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -2,7 +2,6 @@ package lib
 
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.gu.mediaservice.lib.config.CommonConfig
-import com.gu.mediaservice.lib.discovery.EC2._
 import org.joda.time.DateTime
 import play.api.Configuration
 

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/ElasticSearch.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.auth.Authentication.Principal
+import com.gu.mediaservice.lib.config.UsageRightsConfig
 import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearch6Config, ElasticSearch6Executions, ElasticSearchClient, Mappings}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
 import com.gu.mediaservice.model.{Agencies, Agency, Image}
@@ -24,7 +25,7 @@ import play.mvc.Http.Status
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, overQuotaAgencies: () => List[Agency]) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
+class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearch6Config, overQuotaAgencies: () => List[Agency], usageRightsConfig: () => UsageRightsConfig) extends ElasticSearchVersion with ElasticSearchClient with ElasticSearch6Executions with ImageFields with MatchFields with FutureSyntax {
 
   lazy val imagesAlias = elasticConfig.alias
   lazy val url = elasticConfig.url
@@ -32,7 +33,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   lazy val shards = elasticConfig.shards
   lazy val replicas = elasticConfig.replicas
 
-  val searchFilters = new SearchFilters(config)
+  val searchFilters = new SearchFilters(config, usageRightsConfig)
   val syndicationFilter = new SyndicationFilter(config)
 
   val queryBuilder = new QueryBuilder(matchFields, overQuotaAgencies)

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
+import com.gu.mediaservice.lib.config.UsageRightsConfig
 import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearch6Config, ElasticSearch6Executions}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.PublishedUsageStatus
@@ -35,7 +36,9 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
   val elasticConfig = ElasticSearch6Config(alias = "readAlias", url = es6TestUrl,
     cluster = "media-service-test", shards = 1, replicas = 0)
 
-  private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => List.empty)
+  private val usageRightsConfig = UsageRightsConfig(List(), List(), Map("" -> List()))
+
+  private val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => List.empty, () => usageRightsConfig)
   val client = ES.client
 
   def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:6.6.0")
@@ -406,7 +409,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       def overQuotaAgencies = List(Agency("Getty Images"), Agency("AP"))
 
       val search = SearchParams(tier = Internal, structuredQuery = List(isUnderQuotaCondition), length = 50)
-      val elasticsearch = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => overQuotaAgencies)
+      val elasticsearch = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => overQuotaAgencies, () => usageRightsConfig)
 
       whenReady(elasticsearch.search(search), timeout, interval) { result => {
         val overQuotaImages = List(

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -2,18 +2,20 @@ package lib
 
 import java.net.URI
 
+import com.gu.mediaservice.lib.config.UsageRightsStore
 import com.gu.mediaservice.model._
 import lib.usagerights.CostCalculator
 import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{AsyncFunSpec, Matchers}
 
-class ImageExtrasTest extends FunSpec with Matchers with MockitoSugar {
+
+class ImageExtrasTest extends AsyncFunSpec with Matchers with MockitoSugar   {
 
   val Quota = mock[UsageQuota]
+  val usageRightsStore = mock[UsageRightsStore]
 
-  object Costing extends CostCalculator {
-    val quotas = Quota
+  object Costing extends CostCalculator(usageRightsStore, Quota) {
     override def getOverQuota(usageRights: UsageRights) = None
   }
 

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -1,23 +1,26 @@
 package lib.usagerights
 
+import com.gu.mediaservice.lib.config.{UsageRightsConfig, UsageRightsStore}
 import com.gu.mediaservice.model._
 import lib.UsageQuota
+import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{AsyncFunSpec, Matchers}
 
-class CostCalculatorTest extends FunSpec with Matchers with MockitoSugar {
+class CostCalculatorTest extends AsyncFunSpec with Matchers with MockitoSugar {
 
   describe("from usage rights") {
 
     val Quota = mock[UsageQuota]
+    val usageRightsStore = mock[UsageRightsStore]
 
-    object Costing extends CostCalculator {
-      val quotas = Quota
+    when(usageRightsStore.get) thenReturn UsageRightsConfig(List(), List("Getty Images"), Map("Getty Images" -> List("Terry O'Neill")))
+
+    object Costing extends CostCalculator(usageRightsStore, Quota) {
       override def getOverQuota(usageRights: UsageRights) = None
     }
 
-    object OverQuotaCosting extends CostCalculator {
-      val quotas = Quota
+    object OverQuotaCosting extends CostCalculator(usageRightsStore, Quota) {
       override def getOverQuota(usageRights: UsageRights) = Some(Overquota)
     }
 

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.config.MetadataStore
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{EditsApi, EditsController}
@@ -22,8 +23,12 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context)
     () => messageConsumer.actorSystem.terminate()
   }
 
+  val metaDataConfigStore = new MetadataStore(config.configBucket, config)
+  metaDataConfigStore()
+  metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
+
   val editsController = new EditsController(auth, store, notifications, config, controllerComponents)
-  val controller = new EditsApi(auth, config, controllerComponents)
+  val controller = new EditsApi(auth, config, controllerComponents, metaDataConfigStore)
 
   override val router = new Routes(httpErrorHandler, controller, editsController, management)
 }

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -23,8 +23,7 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context)
     () => messageConsumer.actorSystem.terminate()
   }
 
-  val metaDataConfigStore = new MetadataStore(config.configBucket, config)
-  metaDataConfigStore()
+  val metaDataConfigStore = MetadataStore(config.configBucket, config)
   metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
 
   val editsController = new EditsController(auth, store, notifications, config, controllerComponents)

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,4 +1,4 @@
-import com.gu.mediaservice.lib.config.MetadataStore
+import com.gu.mediaservice.lib.config.{MetadataStore, UsageRightsStore}
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{EditsApi, EditsController}
@@ -23,11 +23,14 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context)
     () => messageConsumer.actorSystem.terminate()
   }
 
+  val usageRightsConfigStore = UsageRightsStore(config.configBucket, config)
+  usageRightsConfigStore.scheduleUpdates(actorSystem.scheduler)
+
   val metaDataConfigStore = MetadataStore(config.configBucket, config)
   metaDataConfigStore.scheduleUpdates(actorSystem.scheduler)
 
   val editsController = new EditsController(auth, store, notifications, config, controllerComponents)
-  val controller = new EditsApi(auth, config, controllerComponents, metaDataConfigStore)
+  val controller = new EditsApi(auth, config, controllerComponents, metaDataConfigStore, usageRightsConfigStore)
 
   override val router = new Routes(httpErrorHandler, controller, editsController, management)
 }

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -3,6 +3,7 @@ package controllers
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.config.{MetadataConfig, MetadataStore}
 import com.gu.mediaservice.model._
 import lib.EditsConfig
 import model.UsageRightsProperty
@@ -12,7 +13,8 @@ import play.api.mvc.{BaseController, ControllerComponents}
 import scala.concurrent.ExecutionContext
 
 class EditsApi(auth: Authentication, config: EditsConfig,
-               override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
+               override val controllerComponents: ControllerComponents,
+               metadataStore: MetadataStore)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
 
@@ -32,10 +34,12 @@ class EditsApi(auth: Authentication, config: EditsConfig,
 
   def index = auth { indexResponse }
 
-  val usageRightsResponse = {
-    val usageRightsData = UsageRights.all.map(CategoryResponse.fromUsageRights)
 
-    respond(usageRightsData)
+  def usageRightsResponse = {
+      val metadataConfig = metadataStore.get
+      val usageRightsData = UsageRights.all.map(u => CategoryResponse.fromUsageRights(u, metadataConfig))
+
+      respond(usageRightsData)
   }
 
   def getUsageRights = auth { usageRightsResponse }
@@ -53,7 +57,7 @@ case class CategoryResponse(
 object CategoryResponse {
   // I'd like to have an override of the `apply`, but who knows how you do that
   // with the JSON parsing stuff
-  def fromUsageRights(u: UsageRightsSpec): CategoryResponse =
+  def fromUsageRights(u: UsageRightsSpec, m: MetadataConfig): CategoryResponse =
     CategoryResponse(
       value               = u.category,
       name                = u.name,
@@ -61,7 +65,7 @@ object CategoryResponse {
       description         = u.description,
       defaultRestrictions = u.defaultRestrictions,
       caution             = u.caution,
-      properties          = UsageRightsProperty.getPropertiesForSpec(u)
+      properties          = UsageRightsProperty.getPropertiesForSpec(u, m)
     )
 
   implicit val categoryResponseWrites: Writes[CategoryResponse] = Json.writes[CategoryResponse]

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -13,6 +13,7 @@ class EditsConfig(override val configuration: Configuration) extends CommonConfi
 
   val keyStoreBucket = properties("auth.keystore.bucket")
   val collectionsBucket: String = properties("s3.collections.bucket")
+  val configBucket: String = properties("s3.config.bucket")
 
   val editsTable = properties("dynamo.table.edits")
 

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -23,13 +23,11 @@ object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import UsageRightsConfig.freeSuppliers
-
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
 
   def sortList(l: List[String]) = l.sortWith(_.toLowerCase < _.toLowerCase)
 
-  val props: List[(UsageRightsSpec, MetadataConfig) => List[UsageRightsProperty]] =
+  val props: List[(UsageRightsSpec, MetadataConfig, UsageRightsConfig) => List[UsageRightsProperty]] =
     List(categoryUsageRightsProperties, restrictionProperties)
 
   def companyListToMap(companies: List[Company]): OptionsMap = Map(companies
@@ -37,7 +35,7 @@ object UsageRightsProperty {
 
   def optionsFromCompanyList(companies: List[Company]): Options = sortList(companyListToMap(companies).keys.toList)
 
-  def getPropertiesForSpec(u: UsageRightsSpec, m: MetadataConfig): List[UsageRightsProperty] = props.flatMap(f => f(u, m))
+  def getPropertiesForSpec(u: UsageRightsSpec, m: MetadataConfig, c: UsageRightsConfig): List[UsageRightsProperty] = props.flatMap(f => f(u, m, c))
 
   private def requiredStringField(
     name: String,
@@ -63,14 +61,14 @@ object UsageRightsProperty {
     requiredStringField("creator", "Illustrator",
       optionsMap = Some(companyListToMap(illustrators)), optionsMapKey = Some(key))
 
-  private def restrictionProperties(u: UsageRightsSpec, m: MetadataConfig): List[UsageRightsProperty] = u match {
+  private def restrictionProperties(u: UsageRightsSpec, m: MetadataConfig, c: UsageRightsConfig): List[UsageRightsProperty] = u match {
     case NoRights => List()
     case _ => List(UsageRightsProperty("restrictions", "Restrictions", "text", u.defaultCost.contains(Conditional)))
   }
 
-  def categoryUsageRightsProperties(u: UsageRightsSpec, m: MetadataConfig) = u match {
+  def categoryUsageRightsProperties(u: UsageRightsSpec, m: MetadataConfig, c: UsageRightsConfig) = u match {
     case Agency => List(
-      requiredStringField("supplier", "Supplier", Some(sortList(freeSuppliers))),
+      requiredStringField("supplier", "Supplier", Some(sortList(c.freeSuppliers))),
       UsageRightsProperty(
         "suppliersCollection", "Collection", "string", required = false,
         examples = Some("AFP, FilmMagic, WireImage"))

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -1,8 +1,8 @@
 package model
 
-import play.api.libs.json._
-import com.gu.mediaservice.lib.config.{MetadataConfig, UsageRightsConfig}
+import com.gu.mediaservice.lib.config.{Company, MetadataConfig, UsageRightsConfig}
 import com.gu.mediaservice.model._
+import play.api.libs.json._
 
 
 // TODO: We'll be able to deprecate this and build it up directly from case
@@ -19,22 +19,25 @@ case class UsageRightsProperty(
   examples: Option[String] = None
 )
 
-
 object UsageRightsProperty {
   type OptionsMap = Map[String, List[String]]
   type Options = List[String]
 
-  import MetadataConfig.{contractPhotographersMap, staffPhotographersMap, contractIllustratorsMap, staffIllustrators, creativeCommonsLicense}
   import UsageRightsConfig.freeSuppliers
 
   implicit val jsonWrites: Writes[UsageRightsProperty] = Json.writes[UsageRightsProperty]
 
   def sortList(l: List[String]) = l.sortWith(_.toLowerCase < _.toLowerCase)
 
-  val props: List[(UsageRightsSpec) => List[UsageRightsProperty]] =
+  val props: List[(UsageRightsSpec, MetadataConfig) => List[UsageRightsProperty]] =
     List(categoryUsageRightsProperties, restrictionProperties)
 
-  def getPropertiesForSpec(u: UsageRightsSpec): List[UsageRightsProperty] = props.flatMap(f => f(u))
+  def companyListToMap(companies: List[Company]): OptionsMap = Map(companies
+    .map(c => c.name -> c.photographers): _*)
+
+  def optionsFromCompanyList(companies: List[Company]): Options = sortList(companyListToMap(companies).keys.toList)
+
+  def getPropertiesForSpec(u: UsageRightsSpec, m: MetadataConfig): List[UsageRightsProperty] = props.flatMap(f => f(u, m))
 
   private def requiredStringField(
     name: String,
@@ -46,27 +49,26 @@ object UsageRightsProperty {
   ) = UsageRightsProperty(name, label, "string", required = true, options,
                           optionsMap, optionsMapKey, examples)
 
-  private def publicationField(required: Boolean)  =
-    UsageRightsProperty("publication", "Publication", "string", required,
-      Some(sortList(staffPhotographersMap.keys.toList)))
+  private def publicationField(required: Boolean, options: Options)  =
+    UsageRightsProperty("publication", "Publication", "string", required, Some(options))
 
   private def photographerField(examples: String) =
     requiredStringField("photographer", "Photographer", examples = Some(examples))
 
-  private def photographerField(photographers: OptionsMap, key: String) =
+  private def photographerField(photographers: List[Company], key: String) =
     requiredStringField("photographer", "Photographer",
-      optionsMap = Some(photographers), optionsMapKey = Some(key))
+      optionsMap = Some(companyListToMap(photographers)), optionsMapKey = Some(key))
 
-  private def illustratorField(illustrators: OptionsMap, key: String) =
+  private def illustratorField(illustrators: List[Company], key: String) =
     requiredStringField("creator", "Illustrator",
-      optionsMap = Some(illustrators), optionsMapKey = Some(key))
+      optionsMap = Some(companyListToMap(illustrators)), optionsMapKey = Some(key))
 
-  private def restrictionProperties(u: UsageRightsSpec): List[UsageRightsProperty] = u match {
+  private def restrictionProperties(u: UsageRightsSpec, m: MetadataConfig): List[UsageRightsProperty] = u match {
     case NoRights => List()
     case _ => List(UsageRightsProperty("restrictions", "Restrictions", "text", u.defaultCost.contains(Conditional)))
   }
 
-  def categoryUsageRightsProperties(u: UsageRightsSpec) = u match {
+  def categoryUsageRightsProperties(u: UsageRightsSpec, m: MetadataConfig) = u match {
     case Agency => List(
       requiredStringField("supplier", "Supplier", Some(sortList(freeSuppliers))),
       UsageRightsProperty(
@@ -77,34 +79,34 @@ object UsageRightsProperty {
     case CommissionedAgency => List(requiredStringField("supplier", "Supplier", examples = Some("Demotix")))
 
     case StaffPhotographer => List(
-      publicationField(true),
-      photographerField(staffPhotographersMap, "publication")
+      publicationField(true, optionsFromCompanyList(m.staffPhotographers)),
+      photographerField(m.staffPhotographers, "publication")
     )
 
     case ContractPhotographer => List(
-      publicationField(true),
-      photographerField(contractPhotographersMap, "publication")
+      publicationField(true, optionsFromCompanyList(m.contractedPhotographers)),
+      photographerField(m.contractedPhotographers, "publication")
     )
 
     case CommissionedPhotographer => List(
-      publicationField(false),
+      publicationField(false, optionsFromCompanyList(m.staffPhotographers)),
       photographerField("Sophia Evans, Murdo MacLeod")
     )
 
     case ContractIllustrator => List(
-      publicationField(true),
-      illustratorField(contractIllustratorsMap, "publication")
+      publicationField(true, optionsFromCompanyList(m.contractIllustrators)),
+      illustratorField(m.contractIllustrators, "publication")
     )
 
     case StaffIllustrator => List(
-      requiredStringField("creator", "Illustrator", Some(sortList(staffIllustrators))))
+      requiredStringField("creator", "Illustrator", Some(sortList(m.staffIllustrators))))
 
     case CommissionedIllustrator => List(
-      publicationField(false),
+      publicationField(false, optionsFromCompanyList(m.staffPhotographers)),
       requiredStringField("creator", "Illustrator", examples = Some("Ellie Foreman Peck, Matt Bors")))
 
     case CreativeCommons => List(
-      requiredStringField("licence", "Licence", Some(creativeCommonsLicense)),
+      requiredStringField("licence", "Licence", Some(m.creativeCommonsLicense)),
       requiredStringField("source", "Source", examples = Some("Wikimedia Commons")),
       requiredStringField("creator", "Owner", examples = Some("User:Colin")),
       requiredStringField("contentLink", "Link to content", examples = Some("https://commons.wikimedia.org/wiki/File:Foreign_and_Commonwealth_Office_-_Durbar_Court.jpg"))

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -43,6 +43,7 @@ function getImageLoaderConfig(config) {
     return stripMargin`
         |domain.root=${config.domainRoot}
         |aws.region=${config.aws.region}
+        |s3.config.bucket=${config.stackProps.ConfigBucket}
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
@@ -107,6 +108,7 @@ function getMetadataEditorConfig(config) {
     return stripMargin`
         |domain.root=${config.domainRoot}
         |aws.region=${config.aws.region}
+        |s3.config.bucket=${config.stackProps.ConfigBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.collections.bucket=${config.stackProps.CollectionsBucket}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}


### PR DESCRIPTION
## What does this change?
Similar to [pull 2612](https://github.com/guardian/grid/pull/2612) but for usageRightsConfig

- Extracts `UsageRightsConfig.scala` into a json file on s3 that is read in using a store. Allows suppliers list to be customised without re deploy (and BBC to have different supplier list without a code difference in our fork!)  
- Also makes the UsageRightsSpec in `UsageRights.scala` list customisable from the json file.

As with  [pull 2612](https://github.com/guardian/grid/pull/2612), if the json cannot be parsed on startup an error is thrown which stops the app. But after intial load if subsequent parsing fails (if someone makes the json file invalid) only a warning is logged and the last successful load is kept in the store.

## How can success be measured?
Put the json file in the s3.config.bucket with the name of `usage_rights.json`
ensure the bucket name is added to your /etc/gu properties for api and metadata-editor: `s3.config.bucket=<bucket name>`.

Updating the json config in s3.config.bucket will update supplier list  (after 10 mins).
## Tested?
- [x] locally
- [ ] on TEST
