### PR TITLE
change api key tier log marker helper method to be toString, to be in…

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/GridLogger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/GridLogger.scala
@@ -20,7 +20,7 @@ object GridLogger {
   def info(message: String, imageId: String): Unit = info(message, imageIdMarker(imageId))
 
   private def apiKeyMarkers(apiKey: ApiKey) = Map(
-    "key-tier" -> apiKey.tier,
+    "key-tier" -> apiKey.tier.toString,
     "key-name" -> apiKey.name
   )
 


### PR DESCRIPTION
… the same format as used by the log marker in other locations

In some places `key-tier` was being stored in es as an object (just an empty object0 and others a string, so this makes it a string in all locations