### PR TITLE
Support both uncompressed and compressed messages on Thrall stream

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -4,11 +4,9 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.charset.StandardCharsets
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
-import play.api.Logger
 import play.api.libs.json._
 
 import scala.io.Source.fromInputStream
-import scala.util.Try
 
 object JsonByteArrayUtil extends PlayJsonHelpers {
   private val compressionMarkerByte: Byte = 0x00.toByte
@@ -36,21 +34,13 @@ object JsonByteArrayUtil extends PlayJsonHelpers {
   def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
 
   def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
-    val decompressedString = Try(new String(decompress(bytes), StandardCharsets.UTF_8)).toEither
+    val string = new String(decompress(bytes), StandardCharsets.UTF_8)
 
-    decompressedString match {
-      case Left(value) => {
-        Logger.error("unable to gunzip bytes", value)
+    Json.parse(string).validate[T] match {
+      case JsSuccess(obj, _) => Some(obj)
+      case e: JsError => {
+        logParseErrors(e)
         None
-      }
-      case Right(string) => {
-        Json.parse(string).validate[T] match {
-          case JsSuccess(obj, _) => Some(obj)
-          case e: JsError => {
-            logParseErrors(e)
-            None
-          }
-        }
       }
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -31,10 +31,15 @@ object JsonByteArrayUtil extends PlayJsonHelpers {
     decompressedBytes
   }
 
+  def hasCompressionMarker(bytes: Array[Byte]) = bytes.head == compressionMarkerByte
+
   def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
 
   def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
-    val string = new String(decompress(bytes), StandardCharsets.UTF_8)
+    val string = new String(
+      if (hasCompressionMarker(bytes)) decompress(bytes) else bytes,
+      StandardCharsets.UTF_8
+    )
 
     Json.parse(string).validate[T] match {
       case JsSuccess(obj, _) => Some(obj)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -36,9 +36,4 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
 
     JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
   }
-
-  test("An uncompressed message cannot be read") {
-    val uncompressedJson = Json.toBytes(Json.toJson(circle))
-    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedJson) shouldBe None
-  }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -38,4 +38,9 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)
     JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
   }
+
+  test("An uncompressed message can be read") {
+    val uncompressedJson = Json.toBytes(Json.toJson(circle))
+    JsonByteArrayUtil.fromByteArray[Shape](uncompressedJson) shouldBe Some(circle)
+  }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -17,6 +17,7 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
 
   test("To compressed byte array and back again") {
     val bytes = JsonByteArrayUtil.toByteArray(circle)
+    JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
     JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
   }
 
@@ -34,6 +35,7 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     val compressedBytes = JsonByteArrayUtil.toByteArray(shapes)
     compressedBytes.length < uncompressedBytes.length shouldBe true
 
+    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)
     JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
   }
 }


### PR DESCRIPTION
## What does this change?
We started compressing messages before writing to Kinesis as we wanted to write more data. In doing so we moved to only reading compressed messages and dropping anything that was not compressed.

This PR updates Grid to support both compressed and uncompressed messages, meaning the services that integrate with Grid (e.g rcs-poller-lambda) can optionally compress.

## How can success be measured?
Messages continue to be successfully consumed.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@sihil 

## Tested?
- [ ] locally
- [ ] on TEST
