### PR TITLE
Drop imgops full image preview quality 85>65

### DIFF
--- a/kahuna/public/js/imgops/service.js
+++ b/kahuna/public/js/imgops/service.js
@@ -3,7 +3,7 @@ import angular from 'angular';
 export var imgops = angular.module('kahuna.imgops', []);
 
 imgops.factory('imgops', ['$window', function($window) {
-    const quality = 85;
+    const quality = 65;
 
     const lowResMaxWidth  = 800;
     const lowResMaxHeight = 800;


### PR DESCRIPTION
## What does this change?
JPEG quality for full image preview served by imgops drops from 85 to 65.

## How can success be measured?
Images are ~2 times less weighty. For high frequency detail, quality drop is imperceptible, for large areas of subtle gradients – there will be posterisation, but we accept that because:
- it doesn’t happen often
- applies only to original image preview, not to crops made from it
- speeds up future image pagination feature ;-)

To achieve higher quality at lower filesize, we could use mozjpeg, but the computational complexity raises 50 times (or so I heard). We could also compress images differently depending on level of compression read from the original. But I would just wait for AVIF…

## Screenshots (if applicable)
Sure. This is our usual suspect when it comes to visible loss of quality (not quality of the public debate!):

![image](https://user-images.githubusercontent.com/6032869/69650416-78589000-1066-11ea-9308-60d9c0944378.png)

Here is an image that will put your mind at ease:

![image](https://user-images.githubusercontent.com/6032869/69650554-ae960f80-1066-11ea-819f-58389d702bb0.png)


## Who should look at this?
@guardian/digital-cms 

## Tested?
- [ ] locally
- [ ] on TEST
