### PR TITLE
Feature/delete versioned

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -17,7 +17,7 @@ class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config
     storeImage(imageBucket, optimisedPngKeyFromId(id), file, Some("image/png"))
   }
 
-  def deleteOriginal(id: String) = deleteImage(imageBucket, fileKeyFromId(id))
+  def deleteOriginal(id: String) = deleteVersionedImage(imageBucket, fileKeyFromId(id))
   def deleteThumbnail(id: String) = deleteImage(thumbnailBucket, fileKeyFromId(id))
   def deletePng(id: String) = deleteImage(imageBucket, optimisedPngKeyFromId(id))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.gu.mediaservice.lib.config.CommonConfig
 
-class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config: CommonConfig)
+class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config: CommonConfig, isVersionedS3: Boolean = false)
   extends S3ImageStorage(config) {
 
   def storeOriginal(id: String, file: File, mimeType: Option[String], meta: Map[String, String] = Map.empty) =
@@ -17,7 +17,7 @@ class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config
     storeImage(imageBucket, optimisedPngKeyFromId(id), file, Some("image/png"))
   }
 
-  def deleteOriginal(id: String) = deleteVersionedImage(imageBucket, fileKeyFromId(id))
+  def deleteOriginal(id: String) = if(isVersionedS3) deleteVersionedImage(imageBucket, fileKeyFromId(id)) else deleteImage(imageBucket, fileKeyFromId(id))
   def deleteThumbnail(id: String) = deleteImage(thumbnailBucket, fileKeyFromId(id))
   def deletePng(id: String) = deleteImage(imageBucket, optimisedPngKeyFromId(id))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/S3ImageStorage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/S3ImageStorage.scala
@@ -21,6 +21,12 @@ class S3ImageStorage(config: CommonConfig) extends S3(config) with ImageStorage 
     log.info(s"Deleted image $id from bucket $bucket")
   }
 
+  def deleteVersionedImage(bucket: String, id: String) = Future {
+    val objectVersion = client.getObjectMetadata(bucket, id).getVersionId
+    client.deleteVersion(bucket, id, objectVersion)
+    log.info(s"Deleted image $id from bucket $bucket (version: $objectVersion)")
+  }
+
   def deleteFolder(bucket: String, id: String) = Future {
 		val files = client.listObjects(bucket, id).getObjectSummaries.asScala
 		files.foreach(file => client.deleteObject(bucket, file.getKey))

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -23,6 +23,8 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
 
   lazy val metadataTopicArn: String = properties("indexed.image.sns.topic.arn")
 
+  lazy val isVersionedS3: Boolean = properties.getOrElse("s3.image.versioned", "false").toBoolean
+
   lazy val from: Option[DateTime] = properties.get("rewind.from").map(ISODateTimeFormat.dateTime.parseDateTime)
 
 }

--- a/thrall/app/lib/ThrallStore.scala
+++ b/thrall/app/lib/ThrallStore.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib
 
-class ThrallStore(config: ThrallConfig) extends lib.ImageIngestOperations(config.imageBucket, config.thumbnailBucket, config)
+class ThrallStore(config: ThrallConfig) extends lib.ImageIngestOperations(config.imageBucket, config.thumbnailBucket, config, config.isVersionedS3)


### PR DESCRIPTION
## What does this change?
We use a versioned S3 bucket so that we can have CRR enabled. We found that deleting images doesn't actually delete the image (and so save storage space), instead it places a delete marker on top of the image. This PR is too permanently delete the image instead of place the delete marker. It is configurable so that you can say if the bucket is versioned or not (default is not, keep things how they are currently).

This of course isn't the only way of tackling this problem - you can add a lifecycle rule to your bucket to delete old versions and clear delete markers after a certain period of time. But as this has been done with a config param, then that could also be done and this disabled.


## How can success be measured?
Bucket size + number of objects should decrease over time once enabled


## Tested?
- [ x ] locally
- [ x ] on TEST
