### PR TITLE
Revert "log xmp metadata extracted from image"

### DIFF
--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -15,10 +15,8 @@ import com.drew.metadata.{Directory, Metadata}
 import com.gu.mediaservice.lib.imaging.im4jwrapper.ImageMagick._
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
 import com.gu.mediaservice.model.{Dimensions, FileMetadata}
-import net.logstash.logback.marker.{LogstashMarker, Markers}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.ISODateTimeFormat
-import play.api.Logger
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -117,40 +115,29 @@ object FileMetadataReader {
       }
     } getOrElse Map()
 
-  private def toLogstashFriendlyMarkers(data: Map[String, String]): LogstashMarker = {
-    val cleaned = data.collect {
-      case (key, value) => key.replaceAll("[\\[\\]:/]", "") -> value
-    }
-
-    Markers.appendEntries(cleaned.asJava)
-  }
-
   // Getty made up their own XMP namespace.
   // We're awaiting actual documentation of the properties available, so
   // this only extracts a small subset of properties as a means to identify Getty images.
   private def exportGettyDirectory(metadata: Metadata, imageId:String): Map[String, String] = {
-    val xmpProperties: Map[String, String] = exportXmpProperties(metadata, imageId)
+      val xmpProperties = exportXmpProperties(metadata, imageId)
 
-    val markers = toLogstashFriendlyMarkers(xmpProperties ++ Map("id" -> imageId))
-    Logger.info(s"Extracted xmp metadata for image ${imageId}")(markers)
+      def readProperty(name: String): Option[String] = xmpProperties.get(name)
 
-    def readProperty(name: String): Option[String] = xmpProperties.get(name)
+      def readAssetId: Option[String] = readProperty("GettyImagesGIFT:AssetId").orElse(readProperty("GettyImagesGIFT:AssetID"))
 
-    def readAssetId: Option[String] = readProperty("GettyImagesGIFT:AssetId").orElse(readProperty("GettyImagesGIFT:AssetID"))
-
-    Map(
-      "Asset ID" -> readAssetId,
-      "Call For Image" -> readProperty("GettyImagesGIFT:CallForImage"),
-      "Camera Filename" -> readProperty("GettyImagesGIFT:CameraFilename"),
-      "Camera Make Model" -> readProperty("GettyImagesGIFT:CameraMakeModel"),
-      "Composition" -> readProperty("GettyImagesGIFT:Composition"),
-      "Exclusive Coverage" -> readProperty("GettyImagesGIFT:ExclusiveCoverage"),
-      "Image Rank" -> readProperty("GettyImagesGIFT:ImageRank"),
-      "Original Create Date Time" -> readProperty("GettyImagesGIFT:OriginalCreateDateTime"),
-      "Original Filename" -> readProperty("GettyImagesGIFT:OriginalFilename"),
-      "Personality" -> readProperty("GettyImagesGIFT:Personality"),
-      "Time Shot" -> readProperty("GettyImagesGIFT:TimeShot")
-    ).flattenOptions
+      Map(
+        "Asset ID" -> readAssetId,
+        "Call For Image" -> readProperty("GettyImagesGIFT:CallForImage"),
+        "Camera Filename" -> readProperty("GettyImagesGIFT:CameraFilename"),
+        "Camera Make Model" -> readProperty("GettyImagesGIFT:CameraMakeModel"),
+        "Composition" -> readProperty("GettyImagesGIFT:Composition"),
+        "Exclusive Coverage" -> readProperty("GettyImagesGIFT:ExclusiveCoverage"),
+        "Image Rank" -> readProperty("GettyImagesGIFT:ImageRank"),
+        "Original Create Date Time" -> readProperty("GettyImagesGIFT:OriginalCreateDateTime"),
+        "Original Filename" -> readProperty("GettyImagesGIFT:OriginalFilename"),
+        "Personality" -> readProperty("GettyImagesGIFT:Personality"),
+        "Time Shot" -> readProperty("GettyImagesGIFT:TimeShot")
+      ).flattenOptions
   }
 
   private def dateToUTCString(date: DateTime): String = ISODateTimeFormat.dateTime.print(date.withZone(DateTimeZone.UTC))


### PR DESCRIPTION
Reverts guardian/grid#2631

This was originally added to help diagnose a metadata reading problem, which is fixed in https://github.com/guardian/grid/pull/2634.