### PR TITLE
Update photoshoot title in UI on batch field apply in upload screen

### DIFF
--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
@@ -77,6 +77,7 @@ photoshoot.controller('GrPhotoshootCtrl', [
             const batchApplyEvent = 'events:batch-apply:photoshoot';
 
             $scope.$on(batchApplyEvent, (e, { title }) => {
+                ctrl.photoshootData.title = title;
                 ctrl.save(title);
             });
 


### PR DESCRIPTION
## What does this change?

Update the photoshoot title in upload UI when the batch field apply button is clicked in the field.

## How can success be measured?

Upload more than one image, add a photoshoot title, and click the batch apply button. The new photoshoot title should be visible for every image.

## Screenshots (if applicable)

![photoshoot](https://user-images.githubusercontent.com/7767575/67853647-e7de6c80-fb06-11e9-86d1-82dd02681e22.gif)

## Tested?
- [x] locally
- [x] on TEST
