### PR TITLE
add explicit type to logstash markers

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.json.JsonByteArrayUtil
 import com.gu.mediaservice.model.usage.UsageNotice
-import net.logstash.logback.marker.Markers
+import net.logstash.logback.marker.{LogstashMarker, Markers}
 import play.api.Logger
 import play.api.libs.json.{JodaWrites, Json}
 
@@ -23,7 +23,7 @@ class Kinesis(config: CommonConfig, streamName: String) {
 
     val payload = JsonByteArrayUtil.toByteArray(message, withCompression = false)
 
-    val markers = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
+    val markers: LogstashMarker = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
     Logger.info("Publishing message to kinesis")(markers)
 
     val request = new PutRecordRequest()


### PR DESCRIPTION
## What does this change?
The type of `LogstashMarker.and` is `T` and it looks like scala isn't happy with it; define the type explicitly to avoid run-time error.

See https://github.com/logstash/logstash-logback-encoder/blob/master/src/main/java/net/logstash/logback/marker/LogstashMarker.java#L49-L57

**Runtime error**
```console
java.lang.ClassCastException: net.logstash.logback.marker.MapEntriesAppendingMarker cannot be cast to scala.runtime.Nothing$
	at com.gu.mediaservice.lib.aws.Kinesis.publish(Kinesis.scala:26)
	at com.gu.mediaservice.lib.aws.ThrallMessageSender.publish(ThrallMessageSender.scala:19)
	at controllers.EditsController.publish(EditsController.scala:221)
	at controllers.EditsController.$anonfun$setMetadata$4(EditsController.scala:161)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:44)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)	
--
```

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
