### PR TITLE
Thrall dead letter queue

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -113,7 +113,9 @@ setupLocalKinesis() {
   # ignore stream already exists error
   set +e
   stream_name='media-service-DEV-ThrallMessageQueue-1N0T2UXYNUIC9'
+  deadletter_stream_name='media-service-DEV-deadletter-ThrallMessageQueue-1N0T2UXYNUIC9'
   aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis create-stream --shard-count 1 --stream-name "${stream_name}"
+  aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis create-stream --shard-count 1 --stream-name "${deadletter_stream_name}"
   aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis list-streams
 }
 

--- a/get-local-kinesis-records.sh
+++ b/get-local-kinesis-records.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
-stream_name=media-service-DEV-ThrallMessageQueue-1N0T2UXYNUIC9
-aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis get-records \
- --shard-iterator $(aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis get-shard-iterator --shard-id shardId-000000000000 --shard-iterator-type TRIM_HORIZON --stream-name "${stream_name}" --query "ShardIterator" --output text)
+getRecords()
+{
+  aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis get-records \
+ --shard-iterator $(aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis get-shard-iterator --shard-id shardId-000000000000 --shard-iterator-type TRIM_HORIZON --stream-name "$1" --query "ShardIterator" --output text)
+}
+
+echo "Thrall"
+getRecords  media-service-DEV-ThrallMessageQueue-1N0T2UXYNUIC9
+
+echo "Dead Letter 💀✉️"
+getRecords media-service-DEV-deadletter-ThrallMessageQueue-1N0T2UXYNUIC9

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -9,6 +9,7 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   final override lazy val appName = "thrall"
 
   lazy val queueUrl: String = properties("sqs.queue.url")
+  lazy val thrallDeadLetterKinesisStream = properties("thrall.deadletter.kinesis.stream.name")
 
   lazy val imageBucket: String = properties("s3.image.bucket")
 

--- a/thrall/app/lib/kinesis/ThrallDeadLetter.scala
+++ b/thrall/app/lib/kinesis/ThrallDeadLetter.scala
@@ -1,0 +1,60 @@
+package lib.kinesis
+
+import java.nio.ByteBuffer
+import java.util.UUID
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.kinesis.model.PutRecordRequest
+import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
+import com.gu.mediaservice.lib.aws.UpdateMessage
+import com.gu.mediaservice.lib.json.JsonByteArrayUtil
+import com.gu.mediaservice.model.usage.UsageNotice
+import lib.ThrallConfig
+import net.logstash.logback.marker.{LogstashMarker, Markers}
+import play.api.Logger
+import play.api.libs.json.{JodaWrites, Json}
+
+
+class ThrallDeadLetter(config: ThrallConfig) {
+  private val builder = AmazonKinesisClientBuilder.standard()
+
+  import config.{awsRegion, awsCredentials, thrallKinesisEndpoint, thrallDeadLetterKinesisStream}
+
+  private def getKinesisClient: AmazonKinesis = {
+    Logger.info(s"creating kinesis publisher with endpoint=$thrallKinesisEndpoint , region=$awsRegion")
+    builder
+      .withEndpointConfiguration(new EndpointConfiguration(thrallKinesisEndpoint, awsRegion))
+      .withCredentials(awsCredentials)
+      .build()
+  }
+
+  private lazy val kinesisClient: AmazonKinesis = getKinesisClient
+
+  def publish(message: UpdateMessage) {
+    val partitionKey = UUID.randomUUID().toString
+
+    implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
+    implicit val unw = Json.writes[UsageNotice]
+
+    val payload = JsonByteArrayUtil.toByteArray(message)
+
+    val markers: LogstashMarker = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
+    Logger.info("Republishing message to dead letter stream")(markers)
+
+    val data = ByteBuffer.wrap(payload)
+    val request = new PutRecordRequest()
+      .withStreamName(thrallDeadLetterKinesisStream)
+      .withPartitionKey(partitionKey)
+      .withData(data)
+
+    try {
+      val result = kinesisClient.putRecord(request)
+      Logger.info(s"Published kinesis message to dead letter stream: $result")
+    } catch {
+      case e: Exception =>
+        Logger.error(s"kinesis putRecord exception message for dead letter stream: ${e.getMessage}")
+        // propagate error forward to the client
+        throw e
+    }
+  }
+}

--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -19,8 +19,10 @@ class ThrallMessageConsumer(config: ThrallConfig,
 
   private val workerId = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
+  private val thrallDeadLetter: ThrallDeadLetter = new ThrallDeadLetter(config)
+
   private val thrallEventProcessorFactory = new IRecordProcessorFactory {
-    override def createProcessor(): IRecordProcessor = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, syndicationRightsOps)
+    override def createProcessor(): IRecordProcessor = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, syndicationRightsOps, thrallDeadLetter)
   }
 
   private def createKinesisWorker(cfg: KinesisClientLibConfiguration): Worker = {


### PR DESCRIPTION
## What does this change?

This adds a dead letter queue sender to thrall so that dropped messages can be picked up.

## How can success be measured?

The queue will fill up (we don't yet have a strategy to pick them back up).

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [ ] on TEST

*NB this will need a conf change*