### PR TITLE
Always write compressed to Kinesis.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -21,7 +21,7 @@ class Kinesis(config: CommonConfig, streamName: String) {
     implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
     implicit val unw = Json.writes[UsageNotice]
 
-    val payload = JsonByteArrayUtil.toByteArray(message, withCompression = false)
+    val payload = JsonByteArrayUtil.toByteArray(message, withCompression = true)
 
     val markers: LogstashMarker = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
     Logger.info("Publishing message to kinesis")(markers)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -21,7 +21,7 @@ class Kinesis(config: CommonConfig, streamName: String) {
     implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
     implicit val unw = Json.writes[UsageNotice]
 
-    val payload = JsonByteArrayUtil.toByteArray(message, withCompression = true)
+    val payload = JsonByteArrayUtil.toByteArray(message)
 
     val markers: LogstashMarker = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
     Logger.info("Publishing message to kinesis")(markers)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -33,10 +33,7 @@ object JsonByteArrayUtil extends PlayJsonHelpers {
 
   def hasCompressionMarker(bytes: Array[Byte]) = bytes.head == compressionMarkerByte
 
-  def toByteArray[T](obj: T, withCompression: Boolean = false)(implicit writes: Writes[T]): Array[Byte] = {
-    val bytes = Json.toBytes(Json.toJson(obj))
-    if (withCompression) compress(bytes) else bytes
-  }
+  def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
 
   def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
     val string = new String(

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -15,16 +15,10 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
   val triangle = Shape("triangle", 3)
   val square = Shape("square", 4)
 
-  test("To byte array and back again") {
-    val bytes = JsonByteArrayUtil.toByteArray(circle)
-    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe false
-    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
-  }
-
   test("To compressed byte array and back again") {
-    val bytes = JsonByteArrayUtil.toByteArray(triangle, withCompression = true)
+    val bytes = JsonByteArrayUtil.toByteArray(circle)
     JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
-    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(triangle)
+    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
   }
 
   test("From byte array into different type") {
@@ -37,8 +31,8 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     // compressing `circle` by itself results in a longer byte array 😅
     val shapes = List(circle, triangle, square)
 
-    val uncompressedBytes = JsonByteArrayUtil.toByteArray(shapes, withCompression = false)
-    val compressedBytes = JsonByteArrayUtil.toByteArray(shapes, withCompression = true)
+    val uncompressedBytes = Json.toBytes(Json.toJson(shapes))
+    val compressedBytes = JsonByteArrayUtil.toByteArray(shapes)
     compressedBytes.length < uncompressedBytes.length shouldBe true
 
     JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)


### PR DESCRIPTION
## What does this change?
Since #2634 we're extracting more metadata from images. However, there is a limit to the size of a Kinesis record and sometimes we're exceeding that limit. Add the ability to write compressed to Kinesis.

This is part 3 and 4 of a migration:
- ~Continue writing to Kinesis uncompressed~ (https://github.com/guardian/grid/pull/2644)
- ~Thrall reads off Kinesis in both formats~ (https://github.com/guardian/grid/pull/2644)
- **Write to Kinesis compressed**
- **Don't allow uncompressed bytes to be written to Kinesis**
- Thrall reads off Kinesis only in compressed format

In order to tell if a message read off Kinesis is compressed, we add a marking byte to the head of the byte array - if the marker is there, we decompress and continue to serialise into T and then process the message, if marker is absent, we continue to serialise into T and then process the message.

## How can success be measured?
- no-op for majority of images
- images that are failing to ingest, get ingested

## Screenshots (if applicable)
See https://github.com/guardian/grid/pull/2644.

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
