### PR TITLE
DateTime adjustments

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -4,9 +4,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format._
 
 import scala.util.Try
-
 import com.gu.mediaservice.model.{FileMetadata, ImageMetadata}
-
 import play.api.Logger
 
 object ImageMetadataConverter {
@@ -72,36 +70,49 @@ object ImageMetadataConverter {
 
   // IPTC doesn't appear to enforce the datetime format of the field, which means we have to
   // optimistically attempt various formats observed in the wild. Dire times.
-  private lazy val randomDateFormat = {
-    val parsers = Array(
-      // 2014-12-16T02:23:45+01:00 - Standard dateTimeNoMillis
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser,
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss' 'ZZ").getParser,
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").getParser,
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").getParser,
-      // 2014-12-16T02:23+01:00 - Same as above but missing seconds lol
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm.SSSZZ").getParser,
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mmZZ").getParser,
-      // Tue Dec 16 01:23:45 GMT 2014 - Let's make machine metadata human readable!
-      DateTimeFormat.forPattern("E MMM dd HH:mm:ss.SSS z yyyy").getParser,
-      DateTimeFormat.forPattern("E MMM dd HH:mm:ss z yyyy").getParser,
-      DateTimeFormat.forPattern("E MMM dd HH:mm:ss.SSS 'BST' yyyy").getParser,
-      DateTimeFormat.forPattern("E MMM dd HH:mm:ss 'BST' yyyy").getParser,
-      // 2014-12-16 - Maybe it's just a date
-      ISODateTimeFormat.date.getParser
-    )
-    new DateTimeFormatterBuilder().
-      append(null, parsers).
-      toFormatter
-  }
+  private lazy val dateTimeFormatters: List[DateTimeFormatter] = List(
+    // 2014-12-16T02:23:45+01:00 - Standard dateTimeNoMillis
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"),
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss' 'ZZ"),
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ"),
+
+    // no timezone provided so force UTC rather than use the machine's timezone
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZoneUTC,
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZoneUTC,
+
+    // 2014-12-16T02:23+01:00 - Same as above but missing seconds lol
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm.SSSZZ"),
+    DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mmZZ"),
+    // Tue Dec 16 01:23:45 GMT 2014 - Let's make machine metadata human readable!
+    DateTimeFormat.forPattern("E MMM dd HH:mm:ss.SSS z yyyy"),
+    DateTimeFormat.forPattern("E MMM dd HH:mm:ss z yyyy"),
+
+    /*
+      `BST` can be:
+        - British Summer Time
+        - Bangladesh Standard Time
+        - Bougainville Standard Time
+      See https://24timezones.com/time-zone/bst
+      Be ignorant and assume British Summer Time because we're Europe centric
+     */
+    DateTimeFormat.forPattern("E MMM dd HH:mm:ss.SSS 'BST' yyyy").withZone(DateTimeZone.forOffsetHours(1)),
+    DateTimeFormat.forPattern("E MMM dd HH:mm:ss 'BST' yyyy").withZone(DateTimeZone.forOffsetHours(1)),
+
+
+    // 2014-12-16 - Maybe it's just a date
+    // no timezone provided so force UTC rather than use the machine's timezone
+    ISODateTimeFormat.date.withZoneUTC
+  )
 
   private def parseRandomDate(str: String): Option[DateTime] =
-    safeParsing(randomDateFormat.parseDateTime(str)) map (_.withZone(DateTimeZone.UTC))
+    dateTimeFormatters.foldLeft[Option[DateTime]](None){
+      case (successfulDate@Some(_), _) => successfulDate
+      case (None, formatter) => safeParsing(formatter.parseDateTime(str))
+    }.map(_.withZone(DateTimeZone.UTC))
 
   private def safeParsing[A](parse: => A): Option[A] = Try(parse).toOption
 
-  private def cleanDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+  private def cleanDateFormat = ISODateTimeFormat.dateTime
   def cleanDate(dirtyDate: String, fieldName: String = "none", imageId:String = "none"): String = parseRandomDate(dirtyDate) match {
     case Some(cleanDate) => cleanDateFormat.print(cleanDate)
     case None => {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -83,19 +83,19 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should populate the dateTaken field of ImageMetadata from EXIF Date/Time Original Composite (Mon Jun 18 01:23:45 BST 2018)") {
     val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map("Date/Time Original Composite" -> "Mon Jun 18 01:23:45 BST 2018"), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T00:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from EXIF Date/Time Original Composite with milliseconds (Mon Jun 18 01:23:45.025 BST 2018)") {
     val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map("Date/Time Original Composite" -> "Mon Jun 18 01:23:45.025 BST 2018"), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45.025")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T00:23:45.025Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from IPTC Date Time Created Composite (Mon Jun 18 01:23:45 BST 2018)") {
     val fileMetadata = FileMetadata(iptc = Map("Date Time Created Composite" -> "Mon Jun 18 01:23:45 BST 2018"), exif = Map(), exifSub = Map(), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T01:23:45")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-18T00:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16T02:23:45+01:00)") {
@@ -113,13 +113,13 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2018-06-27T13:54:55)") {
     val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2018-06-27T13:54:55"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(parseDate("2018-06-27T13:54:55")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-27T13:54:55Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2018-06-27T13:54:55.123)") {
     val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2018-06-27T13:54:55.123"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(parseDate("2018-06-27T13:54:55.123")))
+    imageMetadata.dateTaken should be (Some(parseDate("2018-06-27T13:54:55.123Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 GMT 2014)") {
@@ -137,7 +137,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 BST 2014)") {
     val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 BST 2014"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45")))
+    imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T00:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 PDT 2014)") {
@@ -195,47 +195,47 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   }
 
   it("should clean up 'just date' dates into iso format") {
-    ImageMetadataConverter.cleanDate("2014-12-16") shouldBe "2014-12-16T00:00:00.000+00:00"
+    ImageMetadataConverter.cleanDate("2014-12-16") shouldBe "2014-12-16T00:00:00.000Z"
   }
 
   it("should clean up iso dates with seconds into iso format") {
-    ImageMetadataConverter.cleanDate("2014-12-16T01:02:03.040Z") shouldBe "2014-12-16T01:02:03.040+00:00"
+    ImageMetadataConverter.cleanDate("2014-12-16T01:02:03.040Z") shouldBe "2014-12-16T01:02:03.040Z"
   }
 
   it("should clean up iso dates without sub-second precision into iso format") {
-    ImageMetadataConverter.cleanDate("2014-12-16T01:02:03Z") shouldBe "2014-12-16T01:02:03.000+00:00"
+    ImageMetadataConverter.cleanDate("2014-12-16T01:02:03Z") shouldBe "2014-12-16T01:02:03.000Z"
   }
 
   it("should clean up iso dates without seconds into iso format") {
-    ImageMetadataConverter.cleanDate("2014-12-16T01:02Z") shouldBe "2014-12-16T01:02:00.000+00:00"
+    ImageMetadataConverter.cleanDate("2014-12-16T01:02Z") shouldBe "2014-12-16T01:02:00.000Z"
   }
 
   it("should clean up iso dates without seconds but with fractional seconds 'lol' into iso format") {
-    ImageMetadataConverter.cleanDate("2014-12-16T01:02.040Z") shouldBe "2014-12-16T01:02:00.040+00:00"
+    ImageMetadataConverter.cleanDate("2014-12-16T01:02.040Z") shouldBe "2014-12-16T01:02:00.040Z"
   }
 
   it("should clean up machine dates with GMT time zone with subsecond precision into iso format") {
-    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03.040 GMT 2014") shouldBe "2014-12-16T01:02:03.040+00:00"
+    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03.040 GMT 2014") shouldBe "2014-12-16T01:02:03.040Z"
   }
 
   it("should clean up machine dates with GMT time zone without subsecond precision into iso format") {
-    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03 GMT 2014") shouldBe "2014-12-16T01:02:03.000+00:00"
+    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03 GMT 2014") shouldBe "2014-12-16T01:02:03.000Z"
   }
 
   it("should clean up machine dates with valid BST time zone and subsecond precision into iso format") {
-    ImageMetadataConverter.cleanDate("Sat Aug 16 01:02:03.040 BST 2014") shouldBe "2014-08-16T00:02:03.040+00:00"
+    ImageMetadataConverter.cleanDate("Sat Aug 16 01:02:03.040 BST 2014") shouldBe "2014-08-16T00:02:03.040Z"
   }
 
   it("should clean up machine dates with valid BST time zone without subsecond precision into iso format") {
-    ImageMetadataConverter.cleanDate("Sat Aug 16 01:02:03 BST 2014") shouldBe "2014-08-16T00:02:03.000+00:00"
+    ImageMetadataConverter.cleanDate("Sat Aug 16 01:02:03 BST 2014") shouldBe "2014-08-16T00:02:03.000Z"
   }
 
   it("should clean up machine dates with invalid BST time zone and subsecond precision into iso format") {
-    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03.040 BST 2014") shouldBe "2014-12-16T01:02:03.040+00:00"
+    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03.040 BST 2014") shouldBe "2014-12-16T00:02:03.040Z"
   }
 
   it("should clean up machine dates with invalid BST time zone without subsecond precision into iso format") {
-    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03 BST 2014") shouldBe "2014-12-16T01:02:03.000+00:00"
+    ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03 BST 2014") shouldBe "2014-12-16T00:02:03.000Z"
   }
 
 

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -83,7 +83,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Image Rank" -> "3",
         "Original Filename" -> "43885812_SEA.jpg",
         "Exclusive Coverage" -> "False",
-        "Original Create Date Time" -> "0001-01-01T00:00:00.000+00:00"
+        "Original Create Date Time" -> "0001-01-01T00:00:00.000Z"
       )
       val xmp = Map(
         "GettyImagesGIFT:ImageRank" -> "3",
@@ -101,10 +101,10 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "dc:description[1]" -> "Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images",
         "photoshop:City" -> "KITZBUEHEL",
         "GettyImagesGIFT:ExclusiveCoverage" -> "False",
-        "photoshop:DateCreated" -> "2015-01-22T00:00:00.000+00:00",
+        "photoshop:DateCreated" -> "2015-01-22T00:00:00.000Z",
         "photoshop:Credit" -> "AFP/Getty Images",
         "dc:Rights" -> "CHRISTOF STACHE",
-        "GettyImagesGIFT:OriginalCreateDateTime" -> "0001-01-01T00:00:00.000+00:00",
+        "GettyImagesGIFT:OriginalCreateDateTime" -> "0001-01-01T00:00:00.000Z",
         "Iptc4xmpCore:CountryCode" -> "AUT",
         "GettyImagesGIFT:CallForImage" -> "False",
         "photoshop:Country" -> "AUSTRIA",

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -177,7 +177,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Reference Date" -> "2015:04:02",
         "Original Transmission Reference" -> "CRICKET_England_Moeen_111162.JPG",
         "Date Created" -> "2015:04:02",
-        "Date Time Created Composite" -> "Thu Apr 02 16:10:41.000 BST 2015"
+        "Date Time Created Composite" -> "2015-04-02T15:10:41.000Z"
       )
       val exif = Map(
         "Image Description" -> "England's Moeen Ali plays defensively from the bowling of Sri Lanka's Shaminda Eranga, during day five of the second Investec Test match at Headingley, Leeds. PRESS ASSOCIATION Photo. Picture date: Tuesday June 24, 2014. See PA Story CRICKET England. Photo credit should read: Martin Rickett/PA Wire. Editorial use only. RESTRICTIONS: Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
@@ -206,7 +206,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "White Balance" -> "Unknown",
         "Focal Length" -> "600 mm",
         "Date/Time Original" -> "2014:06:24 15:10:41",
-        "Date/Time Original Composite" -> "Tue Jun 24 16:10:41.700 BST 2014",
+        "Date/Time Original Composite" -> "2014-06-24T15:10:41.700Z",
         "White Balance Mode" -> "Auto white balance",
         "Exif Image Width" -> "1264 pixels",
         "Gain Control" -> "Low gain up",
@@ -266,7 +266,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Reference Date" -> "2015:04:02",
         "Original Transmission Reference" -> "CRICKET_England_Moeen_111162.JPG",
         "Date Created" -> "2015:04:02",
-        "Date Time Created Composite" -> "Thu Apr 02 16:10:41.000 BST 2015"
+        "Date Time Created Composite" -> "2015-04-02T15:10:41.000Z"
       )
       val exif = Map(
         "Image Description" -> "England's Moeen Ali plays defensively from the bowling of Sri Lanka's Shaminda Eranga, during day five of the second Investec Test match at Headingley, Leeds. PRESS ASSOCIATION Photo. Picture date: Tuesday June 24, 2014. See PA Story CRICKET England. Photo credit should read: Martin Rickett/PA Wire. Editorial use only. RESTRICTIONS: Use subject to restrictions. Editorial use only. No commercial use. Call 44 (0)1158 447447 for further information.",
@@ -303,7 +303,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "White Balance" -> "Unknown",
         "Focal Length" -> "600 mm",
         "Date/Time Original" -> "2014:06:24 15:10:41",
-        "Date/Time Original Composite" -> "Tue Jun 24 16:10:41.700 BST 2014",
+        "Date/Time Original Composite" -> "2014-06-24T15:10:41.700Z",
         "White Balance Mode" -> "Auto white balance",
         "Exif Image Width" -> "1264 pixels",
         "Gain Control" -> "Low gain up",
@@ -350,7 +350,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "By-line" -> "Graham Turner",
       "Object Name" -> "Tulips",
       "Date Created" -> "2015:04:15",
-      "Date Time Created Composite" -> "Wed Apr 15 02:08:44.000 BST 2015"
+      "Date Time Created Composite" -> "2015-04-15T01:08:44.000Z"
     )
     val exif = Map(
       "Image Description" -> "Reuben Smith age 5 from Hampshire and  \"Darwin Hybrid Mix' tulips in the cut flower Garden at Arundel Castle.\n18,000 tulips were planted in  a total of 52,000 spring bulbs last autumn.\nPhotograph: Graham Turner.",
@@ -376,7 +376,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Flash" -> "Flash did not fire, auto",
       "Focal Length" -> "88 mm",
       "Date/Time Original" -> "2015:04:15 01:08:44",
-      "Date/Time Original Composite" -> "Wed Apr 15 02:08:44.880 BST 2015",
+      "Date/Time Original Composite" -> "2015-04-15T01:08:44.880Z",
       "White Balance Mode" -> "Auto white balance",
       "Shutter Speed Value" -> "1/1599 sec",
       "Exif Image Width" -> "5760 pixels",


### PR DESCRIPTION
## What does this change?
Move to storing computed `fileMetadata` date fields in the `ISODateTimeFormat` as they are easier to parse. From `Sun Aug 25 07:13:27.000 UTC 2019` to `2019-08-25T07:13:27.000Z`.

Here is a sample image on [PROD](https://api.media.gutools.co.uk/images/c35f33340c78a75b09c33c46e68c4c0af211449f/fileMetadata) and [TEST](https://api.media.test.dev-gutools.co.uk/images/c35f33340c78a75b09c33c46e68c4c0af211449f/fileMetadata).

Update the date parsing logic - `getParser` does not obey the timezone, that is `BST` was getting parsed into the local timezone. This is incorrect and means we're now attempting the parsing ourselves.

Finally, `BST` maps to [multiple zones](https://24timezones.com/time-zone/bst):
- British Summer Time
- Bangladesh Standard Time
- Bougainville Standard Time

We're hardcoding to be British Summer Time with `.withZone(DateTimeZone.forOffsetHours(1))`.

## How can success be measured?
Tests can be run from any timezone.

Related https://github.com/guardian/grid/pull/2615

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [x] on TEST
