### PR TITLE
Revert "Correctly identify Bloomberg uploads"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -17,7 +17,6 @@ object SupplierProcessors {
     AllStarParser,
     ApParser,
     BarcroftParser,
-    BloombergParser,
     CorbisParser,
     EpaParser,
     PaParser,
@@ -146,15 +145,6 @@ object BarcroftParser extends ImageProcessor {
     if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
       List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
     }) image.copy(usageRights = Agency("Barcroft Media")) else image
-}
-
-object BloombergParser extends ImageProcessor {
-  def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Bloomberg") => image.copy(
-      usageRights = Agencies.get("bloomberg")
-    )
-    case _ => image
-  }
 }
 
 object CorbisParser extends ImageProcessor {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -13,7 +13,6 @@ object UsageRightsConfig {
     // Note: Even though we have a deal directly with Barcroft, it
     // does not apply to images sourced through Getty. Silly, I know.
     "Barcroft Media",
-    "Bloomberg",
     "Bob Thomas Sports Photography",
     "Carnegie Museum of Art",
     "Catwalking",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -77,7 +77,6 @@ object UsageRightsConfig {
     "Allstar Picture Library",
     "AP",
     "Barcroft Media",
-    "Bloomberg",
     "EPA",
     "Getty Images",
     "PA",

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -164,8 +164,7 @@ object Agencies {
     "getty" -> Agency("Getty Images"),
     "rex" -> Agency("Rex Features"),
     "aap" -> Agency("AAP"),
-    "alamy" -> Agency("Alamy"),
-    "bloomberg" -> Agency("Bloomberg")
+    "alamy" -> Agency("Alamy")
   )
 
   def get(id: String) = all.getOrElse(id, Agency(id))

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -448,25 +448,6 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   }
 
 
-  describe("Bloomberg") {
-    it("should match Bloomberg credit") {
-      val image = createImageFromMetadata("credit" -> "Bloomberg")
-      val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("Bloomberg"))
-      processedImage.metadata.credit should be(Some("Bloomberg"))
-    }
-    
-    it("should detect Bloomberg via Getty as Getty with suppliersCollection Bloomberg and not as Bloomberg") {
-      val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
-      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "atari.jpg")))
-      val processedImage = applyProcessors(gettyImage)
-      processedImage.usageRights should be(Agency("Getty Images", Some("Bloomberg")))
-      processedImage.metadata.credit should be(Some("Bloomberg via Getty Images"))
-      processedImage.metadata.source should be(Some("Bloomberg"))
-    }
-  }
-
-
   def applyProcessors(image: Image): Image =
     SupplierProcessors.process(image)
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -165,7 +165,6 @@ class UsageStore(
         case s if s.agency.supplier.contains("Getty Images") => copyAgency(s, "getty")
         case s if s.agency.supplier.contains("Australian Associated Press") => copyAgency(s, "aap")
         case s if s.agency.supplier.contains("Alamy") => copyAgency(s, "alamy")
-        case s if s.agency.supplier.contains("Bloomberg") => copyAgency(s, "bloomberg")
         case s => s
       }
 


### PR DESCRIPTION
Reverts guardian/grid#2515. Bloomberg isn’t to be it’s own thing any more. Requires:
- [x] removing rights from [these](https://media.gutools.co.uk/search?query=supplier:Bloomberg&nonFree=true) (now they are [here](https://media.gutools.co.uk/search?query=%23usedToBeBloombergNotViaGetty&nonFree=true))
- [x] removing Bloomberg (via Getty) from [a list](https://github.com/guardian/grid/blob/revert-2515-mk-add-bloomberg/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala#L16) of Paid Getty collections