### PR TITLE
Log size of metadata map entries

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -18,13 +18,13 @@ case class FileMetadata(
 ) {
   def toLogMarker = {
     val markers = Map (
-      "iptc" -> iptc.size,
-      "exif" -> exif.size,
-      "exifSub" -> exifSub.size,
-      "xmp" -> xmp.size,
-      "icc" -> icc.size,
-      "getty" -> getty.size,
-      "colourModelInformation" -> colourModelInformation.size,
+      "iptcFieldCount" -> iptc.size,
+      "exifFieldCount" -> exif.size,
+      "exifSubFieldCount" -> exifSub.size,
+      "xmpFieldCount" -> xmp.size,
+      "iccFieldCount" -> icc.size,
+      "gettyFieldCount" -> getty.size,
+      "colourModelInformationFieldCount" -> colourModelInformation.size,
     )
 
     Markers.appendEntries(markers.asJava)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -1,7 +1,10 @@
 package com.gu.mediaservice.model
 
+import net.logstash.logback.marker.Markers
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
+
+import scala.collection.JavaConverters._
 
 case class FileMetadata(
   iptc: Map[String, String]                     = Map(),
@@ -12,8 +15,21 @@ case class FileMetadata(
   getty: Map[String, String]                    = Map(),
   colourModel: Option[String]                   = None,
   colourModelInformation: Map[String, String]   = Map()
+) {
+  def toLogMarker = {
+    val markers = Map (
+      "iptc" -> iptc.size,
+      "exif" -> exif.size,
+      "exifSub" -> exifSub.size,
+      "xmp" -> xmp.size,
+      "icc" -> icc.size,
+      "getty" -> getty.size,
+      "colourModelInformation" -> colourModelInformation.size,
+    )
 
-)
+    Markers.appendEntries(markers.asJava)
+  }
+}
 
 object FileMetadata {
   // TODO: reindex all images to make the getty map always present

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -13,6 +13,7 @@ import com.gu.mediaservice.model._
 import lib.ImageLoaderConfig
 import lib.imaging.FileMetadataReader
 import lib.storage.ImageLoaderStore
+import net.logstash.logback.marker.LogstashMarker
 import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -107,9 +108,12 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
       case Some("image/tiff") => FileMetadataReader.fromICPTCHeadersWithColorInfo(uploadedFile, uploadRequest.imageId, uploadRequest.mimeType.get)
       case _ => FileMetadataReader.fromIPTCHeaders(uploadedFile, uploadRequest.imageId)
     }
-    Logger.info("Have read file headers")(uploadRequest.toLogMarker)
+    val uploadMarkers = uploadRequest.toLogMarker
+    Logger.info("Have read file headers")(uploadMarkers)
 
     fileMetadataFuture.flatMap(fileMetadata => {
+      val markers: LogstashMarker = fileMetadata.toLogMarker.and(uploadMarkers)
+      Logger.info("Have read file metadata")(markers)
 
       // These futures are started outside the for-comprehension, otherwise they will not run in parallel
       val sourceStoreFuture = storeSource(uploadRequest)


### PR DESCRIPTION
##  What does this change?

This PR adds logging to record the size of metadata map entries as markers.

Now, when images with unseasonably large numbers of metadata fields are being processed, we'll know about it.

## How can success be measured?

By checking logs -- on image upload, we should see `Have read file metadata` and the accompanying field counts.

## Who should look at this?

Anyone that cares about unduly large metadata and its affect on Grid performance -- so, anyone worth knowing, really.  👀 

## Tested?
- [x] locally
- [ ] on TEST
