### PR TITLE
wrapping xmp fileMetadata dynamic key value pairs into predefined (key values) object

### DIFF
--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -107,7 +107,6 @@ object FileMetadataReader {
     } getOrElse Map()
 
   private val datePattern = "(.*[Dd]ate.*)".r
-
   private def xmpDirectoryToMap(directory: XmpDirectory, imageId: String): Map[String, String] = {
     directory.getXmpProperties.asScala.toMap.mapValues(nonEmptyTrimmed).collect {
       case (datePattern(key), Some(value)) => key -> ImageMetadataConverter.cleanDate(value, key, imageId)

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -115,9 +115,14 @@ object FileMetadataReader {
   }
 
   private def exportXmpProperties(metadata: Metadata, imageId:String): Seq[KvPair] = {
-    val props = Option(metadata.getFirstDirectoryOfType(classOf[XmpDirectory])) map { directory =>
-      xmpDirectoryToMap(directory, imageId)
-    } getOrElse Map()
+    val directories = metadata.getDirectoriesOfType(classOf[XmpDirectory]).asScala.toList
+    val props: Map[String, String] = directories.foldLeft[Map[String, String]](Map.empty)((acc, dir) => {
+      // An image can have multiple xmp directories. A directory has multiple xmp properties.
+      // A property can be repeated across directories and its value may not be unique.
+      // Keep the first value encountered on the basis that there will only be multiple directories
+      // if there is no space in the previous one as directories have a maximum size.
+      acc ++ xmpDirectoryToMap(dir, imageId).filterKeys(k => !acc.contains(k))
+    })
     FileMetadataWrapper.wrap(props)
   }
 

--- a/stress-test/ping-grid-search.sh
+++ b/stress-test/ping-grid-search.sh
@@ -8,7 +8,7 @@ plain='\x1B[0m' # No Color
 
 export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
 
-profile_param=test
+profile_param=local
 
 accessGridRootInLoop() {
   while true; do

--- a/stress-test/stress-upload.sh
+++ b/stress-test/stress-upload.sh
@@ -10,13 +10,13 @@ export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
 
 pushd /Users/$USER/code/grid/stress-test/test-files
 
-profile_param=test
+profile_param=local
 
-main_filename=test
+main_filename=test-crs
 
 file_extension=png
 
-files_batch_size=5
+files_batch_size=20
 
 test_iterations=10000
 


### PR DESCRIPTION
example solution with:

wrapping xmp fileMetadata dynamic key value pairs into predefined (key values) object