### PR TITLE
removes reindex route from media-api

### DIFF
--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -18,7 +18,6 @@ GET     /images/:imageId/export/:exportId             controllers.MediaApi.getIm
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised            controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
-POST    /images/:id/reindex                           controllers.MediaApi.reindexImage(id: String)
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
 GET     /images                                       controllers.MediaApi.imageSearch
 


### PR DESCRIPTION
## What does this change?
This route is incompatible with the recent changes made to how we extract metadata (https://github.com/guardian/grid/pull/2714). Additionally, it's not being used and we are about to replace it (https://github.com/guardian/grid/pull/2731).

## How can success be measured?
Fewer LOC.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
