### PR TITLE
be more graceful in the handling of a gunzip exception

### DIFF
--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -36,4 +36,9 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
 
     JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
   }
+
+  test("An uncompressed message cannot be read") {
+    val uncompressedJson = Json.toBytes(Json.toJson(circle))
+    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedJson) shouldBe None
+  }
 }


### PR DESCRIPTION
## What does this change?
Gunzip exception is raised when the message isn't compressed. Rather than throwing this exception, catch it, log it and return None for a more graceful code path.

## How can success be measured?
No more `java.util.zip.ZipException: Not in GZIP format` errors in the logs.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
