### PR TITLE
add some client side logging for collection issue

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -92,6 +92,14 @@ grCollectionsPanel.controller('GrNodeCtrl',
     function($scope, collections, subscribe$, inject$, onValChange, collectionsTreeState) {
 
     const ctrl = this;
+
+    try {
+      ctrl.node.data.data.pathId;
+    } catch (e) {
+      console.info('unable to find pathId for node, tree failing to render to completion');
+      console.info(ctrl.node);
+    }
+
     const pathId = ctrl.node.data.data.pathId;
 
     ctrl.saving = false;


### PR DESCRIPTION
## What does this change?
There's a scenario where a node in the collection tree doesn't have a pathId; this causes nodes beyond this one to not render.

Whilst we do not understand how we enter this state, add some logging to help identify the tainted node so we can correct it manually.

## How can success be measured?
We can manually fix things a bit faster.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
