### PR TITLE
adding get edits endpoint to metadata service

### DIFF
--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -60,6 +60,13 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
     } recover { case NoItemFound => emptyResponse }
   }
 
+  def getEdits(id: String) = auth.async {
+    store.get(id) map { dynamoEntry =>
+      val edits = dynamoEntry.asOpt[Edits]
+      respond(data = edits)
+    } recover { case NoItemFound => NotFound }
+  }
+
   def getArchived(id: String) = auth.async {
     store.booleanGet(id, "archived") map { archived =>
       respond(archived.getOrElse(false))

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -3,6 +3,7 @@ GET     /usage-rights/categories                        controllers.EditsApi.get
 
 # Image
 GET     /metadata/:id                                   controllers.EditsController.getAllMetadata(id: String)
+GET     /edits/:id                                      controllers.EditsController.getEdits(id: String)
 
 GET     /metadata/:id/archived                          controllers.EditsController.getArchived(id: String)
 PUT     /metadata/:id/archived                          controllers.EditsController.setArchived(id: String)


### PR DESCRIPTION
## What does this change?
Adding get edits endpoint to metadata service
to be able to re-ingest/reindex user edits to Image elastic search entry

## How can success be measured?
access on local
https://media-metadata.local.dev-gutools.co.uk/edits/:mediaid

image metadata edits should be displayed

## How does metadata/:id differ from this?

`metadata/:id` will give enriched response not a JSON that can be mapped to `Edits` case class
 `edits/:id` response will give response that can be mapped to `Edits` case class


## Tested?
- [x] locally
- [x] on TEST
