### PR TITLE
Allow Kinesis messages to be compressed, but don't...

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -8,6 +8,7 @@ import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.json.JsonByteArrayUtil
 import com.gu.mediaservice.model.usage.UsageNotice
+import net.logstash.logback.marker.Markers
 import play.api.Logger
 import play.api.libs.json.{JodaWrites, Json}
 
@@ -20,9 +21,10 @@ class Kinesis(config: CommonConfig, streamName: String) {
     implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
     implicit val unw = Json.writes[UsageNotice]
 
-    Logger.info("Publishing message to kinesis")(message.toLogMarker)
-
     val payload = JsonByteArrayUtil.toByteArray(message, withCompression = false)
+
+    val markers = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
+    Logger.info("Publishing message to kinesis")(markers)
 
     val request = new PutRecordRequest()
       .withStreamName(streamName)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import com.amazonaws.services.kinesis.model.PutRecordRequest
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
 import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.json.JsonByteArrayUtil
 import com.gu.mediaservice.model.usage.UsageNotice
 import play.api.Logger
 import play.api.libs.json.{JodaWrites, Json}
@@ -19,10 +20,9 @@ class Kinesis(config: CommonConfig, streamName: String) {
     implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
     implicit val unw = Json.writes[UsageNotice]
 
-    val asJson = Json.toJson(message)
     Logger.info("Publishing message to kinesis")(message.toLogMarker)
 
-    val payload = Json.toBytes(asJson)
+    val payload = JsonByteArrayUtil.toByteArray(message, withCompression = false)
 
     val request = new PutRecordRequest()
       .withStreamName(streamName)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -1,0 +1,55 @@
+package com.gu.mediaservice.lib.json
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+
+import play.api.libs.json._
+
+import scala.io.Source.fromInputStream
+
+object JsonByteArrayUtil extends PlayJsonHelpers {
+  private val compressionMarkerByte: Byte = 0x00.toByte
+
+  private def compress(bytes: Array[Byte]): Array[Byte] = {
+    val outputStream = new ByteArrayOutputStream()
+    val zipOutputStream = new GZIPOutputStream(outputStream)
+    zipOutputStream.write(bytes)
+    zipOutputStream.close()
+    outputStream.close()
+    val compressedBytes = outputStream.toByteArray
+    compressionMarkerByte +: compressedBytes
+  }
+
+  private def decompress(bytes: Array[Byte]): Array[Byte] = {
+    val bytesWithoutCompressionMarker = bytes.tail
+    val byteStream = new ByteArrayInputStream(bytesWithoutCompressionMarker)
+    val inputStream = new GZIPInputStream(byteStream)
+    val decompressedBytes = fromInputStream(inputStream).mkString.getBytes
+    byteStream.close()
+    inputStream.close()
+    decompressedBytes
+  }
+
+  def hasCompressionMarker(bytes: Array[Byte]) = bytes.head == compressionMarkerByte
+
+  def toByteArray[T](obj: T, withCompression: Boolean = false)(implicit writes: Writes[T]): Array[Byte] = {
+    val bytes = Json.toBytes(Json.toJson(obj))
+    if (withCompression) compress(bytes) else bytes
+  }
+
+  def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
+    val string = new String(
+      if (hasCompressionMarker(bytes)) decompress(bytes) else bytes,
+      StandardCharsets.UTF_8
+    )
+
+    Json.parse(string).validate[T] match {
+      case JsSuccess(obj, _) => Some(obj)
+      case e: JsError => {
+        logParseErrors(e)
+        None
+      }
+    }
+  }
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -1,0 +1,47 @@
+package com.gu.mediaservice.lib.json
+
+import org.scalatest.{FunSuite, Matchers}
+import play.api.libs.json.Json
+
+case class Shape(name: String, numberOfSides: Int)
+
+object Shape {
+  implicit val reads = Json.reads[Shape]
+  implicit val writes = Json.writes[Shape]
+}
+
+class JsonByteArrayUtilTest extends FunSuite with Matchers {
+  val circle = Shape("circle", 1)
+  val triangle = Shape("triangle", 3)
+  val square = Shape("square", 4)
+
+  test("To byte array and back again") {
+    val bytes = JsonByteArrayUtil.toByteArray(circle)
+    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe false
+    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
+  }
+
+  test("To compressed byte array and back again") {
+    val bytes = JsonByteArrayUtil.toByteArray(triangle, withCompression = true)
+    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
+    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(triangle)
+  }
+
+  test("From byte array into different type") {
+    val bytes = JsonByteArrayUtil.toByteArray(square)
+    JsonByteArrayUtil.fromByteArray[String](bytes) shouldBe None
+  }
+
+  test("Compressing... compresses") {
+    // gzip compression is only effective above a certain length
+    // compressing `circle` by itself results in a longer byte array 😅
+    val shapes = List(circle, triangle, square)
+
+    val uncompressedBytes = JsonByteArrayUtil.toByteArray(shapes, withCompression = false)
+    val compressedBytes = JsonByteArrayUtil.toByteArray(shapes, withCompression = true)
+    compressedBytes.length < uncompressedBytes.length shouldBe true
+
+    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)
+    JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
+  }
+}


### PR DESCRIPTION
## What does this change?
Since https://github.com/guardian/grid/pull/2634 we're extracting more metadata from images. However, there is a limit to the size of a Kinesis record and sometimes we're exceeding that limit. Add the ability to write compressed to Kinesis.

This is part 1 and 2 of a migration:
- **Continue writing to Kinesis uncompressed**
- **Thrall reads off Kinesis in both formats**
- Write to Kinesis compressed
- Don't allow uncompressed bytes to be written to Kinesis
- Thrall reads off Kinesis only in compressed format

In order to tell if a message read off Kinesis is compressed, we add a marking byte to the head of the byte array - if the marker is there, we decompress and continue to serialise into `T` and then process the message, if marker is absent, we continue to serialise into `T` and then process the message.

## How can success be measured?
no-op

## Screenshots (if applicable)
**Current behaviour** 😢 
![image](https://user-images.githubusercontent.com/836140/65348609-835ff180-dbd9-11e9-85e0-e5b463cf59e4.png)

**Once migration complete** 😂 
![image](https://user-images.githubusercontent.com/836140/65348828-f49fa480-dbd9-11e9-8435-27dc8edf1b09.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
