### PR TITLE
Add endpoint for image counts

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
@@ -2,12 +2,12 @@ package com.gu.mediaservice.lib.management
 
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.auth.PermissionsHandler
-import com.gu.mediaservice.lib.elasticsearch6.ElasticSearchClient
-import com.sksamuel.elastic4s.http.cat.CatCountResponse
-import com.sksamuel.elastic4s.http.index.IndexStatsResponse
-import com.sksamuel.elastic4s.http.search.SearchResponse
+import com.gu.mediaservice.lib.elasticsearch6.{
+  ElasticSearchClient,
+  ElasticSearchImageCounts
+}
 import play.api.Logger
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -68,16 +68,14 @@ class ElasticSearchHealthCheck(override val controllerComponents: ControllerComp
   }
 
   def imageCounts: Action[AnyContent] = Action.async {
+    implicit val imageCountsFormat: Format[ElasticSearchImageCounts] =
+      Json.format[ElasticSearchImageCounts]
+
     elasticsearch.countImages().map {
-      case _ @(catCount: CatCountResponse, searchResponse: SearchResponse, indexStats: IndexStatsResponse) =>
-        val json: String =
-          s"""{
-             |  "catCount": ${catCount.count},
-             |  "searchResponseCount": ${searchResponse.hits.total},
-             |  "indexStatsCount" : ${indexStats.indices("images").total.docs.count}
-             |  }""".stripMargin
-        Ok(Json.parse(json))
-      case _ => Logger.warn(s"Can't get stats")
+      case counts: ElasticSearchImageCounts =>
+        Ok(Json.toJson(counts))
+      case _ =>
+        Logger.warn(s"Can't get stats")
         ServiceUnavailable("Can't get stats")
     }
   }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -34,6 +34,7 @@ GET     /usage/quotas/:id                             controllers.UsageControlle
 # Management
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.ManagementWithPermissions.manifest
+GET     /management/imageCounts                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.imageCounts
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.ManagementWithPermissions.disallowRobots


### PR DESCRIPTION
## What does this change?
This change allows the iamge-counter-lambda [in this pull request](https://github.com/guardian/grid/pull/2724) to successfully query the current image counts in the media API.

## How can success be measured?
The endpoint is accessible and returns the current counts.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [ ] on TEST
