### PR TITLE
remove MessageConsumerVersion trait

### DIFF
--- a/thrall/app/controllers/HealthCheck.scala
+++ b/thrall/app/controllers/HealthCheck.scala
@@ -2,12 +2,13 @@ package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import lib._
+import lib.kinesis.ThrallMessageConsumer
 import play.api.Logger
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class HealthCheck(elasticsearch: ElasticSearchVersion, messageConsumer: MessageConsumerVersion, config: ThrallConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
+class HealthCheck(elasticsearch: ElasticSearchVersion, messageConsumer: ThrallMessageConsumer, config: ThrallConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
   def healthCheck = Action.async {

--- a/thrall/app/lib/MessageConsumerVersion.scala
+++ b/thrall/app/lib/MessageConsumerVersion.scala
@@ -1,5 +1,0 @@
-package lib
-
-trait MessageConsumerVersion {
-  def isStopped: Boolean
-}

--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -15,8 +15,7 @@ class ThrallMessageConsumer(config: ThrallConfig,
                             store: ThrallStore,
                             metadataEditorNotifications: MetadataEditorNotifications,
                             syndicationRightsOps: SyndicationRightsOps,
-                            from: Option[DateTime]
-) extends MessageConsumerVersion {
+                            from: Option[DateTime]) {
 
   private val workerId = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
@@ -80,6 +79,6 @@ class ThrallMessageConsumer(config: ThrallConfig,
 
   private def makeThread(worker: Runnable) = new Thread(worker, s"${getClass.getSimpleName}-$workerId")
 
-  override def isStopped: Boolean = !thrallKinesisWorkerThread.isAlive
+  def isStopped: Boolean = !thrallKinesisWorkerThread.isAlive
 
 }


### PR DESCRIPTION
## What does this change?
This is a hangover from the migration from SQS to Kinesis. This trait is only extended in one place now, so isn't needed as we can use the concrete implementation instead for simplicity.

## How can success be measured?
Fewer LOC.

## Screenshots (if applicable)
![img](https://media.giphy.com/media/l4j76TEMbnGtEfVBNG/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
