### PR TITLE
Always read off Kinesis compressed.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -31,15 +31,10 @@ object JsonByteArrayUtil extends PlayJsonHelpers {
     decompressedBytes
   }
 
-  def hasCompressionMarker(bytes: Array[Byte]) = bytes.head == compressionMarkerByte
-
   def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
 
   def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
-    val string = new String(
-      if (hasCompressionMarker(bytes)) decompress(bytes) else bytes,
-      StandardCharsets.UTF_8
-    )
+    val string = new String(decompress(bytes), StandardCharsets.UTF_8)
 
     Json.parse(string).validate[T] match {
       case JsSuccess(obj, _) => Some(obj)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -17,7 +17,6 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
 
   test("To compressed byte array and back again") {
     val bytes = JsonByteArrayUtil.toByteArray(circle)
-    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
     JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
   }
 
@@ -35,7 +34,6 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     val compressedBytes = JsonByteArrayUtil.toByteArray(shapes)
     compressedBytes.length < uncompressedBytes.length shouldBe true
 
-    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)
     JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
   }
 }


### PR DESCRIPTION
## What does this change?
Since #2634 we're extracting more metadata from images. However, there is a limit to the size of a Kinesis record and sometimes we're exceeding that limit. Add the ability to write compressed to Kinesis.

This is part 5 of a migration:
- ~Continue writing to Kinesis uncompressed~ (https://github.com/guardian/grid/pull/2644)
- ~Thrall reads off Kinesis in both formats~ (https://github.com/guardian/grid/pull/2644)
- ~Write to Kinesis compressed~ (https://github.com/guardian/grid/pull/2645)
- ~Don't allow uncompressed bytes to be written to Kinesis~ (https://github.com/guardian/grid/pull/2645)
- Thrall reads off Kinesis only in compressed format

In order to tell if a message read off Kinesis is compressed, we add a marking byte to the head of the byte array - if the marker is there, we decompress and continue to serialise into T and then process the message, if marker is absent, we continue to serialise into T and then process the message.

## How can success be measured?
no-op

## Screenshots (if applicable)
See https://github.com/guardian/grid/pull/2644.

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
