### PR TITLE
Treat via REUTERS as Reuters

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -259,7 +259,7 @@ object ReutersParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     // Reuters and other misspellings
     // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") => image.copy(
+    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") | Some("via REUTERS") => image.copy(
       usageRights = Agency("Reuters"),
       metadata = image.metadata.copy(credit = Some("Reuters"))
     )


### PR DESCRIPTION
Ronseal, says Michael. Awaiting OK from Fiona, but not for too long (`via` as potentially useful is there in the caption and in any case would cause `[name]/via REUTERS` which is even wrong-er).

- [x] tested on TEST