### PR TITLE
update media-api healthcheck

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/ElasticSearchClient.scala
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-trait ElasticSearchClient {
+trait ElasticSearchClient extends ElasticSearch6Executions {
 
   private val tenSeconds = Duration(10, SECONDS)
   private val thirtySeconds = Duration(30, SECONDS)
@@ -51,6 +51,11 @@ trait ElasticSearchClient {
     if (clusterHealthResponse.isError) {
       throw new RuntimeException("cluster health could not be confirmed as green")  // TODO Exception isn't great but our callers aren't looking at our return value
     }
+  }
+
+  def healthCheck(): Future[Boolean] = {
+    val request = search(imagesAlias) limit 0
+    executeAndLog(request, "Health check").map { _ => true}.recover { case _ => false}
   }
 
   def ensureIndexExists(index: String): Unit = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
@@ -2,19 +2,25 @@ package com.gu.mediaservice.lib.management
 
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.auth.PermissionsHandler
+import com.gu.mediaservice.lib.elasticsearch6.ElasticSearchClient
+import play.api.Logger
 import play.api.libs.json.Json
-import play.api.mvc.{BaseController, ControllerComponents}
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait BuildInfo {
   def toJson: String
 }
 
-trait ManagementController extends BaseController with ArgoHelpers {
-  def buildInfo: BuildInfo
-
-  def healthCheck = Action {
+trait HealthCheck extends BaseController {
+  def healthCheck: Action[AnyContent] = Action {
     Ok("OK")
   }
+}
+
+trait ManagementController extends HealthCheck with BaseController with ArgoHelpers {
+  def buildInfo: BuildInfo
 
   def disallowRobots = Action {
     Ok("User-agent: *\nDisallow: /\n")
@@ -33,6 +39,28 @@ class ManagementWithPermissions(override val controllerComponents: ControllerCom
       ServiceUnavailable("Permissions store is empty")
     } else {
       Ok("ok")
+    }
+  }
+}
+
+class ElasticSearchHealthCheck(override val controllerComponents: ControllerComponents, elasticsearch: ElasticSearchClient)(implicit val ec: ExecutionContext) extends HealthCheck {
+  override def healthCheck: Action[AnyContent] = Action.async {
+    elasticHealth.map {
+      case None => Ok("Ok")
+      case Some(err) => {
+        Logger.warn(s"Health check failed with problems: $err")
+        ServiceUnavailable(err)
+      }
+    }
+  }
+
+  protected def elasticHealth: Future[Option[String]] = {
+    elasticsearch.healthCheck().map { result =>
+      if (!result) {
+        Some("Elastic search call failed")
+      } else {
+        None
+      }
     }
   }
 }

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,7 +1,7 @@
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 import com.gu.mediaservice.lib.elasticsearch6.ElasticSearch6Config
 import com.gu.mediaservice.lib.imaging.ImageOperations
-import com.gu.mediaservice.lib.management.ManagementWithPermissions
+import com.gu.mediaservice.lib.management.{ElasticSearchHealthCheck, ManagementWithPermissions}
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers._
 import lib._
@@ -41,7 +41,8 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)
+  val elasticSearchHealthCheck = new ElasticSearchHealthCheck(controllerComponents, elasticSearch)
   val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi, buildInfo)
 
-  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, healthcheckController)
+  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController)
 }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -33,7 +33,7 @@ GET     /usage/quotas                                 controllers.UsageControlle
 GET     /usage/quotas/:id                             controllers.UsageController.quotaForImage(id: String)
 
 # Management
-GET     /management/healthcheck                       com.gu.mediaservice.lib.management.ManagementWithPermissions.healthCheck
+GET     /management/healthcheck                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.ManagementWithPermissions.manifest
 
 # Shoo robots away

--- a/thrall/app/lib/ElasticSearch6.scala
+++ b/thrall/app/lib/ElasticSearch6.scala
@@ -473,11 +473,6 @@ class ElasticSearch6(config: ElasticSearch6Config, metrics: Option[ThrallMetrics
     List(eventualUpdateResponse.map(_ => ElasticSearchUpdateResponse()))
   }
 
-  def healthCheck()(implicit ex: ExecutionContext): Future[Boolean] = {
-    val request = search(imagesAlias) limit 0
-    executeAndLog(request, "Health check").map { _ => true}.recover { case _ => false}
-  }
-
   private val refreshMetadataScript = """
       | ctx._source.metadata = ctx._source.originalMetadata.clone();
       | if (ctx._source.userMetadata != null && ctx._source.userMetadata.metadata != null) {


### PR DESCRIPTION
## What does this change?
Add a request to elasticsearch in media-api's healthcheck. The media-api is only useful iff it can reach elasticsearch, making it's healthcheck fail will mean the ELB will recover faster.

## How can success be measured?
media-api's healthcheck reports healthy

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
