### PR TITLE
Allow selecting truncated filename in viewer

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -210,7 +210,7 @@
             <dd ng:if="ctrl.image.data.uploadInfo.filename"
                 class="image-info__group--dl__value metadata-line__info"
                 title="{{ctrl.image.data.uploadInfo.filename}}">
-                        <span class="metadata-line__info">
+                        <span class="metadata-line__info select-all-wrap">
                             {{ctrl.image.data.uploadInfo.filename}}
                         </span>
             </dd>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1809,6 +1809,10 @@ FIXME: what to do with touch devices
     padding-bottom: 10px;
 }
 
+.select-all-wrap {
+    user-select: all;
+}
+
 .metadata-line__info--crop {
     padding-bottom: 0;
 }


### PR DESCRIPTION
## What does this change?
Double-clicking on (oftentimes) truncated filename in viewer does not select the whole of it for copying (unlike in the browser’s info panel). This change allows that.

## How can success be measured?
At least one person, once, tries successfully to copy the whole filename while seeing it truncated in the UI.

## Screenshots (if applicable)
Don’t be ridiculous.

## Who should look at this?
Ideally nobody, cos I don’t know what BEM is.

## Tested?
- [x] locally
- [x] on TEST
