### PR TITLE
improve uploader by deleting cached copy of image from browser

### DIFF
--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -10,8 +10,6 @@ upload.factory('uploadManager',
 
     function createJobItem(file) {
         var request = fileUploader.upload(file);
-        // TODO: find out where we can revoke these
-        // see: https://developer.mozilla.org/en-US/docs/Web/API/URL.revokeObjectURL
         var dataUrl = $window.URL.createObjectURL(file);
 
         return {
@@ -39,7 +37,13 @@ upload.factory('uploadManager',
 
         // once all `jobItems` in a job are complete, remove it
         // TODO: potentially move these to a `completeJobs` `Set`
-        $q.all(promises).finally(() => jobs.delete(job));
+        $q.all(promises).finally(() => {
+          jobs.delete(job)
+          job.map(jobItem => {
+            console.log(jobItem)
+            $window.revokeObjectURL(jobItem.dataUrl)
+          })
+        });
     }
 
     function uploadUri(uri) {

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -38,11 +38,11 @@ upload.factory('uploadManager',
         // once all `jobItems` in a job are complete, remove it
         // TODO: potentially move these to a `completeJobs` `Set`
         $q.all(promises).finally(() => {
-          jobs.delete(job)
+          jobs.delete(job);
           job.map(jobItem => {
-            console.log(jobItem)
-            $window.revokeObjectURL(jobItem.dataUrl)
-          })
+            console.log(jobItem);
+            $window.revokeObjectURL(jobItem.dataUrl);
+          });
         });
     }
 

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -40,7 +40,6 @@ upload.factory('uploadManager',
         $q.all(promises).finally(() => {
           jobs.delete(job);
           job.map(jobItem => {
-            console.log(jobItem);
             $window.revokeObjectURL(jobItem.dataUrl);
           });
         });


### PR DESCRIPTION
## What does this change?

When an image is uploaded, a URL to it is held by the browser using window.createObjectURL. This could be to blame for poor performance of the upload. 

This revokes the object url for uploaded images when the upload succeeds, this seems to improve memory use post-upload.

## How can success be measured?

Alleviating the firefox upload perf issues @paperboyo is experiencing. 

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
