### PR TITLE
fix: Fix authentication hyperlinks

### DIFF
--- a/docs/04.03-upload-image.md
+++ b/docs/04.03-upload-image.md
@@ -1,6 +1,6 @@
 # Upload Image Directly
 
-See [api key generation](./03.1-authentication.md) for how to generate a target key
+See [api key generation](./04.02-authentication.md) for how to generate a target key
 
 ```bash
     curl -k --data-binary @../images/roundel.jpg \

--- a/docs/04.05-media-api.md
+++ b/docs/04.05-media-api.md
@@ -1,6 +1,6 @@
 # Media API
 
-See [api key generation](./03.1-authentication.md) for how to generate a target key
+See [api key generation](./04.02-authentication.md) for how to generate a target key
 
 ```bash
 curl -k -H "X-Gu-Media-Key: TARGET_KEY"  <media-api-local>/images/imageID


### PR DESCRIPTION
## What does this change?

This fixes the hyperlinks in `04.03-upload-image.md` and `04.05-media-api.md` to point to the correct authentication file, which was renamed from `03-1` to `04-02` at some point.

## How can success be measured?

Clicking on the "api key generation" hyperlink [on this page](https://github.com/guardian/grid/blob/master/docs/04.03-upload-image.md) takes you to [this page](https://github.com/guardian/grid/blob/master/docs/04.02-authentication.md), rather than a 404.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [ ] on TEST
