### PR TITLE
add more logging to image uploads

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -18,10 +18,10 @@ class Kinesis(config: CommonConfig, streamName: String) {
 
     implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
     implicit val unw = Json.writes[UsageNotice]
-    implicit val umw = Json.writes[UpdateMessage]
 
     val asJson = Json.toJson(message)
-    Logger.debug("Publishing message: " + Json.stringify(asJson))
+    Logger.info("Publishing message to kinesis")(message.toLogMarker)
+
     val payload = Json.toBytes(asJson)
 
     val request = new PutRecordRequest()

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -1,10 +1,13 @@
 package com.gu.mediaservice.lib.aws
 
+import java.nio.ByteBuffer
+
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 import org.joda.time.DateTime
+import play.api.libs.json.{JodaWrites, Json}
 
 import scala.collection.JavaConverters._
 
@@ -17,6 +20,13 @@ class ThrallMessageSender(config: CommonConfig) {
   }
 }
 
+object UpdateMessage {
+  implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
+  implicit val unw = Json.writes[UsageNotice]
+  implicit val writes = Json.writes[UpdateMessage]
+}
+
+// TODO add RequestID
 case class UpdateMessage(
   subject: String,
   image: Option[Image] = None,
@@ -32,9 +42,13 @@ case class UpdateMessage(
   syndicationRights: Option[SyndicationRights] = None
 ) {
   def toLogMarker: LogstashMarker = {
+    val message = Json.stringify(Json.toJson(this))
+
     val markers = Map (
       "subject" -> subject,
-      "id" -> id.getOrElse(image.map(_.id).getOrElse("none"))
+      "id" -> id.getOrElse(image.map(_.id).getOrElse("none")),
+      "size" -> message.getBytes.length,
+      "length" -> message.length
     )
 
     Markers.appendEntries(markers.asJava)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.model.usage
 
 import com.gu.mediaservice.lib.formatting.printDateTime
 import org.joda.time.DateTime
-import play.api.libs.json.{JsArray, JsObject, Json}
+import play.api.libs.json.{JodaWrites, JsArray, JsObject, Json}
 
 case class UsageNotice(mediaId: String, usageJson: JsArray) {
   def toJson = Json.obj(

--- a/image-loader/app/model/UploadRequest.scala
+++ b/image-loader/app/model/UploadRequest.scala
@@ -1,6 +1,7 @@
 package model
 
 import java.io.File
+import java.util.UUID
 
 import com.gu.mediaservice.model.UploadInfo
 import net.logstash.logback.marker.{LogstashMarker, Markers}
@@ -10,7 +11,8 @@ import org.joda.time.{DateTime, DateTimeZone}
 import scala.collection.JavaConverters._
 
 case class UploadRequest(
-  id: String,
+  requestId: UUID,
+  imageId: String,
   tempFile: File,
   mimeType: Option[String],
   uploadTime: DateTime,
@@ -24,11 +26,13 @@ case class UploadRequest(
     val fallback = "none"
 
     val markers = Map (
-      "id" -> id,
+      "requestId" -> requestId,
+      "imageId" -> imageId,
       "mimeType" -> mimeType.getOrElse(fallback),
       "uploadTime" -> ISODateTimeFormat.dateTime.print(uploadTime.withZone(DateTimeZone.UTC)),
       "uploadedBy" -> uploadedBy,
-      "filename" -> uploadInfo.filename.getOrElse(fallback)
+      "filename" -> uploadInfo.filename.getOrElse(fallback),
+      "filesize" -> tempFile.length
     ) ++ identifiersMeta
 
     Markers.appendEntries(markers.asJava)


### PR DESCRIPTION
## What does this change?
We've seen latency of image uploads spike and we've not been able to diagnose the root cause. This adds some logging around most of the steps taken in the request with markers, we can then build dashboards in ELK to gain a better understanding of the world.

## How can success be measured?
A better understand of the world.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@jonathonherbert 

## Tested?
- [ ] locally
- [ ] on TEST
