### PR TITLE
prevent image download with right click

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -141,26 +141,26 @@
 <div class="image-holder">
     <div class="easel">
         <div class="easel__canvas"
-            ng:if="!ctrl.crop"
-        >
-            <img class="easel__image easel__image--checkered__background"
-                 alt="preview of original image"
-                 ng:src="{{:: ctrl.optimisedImageUri}}"
-                 grid:track-image="ctrl.image"
-                 grid:track-image-location="original"
-                 grid:track-image-loadtime
-                 gr:image-fade-on-load
-                 ui:drag-data="ctrl.image | asImageDragData" />
+             ng:if="!ctrl.crop"
+             draggable="true"
+             ui:drag-data="ctrl.image | asImageDragData">
+          <img class="easel__image easel__image--checkered__background"
+               alt="preview of original image"
+               ng:src="{{:: ctrl.optimisedImageUri}}"
+               grid:track-image="ctrl.image"
+               grid:track-image-location="original"
+               grid:track-image-loadtime
+               gr:image-fade-on-load/>
         </div>
 
         <!-- TODO: As this loads async, add a loader -->
-        <div class="easel__canvas" ng:if="ctrl.crop">
-            <a draggable="true"
-               class="easel__image-container"
+        <div class="easel__canvas" ng:if="ctrl.crop"
+             draggable="true"
+             ui:drag-data="ctrl.image | asImageAndCropsDragData:ctrl.crop"
+             ui:drag-image="extremeAssets.smallest | assetFile">
+            <a class="easel__image-container"
                ng:init="extremeAssets = (ctrl.crop | getExtremeAssets)"
-               ui:sref="{crop: ctrl.cropKey}"
-               ui:drag-data="ctrl.image | asImageAndCropsDragData:ctrl.crop"
-               ui:drag-image="extremeAssets.smallest | assetFile">
+               ui:sref="{crop: ctrl.cropKey}">
                 <!-- TODO: Add tracking to crop -->
                 <img class="easel__image easel__image--checkered__background"
                      alt="cropped image"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1527,13 +1527,14 @@ FIXME: what to do with touch devices
 }
 
 .easel__image {
-    display: block;
-    margin: 0 auto;
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    max-width: calc(100% - 20px); /* 20px here for padding */
-    max-height: calc(100vh - 68px);
+  display: block;
+  margin: 0 auto;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  max-width: calc(100% - 20px); /* 20px here for padding */
+  max-height: calc(100vh - 68px);
+  pointer-events: none;
 }
 
 .easel__image:fullscreen,


### PR DESCRIPTION
## What does this change?
By adding `pointer-events: none` to the img element, the browser pushes pointer events to the element below the img. That is, when you right click on the image, you're no longer able to download it as the browser does not send the event to the img element.

As a result, we need to push the drag-data to a parent element so that you can still drag the image into Composer, InDesign etc.

Might be better to review [w/out whitespace](https://github.com/guardian/grid/pull/2640/files?w=1)?

## How can success be measured?
- You're no longer able to download full resolution images with right click
- You're still able to drag the image into a CMS as before

## Screenshots (if applicable)
**Before**
![image](https://user-images.githubusercontent.com/836140/64782515-49e61100-d55d-11e9-9efa-6f88fe76fd69.png)

**After**
![image](https://user-images.githubusercontent.com/836140/64782478-376bd780-d55d-11e9-91a8-5413f3e89de3.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
