### PR TITLE
add some safety around collection handling

### DIFF
--- a/kahuna/public/js/services/api/collections-api.js
+++ b/kahuna/public/js/services/api/collections-api.js
@@ -100,7 +100,7 @@ collectionsApi.factory('collections',
     function untilNewCollectionAppears(image, collectionAdded) {
         return image.get().then( (apiImage) => {
             const apiCollections = imageAccessor.getCollectionsIds(apiImage);
-            if (apiCollections.indexOf(collectionAdded.data.pathId) > -1) {
+            if (collectionAdded.data && apiCollections.indexOf(collectionAdded.data.pathId) > -1) {
                 return apiImage;
             } else {
                 return $q.reject();
@@ -143,7 +143,7 @@ collectionsApi.factory('collections',
 
     function filterCollectionResource(image, collectionToMatch){
         return image.data.collections.filter(collection => {
-            return collection.data.pathId === collectionToMatch;
+            return collection.data && collection.data.pathId === collectionToMatch;
         });
     }
 


### PR DESCRIPTION
## What does this change?
`data` is [nullable](https://github.com/guardian/grid/blob/2642689bd360af258d3f2f3df05df91fc238f368/collections/app/controllers/CollectionsController.scala#L184) so check for its presence to avoid `Cannot read property 'pathId' of undefined` clientside errors.

## How can success be measured?
no-op

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
