### PR TITLE
Add total count to markers

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -17,15 +17,18 @@ case class FileMetadata(
   colourModelInformation: Map[String, String]   = Map()
 ) {
   def toLogMarker = {
-    val markers = Map (
+    val fieldCountMarkers = Map (
       "iptcFieldCount" -> iptc.size,
       "exifFieldCount" -> exif.size,
       "exifSubFieldCount" -> exifSub.size,
       "xmpFieldCount" -> xmp.size,
       "iccFieldCount" -> icc.size,
       "gettyFieldCount" -> getty.size,
-      "colourModelInformationFieldCount" -> colourModelInformation.size,
+      "colourModelInformationFieldCount" -> colourModelInformation.size
     )
+
+    val totalFieldCount = fieldCountMarkers.foldLeft(0)(_ + _._2)
+    val markers = fieldCountMarkers + ("totalFieldCount" -> totalFieldCount)
 
     Markers.appendEntries(markers.asJava)
   }


### PR DESCRIPTION
## What does this change?

Adds a total count to the markers added in #2650, to help us see the number of metadata fields in Kibana without resorting to derivations.

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?

## Tested?
- [x] locally
- [ ] on TEST
