### PR TITLE
url encode file name metadata before uploading to s3

### DIFF
--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -1,6 +1,8 @@
 package model
 
 import java.io.File
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import com.gu.mediaservice.lib.aws.S3Object
 import com.gu.mediaservice.lib.cleanup.{MetadataCleaners, SupplierProcessors}
@@ -201,7 +203,7 @@ class ImageUploadOps(store: ImageLoaderStore, config: ImageLoaderConfig, imageOp
     ) ++ uploadRequest.identifiersMeta
 
     val meta = uploadRequest.uploadInfo.filename match {
-      case Some(f) => baseMeta ++ Map("file_name" -> f)
+      case Some(f) => baseMeta ++ Map("file_name" -> URLEncoder.encode(f, StandardCharsets.UTF_8.name()))
       case _ => baseMeta
     }
 


### PR DESCRIPTION
Fixes the issue pointed out by @paperboyo in https://github.com/guardian/grid/pull/2663 

The metadata filename value is now url encoded before being uploaded to s3 as suggested by @mbarton 

Before:
<img width="748" alt="Screenshot 2019-10-22 at 10 22 36" src="https://user-images.githubusercontent.com/8750261/67274046-98b98b80-f4b7-11e9-9cc3-bb4965e69c49.png">

After:
<img width="605" alt="Screenshot 2019-10-22 at 10 28 20" src="https://user-images.githubusercontent.com/8750261/67274063-a1aa5d00-f4b7-11e9-824e-d828e692efae.png">

<img width="492" alt="Screenshot 2019-10-22 at 10 29 41" src="https://user-images.githubusercontent.com/8750261/67274035-91927d80-f4b7-11e9-930b-caf4d63db299.png">


