### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/actions/sbt/Dockerfile
+++ b/.github/actions/sbt/Dockerfile
@@ -1,0 +1,15 @@
+FROM adoptopenjdk:8-jdk-openj9
+
+RUN apt-get -y update
+
+RUN apt-get -y install gnupg
+RUN apt-get -y install graphicsmagick
+RUN apt-get -y install graphicsmagick-imagemagick-compat
+RUN apt-get -y install exiftool
+
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+RUN apt-get -y update
+RUN apt-get -y install sbt
+
+ENTRYPOINT ["sbt"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
     services:
       elasticsearch:
         image: elasticsearch:6.5.4
-        ports:
-        - 9200:9200
         # Wait for elasticsearch to report healthy before continuing.
         # see https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L28
         options: -e "discovery.type=single-node" --expose 9200 --health-cmd "curl localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Grid CI
+on: [push]
+jobs:
+  JSBuild:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        node-version: [8.6.0]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Kahuna
+        working-directory: ./kahuna
+        run: |
+          npm install
+          npm test
+      - name: S3Watcher
+        working-directory: ./s3watcher/lambda
+        run: |
+          npm install
+          npm run build
+      - name: Reaper
+        working-directory: ./reaper
+        run: |
+          npm install
+          npm run riffraff-artefact
+  ScalaBuild:
+    runs-on: ubuntu-18.04
+    services:
+      elasticsearch:
+        image: elasticsearch:6.5.4
+        ports:
+        - 9200:9200
+        # Wait for elasticsearch to report healthy before continuing.
+        # see https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L28
+        options: -e "discovery.type=single-node" --expose 9200 --health-cmd "curl localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 10
+    steps:
+    - uses: actions/checkout@v1
+    - name: SBT
+      uses: ./.github/actions/sbt
+      env:
+        ES6_USE_DOCKER: false
+        ES6_TEST_URL: http://elasticsearch:9200
+      with:
+        args: clean compile test


### PR DESCRIPTION
## What does this change?
Add GitHub Action to build on push. This is so external contributions can be built in a transparent way (our CI service is IP locked). This does everything TeamCity does except upload a deployable to RiffRaff.

There are two Jobs that run in parallel:
- CI for JavaScript apps (Kahuna, S3Watcher, Reaper)
- CI for scala apps

Notes:
- Launches elasticsearch outside the integration tests (making use of #2571)
- Defines custom Dockerfile for scala build with imaging libraries needed for tests and SBT

Observations on GitHub Actions:
- Dependencies are not cached between builds, resulting in a build time of roughly 15 minutes
- Pushes trigger really quickly
- Force pushes can be a little slow to trigger (about 30 seconds)

## How can success be measured?
External contributions have CI performed on them in a transparent way.

## Screenshots (if applicable)
Just see the [Checks](https://github.com/guardian/grid/pull/2615/checks).

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
