### PR TITLE
Revert "Always write compressed to Kinesis."

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -21,7 +21,7 @@ class Kinesis(config: CommonConfig, streamName: String) {
     implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
     implicit val unw = Json.writes[UsageNotice]
 
-    val payload = JsonByteArrayUtil.toByteArray(message)
+    val payload = JsonByteArrayUtil.toByteArray(message, withCompression = false)
 
     val markers: LogstashMarker = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
     Logger.info("Publishing message to kinesis")(markers)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -33,7 +33,10 @@ object JsonByteArrayUtil extends PlayJsonHelpers {
 
   def hasCompressionMarker(bytes: Array[Byte]) = bytes.head == compressionMarkerByte
 
-  def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
+  def toByteArray[T](obj: T, withCompression: Boolean = false)(implicit writes: Writes[T]): Array[Byte] = {
+    val bytes = Json.toBytes(Json.toJson(obj))
+    if (withCompression) compress(bytes) else bytes
+  }
 
   def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
     val string = new String(

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -15,10 +15,16 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
   val triangle = Shape("triangle", 3)
   val square = Shape("square", 4)
 
-  test("To compressed byte array and back again") {
+  test("To byte array and back again") {
     val bytes = JsonByteArrayUtil.toByteArray(circle)
-    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
+    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe false
     JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
+  }
+
+  test("To compressed byte array and back again") {
+    val bytes = JsonByteArrayUtil.toByteArray(triangle, withCompression = true)
+    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
+    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(triangle)
   }
 
   test("From byte array into different type") {
@@ -31,8 +37,8 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     // compressing `circle` by itself results in a longer byte array 😅
     val shapes = List(circle, triangle, square)
 
-    val uncompressedBytes = Json.toBytes(Json.toJson(shapes))
-    val compressedBytes = JsonByteArrayUtil.toByteArray(shapes)
+    val uncompressedBytes = JsonByteArrayUtil.toByteArray(shapes, withCompression = false)
+    val compressedBytes = JsonByteArrayUtil.toByteArray(shapes, withCompression = true)
     compressedBytes.length < uncompressedBytes.length shouldBe true
 
     JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)


### PR DESCRIPTION
Reverts guardian/grid#2645

This is the sibling of https://github.com/guardian/grid/pull/2648