### PR TITLE
store the original file name alongside the original image in aws as metadata

### DIFF
--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -194,16 +194,24 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
     })
   }
 
-  def storeSource(uploadRequest: UploadRequest) = store.storeOriginal(
-    uploadRequest.imageId,
-    uploadRequest.tempFile,
-    uploadRequest.mimeType,
-    Map(
+  def storeSource(uploadRequest: UploadRequest) = {
+    val baseMeta = Map(
       "uploaded_by" -> uploadRequest.uploadedBy,
-      "upload_time" -> printDateTime(uploadRequest.uploadTime),
-      "file_name" -> uploadRequest.uploadInfo.filename.orNull
+      "upload_time" -> printDateTime(uploadRequest.uploadTime)
     ) ++ uploadRequest.identifiersMeta
-  )
+
+    val meta = uploadRequest.uploadInfo.filename match {
+      case Some(f) => baseMeta ++ Map("file_name" -> f)
+      case _ => baseMeta
+    }
+
+    store.storeOriginal(
+      uploadRequest.imageId,
+      uploadRequest.tempFile,
+      uploadRequest.mimeType,
+      meta
+    )
+  }
   def storeThumbnail(uploadRequest: UploadRequest, thumbFile: File) = store.storeThumbnail(
     uploadRequest.imageId,
     thumbFile,

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -200,7 +200,8 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
     uploadRequest.mimeType,
     Map(
       "uploaded_by" -> uploadRequest.uploadedBy,
-      "upload_time" -> printDateTime(uploadRequest.uploadTime)
+      "upload_time" -> printDateTime(uploadRequest.uploadTime),
+      "file_name" -> uploadRequest.uploadInfo.filename.orNull
     ) ++ uploadRequest.identifiersMeta
   )
   def storeThumbnail(uploadRequest: UploadRequest, thumbFile: File) = store.storeThumbnail(


### PR DESCRIPTION
## What does this change?

Store the original file name in metadata with in the image bucket in aws. This is because this info is just currently saved in ES, and so it would be good to have saved in case we need to re-ingest images for whatever reason (and potentially the ES index data is lost).
