### PR TITLE
persistence reasons generation logic fix

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -33,6 +33,8 @@ case class Image(
 
   def hasUsages = usages.nonEmpty
 
+  def canBeDeleted = !hasExports && !hasUsages
+
   def rcsPublishDate: Option[DateTime] = syndicationRights.flatMap(_.published)
 
   def hasInferredSyndicationRightsOrNoRights: Boolean = syndicationRights.forall(_.isInferred)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -28,6 +28,11 @@ case class Image(
   collections:         List[Collection] = Nil,
   syndicationRights:   Option[SyndicationRights] = None,
   userMetadataLastModified: Option[DateTime] = None) {
+
+  def hasExports = exports.nonEmpty
+
+  def hasUsages = usages.nonEmpty
+
   def rcsPublishDate: Option[DateTime] = syndicationRights.flatMap(_.published)
 
   def hasInferredSyndicationRightsOrNoRights: Boolean = syndicationRights.forall(_.isInferred)

--- a/media-api/app/lib/ImagePersistenceReasons.scala
+++ b/media-api/app/lib/ImagePersistenceReasons.scala
@@ -1,0 +1,103 @@
+package lib
+
+import com.gu.mediaservice.model.{CommissionedAgency, Illustrator, Image, ImageMetadata, Photographer, UsageRights}
+
+import scala.collection.mutable.ListBuffer
+
+object ImagePersistenceReasons {
+  def apply(persistedRootCollections: List[String], persistenceIdentifier: String): ImagePersistenceReasons =
+    new ImagePersistenceReasons(persistedRootCollections, persistenceIdentifier)
+}
+
+class ImagePersistenceReasons(persistedRootCollections: List[String], persistenceIdentifier: String) {
+
+  def getImagePersistenceReasons(image: Image) = {
+    val reasons = ListBuffer[String]()
+
+    if (hasPersistenceIdentifier(image, persistenceIdentifier))
+      reasons += "persistence-identifier"
+
+    if (hasExports(image))
+      reasons += "exports"
+
+    if (hasUsages(image))
+      reasons += "usages"
+
+    if (isArchived(image))
+      reasons += "archived"
+
+    if (isPhotographerCategory(image.usageRights))
+      reasons += "photographer-category"
+
+    if (isIllustratorCategory(image.usageRights))
+      reasons += "illustrator-category"
+
+    if (isAgencyCommissionedCategory(image.usageRights))
+      reasons += CommissionedAgency.category
+
+    if (hasLeases(image))
+      reasons += "leases"
+
+    if (isInPersistedCollection(image, persistedRootCollections))
+      reasons += "persisted-collection"
+
+    if (hasPhotoshoot(image))
+      reasons += "photoshoot"
+
+    if (hasLabels(image))
+      reasons += "labeled"
+
+    if (hasUserEdits(image))
+      reasons += "edited"
+
+    reasons.toList
+  }
+
+  private def hasExports(image: Image) = image.exports.nonEmpty
+
+  private def hasUsages(image: Image) = image.usages.nonEmpty
+
+  private def isInPersistedCollection(image: Image, persistedRootCollections: List[String]): Boolean = {
+    // list of the first element of each collection's `path`, i.e all the root collections
+    val collectionPaths: List[String] = image.collections.flatMap(_.path.headOption)
+
+    // is image in at least one persisted collection?
+    (collectionPaths diff persistedRootCollections).length < collectionPaths.length
+  }
+
+  private def hasLabels(image: Image) = image.userMetadata.exists(_.labels.nonEmpty)
+
+  private def hasUserEdits(image: Image) =
+    image.userMetadata.exists(ed => ed.metadata != ImageMetadata.empty)
+
+  private def isIllustratorCategory[T <: UsageRights](usageRights: T) =
+    usageRights match {
+      case _: Illustrator => true
+      case _ => false
+    }
+
+  private def isAgencyCommissionedCategory[T <: UsageRights](usageRights: T) =
+    usageRights match {
+      case _: CommissionedAgency => true
+      case _ => false
+    }
+
+  private def isPhotographerCategory[T <: UsageRights](usageRights: T) =
+    usageRights match {
+      case _: Photographer => true
+      case _ => false
+    }
+
+  private def hasPhotoshoot(image: Image): Boolean = image.userMetadata.exists(_.photoshoot.isDefined)
+
+  private def hasPersistenceIdentifier(image: Image, persistenceIdentifier: String) = {
+    image.identifiers.contains(persistenceIdentifier)
+  }
+
+  private def isArchived(image: Image) =
+    image.userMetadata.exists(_.archived)
+
+  private def hasLeases(image: Image) =
+    image.leases.leases.nonEmpty
+
+}

--- a/media-api/app/lib/ImagePersistenceReasons.scala
+++ b/media-api/app/lib/ImagePersistenceReasons.scala
@@ -17,10 +17,10 @@ class ImagePersistenceReasons(persistedRootCollections: List[String], persistenc
     if (hasPersistenceIdentifier(image, persistenceIdentifier))
       reasons += "persistence-identifier"
 
-    if (hasExports(image))
+    if (image.hasExports)
       reasons += "exports"
 
-    if (hasUsages(image))
+    if (image.hasUsages)
       reasons += "usages"
 
     if (isArchived(image))
@@ -52,10 +52,6 @@ class ImagePersistenceReasons(persistedRootCollections: List[String], persistenc
 
     reasons.toList
   }
-
-  private def hasExports(image: Image) = image.exports.nonEmpty
-
-  private def hasUsages(image: Image) = image.usages.nonEmpty
 
   private def isInPersistedCollection(image: Image, persistedRootCollections: List[String]): Boolean = {
     // list of the first element of each collection's `path`, i.e all the root collections

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -349,7 +349,7 @@ object ImageResponse {
       reasons += "photoshoot"
 
     if (hasLabels(image))
-      reasons += "labels"
+      reasons += "labeled"
 
     if (hasUserEdits(image))
       reasons += "edited"
@@ -373,7 +373,8 @@ object ImageResponse {
 
   private def hasLabels(image: Image) = image.userMetadata.exists(_.labels.nonEmpty)
 
-  private def hasUserEdits(image: Image) = image.userMetadata.exists(_.metadata != null)
+  private def hasUserEdits(image: Image) =
+    image.userMetadata.exists(ed => ed.metadata != ImageMetadata.empty)
 
   private def isIllustratorCategory[T <: UsageRights](usageRights: T) =
     usageRights match {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -41,8 +41,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 
   def imagePersistenceReasons(image: Image): List[String] = imgPersistenceReasons.getImagePersistenceReasons(image)
 
-  def canBeDeleted(image: Image) =
-    !image.hasExports && !image.hasUsages
+  def canBeDeleted(image: Image) = image.canBeDeleted
 
   def create(
               id: String,

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -117,7 +117,17 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       reasons += "photoshoot"
     }
 
+    if (hasUserEdits(image)) {
+      reasons += "edited"
+    }
+
     reasons.toList
+  }
+
+  def hasUserEdits(image: Image) = {
+    val hasUserMeta = image.userMetadata.exists(_.metadata != null)
+    val hasUserLabels = image.userMetadata.exists(_.labels.nonEmpty)
+    hasUserMeta || hasUserLabels
   }
 
   def canBeDeleted(image: Image) = ! hasExports(image) && ! hasUsages(image)
@@ -276,7 +286,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     __.read[JsObject].map { root =>
       val edits = (root \ "userMetadata").asOpt[Edits].getOrElse(Edits.getEmpty)
       val editsJson = Json.toJson(editsEmbeddedEntity(id, edits))
-      
+
       root ++ Json.obj("userMetadata" -> editsJson)
     }
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -15,7 +15,6 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.utils.UriEncoding
 
-import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Try}
 
 class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: UsageQuota) extends EditsResponse {
@@ -38,13 +37,12 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   type MediaLeaseEntity = EmbeddedEntity[MediaLease]
   type MediaLeasesEntity = EmbeddedEntity[LeasesByMedia]
 
-  import ImageResponse.{imagePersistenceReasonsFunction, canImgBeDeleted}
+  private val imgPersistenceReasons = ImagePersistenceReasons.apply(config.persistedRootCollections, config.persistenceIdentifier)
 
-  private val getImagePersistenceReasonsFunction = imagePersistenceReasonsFunction(config.persistedRootCollections, config.persistenceIdentifier)
+  def imagePersistenceReasons(image: Image): List[String] = imgPersistenceReasons.getImagePersistenceReasons(image)
 
-  def imagePersistenceReasons(image: Image): List[String] = getImagePersistenceReasonsFunction(image)
-
-  def canBeDeleted(image: Image) = canImgBeDeleted(image)
+  def canBeDeleted(image: Image) =
+    !image.hasExports && !image.hasUsages
 
   def create(
               id: String,
@@ -315,96 +313,11 @@ object ImageResponse {
 
   def normaliseNewLines(string: String): String = pattern.replaceAllIn(string, "\n")
 
-  def imagePersistenceReasonsFunction(persistedRootCollections: List[String], persistenceIdentifier: String): Image => List[String] = (image: Image) => {
-    val reasons = ListBuffer[String]()
-
-    if (hasPersistenceIdentifier(image, persistenceIdentifier))
-      reasons += "persistence-identifier"
-
-    if (hasExports(image))
-      reasons += "exports"
-
-    if (hasUsages(image))
-      reasons += "usages"
-
-    if (isArchived(image))
-      reasons += "archived"
-
-    if (isPhotographerCategory(image.usageRights))
-      reasons += "photographer-category"
-
-    if (isIllustratorCategory(image.usageRights))
-      reasons += "illustrator-category"
-
-    if (isAgencyCommissionedCategory(image.usageRights))
-      reasons += CommissionedAgency.category
-
-    if (hasLeases(image))
-      reasons += "leases"
-
-    if (isInPersistedCollection(image, persistedRootCollections))
-      reasons += "persisted-collection"
-
-    if (hasPhotoshoot(image))
-      reasons += "photoshoot"
-
-    if (hasLabels(image))
-      reasons += "labeled"
-
-    if (hasUserEdits(image))
-      reasons += "edited"
-
-    reasons.toList
-  }
-
   def canImgBeDeleted(image: Image) = !hasExports(image) && !hasUsages(image)
 
   private def hasExports(image: Image) = image.exports.nonEmpty
 
   private def hasUsages(image: Image) = image.usages.nonEmpty
-
-  private def isInPersistedCollection(image: Image, persistedRootCollections: List[String]): Boolean = {
-    // list of the first element of each collection's `path`, i.e all the root collections
-    val collectionPaths: List[String] = image.collections.flatMap(_.path.headOption)
-
-    // is image in at least one persisted collection?
-    (collectionPaths diff persistedRootCollections).length < collectionPaths.length
-  }
-
-  private def hasLabels(image: Image) = image.userMetadata.exists(_.labels.nonEmpty)
-
-  private def hasUserEdits(image: Image) =
-    image.userMetadata.exists(ed => ed.metadata != ImageMetadata.empty)
-
-  private def isIllustratorCategory[T <: UsageRights](usageRights: T) =
-    usageRights match {
-      case _: Illustrator => true
-      case _ => false
-    }
-
-  private def isAgencyCommissionedCategory[T <: UsageRights](usageRights: T) =
-    usageRights match {
-      case _: CommissionedAgency => true
-      case _ => false
-    }
-
-  private def isPhotographerCategory[T <: UsageRights](usageRights: T) =
-    usageRights match {
-      case _: Photographer => true
-      case _ => false
-    }
-
-  private def hasPhotoshoot(image: Image): Boolean = image.userMetadata.exists(_.photoshoot.isDefined)
-
-  private def hasPersistenceIdentifier(image: Image, persistenceIdentifier: String) = {
-    image.identifiers.contains(persistenceIdentifier)
-  }
-
-  private def isArchived(image: Image) =
-    image.userMetadata.exists(_.archived)
-
-  private def hasLeases(image: Image) =
-    image.leases.leases.nonEmpty
 }
 
 // We're using this to slightly hydrate the json response

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -342,17 +342,18 @@ object ImageResponse {
     if (hasLeases(image))
       reasons += "leases"
 
-    if (isInPersistedCollection(image, persistedRootCollections)) {
+    if (isInPersistedCollection(image, persistedRootCollections))
       reasons += "persisted-collection"
-    }
 
-    if (hasPhotoshoot(image)) {
+    if (hasPhotoshoot(image))
       reasons += "photoshoot"
-    }
 
-    if (hasUserEdits(image)) {
+    if (hasLabels(image))
+      reasons += "labels"
+
+    if (hasUserEdits(image))
       reasons += "edited"
-    }
+
     reasons.toList
   }
 
@@ -370,11 +371,9 @@ object ImageResponse {
     (collectionPaths diff persistedRootCollections).length < collectionPaths.length
   }
 
-  private def hasUserEdits(image: Image) = {
-    val hasUserMeta = image.userMetadata.exists(_.metadata != null)
-    val hasUserLabels = image.userMetadata.exists(_.labels.nonEmpty)
-    hasUserMeta || hasUserLabels
-  }
+  private def hasLabels(image: Image) = image.userMetadata.exists(_.labels.nonEmpty)
+
+  private def hasUserEdits(image: Image) = image.userMetadata.exists(_.metadata != null)
 
   private def isIllustratorCategory[T <: UsageRights](usageRights: T) =
     usageRights match {

--- a/media-api/test/lib/ImagePersistenceReasonsTest.scala
+++ b/media-api/test/lib/ImagePersistenceReasonsTest.scala
@@ -1,0 +1,54 @@
+package lib
+
+import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.usage.Usage
+import org.joda.time.DateTime.now
+import org.scalatest.{FunSpec, Matchers}
+
+class ImagePersistenceReasonsTest extends FunSpec with Matchers {
+
+  it("should generate image persistence reasons") {
+
+    import TestUtils._
+
+    val persistedIdentifier = "test-p-id"
+    val persistedRootCollections = List("coll1", "coll2", "coll3")
+    val imgPersistenceReasons = ImagePersistenceReasons.apply(persistedRootCollections, persistedIdentifier)
+
+    imgPersistenceReasons.getImagePersistenceReasons(img) shouldBe Nil
+    val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
+    val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithExports) shouldBe List("exports")
+    val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithUsages) shouldBe List("usages")
+    val imgWithArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = ImageMetadata.empty)))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithArchive) shouldBe List("archived")
+    val imgWithPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithPhotographerCategory) shouldBe List("photographer-category")
+    val imgWithIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithIllustratorCategory) shouldBe List("illustrator-category")
+    val imgWithAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
+    val imgWithLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithLeases) shouldBe List("leases")
+    val imgWithPersistedRootCollections = img.copy(collections = List(Collection.build(persistedRootCollections.tail, ActionData("testAuthor", now()))))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithPersistedRootCollections) shouldBe List("persisted-collection")
+
+    val imgWithPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithPhotoshoot) shouldBe List("photoshoot")
+
+    val imgWithUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithUserEdits) shouldBe List("edited")
+
+    val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, labels = List("test-label"))))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithLabels) shouldBe List("labeled")
+
+    val imgWithMultipleReasons = img.copy(userMetadata = Some(Edits(
+      labels = List("test-label"),
+      metadata = ImageMetadata(title = Some("test")),
+      photoshoot = Some(Photoshoot("test")))))
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithMultipleReasons) should contain theSameElementsAs List("labeled", "edited", "photoshoot")
+  }
+
+}

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -54,7 +54,7 @@ class ImageResponseTest extends FunSpec with Matchers {
     getImagePersistenceReasonsFunction(imgWithExports) shouldBe List("exports")
     val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
     getImagePersistenceReasonsFunction(imgWithUsages) shouldBe List("usages")
-    val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = null)))
+    val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = ImageMetadata.empty)))
     getImagePersistenceReasonsFunction(imgWitArchive) shouldBe List("archived")
     val imgWitPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
     getImagePersistenceReasonsFunction(imgWitPhotographerCategory) shouldBe List("photographer-category")
@@ -67,14 +67,20 @@ class ImageResponseTest extends FunSpec with Matchers {
     val imgWitPersistedRootCollections = img.copy(collections = List(Collection.build(persistedRootCollections.tail, ActionData("testAuthor", now()))))
     getImagePersistenceReasonsFunction(imgWitPersistedRootCollections) shouldBe List("persisted-collection")
 
-    val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")), photoshoot = Some(Photoshoot("test")))))
-    getImagePersistenceReasonsFunction(imgWitPhotoshoot) shouldBe List("photoshoot", "edited")
+    val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
+    getImagePersistenceReasonsFunction(imgWitPhotoshoot) shouldBe List("photoshoot")
 
     val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
     getImagePersistenceReasonsFunction(imgWitUserEdits) shouldBe List("edited")
 
-    val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = null, labels = List("test-label"))))
-    getImagePersistenceReasonsFunction(imgWithLabels) shouldBe List("labels")
+    val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, labels = List("test-label"))))
+    getImagePersistenceReasonsFunction(imgWithLabels) shouldBe List("labeled")
+
+    val imgWithMultipleReasons = img.copy(userMetadata = Some(Edits(
+      labels = List("test-label"),
+      metadata = ImageMetadata(title = Some("test")),
+      photoshoot = Some(Photoshoot("test")))))
+    getImagePersistenceReasonsFunction(imgWithMultipleReasons) should contain theSameElementsAs  List("labeled", "edited", "photoshoot")
   }
 
   it("should indicate if image can be deleted" +

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -2,10 +2,8 @@ package lib
 
 import com.gu.mediaservice.model.usage.Usage
 import com.gu.mediaservice.model.{CommissionedAgency, ContractPhotographer, Crop, Edits, Image, ImageMetadata, LeasesByMedia, MediaLease, Photoshoot, StaffIllustrator, StaffPhotographer, UsageRights}
-import com.typesafe.config.{ConfigFactory, ConfigValue, ConfigValueFactory}
 import org.joda.time.DateTime
 import org.scalatest.{FunSpec, Matchers}
-import play.api.Configuration
 
 class ImageResponseTest extends FunSpec with Matchers {
   it("should replace \\r linebreaks with \\n") {
@@ -47,41 +45,31 @@ class ImageResponseTest extends FunSpec with Matchers {
     )
 
     val persistedIdentifier = "test-p-id"
-
     val persistedRootCollections = List()
+    val getImagePersistenceReasonsFunction =  ImageResponse.imagePersistenceReasonsFunction(persistedRootCollections, persistedIdentifier)
 
-    ImageResponse.imagePersistenceReasonsFoo(img, persistedRootCollections, persistedIdentifier) shouldBe Nil
+    getImagePersistenceReasonsFunction(img) shouldBe Nil
     val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
-    ImageResponse.imagePersistenceReasonsFoo(imgWithPersistenceIdentifier, persistedRootCollections, persistedIdentifier) shouldBe List("persistence-identifier")
+    getImagePersistenceReasonsFunction(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
     val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
-    ImageResponse.imagePersistenceReasonsFoo(imgWithExports, persistedRootCollections, persistedIdentifier) shouldBe List("exports")
+    getImagePersistenceReasonsFunction(imgWithExports) shouldBe List("exports")
     val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
-    ImageResponse.imagePersistenceReasonsFoo(imgWithUsages, persistedRootCollections, persistedIdentifier) shouldBe List("usages")
+    getImagePersistenceReasonsFunction(imgWithUsages) shouldBe List("usages")
     val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = null)))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitArchive, persistedRootCollections, persistedIdentifier) shouldBe List("archived")
+    getImagePersistenceReasonsFunction(imgWitArchive) shouldBe List("archived")
     val imgWitPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitPhotographerCategory, persistedRootCollections, persistedIdentifier) shouldBe List("photographer-category")
+    getImagePersistenceReasonsFunction(imgWitPhotographerCategory) shouldBe List("photographer-category")
     val imgWitIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitIllustratorCategory, persistedRootCollections, persistedIdentifier) shouldBe List("illustrator-category")
+    getImagePersistenceReasonsFunction(imgWitIllustratorCategory) shouldBe List("illustrator-category")
     val imgWitAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitAgencyCommissionedCategory, persistedRootCollections, persistedIdentifier) shouldBe List(CommissionedAgency.category)
+    getImagePersistenceReasonsFunction(imgWitAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
     val imgWitLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitLeases, persistedRootCollections, persistedIdentifier) shouldBe List("leases")
+    getImagePersistenceReasonsFunction(imgWitLeases) shouldBe List("leases")
 
     val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")), photoshoot = Some(Photoshoot("test")))))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitPhotoshoot, persistedRootCollections, persistedIdentifier) shouldBe List("photoshoot", "edited")
+    getImagePersistenceReasonsFunction(imgWitPhotoshoot) shouldBe List("photoshoot", "edited")
 
     val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
-    ImageResponse.imagePersistenceReasonsFoo(imgWitUserEdits, persistedRootCollections, persistedIdentifier) shouldBe List("edited")
-  }
-
-  private def buildMediaAPIConfig = {
-    import scala.collection.JavaConverters._
-
-    val configs = Map[String, ConfigValue](
-      "persistence.identifier" -> ConfigValueFactory.fromAnyRef("test-p-id")
-    )
-    val typeSafeCfg = ConfigFactory.parseMap(configs.asJava)
-    new MediaApiConfig(new Configuration(typeSafeCfg))
+    getImagePersistenceReasonsFunction(imgWitUserEdits) shouldBe List("edited")
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -1,6 +1,11 @@
 package lib
 
+import com.gu.mediaservice.model.usage.Usage
+import com.gu.mediaservice.model.{CommissionedAgency, ContractPhotographer, Crop, Edits, Image, ImageMetadata, LeasesByMedia, MediaLease, Photoshoot, StaffIllustrator, StaffPhotographer, UsageRights}
+import com.typesafe.config.{ConfigFactory, ConfigValue, ConfigValueFactory}
+import org.joda.time.DateTime
 import org.scalatest.{FunSpec, Matchers}
+import play.api.Configuration
 
 class ImageResponseTest extends FunSpec with Matchers {
   it("should replace \\r linebreaks with \\n") {
@@ -19,5 +24,66 @@ class ImageResponseTest extends FunSpec with Matchers {
     val text = "Here is some text\nthat spans across\nmultiple lines\n"
     val normalisedText = ImageResponse.normaliseNewLines(text)
     normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
+  }
+
+  it("should generate image persistence reasons") {
+    import DateTime.now
+    val img = Image(
+      id = "test-id",
+      uploadTime = now(),
+      uploadedBy = "user",
+      lastModified = None,
+      identifiers = Map.empty,
+      uploadInfo = null,
+      source = null,
+      thumbnail = None,
+      optimisedPng = None,
+      fileMetadata = null,
+      userMetadata = None,
+      metadata = null,
+      originalMetadata = null,
+      usageRights = null,
+      originalUsageRights = null
+    )
+
+    val mediaApiCfg = buildMediaAPIConfig
+    val noS3Client = null
+    val noUsageQuota = null
+    val imageResponse = new ImageResponse(mediaApiCfg, noS3Client, noUsageQuota)
+    import imageResponse._
+
+    imagePersistenceReasons(img) shouldBe Nil
+    val imgWithPersistenceIdentifier = img.copy(identifiers = Map(mediaApiCfg.persistenceIdentifier -> "test-id"))
+    imagePersistenceReasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
+    val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
+    imagePersistenceReasons(imgWithExports) shouldBe List("exports")
+    val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
+    imagePersistenceReasons(imgWithUsages) shouldBe List("usages")
+    val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = null)))
+    imagePersistenceReasons(imgWitArchive) shouldBe List("archived")
+    val imgWitPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
+    imagePersistenceReasons(imgWitPhotographerCategory) shouldBe List("photographer-category")
+    val imgWitIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
+    imagePersistenceReasons(imgWitIllustratorCategory) shouldBe List("illustrator-category")
+    val imgWitAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
+    imagePersistenceReasons(imgWitAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
+    val imgWitLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
+    imagePersistenceReasons(imgWitLeases) shouldBe List("leases")
+
+    val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")), photoshoot = Some(Photoshoot("test")))))
+    imagePersistenceReasons(imgWitPhotoshoot) shouldBe List("photoshoot", "edited")
+
+    val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
+    imagePersistenceReasons(imgWitUserEdits) shouldBe List("edited")
+  }
+
+  private def buildMediaAPIConfig = {
+    import scala.collection.JavaConverters._
+
+    val configs = Map[String, ConfigValue](
+      "persistence.identifier" -> ConfigValueFactory.fromAnyRef("test-p-id")
+    )
+    val typeSafeCfg = ConfigFactory.parseMap(configs.asJava)
+    new MediaApiConfig(new Configuration(typeSafeCfg))
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -45,42 +45,42 @@ class ImageResponseTest extends FunSpec with Matchers {
   it("should generate image persistence reasons") {
     val persistedIdentifier = "test-p-id"
     val persistedRootCollections = List("coll1", "coll2", "coll3")
-    val getImagePersistenceReasonsFunction = ImageResponse.imagePersistenceReasonsFunction(persistedRootCollections, persistedIdentifier)
+    val imgPersistenceReasons = ImagePersistenceReasons.apply(persistedRootCollections, persistedIdentifier)
 
-    getImagePersistenceReasonsFunction(img) shouldBe Nil
+    imgPersistenceReasons.getImagePersistenceReasons(img) shouldBe Nil
     val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
-    getImagePersistenceReasonsFunction(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
     val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
-    getImagePersistenceReasonsFunction(imgWithExports) shouldBe List("exports")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithExports) shouldBe List("exports")
     val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
-    getImagePersistenceReasonsFunction(imgWithUsages) shouldBe List("usages")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithUsages) shouldBe List("usages")
     val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = ImageMetadata.empty)))
-    getImagePersistenceReasonsFunction(imgWitArchive) shouldBe List("archived")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitArchive) shouldBe List("archived")
     val imgWitPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
-    getImagePersistenceReasonsFunction(imgWitPhotographerCategory) shouldBe List("photographer-category")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitPhotographerCategory) shouldBe List("photographer-category")
     val imgWitIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
-    getImagePersistenceReasonsFunction(imgWitIllustratorCategory) shouldBe List("illustrator-category")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitIllustratorCategory) shouldBe List("illustrator-category")
     val imgWitAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
-    getImagePersistenceReasonsFunction(imgWitAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
     val imgWitLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
-    getImagePersistenceReasonsFunction(imgWitLeases) shouldBe List("leases")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitLeases) shouldBe List("leases")
     val imgWitPersistedRootCollections = img.copy(collections = List(Collection.build(persistedRootCollections.tail, ActionData("testAuthor", now()))))
-    getImagePersistenceReasonsFunction(imgWitPersistedRootCollections) shouldBe List("persisted-collection")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitPersistedRootCollections) shouldBe List("persisted-collection")
 
     val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
-    getImagePersistenceReasonsFunction(imgWitPhotoshoot) shouldBe List("photoshoot")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitPhotoshoot) shouldBe List("photoshoot")
 
     val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
-    getImagePersistenceReasonsFunction(imgWitUserEdits) shouldBe List("edited")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWitUserEdits) shouldBe List("edited")
 
     val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, labels = List("test-label"))))
-    getImagePersistenceReasonsFunction(imgWithLabels) shouldBe List("labeled")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithLabels) shouldBe List("labeled")
 
     val imgWithMultipleReasons = img.copy(userMetadata = Some(Edits(
       labels = List("test-label"),
       metadata = ImageMetadata(title = Some("test")),
       photoshoot = Some(Photoshoot("test")))))
-    getImagePersistenceReasonsFunction(imgWithMultipleReasons) should contain theSameElementsAs  List("labeled", "edited", "photoshoot")
+    imgPersistenceReasons.getImagePersistenceReasons(imgWithMultipleReasons) should contain theSameElementsAs  List("labeled", "edited", "photoshoot")
   }
 
   it("should indicate if image can be deleted" +

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -24,67 +24,11 @@ class ImageResponseTest extends FunSpec with Matchers {
     normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
   }
 
-  private val img = Image(
-    id = "test-id",
-    uploadTime = now(),
-    uploadedBy = "user",
-    lastModified = None,
-    identifiers = Map.empty,
-    uploadInfo = null,
-    source = null,
-    thumbnail = None,
-    optimisedPng = None,
-    fileMetadata = null,
-    userMetadata = None,
-    metadata = null,
-    originalMetadata = null,
-    usageRights = null,
-    originalUsageRights = null
-  )
-
-  it("should generate image persistence reasons") {
-    val persistedIdentifier = "test-p-id"
-    val persistedRootCollections = List("coll1", "coll2", "coll3")
-    val imgPersistenceReasons = ImagePersistenceReasons.apply(persistedRootCollections, persistedIdentifier)
-
-    imgPersistenceReasons.getImagePersistenceReasons(img) shouldBe Nil
-    val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
-    val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithExports) shouldBe List("exports")
-    val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithUsages) shouldBe List("usages")
-    val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = ImageMetadata.empty)))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitArchive) shouldBe List("archived")
-    val imgWitPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitPhotographerCategory) shouldBe List("photographer-category")
-    val imgWitIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitIllustratorCategory) shouldBe List("illustrator-category")
-    val imgWitAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
-    val imgWitLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitLeases) shouldBe List("leases")
-    val imgWitPersistedRootCollections = img.copy(collections = List(Collection.build(persistedRootCollections.tail, ActionData("testAuthor", now()))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitPersistedRootCollections) shouldBe List("persisted-collection")
-
-    val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitPhotoshoot) shouldBe List("photoshoot")
-
-    val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWitUserEdits) shouldBe List("edited")
-
-    val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, labels = List("test-label"))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithLabels) shouldBe List("labeled")
-
-    val imgWithMultipleReasons = img.copy(userMetadata = Some(Edits(
-      labels = List("test-label"),
-      metadata = ImageMetadata(title = Some("test")),
-      photoshoot = Some(Photoshoot("test")))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithMultipleReasons) should contain theSameElementsAs  List("labeled", "edited", "photoshoot")
-  }
-
   it("should indicate if image can be deleted" +
     "(it can be deleted if there is no exports or usages)") {
+
+    import TestUtils._
+
     val testCrop = Crop(Some("crop-id"), None, None, CropSpec("test-uri", Bounds(0, 0, 0, 0), None), None, Nil)
     val testUsage = Usage(id = "usage-id", references = Nil, platform = PrintUsage, media = "test", status = PendingUsageStatus, dateAdded = None, dateRemoved = None, now())
 

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -46,35 +46,33 @@ class ImageResponseTest extends FunSpec with Matchers {
       originalUsageRights = null
     )
 
-    val mediaApiCfg = buildMediaAPIConfig
-    val noS3Client = null
-    val noUsageQuota = null
-    val imageResponse = new ImageResponse(mediaApiCfg, noS3Client, noUsageQuota)
-    import imageResponse._
+    val persistedIdentifier = "test-p-id"
 
-    imagePersistenceReasons(img) shouldBe Nil
-    val imgWithPersistenceIdentifier = img.copy(identifiers = Map(mediaApiCfg.persistenceIdentifier -> "test-id"))
-    imagePersistenceReasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
+    val persistedRootCollections = List()
+
+    ImageResponse.imagePersistenceReasonsFoo(img, persistedRootCollections, persistedIdentifier) shouldBe Nil
+    val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
+    ImageResponse.imagePersistenceReasonsFoo(imgWithPersistenceIdentifier, persistedRootCollections, persistedIdentifier) shouldBe List("persistence-identifier")
     val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
-    imagePersistenceReasons(imgWithExports) shouldBe List("exports")
+    ImageResponse.imagePersistenceReasonsFoo(imgWithExports, persistedRootCollections, persistedIdentifier) shouldBe List("exports")
     val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
-    imagePersistenceReasons(imgWithUsages) shouldBe List("usages")
+    ImageResponse.imagePersistenceReasonsFoo(imgWithUsages, persistedRootCollections, persistedIdentifier) shouldBe List("usages")
     val imgWitArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = null)))
-    imagePersistenceReasons(imgWitArchive) shouldBe List("archived")
+    ImageResponse.imagePersistenceReasonsFoo(imgWitArchive, persistedRootCollections, persistedIdentifier) shouldBe List("archived")
     val imgWitPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
-    imagePersistenceReasons(imgWitPhotographerCategory) shouldBe List("photographer-category")
+    ImageResponse.imagePersistenceReasonsFoo(imgWitPhotographerCategory, persistedRootCollections, persistedIdentifier) shouldBe List("photographer-category")
     val imgWitIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
-    imagePersistenceReasons(imgWitIllustratorCategory) shouldBe List("illustrator-category")
+    ImageResponse.imagePersistenceReasonsFoo(imgWitIllustratorCategory, persistedRootCollections, persistedIdentifier) shouldBe List("illustrator-category")
     val imgWitAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
-    imagePersistenceReasons(imgWitAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
+    ImageResponse.imagePersistenceReasonsFoo(imgWitAgencyCommissionedCategory, persistedRootCollections, persistedIdentifier) shouldBe List(CommissionedAgency.category)
     val imgWitLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
-    imagePersistenceReasons(imgWitLeases) shouldBe List("leases")
+    ImageResponse.imagePersistenceReasonsFoo(imgWitLeases, persistedRootCollections, persistedIdentifier) shouldBe List("leases")
 
     val imgWitPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")), photoshoot = Some(Photoshoot("test")))))
-    imagePersistenceReasons(imgWitPhotoshoot) shouldBe List("photoshoot", "edited")
+    ImageResponse.imagePersistenceReasonsFoo(imgWitPhotoshoot, persistedRootCollections, persistedIdentifier) shouldBe List("photoshoot", "edited")
 
     val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
-    imagePersistenceReasons(imgWitUserEdits) shouldBe List("edited")
+    ImageResponse.imagePersistenceReasonsFoo(imgWitUserEdits, persistedRootCollections, persistedIdentifier) shouldBe List("edited")
   }
 
   private def buildMediaAPIConfig = {

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -72,6 +72,9 @@ class ImageResponseTest extends FunSpec with Matchers {
 
     val imgWitUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
     getImagePersistenceReasonsFunction(imgWitUserEdits) shouldBe List("edited")
+
+    val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = null, labels = List("test-label"))))
+    getImagePersistenceReasonsFunction(imgWithLabels) shouldBe List("labels")
   }
 
   it("should indicate if image can be deleted" +

--- a/media-api/test/lib/TestUtils.scala
+++ b/media-api/test/lib/TestUtils.scala
@@ -1,0 +1,26 @@
+package lib
+
+import com.gu.mediaservice.model.Image
+import org.joda.time.DateTime.now
+
+object TestUtils {
+
+  val img = Image(
+    id = "test-id",
+    uploadTime = now(),
+    uploadedBy = "user",
+    lastModified = None,
+    identifiers = Map.empty,
+    uploadInfo = null,
+    source = null,
+    thumbnail = None,
+    optimisedPng = None,
+    fileMetadata = null,
+    userMetadata = None,
+    metadata = null,
+    originalMetadata = null,
+    usageRights = null,
+    originalUsageRights = null
+  )
+
+}


### PR DESCRIPTION
## Fix for Persistence reasons logic
it mainly fix bug: "Edit metadata of an image or add a label, notice it won’t turn persisted"

Plus test coverage for Persistence reasons logic

## How can success be measured?

In Grid after editing title or description or adding a label of a image, image is persisted

## Tested?
- [x] locally
- [x] on TEST

## Screenshots

![Screenshot 2019-09-09 at 14 33 30](https://user-images.githubusercontent.com/10913420/64535316-f7afb080-d30e-11e9-9e72-bb4dd48d75ce.png)

