### PR TITLE
make iframe ancestors and cors allowed origins stage unaware

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -9,6 +9,7 @@ import com.amazonaws.client.builder.AwsClientBuilder
 import play.api.Configuration
 
 import scala.io.Source._
+import scala.util.Try
 
 
 trait CommonConfig {
@@ -53,17 +54,26 @@ trait CommonConfig {
   // Note: had to make these lazy to avoid init order problems ;_;
   lazy val domainRoot: String = properties("domain.root")
   lazy val rootAppName: String = properties.getOrElse("app.name.root", "media")
-  lazy val serviceHosts = ServiceHosts(stringDefault("hosts.kahunaPrefix", s"$rootAppName."),
-                                       stringDefault("hosts.apiPrefix", s"api.$rootAppName."),
-                                       stringDefault("hosts.loaderPrefix", s"loader.$rootAppName."),
-                                       stringDefault("hosts.cropperPrefix", s"cropper.$rootAppName."),
-                                       stringDefault("hosts.metadataPrefix", s"$rootAppName-metadata."),
-                                       stringDefault("hosts.imgopsPrefix", s"$rootAppName-imgops."),
-                                       stringDefault("hosts.usagePrefix", s"$rootAppName-usage."),
-                                       stringDefault("hosts.collectionsPrefix", s"$rootAppName-collections."),
-                                       stringDefault("hosts.leasesPrefix", s"$rootAppName-leases."),
-                                       stringDefault("hosts.authPrefix", s"$rootAppName-auth."))
-  lazy val services = new Services(domainRoot, isProd, serviceHosts)
+  lazy val serviceHosts = ServiceHosts(
+    stringDefault("hosts.kahunaPrefix", s"$rootAppName."),
+    stringDefault("hosts.apiPrefix", s"api.$rootAppName."),
+    stringDefault("hosts.loaderPrefix", s"loader.$rootAppName."),
+    stringDefault("hosts.cropperPrefix", s"cropper.$rootAppName."),
+    stringDefault("hosts.metadataPrefix", s"$rootAppName-metadata."),
+    stringDefault("hosts.imgopsPrefix", s"$rootAppName-imgops."),
+    stringDefault("hosts.usagePrefix", s"$rootAppName-usage."),
+    stringDefault("hosts.collectionsPrefix", s"$rootAppName-collections."),
+    stringDefault("hosts.leasesPrefix", s"$rootAppName-leases."),
+    stringDefault("hosts.authPrefix", s"$rootAppName-auth.")
+  )
+
+  lazy val corsAllowedOrigins: Set[String] = getStringSetFromProperties("security.cors.allowedOrigins")
+
+  lazy val services = new Services(domainRoot, isProd, serviceHosts, corsAllowedOrigins)
+
+  final def getStringSetFromProperties(key: String): Set[String] = Try(
+    properties(key).split(",").map(_.trim).toSet
+  ).getOrElse(Set.empty)
 
   final def apply(key: String): String =
     string(key)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -5,7 +5,7 @@ case class ServiceHosts(kahunaPrefix: String, apiPrefix: String, loaderPrefix: S
                         usagePrefix: String, collectionsPrefix: String, leasesPrefix: String,
                         authPrefix: String)
 
-class Services(val domainRoot: String, isProd: Boolean, hosts: ServiceHosts) {
+class Services(val domainRoot: String, isProd: Boolean, hosts: ServiceHosts, corsAllowedOrigins: Set[String]) {
   val kahunaHost: String      = s"${hosts.kahunaPrefix}$domainRoot"
   val apiHost: String         = s"${hosts.apiPrefix}$domainRoot"
   val loaderHost: String      = s"${hosts.loaderPrefix}$domainRoot"
@@ -30,28 +30,9 @@ class Services(val domainRoot: String, isProd: Boolean, hosts: ServiceHosts) {
 
   val guardianWitnessBaseUri: String = "https://n0ticeapis.com"
 
-  val toolsDomains: Set[String] = if(isProd) {
-    Set(domainRoot)
-  } else {
-    Set(
-      domainRoot.replace("test", "local"),
-      domainRoot.replace("test", "code")
-    )
-  }
-
-  // TODO move to config
-  val corsAllowedTools: Set[String] = toolsDomains.foldLeft(Set[String]()) {(acc, domain) => {
-    val tools = Set(
-      baseUri(s"composer.$domain"),
-      baseUri(s"fronts.$domain")
-    )
-
-    acc ++ tools
-  }}
+  val corsAllowedDomains: Set[String] = corsAllowedOrigins.map(baseUri)
 
   val loginUriTemplate = s"$authBaseUri/login{?redirectUri}"
 
-  def baseUri(host: String) = {
-    s"https://$host"
-  }
+  def baseUri(host: String) = s"https://$host"
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -28,7 +28,7 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
   }
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
-    allowedOrigins = Origins.Matching(Set(config.services.kahunaBaseUri) ++ config.services.corsAllowedTools)
+    allowedOrigins = Origins.Matching(Set(config.services.kahunaBaseUri) ++ config.services.corsAllowedDomains)
   )
 
   lazy val management = new Management(controllerComponents, buildInfo)

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -35,7 +35,7 @@ object KahunaSecurityConfig {
     )
 
     val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com"
-    val frameAncestors = s"frame-ancestors ${config.services.toolsDomains.map(domain => s"*.$domain").mkString(" ")}"
+    val frameAncestors = s"frame-ancestors ${config.frameAncestors.mkString(" ")}"
     val connectSources = s"connect-src ${(services :+ config.imageOrigin).mkString(" ")} 'self' www.google-analytics.com"
     val imageSources = s"img-src data: blob: ${config.services.imgopsBaseUri} https://${config.fullOrigin} https://${config.thumbOrigin} https://${config.cropOrigin} www.google-analytics.com 'self'"
     val fontSources = s"font-src data: 'self'"

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -23,4 +23,6 @@ class KahunaConfig(override val configuration: Configuration) extends CommonConf
   val usageRightsHelpLink: Option[String]= properties.get("links.usageRightsHelp").filterNot(_.isEmpty)
   val invalidSessionHelpLink: Option[String]= properties.get("links.invalidSessionHelp").filterNot(_.isEmpty)
   val supportEmail: Option[String]= properties.get("links.supportEmail").filterNot(_.isEmpty)
+
+  val frameAncestors: Set[String] = getStringSetFromProperties("security.frameAncestors")
 }

--- a/scripts/generate-dot-properties/config.json5
+++ b/scripts/generate-dot-properties/config.json5
@@ -57,5 +57,10 @@
     usageRightsHelp: '',
     invalidSessionHelp: '',
     supportEmail: ''
+  },
+
+  security: {
+    frameAncestors: '',
+    corsAllowedOrigins: ''
   }
 }

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -9,6 +9,7 @@ function getAuthConfig(config) {
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |aws.region=${config.aws.region}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -21,6 +22,7 @@ function getCollectionsConfig(config) {
         |dynamo.table.collections=${config.stackProps.CollectionsDynamoTable}
         |dynamo.table.imageCollections=${config.stackProps.ImageCollectionsDynamoTable}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -33,6 +35,7 @@ function getCropperConfig(config) {
         |publishing.image.host=${config.stackProps.ImageOriginBucket}.s3.amazonaws.com
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -44,6 +47,7 @@ function getImageLoaderConfig(config) {
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -62,6 +66,8 @@ function getKahunaConfig(config) {
         |links.usageRightsHelp=${config.links.usageRightsHelp}
         |links.invalidSessionHelp=${config.links.invalidSessionHelp}
         |links.supportEmail=${config.links.supportEmail}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.frameAncestors=${config.security.frameAncestors}
         |`;
 }
 
@@ -72,6 +78,7 @@ function getLeasesConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |dynamo.tablename.leasesTable=${config.stackProps.LeasesDynamoTable}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -92,6 +99,7 @@ function getMediaApiConfig(config) {
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |quota.store.key=rcs-quota.json
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -104,6 +112,7 @@ function getMetadataEditorConfig(config) {
         |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
         |dynamo.table.edits=${config.stackProps.EditsDynamoTable}
         |indexed.images.sqs.queue.url=${config.stackProps.IndexedImageMetadataQueueUrl}
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 
@@ -151,6 +160,7 @@ function getUsageConfig(config) {
         |crier.preview.name=${config.crier.preview.streamName}
         |crier.live.name=${config.crier.live.streamName}
         |app.name=usage
+        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
 


### PR DESCRIPTION
## What does this change?
Pushing these values to config means we don't leak domains in code and also provides more flexibility.

Now, rather than hardcoding a list of subdomains, read from config a list of fully qualified domains that are allowed to make cors requests. Additionally, pushing iframe ancestors to config means we don't have to allow *.domainroot if we don't want to.

## How can success be measured?


## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
