### PR TITLE
Break up the big function in the ThrallEventConsumer

### DIFF
--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -11,11 +11,13 @@ import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.json.{JsonByteArrayUtil, PlayJsonHelpers}
 import com.gu.mediaservice.model.usage.UsageNotice
 import lib._
+import org.joda.time.DateTime
 import play.api.Logger
-import play.api.libs.json.{JodaReads, Json}
+import play.api.libs.json.{JodaReads, Json, Reads}
 
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.concurrent.{Await, ExecutionContext, Future, TimeoutException}
+import scala.util.{Failure, Success, Try}
 
 class ThrallEventConsumer(es: ElasticSearch6,
                           thrallMetrics: ThrallMetrics,
@@ -39,51 +41,62 @@ class ThrallEventConsumer(es: ElasticSearch6,
 
     try {
       records.asScala.foreach { r =>
-
-        try {
-          implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads
-          implicit val unr = Json.reads[UsageNotice]
-          implicit val umr = Json.reads[UpdateMessage]
-
-          JsonByteArrayUtil.fromByteArray[UpdateMessage](r.getData.array) map { updateMessage =>
-            val timestamp = r.getApproximateArrivalTimestamp
-
-            Logger.info(s"Received ${updateMessage.subject} message at $timestamp")(updateMessage.toLogMarker)
-
-            messageProcessor.chooseProcessor(updateMessage).map { p =>
-              val eventuallyAppliedUpdate: Future[Any] = p.apply(updateMessage)
-              eventuallyAppliedUpdate.map { _ =>
-                Logger.info(s"Completed processing of ${updateMessage.subject} message")(updateMessage.toLogMarker)
-              }.recover {
-                case e: Throwable =>
-                  Logger.error(s"Failed to process ${updateMessage.subject} message; message will be ignored:", e)(updateMessage.toLogMarker)
-              }
-              try {
-                Await.ready(eventuallyAppliedUpdate, Timeout)
-              } catch {
-                case e: TimeoutException =>
-                  Logger.error(
-                    s"Timeout of $Timeout reached while processing ${updateMessage.subject} message; message will be ignored:",
-                    e
-                  )(updateMessage.toLogMarker)
-              }
-            }
-          }
-        } catch {
-          case e: Throwable =>
-            Logger.error("Exception during process record block", e)
-        }
+      parseRecord(r).map(handleUpdateMessage)
       }
 
-      checkpointer.checkpoint(records.asScala.last)
+      try{checkpointer.checkpoint(records.asScala.last)} catch {
+        case e : Throwable =>  Logger.error("Exception during checkpoint: ", e)
+      }
 
     } catch {
       case e: Throwable =>
-        Logger.error("Exception during process records and checkpoint: ", e)
+        Logger.error("Exception during process records: ", e)
     }
 
 
   }
+
+  private def parseRecord(r: Record):Option[UpdateMessage] = {
+    implicit val yourJodaDateReads: Reads[DateTime] = JodaReads.DefaultJodaDateTimeReads
+    implicit val unr = Json.reads[UsageNotice]
+    implicit val umr = Json.reads[UpdateMessage]
+    val timestamp = r.getApproximateArrivalTimestamp
+
+    Try(JsonByteArrayUtil.fromByteArray[UpdateMessage](r.getData.array)) match {
+      case Success(Some(updateMessage: UpdateMessage)) => {
+        Logger.info(s"Received ${updateMessage.subject} message at $timestamp")(updateMessage.toLogMarker)
+        Some(updateMessage)
+      }
+      case Success(None)=> None //No message received
+      case Failure(e) => {
+        Logger.error(s"Exception during process record block at $timestamp", e)
+        None
+      }
+    }
+  }
+
+  private def handleUpdateMessage(updateMessage: UpdateMessage) = {
+    messageProcessor.chooseProcessor(updateMessage).map { p =>
+      val eventuallyAppliedUpdate: Future[Any] = p.apply(updateMessage)
+      eventuallyAppliedUpdate.map { _ =>
+        Logger.info(s"Completed processing of ${updateMessage.subject} message")(updateMessage.toLogMarker)
+      }.recover {
+        case e: Throwable =>
+          Logger.error(s"Failed to process ${updateMessage.subject} message; message will be ignored:", e)(updateMessage.toLogMarker)
+      }
+
+      try {
+        Await.ready(eventuallyAppliedUpdate, Timeout)
+      } catch {
+        case e: TimeoutException =>
+          Logger.error(
+            s"Timeout of $Timeout reached while processing ${updateMessage.subject} message; message will be ignored:",
+            e
+          )(updateMessage.toLogMarker)
+      }
+    }
+  }
+
 
   override def shutdown(checkpointer: IRecordProcessorCheckpointer, reason: ShutdownReason): Unit = {
     if (reason == ShutdownReason.TERMINATE) {

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -75,8 +75,7 @@ class ThrallEventConsumer(es: ElasticSearch6,
 
   private def processUpdateMessage(updateMessage: UpdateMessage) = {
     messageProcessor.chooseProcessor(updateMessage).map { messageProcessor =>
-      val processedMessage = messageProcessor.apply(updateMessage)
-      Try(Await.ready(processedMessage, Timeout))
+      Try(Await.ready(messageProcessor.apply(updateMessage), Timeout))
     } match {
       case Some(Success(_)) =>
         Logger.info(


### PR DESCRIPTION
## What does this change?

The ThrallEventConsumer is a pretty big single function, so I've split it down into a parse and handle. 

## How can success be measured?

This should make it more obvious what is being `try`ed at any one time. This has already decreased the distance in the source between each failure case and it's logger, and has added a separate log line for failure during check-pointing. (Although this may be undesired, do we wish to continue to parse responses if a checkpoint fails to save?)

## Screenshots (if applicable)


## Who should look at this?
@guardian/digital-cms 


## Tested?
- [x] locally
- [x] on TEST
