### PR TITLE
Feature/fix up es scripts

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
@@ -129,6 +129,17 @@ trait ElasticSearchClient {
     Logger.info("Got alias action response: " + aliasActionResponse)
   }
 
+  def changeAliasTo(newIndex: String, oldIndex: String, alias: String = imagesAlias): Unit = {
+    Logger.info(s"Assigning alias $alias to $newIndex")
+    val aliasActionResponse = Await.result(client.execute {
+      aliases(
+        removeAlias(alias, oldIndex),
+        addAlias(alias, newIndex)
+      )
+    }, tenSeconds)
+    Logger.info("Got alias action response: " + aliasActionResponse)
+  }
+
   def removeAliasFrom(index: String) = {
     ???
   }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,30 +10,42 @@ On occasion you will need to update the our [Elasticsearch mappings](https://git
 Unfortunately, you need to change the mapping and then reindex the data to apply said change.
 [Read more about the inspiration](http://www.elasticsearch.org/blog/changing-mapping-with-zero-downtime/)
 
+This performs the following:
+1. Creates a new index (with the new mappings) appending a version number to the new index e.g. `images_5`
+2. Copies over all data from the original index to the new index using scrolling
+3. Points the write alias to the new index
+4. Checks if any new data has been wrote since the script started, if so copies this over as well
+5. Points the read alias to the new index
+
+```
     $ sbt
-    > scripts/run Reindex <ES_HOST>
+    > scripts/run Reindex <ES_URL>
+```
 
-Optionally takes a DateTime string as a second argument. Will perform reindex for documents updated *since the date provieded*
+Optionally takes a DateTime string argument. Will perform reindex for documents updated *since the date provieded*
 
-    > scripts/run Reindex <ES_HOST>  016-01-28T10:55:10.232Z
+    > scripts/run Reindex <ES_URL> FROM_TIME=016-01-28T10:55:10.232Z
 
+Optionally takes a new index name string argument. Will reindex into that new name instead of the default version increment
+
+    > scripts/run Reindex <ES_URL> NEW_INDEX=images
 
 ### UpdateMapping
 When you add a mapping e.g. You add a new field to the [image mapping](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala#L73)
 you should add the mapping with this script as we are using [`strict`](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/dynamic-mapping.html)
 mappings (you cannot just add things willy nilly). Updating mappings is done in 2 steps:
 
-1. Set up a SSH tunnel to the AWS elasticsearch instance: `ssh -L 9300:localhost:9300 <ES_HOST>`
+1. Set up a SSH tunnel to the AWS elasticsearch instance: `ssh -L 9300:localhost:9300 <ES_URL>`
 
 2. Run the script:
 ```
     $ sbt
-    > scripts/run UpdateMapping <ES_HOST>
+    > scripts/run UpdateMapping <ES_URL>
 ```
     
-Optionally takes an index name. e.g. `> scripts/run UpdateMapping <ES_HOST> images_5`
+Optionally takes an index name. e.g. `> scripts/run UpdateMapping <ES_URL> images_5`
 
-To test the connection without making any changes to the mappings, you can run: `sbt scripts/run GetMapping <ES_HOST>`.
+To test the connection without making any changes to the mappings, you can run: `sbt scripts/run GetMapping <ES_URL>`.
 
 ### UpdateSettings
 When you need to close the index to update the settings i.e. when you have to add / reconfigure

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -220,11 +220,11 @@ object UpdateMapping extends EsScript {
         val index = specifiedIndex.getOrElse(imagesAlias)
         println(s"Updating mapping on index: $index")
 
-        val result = Await.result(client.execute {
+        val result = client.execute {
           putMapping(IndexesAndType(s"$index/${Mappings.dummyType}")) as {
             Mappings.imageMapping.fields
           }
-        }, Duration(30, SECONDS))
+        }.await
 
         result.status match {
           case 200 => println(Json.prettyPrint(Json.parse(result.body.get)))

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -1,127 +1,140 @@
 package com.gu.mediaservice.scripts
 
-import org.elasticsearch.action.admin.indices.close.CloseIndexRequest
-import org.elasticsearch.action.admin.indices.open.OpenIndexRequest
-import org.elasticsearch.action.bulk.BulkRequestBuilder
-import org.elasticsearch.action.index.IndexRequestBuilder
-import org.elasticsearch.action.search.{SearchRequestBuilder, SearchResponse}
-import org.elasticsearch.search.SearchHit
-import org.elasticsearch.index.query.QueryBuilders.{matchAllQuery, rangeQuery}
-import org.elasticsearch.common.unit.TimeValue
-import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, IndexSettings, Mappings}
-import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse
+import java.util.concurrent.TimeUnit
+
+import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearchClient, Mappings}
+import com.sksamuel.elastic4s.http.ElasticDsl._
+import com.sksamuel.elastic4s.http.bulk.BulkResponse
+import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse}
+import com.sksamuel.elastic4s.indexes.IndexRequest
+import com.sksamuel.elastic4s.{IndexesAndType, IndexesAndTypes}
 import org.joda.time.DateTime
+import play.api.libs.json.Json
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
-import ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, FiniteDuration, SECONDS}
+import scala.concurrent.{Await, Future}
 
-object MoveIndex extends EsScript {
-  def run(esHost: String, extraArgs: List[String]) {
-
-    object EsClient extends ElasticSearchClient {
-      val imagesAlias = "readAlias"
-      val port = esPort
-      val host = esHost
-      val cluster = esCluster
-      val clientTransportSniff = false
-
-      def move {
-        val srcIndex = getCurrentAlias.get // TODO: error handling if alias isn't attached
-        val srcIndexVersionCheck = """images_(\d+)""".r
-        val srcIndexVersion = srcIndex match {
-          case srcIndexVersionCheck(version) => version.toInt
-          case _ => 1
-        }
-        val newIndex = s"${imagesIndexPrefix}_${srcIndexVersion+1}"
-
-        assignAliasTo(newIndex)
-        removeAliasFrom(srcIndex)
-      }
-    }
-
-    EsClient.move
-  }
-  def usageError: Nothing = {
-    System.err.println("Usage: MoveIndex <ES_HOST>")
-    sys.exit(1)
-  }
-}
 
 object Reindex extends EsScript {
 
-  def run(esHost: String, args: List[String]) = {
-    object EsClient extends ElasticSearchClient {
-      val imagesAlias = "writeAlias"
-      val port = esPort
-      val host = esHost
-      val cluster = esCluster
-      val clientTransportSniff = false
-      val initTime = DateTime.now()
-      val currentIndex = getCurrentIndices.reverse.head
-      val nextIndex = nextIndexName(currentIndex)
+  def run(esUrl: String, args: List[String]) = {
 
-      def nextIndexName(currentIndex: String) = {
-        val srcIndexVersionCheck = """images_(\d+)""".r
-        val srcIndexVersion = currentIndex match {
-          case srcIndexVersionCheck(version) => version.toInt
-          case _ => 1
+    object IndexClient extends EsClient {
+      override def url = esUrl
+
+      val indexResult = client.execute {
+        getIndex(imagesAlias)
+      }.await
+
+      val currentIndex: String = indexResult.status match {
+        case 200 => {
+          indexResult.result.keySet.toList match {
+            case head::Nil => head
+            case _ => throw new Exception(s"There should only be one index associated with alias before reindexing, " +
+              s"however there was: ${indexResult.result.keys}")
+          }
         }
-        s"${imagesIndexPrefix}_${srcIndexVersion + 1}"
+        case _ => throw new Exception(s"Failed updating mapping: ${indexResult.error}")
       }
+
+      val srcIndexVersionCheck = """images_(\d+)""".r
+      val srcIndexVersion = currentIndex match {
+        case srcIndexVersionCheck(version) => version.toInt
+        case _ => 1
+      }
+      val nextIndex = s"${imagesIndexPrefix}_${srcIndexVersion+1}"
     }
 
-    def raise(msg: String) = {
-      System.err.println(s"Reindex error on: $esHost : $msg ")
+    def raiseError(msg: String) = {
+      System.err.println(s"Reindex error on: $esUrl : $msg ")
       System.err.println("Exiting...")
-      EsClient.client.close()
+      IndexClient.client.close()
       System.exit(1)
     }
 
     def validateCurrentState(esClient: ElasticSearchClient, from: Option[DateTime]) = {
-      if(esClient.getCurrentIndices.isEmpty) raise("no index with the 'write' alias exists")
-      if((esClient.getCurrentIndices.length == 2) && from.isEmpty)
-        raise("there are two indices with 'write' alias, check your properties file or use http://localhost:9200/_plugin/head/ ")
       if(from.exists(_.isAfter(DateTime.now())))
-        raise("DateTime parameter 'from' must be earlier than the current time" )
+        raiseError("DateTime parameter 'from' must be earlier than the current time" )
     }
 
-    val imageType = "image"
-    val scrollTime = new TimeValue(5 * 60 * 1000) // 5 minutes in milliseconds
-    val scrollSize = 500
-    val currentIndex = EsClient.currentIndex
-    val newIndex = EsClient.nextIndex
+    def getArg(argKey: String): Option[String] = {
+      args.find(_ contains s"${argKey}=")
+        .map(_ replaceFirst(s"${argKey}=", ""))
+    }
 
-    val from = if(args.isEmpty) None else Some(DateTime.parse(args.head))
-    validateCurrentState(EsClient, from)
-    Await.result(reindex(from, EsClient), Duration.Inf)
+    val scrollTime = new FiniteDuration(5, TimeUnit.MINUTES)
+    val scrollSize = 500
+    val currentIndex = IndexClient.currentIndex
+    val newIndex = getArg("NEW_INDEX") match {
+      case Some(arg) => arg
+      case None => IndexClient.nextIndex
+    }
+    val from = getArg("FROM_TIME") match {
+      case Some(arg) => Some(DateTime.parse(arg))
+      case None => None
+    }
+    validateCurrentState(IndexClient, from)
+    Await.result(reindex(from, IndexClient), Duration.Inf)
+    println(s"Pointing $esImagesReadAlias to new index: $newIndex")
+    IndexClient.changeAliasTo(newIndex, currentIndex, esImagesReadAlias)
+    println(s"Finished reindexing from $currentIndex to $newIndex")
+    IndexClient.client.close()
 
     def reindex(from: Option[DateTime], esClient: ElasticSearchClient) : Future[SearchResponse] = {
+
       def _scroll(scroll: SearchResponse, done: Long = 0): Future[SearchResponse] = {
         val client = esClient.client
         val currentBatch = done + scrollSize
         System.out.println(scrollPercentage(scroll, currentBatch, done))
 
-        def bulkFromHits(hits: Array[SearchHit]): BulkRequestBuilder = {
-          val bulkRequests : Array[IndexRequestBuilder] = hits.map { hit =>
-            client.prepareIndex(newIndex, imageType, hit.id).setSource(hit.source) }
+        def bulkFromHits(hits: Array[SearchHit]): BulkResponse = {
+          val bulkRequests: Array[IndexRequest] = hits.map { hit =>
+            indexInto(s"$newIndex/${Mappings.dummyType}")
+              .withId(hit.id)
+              .source(hit.sourceAsString)
+          }
 
-          val bulk = client.prepareBulk
-          bulkRequests map { bulk.add }
-          bulk
+          val bulkResponse = IndexClient.client.execute({
+            bulk(bulkRequests)
+          }).await
+
+          bulkResponse.status match {
+            case 200 => bulkResponse.result
+            case _ => {
+              IndexClient.client.close()
+              throw new Exception("Failed performing bulk index")
+            }
+          }
         }
+
         def scrollPercentage(scroll: SearchResponse, currentBatch: Long, done: Long): String = {
-          val total = scroll.getHits.totalHits
+          val total = scroll.hits.total
           // roughly accurate as we're using done, which is relative to scrollSize, rather than the actual number of docs in the new index
-          val percentage = (done.toFloat / total) * 100
-          s"Reindexing $currentBatch of $total ($percentage%)"
+          val percentage = (Math.min(done,total).toFloat / total) * 100
+          s"Reindexing ${Math.min(currentBatch,total)} of $total ($percentage%)"
+        }
+
+        def performScroll(scrollId: String, scrollTime: FiniteDuration): SearchResponse = {
+          val scrollResponse = IndexClient.client.execute({
+            searchScroll(scrollId)
+              .keepAlive(scrollTime)
+          }).await
+
+          scrollResponse.status match {
+            case 200 => scrollResponse.result
+            case _ => {
+              IndexClient.client.close()
+              throw new Exception("Failed performing bulk index")
+            }
+          }
         }
 
 
-        val hits = scroll.getHits.hits
+        val hits = scroll.hits.hits
         if(hits.nonEmpty) {
-          bulkFromHits(hits).execute.actionGet
-          val scrollResponse = client.prepareSearchScroll(scroll.getScrollId).setScroll(scrollTime).execute.actionGet
+          bulkFromHits(hits)
+          val scrollResponse = performScroll(scroll.scrollId.get, scrollTime)
           _scroll(scrollResponse, currentBatch)
         } else {
           println("No more results found")
@@ -129,38 +142,49 @@ object Reindex extends EsScript {
         }
       }
 
-      def query(from: Option[DateTime]) : SearchRequestBuilder = {
+      def query(from: Option[DateTime]) : SearchResponse = {
         val queryType = from.map(time =>
-          rangeQuery("lastModified").from(from.get).to(DateTime.now)
+          rangeQuery("lastModified").gte(from.get.getMillis).lte(DateTime.now.getMillis)
         ).getOrElse(
           matchAllQuery()
         )
 
-        EsClient.client.prepareSearch(currentIndex)
-          .setTypes(imageType)
-          .setScroll(scrollTime)
-          .setSize(scrollSize)
-          .setQuery(queryType)
+        val queryResponse = IndexClient.client.execute({
+          search(currentIndex)
+            .types(Mappings.dummyType)
+            .scroll(scrollTime)
+            .size(scrollSize)
+            .query(queryType)
+        }).await
+
+        queryResponse.status match {
+          case 200 => queryResponse.result
+          case _ => {
+            IndexClient.client.close()
+            throw new Exception("Failed performing search query")
+          }
+        }
       }
 
       // if no 'from' time parameter is passed, create a new index
       if(from.isEmpty) {
-        EsClient.createImageIndex(newIndex)
+        IndexClient.createImageIndex(newIndex)
       } else {
         println(s"Reindexing documents modified since: ${from.toString}")
       }
 
       val startTime = DateTime.now()
       println(s"Reindex started at: $startTime")
-      println(s"Reindexing from: ${EsClient.currentIndex} to: $newIndex")
-      val scrollResponse = query(from).execute.actionGet
+      println(s"Reindexing from: ${IndexClient.currentIndex} to: $newIndex")
+      val scrollResponse = query(from)
       _scroll(scrollResponse) flatMap  { case (response: SearchResponse) =>
-        val changedDocuments: Long = query(Option(startTime)).execute.actionGet.getHits.getTotalHits
-        println(s"$changedDocuments")
-        if(changedDocuments > 0) {
-          println(s"Adding ${EsClient.imagesAlias} to $newIndex")
-          EsClient.assignAliasTo(newIndex)
+        println(s"Pointing ${IndexClient.imagesAlias} to new index: $newIndex")
+        IndexClient.changeAliasTo(newIndex, currentIndex)
 
+        val changedDocuments: Long = query(Option(startTime)).hits.total
+        println(s"$changedDocuments changed documents since start")
+
+        if(changedDocuments > 0) {
           println(s"Reindexing changes since start time: $startTime")
           val recurseResponse = reindex(Option(startTime), esClient)
           recurseResponse
@@ -172,138 +196,193 @@ object Reindex extends EsScript {
   }
 
   def usageError: Nothing = {
-    System.err.println("Usage: Reindex error <ES_HOST>")
+    System.err.println("Usage: Reindex error <ES_URL> [NEW_INDEX=<new_index_name>, FROM_TIME=<datetime>]")
     sys.exit(1)
   }
 }
 
+// TODO: add the ability to update a section of the mapping
 object UpdateMapping extends EsScript {
 
-  def run(esHost: String, extraArgs: List[String]) {
-    // TODO: add the ability to update a section of the mapping
-    object EsClient extends ElasticSearchClient {
-      val imagesAlias = "writeAlias"
-      val port = esPort
-      val host = esHost
-      val cluster = esCluster
-      val clientTransportSniff = false
+  def run(esUrl: String, extraArgs: List[String]) {
+
+    object MappingsClient extends EsClient {
+      override def url = esUrl
 
       def updateMappings(specifiedIndex: Option[String]) {
-        val index = getCurrentAlias.getOrElse(imagesAlias)
-        println(s"updating mapping on index: $index")
-        client.admin.indices
-          .preparePutMapping(index)
-          .setType(imageType)
-          .setSource(Mappings.imageMapping)
-          .execute.actionGet
+        val index = specifiedIndex.getOrElse(imagesAlias)
+        println(s"Updating mapping on index: $index")
+
+        val result = Await.result(client.execute {
+          putMapping(IndexesAndType(s"$index/${Mappings.dummyType}")) as {
+            Mappings.imageMapping.fields
+          }
+        }, Duration(30, SECONDS))
+
+        result.status match {
+          case 200 => println(Json.prettyPrint(Json.parse(result.body.get)))
+          case _ => println(s"Failed updating mapping: ${result.error}")
+        }
 
         client.close
       }
+
     }
 
-    EsClient.updateMappings(extraArgs.headOption)
+    MappingsClient.updateMappings(extraArgs.headOption)
   }
 
   def usageError: Nothing = {
-    System.err.println("Usage: UpdateMapping <ES_HOST>")
+    System.err.println("Usage: UpdateMapping <ES_URL>")
     sys.exit(1)
   }
 }
 
 object GetMapping extends EsScript {
 
-  def run(esHost: String, extraArgs: List[String]) {
-    object EsClient extends ElasticSearchClient {
-      val imagesAlias = "writeAlias"
-      val port = esPort
-      val host = esHost
-      val cluster = esCluster
-      val clientTransportSniff = false
+  def run(esUrl: String, extraArgs: List[String]) {
+
+    object MappingsClient extends EsClient {
+      override def url = esUrl
 
       def getMappings(specifiedIndex: Option[String]) {
-        val index = getCurrentAlias.getOrElse(imagesAlias)
-        println(s"getting mapping on index: $index")
-        val result = client.admin.indices
-          .prepareGetMappings(index)
-          .execute.actionGet
+        val index = specifiedIndex.getOrElse(imagesAlias)
+        println(s"Getting mapping on index: $index")
 
-        try {
-          println(result.getMappings.get(index).get(imageType).getSourceAsMap)
-        } catch {
-          case e: Throwable => throw new Exception(s"Error while getting mappings: ${e.getMessage}")
+        val result = Await.result(client.execute(
+          getMapping(IndexesAndTypes(s"$index/${Mappings.dummyType}"))
+        ), Duration(30, SECONDS))
+
+        result.status match {
+          case 200 => println(Json.prettyPrint(Json.parse(result.body.get)))
+          case _ => println(s"Failed getting mapping: ${result.error}")
         }
+
 
         client.close()
       }
     }
 
-    EsClient.getMappings(extraArgs.headOption)
+    MappingsClient.getMappings(extraArgs.headOption)
   }
 
   def usageError: Nothing = {
-    System.err.println("Usage: GetMapping <ES_HOST>")
+    System.err.println("Usage: GetMapping <ES_URL>")
     sys.exit(1)
   }
 }
 
 object UpdateSettings extends EsScript {
 
-  def run(esHost: String, extraArgs: List[String]) {
-    // TODO: add the ability to update a section of the mapping
-    object EsClient extends ElasticSearchClient {
-      val imagesAlias = "writeAlias"
-      val port = esPort
-      val host = esHost
-      val cluster = esCluster
-      val clientTransportSniff = false
+  def run(esUrl: String, extraArgs: List[String]) {
 
-      if (esHost != "localhost") {
-        System.err.println(s"You can only run UpdateSettings on localhost, not '$esHost'")
+    object SettingsClient extends EsClient {
+      override def url = esUrl
+
+      if (!url.contains("localhost")) {
+        System.err.println(s"You can only run UpdateSettings on localhost, not '$esUrl'")
         System.exit(1)
       }
 
-      def updateSettings {
-        val alias = getCurrentAlias.getOrElse(imagesAlias)
-        val indices = client.admin.indices
-        indices.close(new CloseIndexRequest(alias))
+      def updateIdxSettings(specifiedIndex: Option[String]) {
 
-        indices
-          .prepareUpdateSettings(alias)
-          .setSettings(IndexSettings.imageSettings)
-          .execute.actionGet
+        val index = specifiedIndex.getOrElse(imagesAlias)
+        println(s"Getting mapping on index: $index")
 
-        indices.open(new OpenIndexRequest(alias))
+        val settingsToAdd: Map[String, String] = Map("max_result_window" -> "25000")
+
+       val resultFut = for {
+          _ <- client.execute(closeIndex(index))
+          result <- {
+            client.execute(
+              updateSettings(index)
+                .add(settingsToAdd)
+            )
+          }
+          _ <- client.execute(openIndex(index))
+        } yield result
+
+        val result = Await.result(resultFut, Duration(30, SECONDS))
+
+        result.status match {
+          case 200 => println(Json.prettyPrint(Json.parse(result.body.get)))
+          case _ => println(s"Failed updating index settings: ${result.error}")
+        }
+
         client.close
       }
     }
 
-    EsClient.updateSettings
+    SettingsClient.updateIdxSettings(extraArgs.headOption)
   }
 
   def usageError: Nothing = {
-    System.err.println("Usage: UpdateSettings <ES_HOST>")
+    System.err.println("Usage: UpdateSettings <ES_URL>")
+    sys.exit(1)
+  }
+}
+
+object GetSettings extends EsScript {
+
+  def run(esUrl: String, extraArgs: List[String]) {
+
+    object SettingsClient extends EsClient {
+      override def url = esUrl
+
+      def getIdxSettings(specifiedIndex: Option[String]) {
+        val index = specifiedIndex.getOrElse(imagesAlias)
+        println(s"Getting settings on index: $index")
+
+        val result = Await.result(client.execute(
+          getSettings(index)
+        ), Duration(30, SECONDS))
+
+        result.status match {
+          case 200 => println(Json.prettyPrint(Json.parse(result.body.get)))
+          case _ => println(s"Failed getting settings: ${result.error}")
+        }
+
+
+        client.close()
+      }
+    }
+
+    SettingsClient.getIdxSettings(extraArgs.headOption)
+  }
+
+  def usageError: Nothing = {
+    System.err.println("Usage: GetMapping <ES_URL>")
     sys.exit(1)
   }
 }
 
 abstract class EsScript {
   // FIXME: Get from config (no can do as Config is coupled to Play)
-  final val esApp   = "elasticsearch"
-  final val esPort = 9300
   final val esCluster = "media-service"
+  final val esImagesAlias = "writeAlias"
+  final val esImagesReadAlias = "readAlias"
+  final val esShards = 5
+  final val esReplicas = 0
 
   def log(msg: String) = System.out.println(s"[Reindexer]: $msg")
 
   def apply(args: List[String]) {
     // FIXME: Use Stage to get host (for some reason this isn't working)
-    val (esHost, extraArgs) = args match {
+    val (esUrl, extraArgs) = args match {
       case h :: t => (h, t)
       case _ => usageError
     }
 
-    run(esHost, extraArgs)
+    run(esUrl, extraArgs)
   }
 
-  def run(esHost: String, args: List[String])
+  abstract class EsClient extends ElasticSearchClient {
+    override def cluster = esCluster
+    override def imagesAlias = esImagesAlias
+    override def shards = esShards
+    override def replicas = esReplicas
+  }
+
+  def run(esUrl: String, args: List[String])
   def usageError: Nothing
 }

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -6,9 +6,9 @@ object Main extends App {
   args.toList match {
     case "LoadFromS3Bucket" :: as => LoadFromS3Bucket(as)
     case "Reindex"          :: as => Reindex(as)
-    case "MoveIndex"        :: as => MoveIndex(as)
     case "GetMapping"       :: as => GetMapping(as)
     case "UpdateMapping"    :: as => UpdateMapping(as)
+    case "GetSettings"      :: as => GetSettings(as)
     case "UpdateSettings"   :: as => UpdateSettings(as)
     case a :: _ => sys.error(s"Unrecognised command: $a")
     case Nil    => sys.error("Usage: <Command> <args ...>")


### PR DESCRIPTION
## What does this change?

The main purpose of this pr is to allow for extra metadata fields to be added.

The current ES Script seems to be outdated, and for the previous elasticsearch implementation and so no longer works. This has now been updated to use the latest library that is used within the grid, and tidied up a bit adding some extra logging as well.

`MoveIndex` has been removed, it didn't seem to be doing anything useful from what I could see, maybe a WIP.
`GetSettings ` was added, as we have an update settings

I have tested this locally and it seems to all work nicely, but will need to test on our deployed environment to properly test it (locally i only have 560 docs in my ES).

One interesting thing for further discussion is the use of indexes/aliases. When the grid starts up it seems to always revert back to wanting to use the `images` index, even if the alias is pointing to say `images_2`, and it will then point the aliases back to this `images` index. I didn't want to fix that as part of this PR as I didn't know if it was taken out for a reason, and plus its probably better to have that as an independent piece of work.