### PR TITLE
drop messages if there are over 1000 xmp fields

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -7,7 +7,7 @@ import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 import org.joda.time.DateTime
-import play.api.libs.json.{JodaWrites, Json}
+import play.api.libs.json.{JodaReads, JodaWrites, Json}
 
 import scala.collection.JavaConverters._
 
@@ -22,8 +22,11 @@ class ThrallMessageSender(config: CommonConfig) {
 
 object UpdateMessage {
   implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
-  implicit val unw = Json.writes[UsageNotice]
+  implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads
+  implicit val usageNoticeWrites = Json.writes[UsageNotice]
+  implicit val usageNoticeReads = Json.reads[UsageNotice]
   implicit val writes = Json.writes[UpdateMessage]
+  implicit val reads = Json.reads[UpdateMessage]
 }
 
 // TODO add RequestID


### PR DESCRIPTION
## What does this change?
This is (temporary) protection for replaying.

## How can success be measured?
When replaying messages from Kinesis, drop those that have a large number of xmp fields as they are stressing out the ES cluster.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
