### PR TITLE
Treat VIA REUTERS as Reuters

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -259,7 +259,7 @@ object ReutersParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     // Reuters and other misspellings
     // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") | Some("via REUTERS") => image.copy(
+    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") => image.copy(
       usageRights = Agency("Reuters"),
       metadata = image.metadata.copy(credit = Some("Reuters"))
     )


### PR DESCRIPTION
Boring this becomes.

- [x] tested on TEST