### PR TITLE
specialInstructions in free-text search and as a chip

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/Mappings.scala
@@ -92,7 +92,7 @@ object Mappings {
     keywordField("source").copyTo("metadata.englishAnalysedCatchAll"),
     nonAnalysedList("keywords").copyTo("metadata.englishAnalysedCatchAll"),
     nonAnalysedList("subjects"),
-    keywordField("specialInstructions"),
+    keywordField("specialInstructions").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("subLocation").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("city").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("state").copyTo("metadata.englishAnalysedCatchAll"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch6/Mappings.scala
@@ -92,7 +92,7 @@ object Mappings {
     keywordField("source").copyTo("metadata.englishAnalysedCatchAll"),
     nonAnalysedList("keywords").copyTo("metadata.englishAnalysedCatchAll"),
     nonAnalysedList("subjects"),
-    keywordField("specialInstructions").copyTo("metadata.englishAnalysedCatchAll"),
+    standardAnalysed("specialInstructions").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("subLocation").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("city").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("state").copyTo("metadata.englishAnalysedCatchAll"),

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -23,6 +23,7 @@ export const filterFields = [
     'location',
     'source',
     'state',
+    'specialInstructions',
     'subject',
     'supplier',
     'uploader',

--- a/media-api/app/lib/elasticsearch/MatchFields.scala
+++ b/media-api/app/lib/elasticsearch/MatchFields.scala
@@ -9,7 +9,7 @@ trait MatchFields extends ImageFields {
 
   val matchFields: Seq[String] = Seq("id") ++
     Seq("description", "title", "byline", "source", "credit", "keywords",
-      "subLocation", "city", "state", "country", "suppliersReference", "englishAnalysedCatchAll").map(metadataField) ++
+      "subLocation", "city", "state", "country", "specialInstructions", "suppliersReference", "englishAnalysedCatchAll").map(metadataField) ++
     Seq("labels").map(editsField) ++
     config.queriableIdentifiers.map(identifierField) ++
     Seq("restrictions").map(usageRightsField)

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -106,6 +106,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     "copyright" |
     "source" |
     "category" |
+    "specialInstructions" |
     "subject" |
     "supplier" |
     "collection" |


### PR DESCRIPTION
## What does this change?
Adds `specialInstructions` to free-text search and adds `specialInstructions` chip.

## How can success be measured?
Users can search `specialInstructions`.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST