### PR TITLE
adding get edits endpoint to metadata service

### DIFF
--- a/admin-tools/app/AdminToolsComponents.scala
+++ b/admin-tools/app/AdminToolsComponents.scala
@@ -1,4 +1,3 @@
-import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.AdminToolsCtr
 import lib.AdminToolsConfig

--- a/admin-tools/app/AdminToolsComponents.scala
+++ b/admin-tools/app/AdminToolsComponents.scala
@@ -3,6 +3,7 @@ import com.gu.mediaservice.lib.play.GridComponents
 import controllers.AdminToolsCtr
 import lib.AdminToolsConfig
 import play.api.ApplicationLoader.Context
+import router.Routes
 
 class AdminToolsComponents(context: Context) extends GridComponents(context) {
 
@@ -10,7 +11,7 @@ class AdminToolsComponents(context: Context) extends GridComponents(context) {
 
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val controller = new AdminToolsCtr(controllerComponents)
+  val controller = new AdminToolsCtr(auth, controllerComponents)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management)
 }

--- a/admin-tools/app/AdminToolsComponents.scala
+++ b/admin-tools/app/AdminToolsComponents.scala
@@ -1,0 +1,16 @@
+import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.play.GridComponents
+import controllers.AdminToolsCtr
+import lib.AdminToolsConfig
+import play.api.ApplicationLoader.Context
+
+class AdminToolsComponents(context: Context) extends GridComponents(context) {
+
+  override def config: CommonConfig = new AdminToolsConfig(configuration)
+
+  final override val buildInfo = utils.buildinfo.BuildInfo
+
+  val controller = new AdminToolsCtr(controllerComponents)
+
+  override lazy val router = new Routes(httpErrorHandler, controller, management)
+}

--- a/admin-tools/app/AdminToolsComponents.scala
+++ b/admin-tools/app/AdminToolsComponents.scala
@@ -7,11 +7,11 @@ import router.Routes
 
 class AdminToolsComponents(context: Context) extends GridComponents(context) {
 
-  override def config: CommonConfig = new AdminToolsConfig(configuration)
+  final override lazy val config = new AdminToolsConfig(configuration)
 
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val controller = new AdminToolsCtr(auth, controllerComponents)
+  val controller = new AdminToolsCtr(config, controllerComponents)
 
-  override lazy val router = new Routes(httpErrorHandler, controller, management)
+  override lazy val router = new Routes(httpErrorHandler, controller)
 }

--- a/admin-tools/app/AppLoader.scala
+++ b/admin-tools/app/AppLoader.scala
@@ -1,0 +1,3 @@
+import com.gu.mediaservice.lib.play.GridAppLoader
+
+class AppLoader extends GridAppLoader(new AdminToolsComponents(_))

--- a/admin-tools/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/app/controllers/AdminToolsCtr.scala
@@ -19,4 +19,10 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
     indexResponse
   }
 
+  def project(mediaId: String) = Action {
+    indexResponse
+  }
+
+
+
 }

--- a/admin-tools/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/app/controllers/AdminToolsCtr.scala
@@ -1,11 +1,22 @@
 package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth.Authentication
+import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
 
-class AdminToolsCtr(override val controllerComponents: ControllerComponents) extends BaseController  with ArgoHelpers {
+class AdminToolsCtr(auth: Authentication, override val controllerComponents: ControllerComponents) extends BaseController with ArgoHelpers {
 
-  def index = {
-
+  private val indexResponse = {
+    val indexData = Json.obj(
+      "description" -> "This is Admin tools API"
+    )
+    val indexLinks = Nil
+    respond(indexData, indexLinks)
   }
+
+  def index = auth {
+    indexResponse
+  }
+
 }

--- a/admin-tools/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/app/controllers/AdminToolsCtr.scala
@@ -1,10 +1,10 @@
 package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
-import lib.AdminToolsConfig
+import com.gu.mediaservice.model.Image._
+import lib.{AdminToolsConfig, ImageDataMerger}
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
-
 class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents) extends BaseController with ArgoHelpers {
 
   private val indexResponse = {
@@ -18,11 +18,10 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
   def index = Action {
     indexResponse
   }
+  val merger = new ImageDataMerger(config)
 
   def project(mediaId: String) = Action {
-    indexResponse
+    val image = merger.getMergedImageData(mediaId)
+    Ok(Json.toJson(image)).as(ArgoMediaType)
   }
-
-
-
 }

--- a/admin-tools/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/app/controllers/AdminToolsCtr.scala
@@ -1,11 +1,11 @@
 package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
-import com.gu.mediaservice.lib.auth.Authentication
+import lib.AdminToolsConfig
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
 
-class AdminToolsCtr(auth: Authentication, override val controllerComponents: ControllerComponents) extends BaseController with ArgoHelpers {
+class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents) extends BaseController with ArgoHelpers {
 
   private val indexResponse = {
     val indexData = Json.obj(
@@ -15,7 +15,7 @@ class AdminToolsCtr(auth: Authentication, override val controllerComponents: Con
     respond(indexData, indexLinks)
   }
 
-  def index = auth {
+  def index = Action {
     indexResponse
   }
 

--- a/admin-tools/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/app/controllers/AdminToolsCtr.scala
@@ -5,7 +5,10 @@ import com.gu.mediaservice.model.Image._
 import lib.{AdminToolsConfig, ImageDataMerger}
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
-class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents) extends BaseController with ArgoHelpers {
+
+import scala.concurrent.ExecutionContext
+
+class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext) extends BaseController with ArgoHelpers {
 
   private val indexResponse = {
     val indexData = Json.obj(
@@ -20,8 +23,7 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
   }
   val merger = new ImageDataMerger(config)
 
-  def project(mediaId: String) = Action {
-    val image = merger.getMergedImageData(mediaId)
-    Ok(Json.toJson(image)).as(ArgoMediaType)
+  def project(mediaId: String) = Action.async {
+    merger.getMergedImageData(mediaId).map(i => Ok(Json.toJson(i)).as(ArgoMediaType))
   }
 }

--- a/admin-tools/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/app/controllers/AdminToolsCtr.scala
@@ -1,0 +1,11 @@
+package controllers
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import play.api.mvc.{BaseController, ControllerComponents}
+
+class AdminToolsCtr(override val controllerComponents: ControllerComponents) extends BaseController  with ArgoHelpers {
+
+  def index = {
+
+  }
+}

--- a/admin-tools/app/lib/AdminToolsConfig.scala
+++ b/admin-tools/app/lib/AdminToolsConfig.scala
@@ -8,4 +8,7 @@ class AdminToolsConfig(override val configuration: Configuration) extends Common
 
   override lazy val domainRoot: String = "local.dev-gutools.co.uk"
   override lazy val properties = Map("auth.keystore.bucket" -> "not-used")
+
+  // TODO inject this value
+  val apiKey = "dev-"
 }

--- a/admin-tools/app/lib/AdminToolsConfig.scala
+++ b/admin-tools/app/lib/AdminToolsConfig.scala
@@ -1,0 +1,8 @@
+package lib
+
+import com.gu.mediaservice.lib.config.CommonConfig
+import play.api.Configuration
+
+class AdminToolsConfig(override val configuration: Configuration) extends CommonConfig {
+  override def appName: String = "admin-tools"
+}

--- a/admin-tools/app/lib/AdminToolsConfig.scala
+++ b/admin-tools/app/lib/AdminToolsConfig.scala
@@ -5,4 +5,7 @@ import play.api.Configuration
 
 class AdminToolsConfig(override val configuration: Configuration) extends CommonConfig {
   override def appName: String = "admin-tools"
+
+  override lazy val domainRoot: String = "local.dev-gutools.co.uk"
+  override lazy val properties = Map("auth.keystore.bucket" -> "not-used")
 }

--- a/admin-tools/app/lib/ImageDataMerger.scala
+++ b/admin-tools/app/lib/ImageDataMerger.scala
@@ -1,10 +1,12 @@
 package lib
 
+import java.net.URL
+
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.model.Image
+import com.gu.mediaservice.model.{Collection, Image}
 import com.gu.mediaservice.model.Image._
 import okhttp3.{OkHttpClient, Request}
-import play.api.libs.json.Json
+import play.api.libs.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -14,13 +16,25 @@ class ImageDataMerger(config: AdminToolsConfig)(implicit ec: ExecutionContext) {
   def getMergedImageData(mediaId: String): Future[Image] = {
     for {
       image <- getImageLoaderProjection(mediaId)
-    } yield image
+      collections <- getCollectionsResponse(mediaId)
+    } yield image.copy(
+      collections = collections
+    )
+  }
+
+  private def makeRequest (url: URL): JsValue = {
+    val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
+    val response = client.newCall(request).execute
+    Json.parse(response.body.string)
   }
 
   private def getImageLoaderProjection(mediaId: String): Future[Image] = Future{
-    val url = s"${config.services.loaderBaseUri}/images/project/${mediaId}"
-    val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
-    val response = client.newCall(request).execute
-    Json.parse(response.body.string).as[Image]
+    val url = new URL(s"${config.services.loaderBaseUri}/images/project/${mediaId}")
+    makeRequest(url).as[Image]
+  }
+
+  private def getCollectionsResponse(mediaId: String): Future[List[Collection]] = Future{
+    val url = new URL(s"${config.services.collectionsBaseUri}/images/${mediaId}")
+    (makeRequest(url) \ "data").as[List[Collection]]
   }
 }

--- a/admin-tools/app/lib/ImageDataMerger.scala
+++ b/admin-tools/app/lib/ImageDataMerger.scala
@@ -43,7 +43,6 @@ class ImageDataMerger(config: AdminToolsConfig)(implicit ec: ExecutionContext) {
   }
 
   private def getEdits(mediaId: String): Future[Option[Edits]] = Future {
-    println("getEdits")
     val url = new URL(s"${config.services.metadataBaseUri}/user-metadata/$mediaId")
     val res = makeRequest(url)
     if (res.statusCode != 200) None else Some((res.body \ "data").as[Edits])

--- a/admin-tools/app/lib/ImageDataMerger.scala
+++ b/admin-tools/app/lib/ImageDataMerger.scala
@@ -3,38 +3,50 @@ package lib
 import java.net.URL
 
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.model.{Collection, Image}
 import com.gu.mediaservice.model.Image._
+import com.gu.mediaservice.model.{Collection, Image}
 import okhttp3.{OkHttpClient, Request}
 import play.api.libs.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ImageDataMerger(config: AdminToolsConfig)(implicit ec: ExecutionContext) {
-  val client = new OkHttpClient
 
-  def getMergedImageData(mediaId: String): Future[Image] = {
+  private val httpClient = new OkHttpClient
+
+  def getMergedImageData(mediaId: String): Option[Future[Image]] = {
+    val maybeImage: Option[Image] = getImageLoaderProjection(mediaId)
+     maybeImage.map(aggregate)
+  }
+
+  private def aggregate(image: Image): Future[Image] = {
+    val mediaId = image.id
     for {
-      image <- getImageLoaderProjection(mediaId)
       collections <- getCollectionsResponse(mediaId)
     } yield image.copy(
       collections = collections
     )
   }
 
-  private def makeRequest (url: URL): JsValue = {
-    val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
-    val response = client.newCall(request).execute
-    Json.parse(response.body.string)
+  private def getImageLoaderProjection(mediaId: String): Option[Image] =  {
+    val url = new URL(s"${config.services.loaderBaseUri}/images/project/$mediaId")
+    val res = makeRequest(url)
+    if (res.statusCode == 200) Some(res.body.as[Image]) else None
   }
 
-  private def getImageLoaderProjection(mediaId: String): Future[Image] = Future{
-    val url = new URL(s"${config.services.loaderBaseUri}/images/project/${mediaId}")
-    makeRequest(url).as[Image]
-  }
-
-  private def getCollectionsResponse(mediaId: String): Future[List[Collection]] = Future{
+  private def getCollectionsResponse(mediaId: String): Future[List[Collection]] = Future {
     val url = new URL(s"${config.services.collectionsBaseUri}/images/${mediaId}")
-    (makeRequest(url) \ "data").as[List[Collection]]
+    val res = makeRequest(url)
+    if (res.statusCode != 200) List.empty[Collection] else (res.body \ "data").as[List[Collection]]
+  }
+
+  case class ResponseWrapper(body: JsValue, statusCode: Int)
+
+  private def makeRequest(url: URL): ResponseWrapper = {
+    val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
+    val response = httpClient.newCall(request).execute
+    response.code
+    val json = Json.parse(response.body.string)
+    ResponseWrapper(json, response.code)
   }
 }

--- a/admin-tools/app/lib/ImageDataMerger.scala
+++ b/admin-tools/app/lib/ImageDataMerger.scala
@@ -6,14 +6,18 @@ import com.gu.mediaservice.model.Image._
 import okhttp3.{OkHttpClient, Request}
 import play.api.libs.json.Json
 
-class ImageDataMerger(config: AdminToolsConfig) {
+import scala.concurrent.{ExecutionContext, Future}
+
+class ImageDataMerger(config: AdminToolsConfig)(implicit ec: ExecutionContext) {
   val client = new OkHttpClient
 
-  def getMergedImageData(mediaId: String): Image = {
-    getImageLoaderProjection(mediaId)
+  def getMergedImageData(mediaId: String): Future[Image] = {
+    for {
+      image <- getImageLoaderProjection(mediaId)
+    } yield image
   }
 
-  private def getImageLoaderProjection(mediaId: String): Image = {
+  private def getImageLoaderProjection(mediaId: String): Future[Image] = Future{
     val url = s"${config.services.loaderBaseUri}/images/project/${mediaId}"
     val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
     val response = client.newCall(request).execute

--- a/admin-tools/app/lib/ImageDataMerger.scala
+++ b/admin-tools/app/lib/ImageDataMerger.scala
@@ -1,0 +1,22 @@
+package lib
+
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.model.Image
+import com.gu.mediaservice.model.Image._
+import okhttp3.{OkHttpClient, Request}
+import play.api.libs.json.Json
+
+class ImageDataMerger(config: AdminToolsConfig) {
+  val client = new OkHttpClient
+
+  def getMergedImageData(mediaId: String): Image = {
+    getImageLoaderProjection(mediaId)
+  }
+
+  private def getImageLoaderProjection(mediaId: String): Image = {
+    val url = s"${config.services.loaderBaseUri}/images/project/${mediaId}"
+    val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
+    val response = client.newCall(request).execute
+    Json.parse(response.body.string).as[Image]
+  }
+}

--- a/admin-tools/conf/routes
+++ b/admin-tools/conf/routes
@@ -1,0 +1,1 @@
+GET     /                           controllers.AdminToolsCtr.index

--- a/admin-tools/conf/routes
+++ b/admin-tools/conf/routes
@@ -1,1 +1,2 @@
 GET     /                           controllers.AdminToolsCtr.index
+GET     /images/:id/project         controllers.AdminToolsCtr.project(id: String)

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ Global / concurrentRestrictions := Seq(
 
 val awsSdkVersion = "1.11.302"
 val elastic4sVersion = "6.4.0"
+val okHttpVersion = "3.12.1"
 
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
@@ -93,7 +94,7 @@ lazy val cropper = playProject("cropper", 9006)
 
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
-    "com.squareup.okhttp3" % "okhttp" % "3.12.1",
+    "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
     "org.apache.tika" % "tika-core" % "1.20"
   )
 }
@@ -118,7 +119,11 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
   )
 )
 
-lazy val adminTools = playProject("admin-tools", 9013)
+lazy val adminTools = playProject("admin-tools", 9013).settings {
+  libraryDependencies ++= Seq(
+    "com.squareup.okhttp3" % "okhttp" % okHttpVersion
+  )
+}
 
 lazy val metadataEditor = playProject("metadata-editor", 9007)
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val root = project("grid", path = Some("."))
     )
   )
 
-addCommandAlias("runAll", "all auth/run media-api/run thrall/run image-loader/run metadata-editor/run kahuna/run collections/run cropper/run usage/run leases/run")
+addCommandAlias("runAll", "all auth/run media-api/run thrall/run image-loader/run metadata-editor/run kahuna/run collections/run cropper/run usage/run leases/run admin-tools/run")
 
 // Required to allow us to run more than four play projects in parallel from a single SBT shell
 Global / concurrentRestrictions := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val commonSettings = Seq(
 )
 
 lazy val root = project("grid", path = Some("."))
-  .aggregate(commonLib, auth, collections, cropper, imageLoader, leases, thrall, kahuna, metadataEditor, usage, mediaApi)
+  .aggregate(commonLib, auth, collections, cropper, imageLoader, leases, thrall, kahuna, metadataEditor, usage, mediaApi, adminTools)
   .enablePlugins(RiffRaffArtifact)
   .settings(
     riffRaffManifestProjectName := s"media-service::grid::all",
@@ -30,6 +30,7 @@ lazy val root = project("grid", path = Some("."))
       (packageBin in Debian in metadataEditor).value -> s"${(name in metadataEditor).value}/${(name in metadataEditor).value}.deb",
       (packageBin in Debian in usage).value -> s"${(name in usage).value}/${(name in usage).value}.deb",
       (packageBin in Debian in mediaApi).value -> s"${(name in mediaApi).value}/${(name in mediaApi).value}.deb",
+      (packageBin in Debian in adminTools).value -> s"${(name in adminTools).value}/${(name in adminTools).value}.deb",
       file("riff-raff.yaml") -> "riff-raff.yaml"
     )
   )
@@ -116,6 +117,8 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
     "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test
   )
 )
+
+lazy val adminTools = playProject("admin-tools", 9013)
 
 lazy val metadataEditor = playProject("metadata-editor", 9007)
 

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -60,6 +60,13 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
     } recover { case NoItemFound => emptyResponse }
   }
 
+  def getEdits(id: String) = auth.async {
+    store.get(id) map { dynamoEntry =>
+      val edits = dynamoEntry.asOpt[Edits]
+      respond(data = edits)
+    } recover { case NoItemFound => NotFound }
+  }
+
   def getArchived(id: String) = auth.async {
     store.booleanGet(id, "archived") map { archived =>
       respond(archived.getOrElse(false))

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -3,6 +3,7 @@ GET     /usage-rights/categories                        controllers.EditsApi.get
 
 # Image
 GET     /metadata/:id                                   controllers.EditsController.getAllMetadata(id: String)
+GET     /edits/:id                                      controllers.EditsController.getEdits(id: String)
 
 GET     /metadata/:id/archived                          controllers.EditsController.getArchived(id: String)
 PUT     /metadata/:id/archived                          controllers.EditsController.setArchived(id: String)

--- a/nginx-mappings.yml
+++ b/nginx-mappings.yml
@@ -23,3 +23,5 @@ mappings:
     port: 9012
   - prefix: es.media
     port: 9200
+  - prefix: admin-tools.media
+    port: 9013

--- a/the_pingler.sh
+++ b/the_pingler.sh
@@ -12,8 +12,9 @@ USAGE="http://localhost:9009/management/healthcheck"
 COLLECTIONS="http://localhost:9010/management/healthcheck"
 AUTH="http://localhost:9011/management/healthcheck"
 LEASES="http://localhost:9012/management/healthcheck"
+ADMIN_TOOLS="http://localhost:9013"
 
-lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $KAHUNA $API $USAGE $AUTH $LEASES"
+lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"
 
 echo "You have started the Pingler!"
 echo


### PR DESCRIPTION
## What does this change?
Adding get edits endpoint to metadata service
to be able to re-ingest/reindex user edits to Image elastic search entry

## How can success be measured?
access on local
https://media-metadata.local.dev-gutools.co.uk/edits/:mediaid

image metadata edits should be displayed

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
