### PR TITLE
Revert "Always read off Kinesis compressed."

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -31,10 +31,15 @@ object JsonByteArrayUtil extends PlayJsonHelpers {
     decompressedBytes
   }
 
+  def hasCompressionMarker(bytes: Array[Byte]) = bytes.head == compressionMarkerByte
+
   def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
 
   def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
-    val string = new String(decompress(bytes), StandardCharsets.UTF_8)
+    val string = new String(
+      if (hasCompressionMarker(bytes)) decompress(bytes) else bytes,
+      StandardCharsets.UTF_8
+    )
 
     Json.parse(string).validate[T] match {
       case JsSuccess(obj, _) => Some(obj)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -17,6 +17,7 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
 
   test("To compressed byte array and back again") {
     val bytes = JsonByteArrayUtil.toByteArray(circle)
+    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
     JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
   }
 
@@ -34,6 +35,7 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     val compressedBytes = JsonByteArrayUtil.toByteArray(shapes)
     compressedBytes.length < uncompressedBytes.length shouldBe true
 
+    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)
     JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
   }
 }


### PR DESCRIPTION
Reverts guardian/grid#2646

A few images have got a lot of xmp metadata, which is being indexed into individual fields. This is putting strain on elasticsearch.

Reverting will mean we drop these messages before they even get to thrall, so elasticsearch is happier. The impact is some images will not upload.