### PR TITLE
a simpler check of the node version

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -92,15 +92,13 @@ fileExists() {
   test -e "$1"
 }
 
-changeNodeVersion() {
-  if ! fileExists "$NVM_DIR/nvm.sh"; then
-    node_version=`cat .nvmrc`
-    echo -e "${red}nvm not found ${plain} NVM is required to run this project"
-    echo -e "Install it from https://github.com/creationix/nvm#installation"
+checkNodeVersion() {
+  runningNodeVersion=$(node -v)
+  requiredNodeVersion=$(cat .nvmrc)
+
+  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
+    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}"
     exit 1
-  else
-    source "$NVM_DIR/nvm.sh"
-    nvm install
   fi
 }
 
@@ -119,7 +117,7 @@ setupLocalKinesis() {
 
 main() {
     checkRequirements
-    changeNodeVersion
+    checkNodeVersion
     setupImgops
     downloadApplicationConfig
     startDockerContainers


### PR DESCRIPTION
## What does this change?
`nvm` seems to install differently on machines, which causes the invocation of node to fail in some scenarios. This implements a simpler check for the node version that isn't opinionated on how different versions of node are maintained.

## How can success be measured?
`dev-start.sh` works for all machines!

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/73283482-0f6ad100-41eb-11ea-9380-3b1fa5fdb42c.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
