### PR TITLE
Don't blow up when normalising whitespace chars when many are consecutive

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -310,7 +310,7 @@ object ImageResponse {
     _.suppliersReference
   ).using(_.map(ImageResponse.normaliseNewLines))
 
-  private val pattern = """[\r|\n|\r\n]+""".r
+  private val pattern = """[\r\n]+""".r
 
   def normaliseNewLines(string: String): String = pattern.replaceAllIn(string, "\n")
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -299,20 +299,20 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 object ImageResponse {
 
   val newlineNormalisingImageMetadataWriter: Writes[ImageMetadata] = (input: ImageMetadata) => {
-    Json.toJson(normaliseNewLines(input))
+    Json.toJson(normaliseNewLinesInImageMeta(input))
   }
 
-  def normaliseNewLines(imageMetadata: ImageMetadata): ImageMetadata = imageMetadata.modifyAll(
+  def normaliseNewLinesInImageMeta(imageMetadata: ImageMetadata): ImageMetadata = imageMetadata.modifyAll(
     _.description,
     _.copyrightNotice,
     _.copyright,
     _.specialInstructions,
     _.suppliersReference
-  ).using(_.map(ImageResponse.normaliseNewLines))
+  ).using(_.map(ImageResponse.normaliseNewlineChars))
 
   private val pattern = """[\r\n]+""".r
 
-  def normaliseNewLines(string: String): String = pattern.replaceAllIn(string, "\n")
+  def normaliseNewlineChars(string: String): String = pattern.replaceAllIn(string, "\n")
 
   def canImgBeDeleted(image: Image) = !hasExports(image) && !hasUsages(image)
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -310,7 +310,7 @@ object ImageResponse {
     _.suppliersReference
   ).using(_.map(ImageResponse.normaliseNewLines))
 
-  private val pattern = """(\r|\n|\r\n)+""".r
+  private val pattern = """[\r|\n|\r\n]+""".r
 
   def normaliseNewLines(string: String): String = pattern.replaceAllIn(string, "\n")
 

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -18,6 +18,12 @@ class ImageResponseTest extends FunSpec with Matchers {
     normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
   }
 
+  it("not cause a stack overflow when many consecutive newline characters are present") {
+    val text = "\n\r\n\n\n\r\r\r\n" * 1000
+    val normalisedText = ImageResponse.normaliseNewLines(text)
+    normalisedText shouldBe "\n"
+  }
+
   it("should not touch \\n linebreaks") {
     val text = "Here is some text\nthat spans across\nmultiple lines\n"
     val normalisedText = ImageResponse.normaliseNewLines(text)

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -8,25 +8,25 @@ import org.scalatest.{FunSpec, Matchers}
 class ImageResponseTest extends FunSpec with Matchers {
   it("should replace \\r linebreaks with \\n") {
     val text = "Here is some text\rthat spans across\rmultiple lines\r"
-    val normalisedText = ImageResponse.normaliseNewLines(text)
+    val normalisedText = ImageResponse.normaliseNewlineChars(text)
     normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
   }
 
   it("should replace \\r\\n linebreaks with \\n") {
     val text = "Here is some text\r\nthat spans across\r\nmultiple lines\r\n"
-    val normalisedText = ImageResponse.normaliseNewLines(text)
+    val normalisedText = ImageResponse.normaliseNewlineChars(text)
     normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
   }
 
   it("not cause a stack overflow when many consecutive newline characters are present") {
-    val text = "\n\r\n\n\n\r\r\r\n" * 1000
-    val normalisedText = ImageResponse.normaliseNewLines(text)
+    val text = "\n\r\n\n\n\r\r\r\n" * 10000
+    val normalisedText = ImageResponse.normaliseNewlineChars(text)
     normalisedText shouldBe "\n"
   }
 
   it("should not touch \\n linebreaks") {
     val text = "Here is some text\nthat spans across\nmultiple lines\n"
-    val normalisedText = ImageResponse.normaliseNewLines(text)
+    val normalisedText = ImageResponse.normaliseNewlineChars(text)
     normalisedText shouldBe "Here is some text\nthat spans across\nmultiple lines\n"
   }
 


### PR DESCRIPTION
## What does this change?

The regex `(\r|\n|\r\n)+` can produce a stack overflow when many whitespace chars are consecutive.

By changing the capturing group to the character group `[\r\n]+` our hypothesis is we avoid having to maintain the match data as the group captures more characters. In testing, this regex can handle strings many orders of magnitude longer than the previous expression.

### Some context

This is an attempt to solve an odd stack overflow error that surfaced in our logs. Because the error occurred during a recursion, we're left with little information about its provenance --

```
java.lang.StackOverflowError: null
	at java.util.regex.Pattern$BmpCharProperty.match(Pattern.java:3812)
	at java.util.regex.Pattern$Branch.match(Pattern.java:4618)
	at java.util.regex.Pattern$GroupHead.match(Pattern.java:4672)
	at java.util.regex.Pattern$Loop.match(Pattern.java:4799)
	at java.util.regex.Pattern$GroupTail.match(Pattern.java:4731)
	at java.util.regex.Pattern$BranchConn.match(Pattern.java:4582)
	at java.util.regex.Pattern$BmpCharProperty.match(Pattern.java:3812)
```

In the absence of more information, we've found a few cases where this problem could occur in our application code, and we're patching them.

## How can success be measured?

Query for an image with a large number of consecutive newlines in the description. The server should no longer stop. (Caveat -- we couldn't find one via search.)

## Tested?
- [x] locally
- [ ] on TEST
