### PR TITLE
Don't add a last modified date to leases if there aren't any leases when the image is created

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -24,7 +24,7 @@ object LeasesByMedia {
 
   implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
 
-  def empty = LeasesByMedia(Nil, Some(DateTime.now))
+  def empty = LeasesByMedia(Nil, None)
 
   def build (leases: List[MediaLease]) = {
     val lastModified = leases.sortBy(_.createdAt).reverse.headOption.map(_.createdAt).getOrElse(DateTime.now)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -27,8 +27,8 @@ object LeasesByMedia {
   def empty = LeasesByMedia(Nil, None)
 
   def build (leases: List[MediaLease]) = {
-    val lastModified = leases.sortBy(_.createdAt).reverse.headOption.map(_.createdAt).getOrElse(DateTime.now)
-    LeasesByMedia(leases, Some(lastModified))
+    val lastModified = leases.sortBy(_.createdAt).reverse.headOption.map(_.createdAt)
+    LeasesByMedia(leases, lastModified)
   }
 
   def toJson(leases: JsValue, lastModified: JsValue) : JsObject = {

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -96,6 +96,15 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
           lastModified.nonEmpty shouldBe false
         }
 
+        "initial indexing does not add lastModified to the leases object" in {
+          val id = UUID.randomUUID().toString
+          val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), None)
+
+          Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
+          val loadedImage = reloadedImage(id).get
+          loadedImage.leases.lastModified shouldBe None
+        }
+
         "updating an existing image should set the last modified date" in {
           val id = UUID.randomUUID().toString
           val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), None)


### PR DESCRIPTION
## What does this change?

At the moment, when an image is created, its leases object is populated by a lastModified date, rather than being blank. This presents problems for users searching for images without leases. Given that it's not possible to check for the presence of an empty array, an absent lastModified value is the only way we know to ask this question.

This PR makes sure the lastModified field is not set until leases are added.

(This situation is not quite perfect -- we can imagine an image that previously had leases that are now removed failing to show up for this kind of search -- but ... good enough? @akash1810 @paperboyo)

## How can success be measured?

Upload an image. Within the leases object, the `lastModified` property should be  `null`.  A search with `search?query=-has:leases` should include that image.

## Tested?
- [x] locally
- [x] on TEST
