### PR TITLE
(Solving GRID memory outage on large file metadata) xmp file metadata schema aggregation

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -26,7 +26,7 @@ object ImageMetadataConverter {
 
   def fromFileMetadata(fileMetadata: FileMetadata): ImageMetadata = {
     val xmp = fileMetadata.xmp
-    val readXmpSimpleStringProp: String => Option[String] = (name: String) => {
+    val readXmpHeadProp: String => Option[String] = (name: String) => {
       xmp.get(name) match {
         case Some(JsString(value)) => Some(value)
         case Some(JsArray(value)) => value.headOption.map(_.toString)
@@ -37,44 +37,43 @@ object ImageMetadataConverter {
     ImageMetadata(
       dateTaken           = (fileMetadata.exifSub.get("Date/Time Original Composite") flatMap parseRandomDate) orElse
                             (fileMetadata.iptc.get("Date Time Created Composite") flatMap parseRandomDate) orElse
-                            (readXmpSimpleStringProp("photoshop:DateCreated") flatMap parseRandomDate),
-      description         = readXmpSimpleStringProp("dc:description[1]") orElse
+                            (readXmpHeadProp("photoshop:DateCreated") flatMap parseRandomDate),
+      description         = readXmpHeadProp("dc:description") orElse
                             fileMetadata.iptc.get("Caption/Abstract") orElse
                             fileMetadata.exif.get("Image Description"),
-      credit              = readXmpSimpleStringProp("photoshop:Credit") orElse
+      credit              = readXmpHeadProp("photoshop:Credit") orElse
                             fileMetadata.iptc.get("Credit"),
-      // FIXME: Have a way of dealing with arrays, like [1] here.
-      byline              = readXmpSimpleStringProp("dc:creator[1]") orElse
+      byline              = readXmpHeadProp("dc:creator") orElse
                             fileMetadata.iptc.get("By-line") orElse
                             fileMetadata.exif.get("Artist"),
-      bylineTitle         = readXmpSimpleStringProp("photoshop:AuthorsPosition") orElse
+      bylineTitle         = readXmpHeadProp("photoshop:AuthorsPosition") orElse
                             fileMetadata.iptc.get("By-line Title"),
-      title               = readXmpSimpleStringProp("photoshop:Headline") orElse
+      title               = readXmpHeadProp("photoshop:Headline") orElse
                             fileMetadata.iptc.get("Headline"),
-      copyrightNotice     = readXmpSimpleStringProp("dc:Rights") orElse
+      copyrightNotice     = readXmpHeadProp("dc:Rights") orElse
                             fileMetadata.iptc.get("Copyright Notice"),
       // FIXME: our copyright and copyrightNotice fields should be one field (they read from equivalent fields).
       copyright           = fileMetadata.exif.get("Copyright") orElse
                             fileMetadata.iptc.get("Copyright Notice"),
       // Here we combine two separate fields, based on bad habits of our suppliers.
-      suppliersReference  = readXmpSimpleStringProp("photoshop:TransmissionReference") orElse
+      suppliersReference  = readXmpHeadProp("photoshop:TransmissionReference") orElse
                             fileMetadata.iptc.get("Original Transmission Reference") orElse
-                            readXmpSimpleStringProp("dc:title[1]") orElse
+                            readXmpHeadProp("dc:title") orElse
                             fileMetadata.iptc.get("Object Name"),
-      source              = readXmpSimpleStringProp("photoshop:Source") orElse
+      source              = readXmpHeadProp("photoshop:Source") orElse
                             fileMetadata.iptc.get("Source"),
-      specialInstructions = readXmpSimpleStringProp("photoshop:Instructions") orElse
+      specialInstructions = readXmpHeadProp("photoshop:Instructions") orElse
                             fileMetadata.iptc.get("Special Instructions"),
       // FIXME: Read XMP dc:subject array:
       keywords            = fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toList) getOrElse Nil,
       // FIXME: Parse newest location schema: http://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#location-structure
-      subLocation         = readXmpSimpleStringProp("Iptc4xmpCore:Location") orElse
+      subLocation         = readXmpHeadProp("Iptc4xmpCore:Location") orElse
                             fileMetadata.iptc.get("Sub-location"),
-      city                = readXmpSimpleStringProp("photoshop:City") orElse
+      city                = readXmpHeadProp("photoshop:City") orElse
                             fileMetadata.iptc.get("City"),
-      state               = readXmpSimpleStringProp("photoshop:State") orElse
+      state               = readXmpHeadProp("photoshop:State") orElse
                             fileMetadata.iptc.get("Province/State"),
-      country             = readXmpSimpleStringProp("photoshop:Country") orElse
+      country             = readXmpHeadProp("photoshop:Country") orElse
                             fileMetadata.iptc.get("Country/Primary Location Name"),
       subjects            = extractSubjects(fileMetadata))
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -10,7 +10,7 @@ case class FileMetadata(
   iptc: Map[String, String]                     = Map(),
   exif: Map[String, String]                     = Map(),
   exifSub: Map[String, String]                  = Map(),
-  xmp: Map[String, String]                      = Map(),
+  xmp: Map[String, JsValue]                      = Map(),
   icc: Map[String, String]                      = Map(),
   getty: Map[String, String]                    = Map(),
   colourModel: Option[String]                   = None,
@@ -41,7 +41,7 @@ object FileMetadata {
     (__ \ "iptc").read[Map[String,String]] ~
     (__ \ "exif").read[Map[String,String]] ~
     (__ \ "exifSub").read[Map[String,String]] ~
-    (__ \ "xmp").read[Map[String,String]] ~
+    (__ \ "xmp").read[Map[String,JsValue]] ~
     (__ \ "icc").readNullable[Map[String,String]].map(_ getOrElse Map()).map(removeLongValues) ~
     (__ \ "getty").readNullable[Map[String,String]].map(_ getOrElse Map()) ~
     (__ \ "colourModel").readNullable[String] ~
@@ -63,7 +63,7 @@ object FileMetadata {
     (JsPath \ "iptc").write[Map[String,String]] and
       (JsPath \ "exif").write[Map[String,String]] and
       (JsPath \ "exifSub").write[Map[String,String]] and
-      (JsPath \ "xmp").write[Map[String,String]] and
+      (JsPath \ "xmp").write[Map[String,JsValue]] and
       (JsPath \ "icc").write[Map[String,String]].contramap[Map[String, String]](removeLongValues) and
       (JsPath \ "getty").write[Map[String,String]] and
       (JsPath \ "colourModel").writeNullable[String] and

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
@@ -62,20 +62,20 @@ object FileMetadataAggregator {
 
   def aggregateMetadataMap(flatProperties: Map[String, String]): Map[String, JsValue] = {
 
-    val arrayNormKeyValuePairToIdx = flatProperties.filter { case (k, _) => isArrayKey(k) }.map { case (k, v) =>
+    val arrayKeyValuePairToIdx = flatProperties.filter { case (k, _) => isArrayKey(k) }.map { case (k, v) =>
       val idx = k.substring(k.lastIndexOf("[") + 1, k.lastIndexOf("]")).trim.toInt
       s"${normaliseArrayKey(k)}-$v" -> idx
     }
 
     val initialMetadataStructure = flatProperties.map { case (k, v) => k -> JsString(v) }
 
-    var aggMetadata = aggregateCurrentMetadataLevel(initialMetadataStructure, arrayNormKeyValuePairToIdx)
+    var aggMetadata = aggregateCurrentMetadataLevel(initialMetadataStructure, arrayKeyValuePairToIdx)
 
     def anyKeyIsArrayKey(keys: Set[String]) = keys.exists(isArrayKey)
 
     def anyKeyIsDynamicObjectKey(keys: Set[String]) = keys.exists(isDynamicObjectKey)
 
-    while (anyKeyIsArrayKey(aggMetadata.keySet) || anyKeyIsDynamicObjectKey(aggMetadata.keySet)) aggMetadata = aggregateCurrentMetadataLevel(aggMetadata, arrayNormKeyValuePairToIdx)
+    while (anyKeyIsArrayKey(aggMetadata.keySet) || anyKeyIsDynamicObjectKey(aggMetadata.keySet)) aggMetadata = aggregateCurrentMetadataLevel(aggMetadata, arrayKeyValuePairToIdx)
 
     aggMetadata
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
@@ -53,7 +53,7 @@ object FileMetadataAggregator {
         if (mutableMap.contains(aggregatedKey)) {
           val updated: List[MetadataEntry] = mutableMap(aggregatedKey) match {
             case scala.util.Left(value) => List(value, newMetadataEntry)
-            case scala.util.Right(value) => value :+ newMetadataEntry
+            case scala.util.Right(value) => newMetadataEntry +: value
           }
           mutableMap(aggregatedKey) = scala.util.Right(updated)
         } else {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
@@ -14,7 +14,8 @@ object FileMetadataAggregator {
     val slashIdx = k.lastIndexOf("/")
     val objectName = k.substring(0, slashIdx)
     val objectFieldName = k.substring(slashIdx + 1)
-    val stringifiedObj = Json.stringify(JsObject(Seq((objectFieldName, v)))).replace("\"", "'")
+    val stringifiedObj = Json.stringify(JsObject(Seq((objectFieldName, v))))
+      .replace("\"", "'")
     (objectName, JsArray(Seq(JsString(stringifiedObj))))
   }
 
@@ -46,13 +47,13 @@ object FileMetadataAggregator {
 
     nodes.foreach {
       case (k, v) =>
-        val (aggKey, aggV) = entryToAggregatedKeyAndJsValue(k, v)
-        if (mutableMap.contains(aggKey) && aggV.isInstanceOf[JsArray]) {
-          val cur = mutableMap(aggKey).as[JsArray]
-          val updated = cur ++ aggV.as[JsArray]
-          mutableMap(aggKey) = updated
+        val (aggregatedKey, newValue) = entryToAggregatedKeyAndJsValue(k, v)
+        if (mutableMap.contains(aggregatedKey) && newValue.isInstanceOf[JsArray]) {
+          val cur = mutableMap(aggregatedKey).as[JsArray]
+          val updated = cur ++ newValue.as[JsArray]
+          mutableMap(aggregatedKey) = updated
         } else {
-          mutableMap.put(aggKey, aggV)
+          mutableMap.put(aggregatedKey, newValue)
         }
     }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
@@ -19,10 +19,28 @@ object FileMetadataAggregator {
   }
 
   private def entryToAggregatedKeyAndJsValue(k: String, v: JsValue): (String, JsValue) = {
-   if (isArrayKey(k)) (normaliseArrayKey(k), JsArray(Seq(v))) else if (isDynamicObjectKey(k)) toObjectNameAndValue(k, v) else (k, v)
+    if (isArrayKey(k)) (normaliseArrayKey(k), JsArray(Seq(v))) else if (isDynamicObjectKey(k)) toObjectNameAndValue(k, v)
+    else (k, v)
   }
 
-  def aggregateCurrentMetadataLevel(nodes: Map[String, JsValue]): Map[String, JsValue] = {
+  private def sortAggregatedValuesAtLevel(nodes: Map[String, JsValue], arrayNormKeyValuePairToIdx: Map[String, Int]) = {
+    nodes.map {
+      case (k, v) =>
+        val sortedValues = if (v.isInstanceOf[JsArray]) {
+          val sorted = v.as[JsArray].value.map(item => {
+            val idx = if (item.isInstanceOf[JsString]) {
+              val entryValue = item.as[JsString].value
+              arrayNormKeyValuePairToIdx.getOrElse(s"$k-$entryValue", Int.MaxValue)
+            } else Int.MaxValue
+            (item, idx)
+          }).sortBy(_._2).map(_._1)
+          JsArray(sorted)
+        } else v
+        k -> sortedValues
+    }
+  }
+
+  private def aggregateCurrentMetadataLevel(nodes: Map[String, JsValue], arrayNormKeyValuePairToIdx: Map[String, Int]): Map[String, JsValue] = {
 
     val mutableMap = scala.collection.mutable.Map[String, JsValue]()
 
@@ -38,20 +56,25 @@ object FileMetadataAggregator {
         }
     }
 
-    mutableMap.toMap
+    sortAggregatedValuesAtLevel(mutableMap.toMap, arrayNormKeyValuePairToIdx)
   }
 
   def aggregateMetadataMap(flatProperties: Map[String, String]): Map[String, JsValue] = {
 
+    val arrayNormKeyValuePairToIdx = flatProperties.filter { case (k, _) => isArrayKey(k) }.map { case (k, v) =>
+      val idx = k.substring(k.lastIndexOf("[") + 1, k.lastIndexOf("]")).trim.toInt
+      s"${normaliseArrayKey(k)}-$v" -> idx
+    }
+
     val initialMetadataStructure = flatProperties.map { case (k, v) => k -> JsString(v) }
 
-    var aggMetadata = aggregateCurrentMetadataLevel(initialMetadataStructure)
+    var aggMetadata = aggregateCurrentMetadataLevel(initialMetadataStructure, arrayNormKeyValuePairToIdx)
 
     def anyKeyIsArrayKey(keys: Set[String]) = keys.exists(isArrayKey)
 
     def anyKeyIsDynamicObjectKey(keys: Set[String]) = keys.exists(isDynamicObjectKey)
 
-    while (anyKeyIsArrayKey(aggMetadata.keySet) || anyKeyIsDynamicObjectKey(aggMetadata.keySet)) aggMetadata = aggregateCurrentMetadataLevel(aggMetadata)
+    while (anyKeyIsArrayKey(aggMetadata.keySet) || anyKeyIsDynamicObjectKey(aggMetadata.keySet)) aggMetadata = aggregateCurrentMetadataLevel(aggMetadata, arrayNormKeyValuePairToIdx)
 
     aggMetadata
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadataAggregator.scala
@@ -1,0 +1,68 @@
+package com.gu.mediaservice.model
+
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
+
+import scala.collection.mutable.ArrayBuffer
+
+object FileMetadataAggregator {
+
+  def aggregateMetadataMap(initialMap: Map[String, String]): Map[String, JsValue] = {
+
+    val getNormalisedKeyAndValType: String => (String, String, JsType) = (k: String) => {
+      val isArrayKey = k.endsWith("]")
+      val isSimpleDynamicObject = k.contains("/")
+      val res = if (isArrayKey) {
+        (k.substring(0, k.lastIndexOf("[")), "", JArr)
+      } else if (isSimpleDynamicObject) {
+        val sIdx = k.lastIndexOf("/")
+        val l = k.substring(0, sIdx)
+        val r = k.substring(sIdx + 1)
+        (l, r, JObj)
+      } else {
+        (k, "", JStr)
+      }
+      res
+    }
+
+    val mutableMap = scala.collection.mutable.Map[String, (JsType, ArrayBuffer[String])]()
+
+    for (originalKey <- initialMap.keySet) {
+      val value = initialMap(originalKey)
+      val (normalisedKey, rest, typ) = getNormalisedKeyAndValType(originalKey)
+      if (mutableMap.contains(normalisedKey)) {
+        if (rest.nonEmpty) mutableMap(normalisedKey)._2 += rest
+        mutableMap(normalisedKey)._2 += value
+      } else {
+        if (rest.nonEmpty) {
+          mutableMap.put(normalisedKey, (typ, ArrayBuffer(rest, value)))
+        } else {
+          mutableMap.put(normalisedKey, (typ, ArrayBuffer(value)))
+        }
+      }
+    }
+
+    val normalisedMap: Map[String, JsValue] = mutableMap.map {
+      case (k, v) =>
+        val props = v._2
+        v._1 match {
+          case JObj =>
+            val tups = for (i <- props.indices by 2) yield (props(i), JsString(props(i + 1)))
+            (k, JsObject(tups))
+          case JArr | JStr =>
+            val value = if (props.size > 1) JsArray(props.map(JsString)) else JsString(props.head)
+            (k, value)
+        }
+    }.toMap
+
+    normalisedMap
+  }
+
+}
+
+trait JsType
+
+case object JArr extends JsType
+
+case object JStr extends JsType
+
+case object JObj extends JsType

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -3,6 +3,7 @@ package com.gu.mediaservice.lib.metadata
 import com.gu.mediaservice.model.FileMetadata
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.JsString
 
 class ImageMetadataConverterTest extends FunSpec with Matchers {
 
@@ -99,55 +100,55 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16T02:23:45+01:00)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2014-12-16T02:23:45+01:00"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("2014-12-16T02:23:45+01:00")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16T02:23+01:00)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2014-12-16T02:23+01:00"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("2014-12-16T02:23+01:00")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:00Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2018-06-27T13:54:55)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2018-06-27T13:54:55"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("2018-06-27T13:54:55")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2018-06-27T13:54:55Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2018-06-27T13:54:55.123)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2018-06-27T13:54:55.123"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("2018-06-27T13:54:55.123")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2018-06-27T13:54:55.123Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 GMT 2014)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 GMT 2014"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("Tue Dec 16 01:23:45 GMT 2014")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 UTC 2014)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 UTC 2014"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("Tue Dec 16 01:23:45 UTC 2014")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 BST 2014)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 BST 2014"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("Tue Dec 16 01:23:45 BST 2014")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T00:23:45Z")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (Tue Dec 16 01:23:45 PDT 2014)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "Tue Dec 16 01:23:45 PDT 2014"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("Tue Dec 16 01:23:45 PDT 2014")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(parseDate("2014-12-16T01:23:45-08:00")))
   }
 
   it("should populate the dateTaken field of ImageMetadata from XMP photoshop:DateCreated (2014-12-16)") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "2014-12-16"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("2014-12-16")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (Some(DateTime.parse("2014-12-16T00:00:00Z")))
   }
@@ -171,7 +172,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   }
 
   it("should leave the dateTaken field of ImageMetadata empty if XMP photoshop:DateCreated is not a valid date") {
-    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> "not a date"))
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("not a date")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.dateTaken should be (None)
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
@@ -1,0 +1,140 @@
+package com.gu.mediaservice.model
+
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.{JsArray, JsString}
+
+class FileMetadataAggregatorTest extends FlatSpec with Matchers {
+
+  it should "aggregate flat file metadata" in {
+
+    val testInput = Map(
+      "dc:format" -> "image/png",
+      "xmpMM:History[2]/stEvt:changed" -> "/",
+      "xmpMM:History[5]/stEvt:parameters" -> "converted from application/vnd.adobe.photoshop to image/png",
+      "photoshop:ColorMode" -> "3",
+      "dc:creator[1]" -> "tmp",
+      "xmp:MetadataDate" -> "2019-07-04T13:12:26.000Z",
+      "photoshop:DocumentAncestors[3]" -> "0024E0DBC7EAA19ECC90B9B2F5F1E071",
+      "xmpMM:History[6]/stEvt:instanceID" -> "xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f",
+      "xmpMM:History[2]/stEvt:when" -> "2018-02-06T16:37:53Z",
+      "exif:PixelXDimension" -> "2000",
+      "photoshop:ICCProfile" -> "sRGB IEC61966-2.1",
+      "photoshop:DocumentAncestors[2]" -> "00116C18A16B635936270C3F4DD02EF9",
+      "photoshop:DocumentAncestors[4]" -> "00A4B614125CF2B9AC52D7A1198EE974",
+      "xmpMM:DerivedFrom/stRef:documentID" -> "xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404",
+      "xmpMM:History[4]/stEvt:parameters" -> "from application/vnd.adobe.photoshop to image/png",
+      "xmpMM:History[6]/stEvt:action" -> "saved",
+      "xmp:ModifyDate" -> "2019-07-04T13:12:26.000Z",
+      "xmpMM:History[1]/stEvt:instanceID" -> "xmp.iid:65d63b5e-a24e-4e51-89bd-6693ce193404",
+      "xmpMM:OriginalDocumentID" -> "xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404",
+      "xmpMM:History[3]/stEvt:changed" -> "/",
+      "xmpMM:DerivedFrom/stRef:originalDocumentID" -> "xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404",
+      "xmpMM:History[1]/stEvt:when" -> "2018-02-06T16:36:48Z",
+      "xmpMM:History[2]/stEvt:instanceID" -> "xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded",
+      "xmpMM:History[4]/stEvt:action" -> "converted",
+      "tiff:YResolution" -> "1181100/10000",
+      "exif:PixelYDimension" -> "2000",
+      "xmpMM:History[3]/stEvt:instanceID" -> "xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9",
+      "xmpMM:History[1]/stEvt:action" -> "created",
+      "xmp:CreateDate" -> "2018-02-06T16:36:48.000Z",
+      "dc:rights[1]" -> "B814F57A-329B-441B-8564-F6D3A0973F14",
+      "xmp:CreatorTool" -> "Adobe Photoshop CC 2019 (Macintosh)",
+      "dc:rights[1]/xml:lang" -> "x-default",
+      "xmpMM:History[3]/stEvt:softwareAgent" -> "Adobe Photoshop CC 2019 (Macintosh)",
+      "xmpMM:DocumentID" -> "adobe:docid:photoshop:b55c9154-805d-a14a-a383-6b3945315d73",
+      "xmpMM:History[6]/stEvt:when" -> "2019-07-04T14:12:26+01:00",
+      "xmpMM:History[3]/stEvt:when" -> "2019-07-04T14:12:26+01:00",
+      "tiff:Orientation" -> "1",
+      "xmpMM:History[2]/stEvt:softwareAgent" -> "Adobe Photoshop CC (Macintosh)",
+      "xmpMM:History[6]/stEvt:softwareAgent" -> "Adobe Photoshop CC 2019 (Macintosh)",
+      "xmpMM:DerivedFrom/stRef:instanceID" -> "xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9",
+      "xmpMM:History[1]/stEvt:softwareAgent" -> "Adobe Photoshop CC (Macintosh)",
+      "photoshop:DocumentAncestors[1]" -> "0",
+      "xmpMM:History[5]/stEvt:action" -> "derived",
+      "exif:ColorSpace" -> "1",
+      "xmpMM:History[3]/stEvt:action" -> "saved",
+      "xmpMM:History[6]/stEvt:changed" -> "/",
+      "tiff:ResolutionUnit" -> "3",
+      "tiff:XResolution" -> "1181100/10000",
+      "xmpMM:History[2]/stEvt:action" -> "saved",
+      "xmpMM:InstanceID" -> "xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f"
+    )
+
+    val actual = FileMetadataAggregator.aggregateMetadataMap(testInput)
+
+    val expected = Map(
+      "dc:format" -> JsString("image/png"),
+      "photoshop:ColorMode" -> JsString("3"),
+      "xmp:MetadataDate" -> JsString("2019-07-04T13:12:26.000Z"),
+      "xmpMM:DerivedFrom" -> JsArray(Seq(
+        "{'stRef:documentID':'xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
+        "{'stRef:originalDocumentID':'xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
+        "{'stRef:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}"
+      ).map(JsString)),
+      "exif:PixelXDimension" -> JsString("2000"),
+      "photoshop:ICCProfile" -> JsString("sRGB IEC61966-2.1"),
+      "xmp:ModifyDate" -> JsString("2019-07-04T13:12:26.000Z"),
+      "xmpMM:OriginalDocumentID" -> JsString("xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404"),
+      "tiff:YResolution" -> JsString("1181100/10000"),
+      "exif:PixelYDimension" -> JsString("2000"),
+      "xmp:CreateDate" -> JsString("2018-02-06T16:36:48.000Z"),
+      "dc:rights" -> JsArray(Seq(
+        JsString("B814F57A-329B-441B-8564-F6D3A0973F14"),
+        JsArray(Seq(
+          "{'xml:lang':'x-default'}"
+        ).map(JsString))
+      )),
+      "xmp:CreatorTool" -> JsString("Adobe Photoshop CC 2019 (Macintosh)"),
+      "photoshop:DocumentAncestors" -> JsArray(Seq(
+        "0",
+        "00116C18A16B635936270C3F4DD02EF9",
+        "0024E0DBC7EAA19ECC90B9B2F5F1E071",
+        "00A4B614125CF2B9AC52D7A1198EE974"
+      ).map(JsString)),
+      "xmpMM:DocumentID" -> JsString("adobe:docid:photoshop:b55c9154-805d-a14a-a383-6b3945315d73"),
+      "tiff:Orientation" -> JsString("1"),
+      "dc:creator" -> JsArray(Seq(JsString("tmp"))),
+      "exif:ColorSpace" -> JsString("1"),
+      "xmpMM:History" -> JsArray(Seq(
+        JsArray(Seq(
+          "{'stEvt:instanceID':'xmp.iid:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
+          "{'stEvt:when':'2018-02-06T16:36:48Z'}",
+          "{'stEvt:action':'created'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}"
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'stEvt:parameters':'from application/vnd.adobe.photoshop to image/png'}",
+          "{'stEvt:action':'converted'}"
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'stEvt:changed':'/'}",
+          "{'stEvt:when':'2018-02-06T16:37:53Z'}",
+          "{'stEvt:instanceID':'xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
+          "{'stEvt:action':'saved'}"
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'stEvt:changed':'/'}",
+          "{'stEvt:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
+          "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
+          "{'stEvt:action':'saved'}"
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'stEvt:parameters':'converted from application/vnd.adobe.photoshop to image/png'}", "{'stEvt:action':'derived'}"
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'stEvt:instanceID':'xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f'}", "{'stEvt:action':'saved'}", "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}", "{'stEvt:changed':'/'}"
+        ).map(JsString))
+      )),
+      "tiff:ResolutionUnit" -> JsString("3"),
+      "tiff:XResolution" -> JsString("1181100/10000"),
+      "xmpMM:InstanceID" -> JsString("xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f")
+    )
+
+    actual shouldEqual expected
+
+  }
+
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.{JsArray, JsString}
 
 class FileMetadataAggregatorTest extends FlatSpec with Matchers {
 
-  it should "aggregate flat file metadata" in {
+  it should "organise flat metadata into aggregated form and preserve the order of properties if they are stored in arrays" in {
 
     val testInput = Map(
       "dc:format" -> "image/png",
@@ -79,10 +79,10 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
       "exif:PixelYDimension" -> JsString("2000"),
       "xmp:CreateDate" -> JsString("2018-02-06T16:36:48.000Z"),
       "dc:rights" -> JsArray(Seq(
-        JsString("B814F57A-329B-441B-8564-F6D3A0973F14"),
         JsArray(Seq(
           "{'xml:lang':'x-default'}"
-        ).map(JsString))
+        ).map(JsString)),
+        JsString("B814F57A-329B-441B-8564-F6D3A0973F14")
       )),
       "xmp:CreatorTool" -> JsString("Adobe Photoshop CC 2019 (Macintosh)"),
       "photoshop:DocumentAncestors" -> JsArray(Seq(
@@ -100,32 +100,36 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
           "{'stEvt:instanceID':'xmp.iid:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
           "{'stEvt:when':'2018-02-06T16:36:48Z'}",
           "{'stEvt:action':'created'}",
-          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}"
-        ).map(JsString)),
-        JsArray(Seq(
-          "{'stEvt:parameters':'from application/vnd.adobe.photoshop to image/png'}",
-          "{'stEvt:action':'converted'}"
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
         ).map(JsString)),
         JsArray(Seq(
           "{'stEvt:changed':'/'}",
           "{'stEvt:when':'2018-02-06T16:37:53Z'}",
           "{'stEvt:instanceID':'xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded'}",
           "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
-          "{'stEvt:action':'saved'}"
+          "{'stEvt:action':'saved'}",
         ).map(JsString)),
         JsArray(Seq(
           "{'stEvt:changed':'/'}",
           "{'stEvt:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}",
           "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
           "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
-          "{'stEvt:action':'saved'}"
+          "{'stEvt:action':'saved'}",
         ).map(JsString)),
         JsArray(Seq(
-          "{'stEvt:parameters':'converted from application/vnd.adobe.photoshop to image/png'}", "{'stEvt:action':'derived'}"
+          "{'stEvt:parameters':'from application/vnd.adobe.photoshop to image/png'}",
+          "{'stEvt:action':'converted'}",
         ).map(JsString)),
         JsArray(Seq(
-          "{'stEvt:instanceID':'xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f'}", "{'stEvt:action':'saved'}", "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
-          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}", "{'stEvt:changed':'/'}"
+          "{'stEvt:parameters':'converted from application/vnd.adobe.photoshop to image/png'}",
+          "{'stEvt:action':'derived'}",
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'stEvt:instanceID':'xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f'}",
+          "{'stEvt:action':'saved'}",
+          "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
+          "{'stEvt:changed':'/'}",
         ).map(JsString))
       )),
       "tiff:ResolutionUnit" -> JsString("3"),

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.model
 
 import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json
 import play.api.libs.json.{JsArray, JsString}
 
 class FileMetadataAggregatorTest extends FlatSpec with Matchers {
@@ -67,9 +68,9 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
       "photoshop:ColorMode" -> JsString("3"),
       "xmp:MetadataDate" -> JsString("2019-07-04T13:12:26.000Z"),
       "xmpMM:DerivedFrom" -> JsArray(Seq(
+        "{'stRef:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}",
         "{'stRef:documentID':'xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
         "{'stRef:originalDocumentID':'xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
-        "{'stRef:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}"
       ).map(JsString)),
       "exif:PixelXDimension" -> JsString("2000"),
       "photoshop:ICCProfile" -> JsString("sRGB IEC61966-2.1"),
@@ -97,24 +98,24 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
       "exif:ColorSpace" -> JsString("1"),
       "xmpMM:History" -> JsArray(Seq(
         JsArray(Seq(
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
+          "{'stEvt:action':'created'}",
           "{'stEvt:instanceID':'xmp.iid:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
           "{'stEvt:when':'2018-02-06T16:36:48Z'}",
-          "{'stEvt:action':'created'}",
-          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
         ).map(JsString)),
         JsArray(Seq(
+          "{'stEvt:action':'saved'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
+          "{'stEvt:instanceID':'xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded'}",
           "{'stEvt:changed':'/'}",
           "{'stEvt:when':'2018-02-06T16:37:53Z'}",
-          "{'stEvt:instanceID':'xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded'}",
-          "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
-          "{'stEvt:action':'saved'}",
         ).map(JsString)),
         JsArray(Seq(
+          "{'stEvt:action':'saved'}",
+          "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
           "{'stEvt:changed':'/'}",
           "{'stEvt:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}",
-          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
-          "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
-          "{'stEvt:action':'saved'}",
         ).map(JsString)),
         JsArray(Seq(
           "{'stEvt:parameters':'from application/vnd.adobe.photoshop to image/png'}",
@@ -125,11 +126,11 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
           "{'stEvt:action':'derived'}",
         ).map(JsString)),
         JsArray(Seq(
+          "{'stEvt:changed':'/'}",
+          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
+          "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
           "{'stEvt:instanceID':'xmp.iid:d9500a13-3c27-401c-a2cc-1fd027b0424f'}",
           "{'stEvt:action':'saved'}",
-          "{'stEvt:when':'2019-07-04T14:12:26+01:00'}",
-          "{'stEvt:softwareAgent':'Adobe Photoshop CC 2019 (Macintosh)'}",
-          "{'stEvt:changed':'/'}",
         ).map(JsString))
       )),
       "tiff:ResolutionUnit" -> JsString("3"),

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataAggregatorTest.scala
@@ -1,7 +1,6 @@
 package com.gu.mediaservice.model
 
 import org.scalatest.{FlatSpec, Matchers}
-import play.api.libs.json
 import play.api.libs.json.{JsArray, JsString}
 
 class FileMetadataAggregatorTest extends FlatSpec with Matchers {
@@ -51,6 +50,20 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
       "xmpMM:DerivedFrom/stRef:instanceID" -> "xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9",
       "xmpMM:History[1]/stEvt:softwareAgent" -> "Adobe Photoshop CC (Macintosh)",
       "photoshop:DocumentAncestors[1]" -> "0",
+      "2darr:test[3][4]" -> "d",
+      "2darr:test[2][1]" -> "a",
+      "2darr:test[3][3]" -> "c",
+      "2darr:test[1][2]" -> "b",
+      "2darr:test[1][1]" -> "0",
+      "2darr:test[1][1]" -> "a",
+      "2darr:test[1][3]" -> "c",
+      "2darr:test[3][1]" -> "a",
+      "2darr:test[3][2]" -> "b",
+      "test:nested-object[1]/prop[1]" -> "0",
+      "test:nested-object[1]/prop[2]" -> "1",
+      "test:nested-object[1]/prop[3]" -> "2",
+      "test:nested-object[1]/prop2[1]" -> "0",
+      "test:nested-object[2]/prop[1]" -> "a",
       "xmpMM:History[5]/stEvt:action" -> "derived",
       "exif:ColorSpace" -> "1",
       "xmpMM:History[3]/stEvt:action" -> "saved",
@@ -92,6 +105,22 @@ class FileMetadataAggregatorTest extends FlatSpec with Matchers {
         "0024E0DBC7EAA19ECC90B9B2F5F1E071",
         "00A4B614125CF2B9AC52D7A1198EE974"
       ).map(JsString)),
+      "2darr:test" -> JsArray(
+        Seq(
+          JsArray(Seq("a", "b", "c").map(JsString)),
+          JsArray(Seq("a").map(JsString)),
+          JsArray(Seq("a", "b", "c", "d").map(JsString)),
+        )
+      ),
+      "test:nested-object" -> JsArray(Seq(
+        JsArray(Seq(
+          "{'prop':['0','1','2']}",
+          "{'prop2':['0']}",
+        ).map(JsString)),
+        JsArray(Seq(
+          "{'prop':['a']}",
+        ).map(JsString))
+      )),
       "xmpMM:DocumentID" -> JsString("adobe:docid:photoshop:b55c9154-805d-a14a-a383-6b3945315d73"),
       "tiff:Orientation" -> JsString("1"),
       "dc:creator" -> JsArray(Seq(JsString("tmp"))),

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -115,15 +115,9 @@ object FileMetadataReader {
     }
   }
   private def exportRawXmpProperties(metadata: Metadata, imageId:String): Map[String, String] = {
-    val directories = metadata.getDirectoriesOfType(classOf[XmpDirectory]).asScala.toList
-    val props: Map[String, String] = directories.foldLeft[Map[String, String]](Map.empty)((acc, dir) => {
-      // An image can have multiple xmp directories. A directory has multiple xmp properties.
-      // A property can be repeated across directories and its value may not be unique.
-      // Keep the first value encountered on the basis that there will only be multiple directories
-      // if there is no space in the previous one as directories have a maximum size.
-      acc ++ xmpDirectoryToMap(dir, imageId).filterKeys(k => !acc.contains(k))
-    })
-    props
+    Option(metadata.getFirstDirectoryOfType(classOf[XmpDirectory])) map { directory =>
+      xmpDirectoryToMap(directory, imageId)
+    } getOrElse Map()
   }
   private def exportXmpPropertiesInTransformedSchema(metadata: Metadata, imageId:String): Map[String, JsValue] = {
     val props = exportRawXmpProperties(metadata, imageId)

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -14,9 +14,10 @@ import com.drew.metadata.xmp.XmpDirectory
 import com.drew.metadata.{Directory, Metadata}
 import com.gu.mediaservice.lib.imaging.im4jwrapper.ImageMagick._
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
-import com.gu.mediaservice.model.{Dimensions, FileMetadata}
+import com.gu.mediaservice.model.{Dimensions, FileMetadata, FileMetadataAggregator}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.json.JsValue
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -67,7 +68,7 @@ object FileMetadataReader {
       iptc = exportDirectory(metadata, classOf[IptcDirectory]),
       exif = exportDirectory(metadata, classOf[ExifIFD0Directory]),
       exifSub = exportDirectory(metadata, classOf[ExifSubIFDDirectory]),
-      xmp = exportXmpProperties(metadata, imageId),
+      xmp = exportXmpPropertiesInTransformedSchema(metadata, imageId),
       icc = exportDirectory(metadata, classOf[IccDirectory]),
       getty = exportGettyDirectory(metadata, imageId),
       colourModel = None,
@@ -113,16 +114,21 @@ object FileMetadataReader {
       case (key, Some(value)) => key -> value
     }
   }
-  private def exportXmpProperties(metadata: Metadata, imageId:String): Map[String, String] =
+  private def exportRawXmpProperties(metadata: Metadata, imageId:String): Map[String, String] = {
     Option(metadata.getFirstDirectoryOfType(classOf[XmpDirectory])) map { directory =>
       xmpDirectoryToMap(directory, imageId)
     } getOrElse Map()
+  }
+  private def exportXmpPropertiesInTransformedSchema(metadata: Metadata, imageId:String): Map[String, JsValue] = {
+    val props = exportRawXmpProperties(metadata, imageId)
+    FileMetadataAggregator.aggregateMetadataMap(props)
+  }
 
   // Getty made up their own XMP namespace.
   // We're awaiting actual documentation of the properties available, so
   // this only extracts a small subset of properties as a means to identify Getty images.
   private def exportGettyDirectory(metadata: Metadata, imageId:String): Map[String, String] = {
-      val xmpProperties = exportXmpProperties(metadata, imageId)
+      val xmpProperties = exportRawXmpProperties(metadata, imageId)
 
       def readProperty(name: String): Option[String] = xmpProperties.get(name)
 

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -115,9 +115,15 @@ object FileMetadataReader {
     }
   }
   private def exportRawXmpProperties(metadata: Metadata, imageId:String): Map[String, String] = {
-    Option(metadata.getFirstDirectoryOfType(classOf[XmpDirectory])) map { directory =>
-      xmpDirectoryToMap(directory, imageId)
-    } getOrElse Map()
+    val directories = metadata.getDirectoriesOfType(classOf[XmpDirectory]).asScala.toList
+    val props: Map[String, String] = directories.foldLeft[Map[String, String]](Map.empty)((acc, dir) => {
+      // An image can have multiple xmp directories. A directory has multiple xmp properties.
+      // A property can be repeated across directories and its value may not be unique.
+      // Keep the first value encountered on the basis that there will only be multiple directories
+      // if there is no space in the previous one as directories have a maximum size.
+      acc ++ xmpDirectoryToMap(dir, imageId).filterKeys(k => !acc.contains(k))
+    })
+    props
   }
   private def exportXmpPropertiesInTransformedSchema(metadata: Metadata, imageId:String): Map[String, JsValue] = {
     val props = exportRawXmpProperties(metadata, imageId)

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -4,6 +4,7 @@ import lib.imaging.FileMetadataReader
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.{JsArray, JsString, JsValue}
 
 /**
  * Test that the Reader returns the expected FileMetadata.
@@ -13,6 +14,7 @@ import org.scalatest.{FunSpec, Matchers}
  * highlight differences and integration issues when upgrading the library.
  */
 class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
+
   import test.lib.ResourceHelpers._
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(1000, Millis), interval = Span(25, Millis))
@@ -21,9 +23,9 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("getty.jpg")
     val dimsFuture = FileMetadataReader.dimensions(image, Some("image/jpeg"))
     whenReady(dimsFuture) { dimOpt =>
-      dimOpt should be ('defined)
-      dimOpt.get.width should be (100)
-      dimOpt.get.height should be (60)
+      dimOpt should be('defined)
+      dimOpt.get.width should be(100)
+      dimOpt.get.height should be(60)
     }
   }
 
@@ -31,9 +33,9 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("flower.tif")
     val dimsFuture = FileMetadataReader.dimensions(image, Some("image/tiff"))
     whenReady(dimsFuture) { dimOpt =>
-      dimOpt should be ('defined)
-      dimOpt.get.width should be (73)
-      dimOpt.get.height should be (43)
+      dimOpt should be('defined)
+      dimOpt.get.width should be(73)
+      dimOpt.get.height should be(43)
     }
   }
 
@@ -41,9 +43,9 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("schaik.com_pngsuite/basn0g08.png")
     val dimsFuture = FileMetadataReader.dimensions(image, Some("image/png"))
     whenReady(dimsFuture) { dimOpt =>
-      dimOpt should be ('defined)
-      dimOpt.get.width should be (32)
-      dimOpt.get.height should be (32)
+      dimOpt should be('defined)
+      dimOpt.get.width should be(32)
+      dimOpt.get.height should be(32)
     }
   }
 
@@ -86,30 +88,31 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "Original Create Date Time" -> "0001-01-01T00:00:00.000Z"
       )
       val xmp = Map(
-        "GettyImagesGIFT:ImageRank" -> "3",
-        "GettyImagesGIFT:OriginalFilename" -> "43885812_SEA.jpg",
-        "dc:creator[1]" -> "CHRISTOF STACHE",
-        "dc:title[1]" -> "536991815",
-        "dc:title[1]/xml:lang" -> "x-default",
-        "photoshop:SupplementalCategories[1]" -> "SKI",
-        "photoshop:Headline" -> "Austria's Matthias Mayer attends the men",
-        "photoshop:TransmissionReference" -> "-",
-        "dc:description[1]/xml:lang" -> "x-default",
-        "photoshop:AuthorsPosition" -> "Stringer",
-        "photoshop:CaptionWriter" -> "CS/IW",
-        "plus:ImageSupplierImageId" -> "DV1945213",
-        "dc:description[1]" -> "Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images",
-        "photoshop:City" -> "KITZBUEHEL",
-        "GettyImagesGIFT:ExclusiveCoverage" -> "False",
-        "photoshop:DateCreated" -> "2015-01-22T00:00:00.000Z",
-        "photoshop:Credit" -> "AFP/Getty Images",
-        "dc:Rights" -> "CHRISTOF STACHE",
-        "GettyImagesGIFT:OriginalCreateDateTime" -> "0001-01-01T00:00:00.000Z",
-        "Iptc4xmpCore:CountryCode" -> "AUT",
-        "GettyImagesGIFT:CallForImage" -> "False",
-        "photoshop:Country" -> "AUSTRIA",
-        "photoshop:Source" -> "AFP",
-        "photoshop:Category" -> "S"
+        "GettyImagesGIFT:ImageRank" -> JsString("3"),
+        "GettyImagesGIFT:OriginalFilename" -> JsString("43885812_SEA.jpg"),
+        "dc:creator" -> JsArray(Seq(JsString("CHRISTOF STACHE"))),
+        "dc:title" -> JsArray(Seq(JsString("536991815"), JsArray(Seq(JsString("{'xml:lang':'x-default'}"))))),
+        "photoshop:SupplementalCategories" -> JsArray(Seq(JsString("SKI"))),
+        "photoshop:Headline" -> JsString("Austria's Matthias Mayer attends the men"),
+        "photoshop:TransmissionReference" -> JsString("-"),
+        "photoshop:AuthorsPosition" -> JsString("Stringer"),
+        "photoshop:CaptionWriter" -> JsString("CS/IW"),
+        "plus:ImageSupplierImageId" -> JsString("DV1945213"),
+        "dc:description" -> JsArray(Seq(
+          JsString("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
+          JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+        )),
+        "photoshop:City" -> JsString("KITZBUEHEL"),
+        "GettyImagesGIFT:ExclusiveCoverage" -> JsString("False"),
+        "photoshop:DateCreated" -> JsString("2015-01-22T00:00:00.000Z"),
+        "photoshop:Credit" -> JsString("AFP/Getty Images"),
+        "dc:Rights" -> JsString("CHRISTOF STACHE"),
+        "GettyImagesGIFT:OriginalCreateDateTime" -> JsString("0001-01-01T00:00:00.000Z"),
+        "Iptc4xmpCore:CountryCode" -> JsString("AUT"),
+        "GettyImagesGIFT:CallForImage" -> JsString("False"),
+        "photoshop:Country" -> JsString("AUSTRIA"),
+        "photoshop:Source" -> JsString("AFP"),
+        "photoshop:Category" -> JsString("S")
       )
 
       sameMaps(metadata.iptc, iptc)
@@ -121,36 +124,42 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
   }
 
   it("should read the xmp metadata as stored in the image (process image using GettyImagesGIFT prefix first)") {
-    val prefix0Xmp: Map[String, String] = Map(
-      "photoshop:AuthorsPosition" -> "Staff",
-      "GettyImagesGIFT:Personality[1]" -> "Petr Cech",
-      "dc:description[1]/xml:lang" -> "x-default",
-      "photoshop:SupplementalCategories[1]" -> "FOC",
-      "photoshop:DateCreated" -> "2008-08-20T00:00:00.000Z",
-      "Iptc4xmpCore:CountryCode" -> "GBR",
-      "photoshop:Credit" -> "Getty Images",
-      "photoshop:CaptionWriter" -> "jm",
-      "GettyImagesGIFT:CameraMakeModel" -> "Canon EOS-1D Mark III",
-      "photoshop:City" -> "London",
-      "dc:description[1]" -> "LONDON - AUGUST 20:  Czech Republic goalkeeper Petr Cech in action during the international friendly match between England and the Czech Republic at Wembley Stadium on August 20, 2008 in London, England.  (Photo by Phil Cole/Getty Images)",
-      "photoshop:Headline" -> "England v Czech Republic - International Friendly",
-      "dc:title[1]/xml:lang" -> "x-default",
-      "dc:rights[1]/xml:lang" -> "x-default",
-      "photoshop:TransmissionReference" -> "81774706",
-      "photoshop:Source" -> "Getty Images Europe",
-      "GettyImagesGIFT:CameraFilename" -> "8R8Z0144.JPG",
-      "photoshop:Category" -> "S",
-      "dc:title[1]" -> "81774706JM148_England_v_Cze",
-      "GettyImagesGIFT:OriginalFilename" -> "2008208_81774706JM148_England_v_Cze.jpg",
-      "GettyImagesGIFT:OriginalCreateDateTime" -> "2008-08-20T20:25:49.000Z",
-      "dc:rights[1]" -> "2008 Getty Images",
-      "GettyImagesGIFT:TimeShot" -> "212019+0200",
-      "photoshop:Country" -> "United Kingdom",
-      "GettyImagesGIFT:Composition" -> "Full Length",
-      "GettyImagesGIFT:ImageRank" -> "3",
-      "xmpMM:InstanceID" -> "uuid:faf5bdd5-ba3d-11da-ad31-d33d75182f1b",
-      "dc:creator[1]" -> "Phil Cole",
-      "GettyImagesGIFT:CameraSerialNumber" -> "0000571198"
+    val prefix0Xmp: Map[String, JsValue] = Map(
+      "photoshop:AuthorsPosition" -> JsString("Staff"),
+      "GettyImagesGIFT:Personality" -> JsArray(Seq(JsString("Petr Cech"))),
+      "photoshop:SupplementalCategories" -> JsArray(Seq(JsString("FOC"))),
+      "photoshop:DateCreated" -> JsString("2008-08-20T00:00:00.000Z"),
+      "Iptc4xmpCore:CountryCode" -> JsString("GBR"),
+      "photoshop:Credit" -> JsString("Getty Images"),
+      "photoshop:CaptionWriter" -> JsString("jm"),
+      "GettyImagesGIFT:CameraMakeModel" -> JsString("Canon EOS-1D Mark III"),
+      "photoshop:City" -> JsString("London"),
+      "dc:description" -> JsArray(Seq(
+        JsString("LONDON - AUGUST 20:  Czech Republic goalkeeper Petr Cech in action during the international friendly match between England and the Czech Republic at Wembley Stadium on August 20, 2008 in London, England.  (Photo by Phil Cole/Getty Images)"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "photoshop:Headline" -> JsString("England v Czech Republic - International Friendly"),
+      "photoshop:TransmissionReference" -> JsString("81774706"),
+      "photoshop:Source" -> JsString("Getty Images Europe"),
+      "GettyImagesGIFT:CameraFilename" -> JsString("8R8Z0144.JPG"),
+      "photoshop:Category" -> JsString("S"),
+      "dc:title" -> JsArray(Seq(
+        JsString("81774706JM148_England_v_Cze"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "GettyImagesGIFT:OriginalFilename" -> JsString("2008208_81774706JM148_England_v_Cze.jpg"),
+      "GettyImagesGIFT:OriginalCreateDateTime" -> JsString("2008-08-20T20:25:49.000Z"),
+      "dc:rights" -> JsArray(Seq(
+        JsString("2008 Getty Images"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "GettyImagesGIFT:TimeShot" -> JsString("212019+0200"),
+      "photoshop:Country" -> JsString("United Kingdom"),
+      "GettyImagesGIFT:Composition" -> JsString("Full Length"),
+      "GettyImagesGIFT:ImageRank" -> JsString("3"),
+      "xmpMM:InstanceID" -> JsString("uuid:faf5bdd5-ba3d-11da-ad31-d33d75182f1b"),
+      "dc:creator" -> JsArray(Seq(JsString("Phil Cole"))),
+      "GettyImagesGIFT:CameraSerialNumber" -> JsString("0000571198")
     )
 
     // `getty.jpg` uses the `GettyImagesGIFT` prefix, processing it first will populate the `XMPSchemaRegistry` cache,
@@ -165,38 +174,42 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
   }
 
   it("should read the xmp metadata as stored in the image (process  image using prefix0 prefix first)") {
-    val gettyGiftXmp: Map[String, String] = Map(
-      "GettyImagesGIFT:ImageRank" -> "3",
-      "GettyImagesGIFT:OriginalFilename" -> "43885812_SEA.jpg",
-      "dc:creator[1]" -> "CHRISTOF STACHE",
-      "dc:title[1]" -> "536991815",
-      "dc:title[1]/xml:lang" -> "x-default",
-      "photoshop:SupplementalCategories[1]" -> "SKI",
-      "photoshop:Headline" -> "Austria's Matthias Mayer attends the men",
-      "photoshop:TransmissionReference" -> "-",
-      "dc:description[1]/xml:lang" -> "x-default",
-      "photoshop:AuthorsPosition" -> "Stringer",
-      "photoshop:CaptionWriter" -> "CS/IW",
-      "plus:ImageSupplierImageId" -> "DV1945213",
-      "dc:description[1]" -> "Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images",
-      "photoshop:City" -> "KITZBUEHEL",
-      "GettyImagesGIFT:ExclusiveCoverage" -> "False",
-      "photoshop:DateCreated" -> "2015-01-22T00:00:00.000Z",
-      "photoshop:Credit" -> "AFP/Getty Images",
-      "dc:Rights" -> "CHRISTOF STACHE",
-      "GettyImagesGIFT:OriginalCreateDateTime" -> "0001-01-01T00:00:00.000Z",
-      "Iptc4xmpCore:CountryCode" -> "AUT",
-      "GettyImagesGIFT:CallForImage" -> "False",
-      "photoshop:Country" -> "AUSTRIA",
-      "photoshop:Source" -> "AFP",
-      "photoshop:Category" -> "S"
+    val gettyGiftXmp: Map[String, JsValue] = Map(
+      "GettyImagesGIFT:ImageRank" -> JsString("3"),
+      "GettyImagesGIFT:OriginalFilename" -> JsString("43885812_SEA.jpg"),
+      "dc:creator" -> JsArray(Seq(JsString("CHRISTOF STACHE"))),
+      "dc:title" -> JsArray(Seq(
+        JsString("536991815"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "photoshop:SupplementalCategories" -> JsArray(Seq(JsString("SKI"))),
+      "photoshop:Headline" -> JsString("Austria's Matthias Mayer attends the men"),
+      "photoshop:TransmissionReference" -> JsString("-"),
+      "photoshop:AuthorsPosition" -> JsString("Stringer"),
+      "photoshop:CaptionWriter" -> JsString("CS/IW"),
+      "plus:ImageSupplierImageId" -> JsString("DV1945213"),
+      "dc:description" -> JsArray(Seq(
+        JsString("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "photoshop:City" -> JsString("KITZBUEHEL"),
+      "GettyImagesGIFT:ExclusiveCoverage" -> JsString("False"),
+      "photoshop:DateCreated" -> JsString("2015-01-22T00:00:00.000Z"),
+      "photoshop:Credit" -> JsString("AFP/Getty Images"),
+      "dc:Rights" -> JsString("CHRISTOF STACHE"),
+      "GettyImagesGIFT:OriginalCreateDateTime" -> JsString("0001-01-01T00:00:00.000Z"),
+      "Iptc4xmpCore:CountryCode" -> JsString("AUT"),
+      "GettyImagesGIFT:CallForImage" -> JsString("False"),
+      "photoshop:Country" -> JsString("AUSTRIA"),
+      "photoshop:Source" -> JsString("AFP"),
+      "photoshop:Category" -> JsString("S")
     )
 
     // `cech.jpg` uses the `prefix0` prefix, processing it first will populate the `XMPSchemaRegistry` cache,
     // resulting in `getty.jpg` to be read differently from the content in the file which uses the `GettyImagesGIFT` prefix.
     val prefix0MetadataFuture = FileMetadataReader.fromIPTCHeaders(fileAt("cech.jpg"), "dummy")
     whenReady(prefix0MetadataFuture) { _ =>
-    val gettyGiftXmpFuture = FileMetadataReader.fromIPTCHeaders(fileAt("getty.jpg"), "dummy")
+      val gettyGiftXmpFuture = FileMetadataReader.fromIPTCHeaders(fileAt("getty.jpg"), "dummy")
       whenReady(gettyGiftXmpFuture) { metadata =>
         sameMaps(metadata.xmp, gettyGiftXmp)
       }
@@ -204,36 +217,42 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
   }
 
   it("should always use the GettyImagesGIFT namespace for XMP metadata using the Getty schema") {
-    val expected: Map[String, String] = Map(
-      "photoshop:AuthorsPosition" -> "Staff",
-      "GettyImagesGIFT:Personality[1]" -> "Petr Cech",
-      "dc:description[1]/xml:lang" -> "x-default",
-      "photoshop:SupplementalCategories[1]" -> "FOC",
-      "photoshop:DateCreated" -> "2008-08-20T00:00:00.000Z",
-      "Iptc4xmpCore:CountryCode" -> "GBR",
-      "photoshop:Credit" -> "Getty Images",
-      "photoshop:CaptionWriter" -> "jm",
-      "GettyImagesGIFT:CameraMakeModel" -> "Canon EOS-1D Mark III",
-      "photoshop:City" -> "London",
-      "dc:description[1]" -> "LONDON - AUGUST 20:  Czech Republic goalkeeper Petr Cech in action during the international friendly match between England and the Czech Republic at Wembley Stadium on August 20, 2008 in London, England.  (Photo by Phil Cole/Getty Images)",
-      "photoshop:Headline" -> "England v Czech Republic - International Friendly",
-      "dc:title[1]/xml:lang" -> "x-default",
-      "dc:rights[1]/xml:lang" -> "x-default",
-      "photoshop:TransmissionReference" -> "81774706",
-      "photoshop:Source" -> "Getty Images Europe",
-      "GettyImagesGIFT:CameraFilename" -> "8R8Z0144.JPG",
-      "photoshop:Category" -> "S",
-      "dc:title[1]" -> "81774706JM148_England_v_Cze",
-      "GettyImagesGIFT:OriginalFilename" -> "2008208_81774706JM148_England_v_Cze.jpg",
-      "GettyImagesGIFT:OriginalCreateDateTime" -> "2008-08-20T20:25:49.000Z",
-      "dc:rights[1]" -> "2008 Getty Images",
-      "GettyImagesGIFT:TimeShot" -> "212019+0200",
-      "photoshop:Country" -> "United Kingdom",
-      "GettyImagesGIFT:Composition" -> "Full Length",
-      "GettyImagesGIFT:ImageRank" -> "3",
-      "xmpMM:InstanceID" -> "uuid:faf5bdd5-ba3d-11da-ad31-d33d75182f1b",
-      "dc:creator[1]" -> "Phil Cole",
-      "GettyImagesGIFT:CameraSerialNumber" -> "0000571198"
+    val expected: Map[String, JsValue] = Map(
+      "photoshop:AuthorsPosition" -> JsString("Staff"),
+      "GettyImagesGIFT:Personality" -> JsArray(Seq(JsString("Petr Cech"))),
+      "photoshop:SupplementalCategories" -> JsArray(Seq(JsString("FOC"))),
+      "photoshop:DateCreated" -> JsString("2008-08-20T00:00:00.000Z"),
+      "Iptc4xmpCore:CountryCode" -> JsString("GBR"),
+      "photoshop:Credit" -> JsString("Getty Images"),
+      "photoshop:CaptionWriter" -> JsString("jm"),
+      "GettyImagesGIFT:CameraMakeModel" -> JsString("Canon EOS-1D Mark III"),
+      "photoshop:City" -> JsString("London"),
+      "dc:description" -> JsArray(Seq(
+        JsString("LONDON - AUGUST 20:  Czech Republic goalkeeper Petr Cech in action during the international friendly match between England and the Czech Republic at Wembley Stadium on August 20, 2008 in London, England.  (Photo by Phil Cole/Getty Images)"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "photoshop:Headline" -> JsString("England v Czech Republic - International Friendly"),
+      "photoshop:TransmissionReference" -> JsString("81774706"),
+      "photoshop:Source" -> JsString("Getty Images Europe"),
+      "GettyImagesGIFT:CameraFilename" -> JsString("8R8Z0144.JPG"),
+      "photoshop:Category" -> JsString("S"),
+      "dc:title" -> JsArray(Seq(
+        JsString("81774706JM148_England_v_Cze"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "GettyImagesGIFT:OriginalFilename" -> JsString("2008208_81774706JM148_England_v_Cze.jpg"),
+      "GettyImagesGIFT:OriginalCreateDateTime" -> JsString("2008-08-20T20:25:49.000Z"),
+      "dc:rights" -> JsArray(Seq(
+        JsString("2008 Getty Images"),
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
+      )),
+      "GettyImagesGIFT:TimeShot" -> JsString("212019+0200"),
+      "photoshop:Country" -> JsString("United Kingdom"),
+      "GettyImagesGIFT:Composition" -> JsString("Full Length"),
+      "GettyImagesGIFT:ImageRank" -> JsString("3"),
+      "xmpMM:InstanceID" -> JsString("uuid:faf5bdd5-ba3d-11da-ad31-d33d75182f1b"),
+      "dc:creator" -> JsArray(Seq(JsString("Phil Cole"))),
+      "GettyImagesGIFT:CameraSerialNumber" -> JsString("0000571198")
     )
     val metadataFuture = FileMetadataReader.fromIPTCHeaders(fileAt("cech.jpg"), "dummy")
     whenReady(metadataFuture) { metadata =>
@@ -535,7 +554,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("schaik.com_pngsuite/basn0g08.png")
     val metadataFuture = FileMetadataReader.fromICPTCHeadersWithColorInfo(image, "dummy", "image/png")
     whenReady(metadataFuture) { metadata =>
-      metadata.colourModelInformation should contain (
+      metadata.colourModelInformation should contain(
         "colorType" -> "Greyscale"
       )
     }
@@ -545,7 +564,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("schaik.com_pngsuite/basn3p08.png")
     val metadataFuture = FileMetadataReader.fromICPTCHeadersWithColorInfo(image, "dummy", "image/png")
     whenReady(metadataFuture) { metadata =>
-      metadata.colourModelInformation should contain (
+      metadata.colourModelInformation should contain(
         "colorType" -> "Indexed Color"
       )
     }
@@ -555,7 +574,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("schaik.com_pngsuite/basn2c08.png")
     val metadataFuture = FileMetadataReader.fromICPTCHeadersWithColorInfo(image, "dummy", "image/png")
     whenReady(metadataFuture) { metadata =>
-      metadata.colourModelInformation should contain (
+      metadata.colourModelInformation should contain(
         "colorType" -> "True Color"
       )
     }
@@ -565,7 +584,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("schaik.com_pngsuite/basn6a08.png")
     val metadataFuture = FileMetadataReader.fromICPTCHeadersWithColorInfo(image, "dummy", "image/png")
     whenReady(metadataFuture) { metadata =>
-      metadata.colourModelInformation should contain (
+      metadata.colourModelInformation should contain(
         "colorType" -> "True Color with Alpha"
       )
     }
@@ -575,7 +594,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("flower.tif")
     val metadataFuture = FileMetadataReader.fromICPTCHeadersWithColorInfo(image, "dummy", "image/tiff")
     whenReady(metadataFuture) { metadata =>
-      metadata.colourModelInformation should contain (
+      metadata.colourModelInformation should contain(
         "photometricInterpretation" -> "BlackIsZero"
       )
     }
@@ -585,19 +604,19 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
     val image = fileAt("lighthouse.tif")
     val metadataFuture = FileMetadataReader.fromICPTCHeadersWithColorInfo(image, "dummy", "image/tiff")
     whenReady(metadataFuture) { metadata =>
-      metadata.colourModelInformation should contain (
+      metadata.colourModelInformation should contain(
         "photometricInterpretation" -> "RGB"
       )
     }
   }
 
-  def sameMaps(actual: Map[String, String], expected: Map[String, String]) = {
+  def sameMaps[T](actual: Map[String, T], expected: Map[String, T]) = {
     // Detect mismatching keys
-    actual.keys should be (expected.keys)
+    actual.keys should be(expected.keys)
 
     // Detect mismatching values individually for better errors
     actual.keys.foreach { key =>
-      actual.get(key) should be (expected.get(key))
+      actual.get(key) should be(expected.get(key))
     }
   }
 }

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -90,8 +90,11 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       val xmp = Map(
         "GettyImagesGIFT:ImageRank" -> JsString("3"),
         "GettyImagesGIFT:OriginalFilename" -> JsString("43885812_SEA.jpg"),
+        "dc:title" -> JsArray(Seq(
+          JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
+          JsString("536991815"),
+          )),
         "dc:creator" -> JsArray(Seq(JsString("CHRISTOF STACHE"))),
-        "dc:title" -> JsArray(Seq(JsString("536991815"), JsArray(Seq(JsString("{'xml:lang':'x-default'}"))))),
         "photoshop:SupplementalCategories" -> JsArray(Seq(JsString("SKI"))),
         "photoshop:Headline" -> JsString("Austria's Matthias Mayer attends the men"),
         "photoshop:TransmissionReference" -> JsString("-"),
@@ -99,8 +102,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
         "photoshop:CaptionWriter" -> JsString("CS/IW"),
         "plus:ImageSupplierImageId" -> JsString("DV1945213"),
         "dc:description" -> JsArray(Seq(
+          JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
           JsString("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
-          JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
         )),
         "photoshop:City" -> JsString("KITZBUEHEL"),
         "GettyImagesGIFT:ExclusiveCoverage" -> JsString("False"),
@@ -135,8 +138,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "GettyImagesGIFT:CameraMakeModel" -> JsString("Canon EOS-1D Mark III"),
       "photoshop:City" -> JsString("London"),
       "dc:description" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("LONDON - AUGUST 20:  Czech Republic goalkeeper Petr Cech in action during the international friendly match between England and the Czech Republic at Wembley Stadium on August 20, 2008 in London, England.  (Photo by Phil Cole/Getty Images)"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "photoshop:Headline" -> JsString("England v Czech Republic - International Friendly"),
       "photoshop:TransmissionReference" -> JsString("81774706"),
@@ -144,14 +147,14 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "GettyImagesGIFT:CameraFilename" -> JsString("8R8Z0144.JPG"),
       "photoshop:Category" -> JsString("S"),
       "dc:title" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("81774706JM148_England_v_Cze"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "GettyImagesGIFT:OriginalFilename" -> JsString("2008208_81774706JM148_England_v_Cze.jpg"),
       "GettyImagesGIFT:OriginalCreateDateTime" -> JsString("2008-08-20T20:25:49.000Z"),
       "dc:rights" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("2008 Getty Images"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "GettyImagesGIFT:TimeShot" -> JsString("212019+0200"),
       "photoshop:Country" -> JsString("United Kingdom"),
@@ -179,8 +182,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "GettyImagesGIFT:OriginalFilename" -> JsString("43885812_SEA.jpg"),
       "dc:creator" -> JsArray(Seq(JsString("CHRISTOF STACHE"))),
       "dc:title" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("536991815"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "photoshop:SupplementalCategories" -> JsArray(Seq(JsString("SKI"))),
       "photoshop:Headline" -> JsString("Austria's Matthias Mayer attends the men"),
@@ -189,8 +192,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "photoshop:CaptionWriter" -> JsString("CS/IW"),
       "plus:ImageSupplierImageId" -> JsString("DV1945213"),
       "dc:description" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "photoshop:City" -> JsString("KITZBUEHEL"),
       "GettyImagesGIFT:ExclusiveCoverage" -> JsString("False"),
@@ -228,8 +231,8 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "GettyImagesGIFT:CameraMakeModel" -> JsString("Canon EOS-1D Mark III"),
       "photoshop:City" -> JsString("London"),
       "dc:description" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("LONDON - AUGUST 20:  Czech Republic goalkeeper Petr Cech in action during the international friendly match between England and the Czech Republic at Wembley Stadium on August 20, 2008 in London, England.  (Photo by Phil Cole/Getty Images)"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "photoshop:Headline" -> JsString("England v Czech Republic - International Friendly"),
       "photoshop:TransmissionReference" -> JsString("81774706"),
@@ -237,14 +240,14 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "GettyImagesGIFT:CameraFilename" -> JsString("8R8Z0144.JPG"),
       "photoshop:Category" -> JsString("S"),
       "dc:title" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("81774706JM148_England_v_Cze"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "GettyImagesGIFT:OriginalFilename" -> JsString("2008208_81774706JM148_England_v_Cze.jpg"),
       "GettyImagesGIFT:OriginalCreateDateTime" -> JsString("2008-08-20T20:25:49.000Z"),
       "dc:rights" -> JsArray(Seq(
+        JsArray(Seq(JsString("{'xml:lang':'x-default'}"))),
         JsString("2008 Getty Images"),
-        JsArray(Seq(JsString("{'xml:lang':'x-default'}")))
       )),
       "GettyImagesGIFT:TimeShot" -> JsString("212019+0200"),
       "photoshop:Country" -> JsString("United Kingdom"),

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -11,6 +11,7 @@ import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import play.api.libs.json.JsString
 
 import scala.concurrent.duration._
 import scala.util.Properties
@@ -117,8 +118,8 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
       Some(DateTime.parse("2018-07-03T00:00:00")),
       None,
       fileMetadata = Some(FileMetadata(xmp = Map(
-        "foo" -> "bar",
-        "toolong" -> stringLongerThan(100000)
+        "foo" -> JsString("bar"),
+        "toolong" -> JsString(stringLongerThan(100000))
       )))
     ),
 

--- a/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
+++ b/media-api/test/lib/elasticsearch/impls/elasticsearch6/MediaApiElasticSearch6Test.scala
@@ -16,7 +16,7 @@ import org.joda.time.DateTime
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
 import play.api.Configuration
-import play.api.libs.json.Json
+import play.api.libs.json.{JsString, Json}
 import play.api.mvc.AnyContent
 import play.api.mvc.Security.AuthenticatedRequest
 
@@ -310,7 +310,7 @@ class MediaApiElasticSearch6Test extends ElasticSearchTestBase with Eventually w
       val hasFileMetadataSearch = SearchParams(tier = Internal, structuredQuery = List(hasFileMetadataCondition))
       whenReady(ES.search(hasFileMetadataSearch), timeout, interval) { result =>
         result.total shouldBe 1
-        result.hits.head._2.fileMetadata.xmp.get("foo") shouldBe Some("bar")
+        result.hits.head._2.fileMetadata.xmp.get("foo") shouldBe Some(JsString("bar"))
       }
     }
 

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -12,7 +12,7 @@ import helpers.Fixtures
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
-import play.api.libs.json.{JsDefined, JsLookupResult, Json}
+import play.api.libs.json.{JsDefined, JsLookupResult, JsString, Json}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -72,7 +72,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
         "file metadata fields longer than the index keyword limit are still persisted" in {
           val id = UUID.randomUUID().toString
           val reallyLongTRC = stringLongerThan(250000)
-          val fileMetadata = FileMetadata(xmp = Map("foo" -> "bar"), exif = Map("Green TRC" -> reallyLongTRC))
+          val fileMetadata = FileMetadata(xmp = Map("foo" -> JsString("bar")), exif = Map("Green TRC" -> reallyLongTRC))
 
           val imageWithReallyLongMetadataField = createImageForSyndication(id = UUID.randomUUID().toString,
             rightsAcquired = true,


### PR DESCRIPTION
## What problem are we trying to solve
Preventing Grid to go down after multiple uploads of photos that have a lot of metadata

## How we can measure success:
We can upload more photos in larger batches then before, and Grid will not go down

## Solution
We noticed after conduction couple of stress tests that the structure of metadata makes a difference in terms of memory usage in ElasticSearch

Multidimensional aggregated metadata tend to behave better rather then a lot of key value entires 

In a initial form file metadata delivered by metadata-extractor are in a flat form, even if they are arrays 

for example:

```
"photoshop:DocumentAncestors[1551]": "E43B470C75C2D8F67DE029282B639CB1",
"photoshop:DocumentAncestors[4449]": "xmp.did:67635cef-5cb5-4f91-9af6-5c409d5d931a",
"photoshop:DocumentAncestors[4788]": "xmp.did:7ba6f3b4-d4ca-46de-856d-96342ed089d9",
"photoshop:DocumentAncestors[6696]": "xmp.did:ebf51e72-e67b-48ce-ad2a-17deccf20478",
"photoshop:DocumentAncestors[4134]": "xmp.did:53584ddf-22c7-4b3b-8c61-be0c64eb48db",
"photoshop:DocumentAncestors[5621]": "xmp.did:EE7CE67A092068118083ED46ECBFBA11",
"photoshop:DocumentAncestors[3914]": "xmp.did:46d00d98-735f-4893-8f54-a4e22fc8b6f8",
"photoshop:DocumentAncestors[1881]": "adobe:docid:photoshop:457f9118-16ff-117a-ba68-c34cede39715",
"photoshop:DocumentAncestors[259]": "27A9A0619187D9F465D7389F96E31F7E",
"photoshop:DocumentAncestors[5679]": "xmp.did:F87F1174072068118A6DC80C740D598B",
"photoshop:DocumentAncestors[1407]": "D0C1E78EEE5538D041449A3A47AED786",
```

for very large arrays that cause heap overload in elastic search while photo upload

## What does this change?
Adding `xmp file metadata` schema aggregation from flat key -> value structure
to multi dimensional data structure

- simple `key - value` pairs will stay as they are
- array values will be aggregated
for example
```
test[1]: v1,
test[2]: v2
```

will be aggregated to

```test: [v1, v2]```

- custom objects values will be grouped together
for example
```
"xmpMM:DerivedFrom/stRef:documentID": "xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404",
 "xmpMM:DerivedFrom/stRef:originalDocumentID": "xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404",
"xmpMM:DerivedFrom/stRef:instanceID":  "xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9",
```
will be aggregated to 

```
"xmpMM:DerivedFrom": [
        "{'stRef:documentID':'xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
        "{'stRef:originalDocumentID':'xmp.did:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
        "{'stRef:instanceID':'xmp.iid:adbc5207-3f5b-4480-9e67-ed2a1871deb9'}"
      ]
```
- arrays of custom objects values will be grouped together and aggregated into array of objects
for example:

```
"xmpMM:History[1]/stEvt:instanceID": "xmp.iid:65d63b5e-a24e-4e51-89bd-6693ce193404",
"xmpMM:History[1]/stEvt:when": "2018-02-06T16:36:48Z",
"xmpMM:History[1]/stEvt:action": "created",
 "xmpMM:History[1]/stEvt:softwareAgent": "Adobe Photoshop CC (Macintosh)",
"xmpMM:History[2]/stEvt:changed": "/",
"xmpMM:History[2]/stEvt:when": "2018-02-06T16:37:53Z",
"xmpMM:History[2]/stEvt:instanceID": "xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded",
"xmpMM:History[2]/stEvt:softwareAgent": "Adobe Photoshop CC (Macintosh)",
 "xmpMM:History[2]/stEvt:action": "saved"
```
will be transformed to

```
"xmpMM:History": [
    [
        "{'stEvt:instanceID':'xmp.iid:65d63b5e-a24e-4e51-89bd-6693ce193404'}",
        "{'stEvt:when':'2018-02-06T16:36:48Z'}",
        "{'stEvt:action':'created'}",
        "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}"
    ],
    [
        "{'stEvt:changed':'/'}",
        "{'stEvt:when':'2018-02-06T16:37:53Z'}",
        "{'stEvt:instanceID':'xmp.iid:f9859689-1601-43ae-99a2-9bfb3c159ded'}",
        "{'stEvt:softwareAgent':'Adobe Photoshop CC (Macintosh)'}",
        "{'stEvt:action':'saved'}"
    ]
]
```

## Outcomes of stress tests
tested across https://media.test.dev-gutools.co.uk/

Test input: constant upload of 80 photos with large metadata per batch
(process details: preparing of photos took couple seconds, then 80 requests were send in parallel)

- `before this change` (including reading all xmp file directories)
Grid started to go down after uploading around 98 photos, and it was working occasionally, but most of the time it was inaccessible, and heap usage in ElasticSearch was high (mostly red on cerebro metrics) 

Then it went down completely after uploading 125 photos
And ES cluster was `red` after conducting that stress test

- `after this change` (including reading all xmp file directories)
I was able to upload 1053 photos and Grid did not crash and heap was stable on ES cluster
ES cluster remain `green` while running the tests
after that i stopped the test

## Tested?
- [x] locally
- [x] on TEST
