### PR TITLE
Making LeasesByMedia constructor package private, such that it is created only by build or empty functions and adding leases package and optimise imports

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer
 
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 import org.joda.time.DateTime

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -1,5 +1,6 @@
 package com.gu.mediaservice.model
 
+import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease, LeasesByMedia}
 import com.gu.mediaservice.model.usage.{SyndicationUsage, Usage}
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
@@ -1,4 +1,4 @@
-package com.gu.mediaservice.model
+package com.gu.mediaservice.model.leases
 
 import com.gu.mediaservice.lib.formatting.printDateTime
 import org.joda.time.DateTime

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -1,10 +1,10 @@
-package com.gu.mediaservice.model
+package com.gu.mediaservice.model.leases
 
 import play.api.libs.json._
 import org.joda.time.DateTime
 import JodaWrites._
 
-case class LeasesByMedia(
+case class LeasesByMedia private[leases] (
   leases: List[MediaLease],
   lastModified: Option[DateTime]
 )
@@ -25,6 +25,8 @@ object LeasesByMedia {
   implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
 
   def empty = LeasesByMedia(Nil, None)
+
+  private[leases] def apply(leases: List[MediaLease], lastModified: Option[DateTime]): LeasesByMedia = new LeasesByMedia(leases, lastModified)
 
   def build (leases: List[MediaLease]) = {
     val lastModified = leases.sortBy(_.createdAt).reverse.headOption.map(_.createdAt)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/MediaLease.scala
@@ -1,4 +1,4 @@
-package com.gu.mediaservice.model
+package com.gu.mediaservice.model.leases
 
 import play.api.libs.json._
 import org.joda.time.DateTime

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
@@ -3,6 +3,7 @@ package com.gu.mediaservice.model
 import java.net.URI
 import java.util.UUID
 
+import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease, LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage._
 import org.joda.time.DateTime
 import org.scalatest.{FunSpec, Matchers}
@@ -100,8 +101,7 @@ class ImageTest extends FunSpec with Matchers {
         digitalUsage
       )
 
-      val leaseByMedia = LeasesByMedia(
-        lastModified = None,
+      val leaseByMedia = LeasesByMedia.build(
         leases = List(MediaLease(
           id = None,
           leasedBy = None,
@@ -138,16 +138,13 @@ class ImageTest extends FunSpec with Matchers {
   it("should be QueuedForSyndication if there is an allow syndication lease and no syndication usage") {
     val imageId = UUID.randomUUID().toString
 
-    val leaseByMedia = LeasesByMedia(
-      lastModified = None,
-      leases = List(MediaLease(
-        id = None,
-        leasedBy = None,
-        access = AllowSyndicationLease,
-        notes = None,
-        mediaId = imageId
-      ))
-    )
+    val leaseByMedia = LeasesByMedia.build(leases = List(MediaLease(
+      id = None,
+      leasedBy = None,
+      access = AllowSyndicationLease,
+      notes = None,
+      mediaId = imageId
+    )))
 
     val usages = List(
       digitalUsage
@@ -166,8 +163,7 @@ class ImageTest extends FunSpec with Matchers {
   it("should be BlockedForSyndication if there is a deny syndication lease and no syndication usage") {
     val imageId = UUID.randomUUID().toString
 
-    val leaseByMedia = LeasesByMedia(
-      lastModified = None,
+    val leaseByMedia = LeasesByMedia.build(
       leases = List(MediaLease(
         id = None,
         leasedBy = None,

--- a/leases/app/controllers/MediaLeaseController.scala
+++ b/leases/app/controllers/MediaLeaseController.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model._
 import com.gu.mediaservice.lib.auth._
-import com.gu.mediaservice.model.{LeasesByMedia, MediaLease}
+import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import lib.{LeaseNotifier, LeaseStore, LeasesConfig}
 import play.api.libs.json._
 import play.api.mvc._

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -1,10 +1,8 @@
 package lib
 
 import com.gu.mediaservice.lib.aws.{ThrallMessageSender, UpdateMessage}
-import com.gu.mediaservice.lib.formatting._
-import com.gu.mediaservice.model.{LeaseNotice, LeasesByMedia, MediaLease}
+import com.gu.mediaservice.model.leases.MediaLease
 import org.joda.time.DateTime
-import play.api.libs.json._
 
 class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends ThrallMessageSender(config) {
   def sendReindexLeases(mediaId: String) = {

--- a/leases/app/lib/LeaseStore.scala
+++ b/leases/app/lib/LeaseStore.scala
@@ -1,7 +1,7 @@
 package lib
 
 import com.gu.mediaservice.lib.aws.DynamoDB
-import com.gu.mediaservice.model.{MediaLease, MediaLeaseType}
+import com.gu.mediaservice.model.leases.{MediaLease, MediaLeaseType}
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import org.joda.time.DateTime

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -1,6 +1,7 @@
 package lib
 
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{AllowUseLease, DenyUseLease, LeasesByMedia, MediaLease}
 import lib.usagerights.CostCalculator
 
 case class ValidityCheck(invalid: Boolean, overrideable: Boolean, shouldOverride: Boolean) {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -6,6 +6,7 @@ import com.gu.mediaservice.lib.argo.model._
 import com.gu.mediaservice.lib.auth.{Internal, Tier}
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage._
 import com.softwaremill.quicklens._
 import lib.usagerights.CostCalculator

--- a/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/impls/elasticsearch6/SyndicationFilter.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch.impls.elasticsearch6
 
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease}
 import com.gu.mediaservice.model.usage.SyndicationUsage
 import com.sksamuel.elastic4s.searches.queries.Query
 import lib.MediaApiConfig

--- a/media-api/test/lib/ImagePersistenceReasonsTest.scala
+++ b/media-api/test/lib/ImagePersistenceReasonsTest.scala
@@ -1,6 +1,7 @@
 package lib
 
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.Usage
 import org.joda.time.DateTime.now
 import org.scalatest.{FunSpec, Matchers}

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -1,7 +1,7 @@
 package lib
 
-import com.gu.mediaservice.model.usage.{PendingUsageStatus, PrintUsage, Usage, UsageType}
-import com.gu.mediaservice.model.{ActionData, Bounds, Collection, CommissionedAgency, ContractPhotographer, Crop, CropSpec, Edits, Image, ImageMetadata, LeasesByMedia, MediaLease, Photoshoot, StaffIllustrator, StaffPhotographer, UsageRights}
+import com.gu.mediaservice.model.usage.{PendingUsageStatus, PrintUsage, Usage}
+import com.gu.mediaservice.model.{Bounds, Crop, CropSpec}
 import org.joda.time.DateTime.now
 import org.scalatest.{FunSpec, Matchers}
 

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -3,6 +3,7 @@ package lib.elasticsearch
 import java.net.URI
 import java.util.UUID
 
+import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease, LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.{UsageStatus => Status, _}
 import com.gu.mediaservice.model.{StaffPhotographer, _}
 import org.joda.time.DateTime
@@ -15,12 +16,12 @@ trait Fixtures {
   val screengrab = Screengrab(None, None)
 
   def createImage(
-                   id: String,
-                   usageRights: UsageRights,
-                   syndicationRights: Option[SyndicationRights] = None,
-                   leases: Option[LeasesByMedia] = None,
-                   usages: List[Usage] = Nil,
-                   fileMetadata: Option[FileMetadata] = None
+    id: String,
+    usageRights: UsageRights,
+    syndicationRights: Option[SyndicationRights] = None,
+    leases: Option[LeasesByMedia] = None,
+    usages: List[Usage] = Nil,
+    fileMetadata: Option[FileMetadata] = None
   ): Image = {
     Image(
       id = id,
@@ -74,10 +75,7 @@ trait Fixtures {
 
     val syndicationRights = SyndicationRights(rcsPublishDate, Nil, rights)
 
-    val leaseByMedia = lease.map(l => LeasesByMedia(
-      lastModified = None,
-      leases = List(l)
-    ))
+    val leaseByMedia = lease.map(l => LeasesByMedia.build(List(l)))
 
     createImage(id, usageRights, Some(syndicationRights), leaseByMedia, usages, fileMetadata)
   }

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -4,6 +4,7 @@ import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
 import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearch6Config, ElasticSearch6Executions}
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.DenySyndicationLease
 import com.gu.mediaservice.model.usage.PublishedUsageStatus
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http._
@@ -24,7 +25,7 @@ import scala.concurrent.{Await, Future}
 
 class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually with ElasticSearch6Executions with MockitoSugar {
 
-  implicit val request  = mock[AuthenticatedRequest[AnyContent, Principal]]
+  implicit val request = mock[AuthenticatedRequest[AnyContent, Principal]]
 
   private val index = "images"
 
@@ -66,7 +67,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
   describe("Native elastic search sanity checks") {
 
-    def eventualMatchAllSearchResponse = client.execute (ElasticDsl.search(index) size expectedNumberOfImages * 2)
+    def eventualMatchAllSearchResponse = client.execute(ElasticDsl.search(index) size expectedNumberOfImages * 2)
 
     it("images are actually persisted in Elastic search") {
       val searchResponse = Await.result(eventualMatchAllSearchResponse, fiveSeconds)
@@ -327,7 +328,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       val search = SearchParams(tier = Internal, structuredQuery = List(isInvalidCondition))
       whenReady(ES.search(search), timeout, interval) { result => {
         result.total shouldBe 0
-      }}
+      }
+      }
     }
 
     it("should return owned photographs") {
@@ -351,7 +353,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe expected.size
         expected.foreach(imageIds.contains(_) shouldBe true)
-      }}
+      }
+      }
     }
 
     it("should return owned illustrations") {
@@ -365,7 +368,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe expected.size
         expected.foreach(imageIds.contains(_) shouldBe true)
-      }}
+      }
+      }
     }
 
     it("should return all owned images") {
@@ -391,7 +395,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
         val imageIds = result.hits.map(_._1)
         imageIds.size shouldBe expected.size
         expected.foreach(imageIds.contains(_) shouldBe true)
-      }}
+      }
+      }
     }
 
     it("should return all images when no agencies are over quota") {
@@ -399,7 +404,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
       whenReady(ES.search(search), timeout, interval) { result => {
         result.total shouldBe images.size
-      }}
+      }
+      }
     }
 
     it("should return any image whose agency is not over quota") {
@@ -418,7 +424,8 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
         result.total shouldBe expectedUnderQuotaImages.size
         val imageIds = result.hits.map(_._1)
         expectedUnderQuotaImages.foreach(imageIds.contains(_) shouldBe true)
-      }}
+      }
+      }
     }
   }
 
@@ -432,6 +439,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
 
   private def purgeTestImages = {
     def deleteImages = executeAndLog(deleteByQuery(index, "_doc", matchAllQuery()), s"Deleting images")
+
     Await.result(deleteImages, fiveSeconds)
     eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(totalImages shouldBe 0)
   }

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -4,6 +4,7 @@ import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.elasticsearch6.{ElasticSearch6Config, ElasticSearch6Executions, ElasticSearchClient, Mappings}
 import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.Usage
 import com.gu.mediaservice.syntax._
 import com.sksamuel.elastic4s.http.ElasticDsl._

--- a/thrall/app/lib/ElasticSearchRouter.scala
+++ b/thrall/app/lib/ElasticSearchRouter.scala
@@ -1,5 +1,6 @@
 package lib
-import com.gu.mediaservice.model.{Image, MediaLease, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.model.leases.MediaLease
+import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
 import play.api.libs.json.{JsLookupResult, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/thrall/app/lib/ElasticSearchVersion.scala
+++ b/thrall/app/lib/ElasticSearchVersion.scala
@@ -1,6 +1,7 @@
 package lib
 
-import com.gu.mediaservice.model.{Image, MediaLease, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.model.leases.MediaLease
+import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
 import play.api.libs.json.{JsLookupResult, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -3,6 +3,7 @@ package lib.kinesis
 import com.gu.mediaservice.lib.aws.{EsResponse, UpdateMessage}
 import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.{Usage, UsageNotice}
 import lib._
 import org.joda.time.DateTime

--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -4,6 +4,7 @@ import java.net.URI
 import java.util.UUID
 
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.{DigitalUsage, PublishedUsageStatus, Usage}
 import org.joda.time.DateTime
 
@@ -65,10 +66,7 @@ trait Fixtures {
 
     val syndicationRights = SyndicationRights(rcsPublishDate, Nil, rights)
 
-    val leaseByMedia = lease.map(l => LeasesByMedia(
-      lastModified = leasesLastModified,
-      leases = List(l)
-    ))
+    val leaseByMedia = lease.map(l => LeasesByMedia.build(List(l)))
 
     createImage(id, StaffPhotographer("Tom Jenkins", "The Guardian"), Some(syndicationRights), leaseByMedia, usages, fileMetadata = fileMetadata)
   }

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import com.gu.mediaservice.model
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.MediaLease
 import com.whisk.docker.impl.spotify.DockerKitSpotify
 import com.whisk.docker.scalatest.DockerTestKit
 import com.whisk.docker.{DockerContainer, DockerKit}
@@ -26,6 +27,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
   val fiveSeconds = Duration(5, SECONDS)
 
   def ES: ElasticSearchVersion
+
   def esContainer: Option[DockerContainer]
 
   override def beforeAll {
@@ -34,7 +36,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
   }
 
   override def afterAll: Unit = {
-   super.afterAll()
+    super.afterAll()
   }
 
   final override def dockerContainers: List[DockerContainer] =
@@ -278,7 +280,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
         reloadedImage(id).get.exports.isEmpty shouldBe true
         val exports = List(crop)
 
-        Await.result(Future.sequence(ES.updateImageExports(id, JsDefined(Json.toJson(exports)))), fiveSeconds)  // TODO rename to add
+        Await.result(Future.sequence(ES.updateImageExports(id, JsDefined(Json.toJson(exports)))), fiveSeconds) // TODO rename to add
 
         reloadedImage(id).get.exports.nonEmpty shouldBe true
         reloadedImage(id).get.exports.head.id shouldBe crop.id
@@ -311,7 +313,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
         reloadedImage(id).get.leases.leases.isEmpty shouldBe true
 
-        val lease = model.MediaLease(
+        val lease = model.leases.MediaLease(
           id = Some(UUID.randomUUID().toString),
           leasedBy = None,
           notes = Some("A test lease"),
@@ -327,7 +329,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
       }
 
       "can remove image lease" in {
-        val lease = model.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
+        val lease = model.leases.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(id, true, Some(DateTime.now()), lease = Some(lease))
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
@@ -339,7 +341,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
       }
 
       "removing a lease should update the leases last modified time" in {
-        val lease = model.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
+        val lease = model.leases.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
         val timeBeforeEdit = DateTime.now
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(
@@ -415,13 +417,13 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
         val existingUsage = usage(id = "existing")
         Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(existingUsage))), asJsLookup(DateTime.now))), fiveSeconds)
-        reloadedImage(id).get.usages.head.id shouldEqual("existing")
+        reloadedImage(id).get.usages.head.id shouldEqual ("existing")
 
         val moreRecentUsage = usage(id = "most-recent")
         Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(moreRecentUsage))), asJsLookup(DateTime.now))), fiveSeconds)
 
         reloadedImage(id).get.usages.size shouldBe 1
-        reloadedImage(id).get.usages.head.id shouldEqual("most-recent")
+        reloadedImage(id).get.usages.head.id shouldEqual ("most-recent")
       }
 
       "should ignore usage update requests when the proposed last modified date is older than the current" in {
@@ -436,7 +438,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
         val staleLastModified = DateTime.now.minusWeeks(1)
         Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(staleUsage))), asJsLookup(staleLastModified))), fiveSeconds)
 
-        reloadedImage(id).get.usages.head.id shouldEqual("recent")
+        reloadedImage(id).get.usages.head.id shouldEqual ("recent")
       }
     }
 
@@ -657,7 +659,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
   }
 
   private def indexedImage(id: String) = {
-    Thread.sleep(1000)  // TODO use eventually clause
+    Thread.sleep(1000) // TODO use eventually clause
     Await.result(ES.getImage(id), fiveSeconds)
   }
 


### PR DESCRIPTION
## What does this change?
- Making LeasesByMedia constructor package private, such that it is created only by build or empty functions
- Scopes the models in the `leases` folder to a `leases` package. This convention allows us to have package private features.

## Why we are doing this

the whole intention is that `LeasesByMedia(leases, lastModified)` constructor is private
because there is some logic in place regarding what should happen if leases: `List[MediaLease]` is empty or not
So the only valid creation of that object is via `build` or `empty` function

## Tested?
- [x] locally
- [ ] on TEST
