### PR TITLE
admin-tool lambda execution

### DIFF
--- a/admin-tools/README.md
+++ b/admin-tools/README.md
@@ -13,3 +13,7 @@ See the [routes file](https://github.com/guardian/media-service/blob/master/admi
 
 - this project can be run locally as Play APP
 - in PROD and TEST it si running as Lambda function
+
+### Build artifact for lambda
+
+sbt admin-tools-lambda/assembly

--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -14,15 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
-  private val cfg = ImageDataMergerConfig(
-    apiKey = config.apiKey,
-    imgLoaderApiBaseUri = config.services.loaderBaseUri,
-    collectionsApiBaseUri = config.services.collectionsBaseUri,
-    metadataApiBaseUri = config.services.metadataBaseUri,
-    cropperApiBaseUri = config.services.cropperBaseUri,
-    leasesApiBaseUri = config.services.leasesBaseUri,
-    usageBaseApiUri = config.services.usageBaseUri
-  )
+  private val cfg = ImageDataMergerConfig(config.apiKey, config.services)
 
   private val merger = new ImageDataMerger(cfg)
 

--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -41,13 +41,10 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
   }
 
   def project(mediaId: String) = Action.async {
-    val maybeImageFuture: Option[Future[Image]] = merger.getMergedImageData(mediaId)
-    maybeImageFuture match {
-      case Some(imageFuture) =>
-        imageFuture.map { image =>
-          Ok(Json.toJson(image)).as(ArgoMediaType)
-        }
-      case None => Future(NotFound)
+    val futureMaybeImage: Future[Option[Image]] = merger.getMergedImageData(mediaId)
+    futureMaybeImage.map {
+      case Some(img) => Ok(Json.toJson(img)).as(ArgoMediaType)
+      case None => NotFound
     }
   }
 }

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
@@ -1,11 +1,12 @@
 package com.gu.mediaservice
 
+import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
 import com.gu.mediaservice.model.Image
 import play.api.libs.json.Json
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 class LambdaHandler {
 
@@ -15,15 +16,11 @@ class LambdaHandler {
 
     val mediaId = params.get("mediaId").asInstanceOf[String]
 
-    val cfg = ImageDataMergerConfig(
-      apiKey = sys.env("API_KEY"),
-      imgLoaderApiBaseUri = "https://loader.media.test.dev-gutools.co.uk",
-      collectionsApiBaseUri = "https://media-collections.test.dev-gutools.co.uk",
-      metadataApiBaseUri = "https://media-metadata.test.dev-gutools.co.uk",
-      cropperApiBaseUri = "https://cropper.media.test.dev-gutools.co.uk",
-      leasesApiBaseUri = "https://media-leases.test.dev-gutools.co.uk",
-      usageBaseApiUri = "https://media-usage.test.dev-gutools.co.uk"
-    )
+    val domainRoot = sys.env("DOMAIN_ROOT")
+    val apiKey = sys.env("API_KEY")
+    val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
+
+    val cfg = ImageDataMergerConfig(apiKey, services)
 
     println(s"starting handleImageProjection for mediaId=$mediaId")
     println(s"with config: $cfg")

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
@@ -17,6 +17,7 @@ class LambdaHandler {
     val mediaId = params.get("mediaId").asInstanceOf[String]
 
     val domainRoot = sys.env("DOMAIN_ROOT")
+    // TODO consider using parameter store with KMS for API_KEY
     val apiKey = sys.env("API_KEY")
     val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
 

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
@@ -1,27 +1,42 @@
 package com.gu.mediaservice
 
+import play.api.libs.json.Json
+
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
 
 class LambdaHandler {
 
   def handleImageProjection(mediaId: String) = {
 
     val cfg = ImageDataMergerConfig(
-      apiKey = "TODO",
-      imgLoaderApiBaseUri = "TODO",
-      collectionsApiBaseUri = "TODO",
-      metadataApiBaseUri = "TODO",
-      cropperApiBaseUri = "TODO",
-      leasesApiBaseUri = "TODO",
-      usageBaseApiUri = "TODO"
+      apiKey = sys.env("API_KEY"),
+      imgLoaderApiBaseUri = "https://loader.media.test.dev-gutools.co.uk",
+      collectionsApiBaseUri = "https://media-collections.test.dev-gutools.co.uk",
+      metadataApiBaseUri = "https://media-metadata.test.dev-gutools.co.uk",
+      cropperApiBaseUri = "https://cropper.media.test.dev-gutools.co.uk",
+      leasesApiBaseUri = "https://media-leases.test.dev-gutools.co.uk",
+      usageBaseApiUri = "https://media-usage.test.dev-gutools.co.uk"
     )
+
+    println(s"starting handleImageProjection for mediaId=$mediaId")
+    println(s"with config: $cfg")
 
     val merger = new ImageDataMerger(cfg)
 
-    val image = merger.getMergedImageData(mediaId)
+    val maybeImageFuture = merger.getMergedImageData(mediaId)
 
-    println(s"image projected \n $image")
+    val maybeJson = maybeImageFuture.map { imgFuture =>
+      val img = Await.result(imgFuture, Duration.Inf)
+      Json.toJson(img)
+    }
 
-    image
+    maybeJson match {
+      case Some(img) =>
+        println(s"image projected \n $img")
+        img
+      case _ => Json.obj("message" -> s"image with id=$mediaId not-found")
+    }
   }
 }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -35,7 +35,7 @@ class ImageDataMerger(config: ImageDataMergerConfig)(implicit ec: ExecutionConte
   }
 
   private def aggregate(image: Image): Future[Image] = {
-    println(s"starting to aggregate image $image")
+    println(s"starting to aggregate image")
     val mediaId = image.id
     for {
       collections <- getCollectionsResponse(mediaId)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -107,9 +107,13 @@ class ImageDataMerger(config: ImageDataMergerConfig)(implicit ec: ExecutionConte
   private def makeRequest(url: URL): ResponseWrapper = {
     val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, config.apiKey).build
     val response = httpClient.newCall(request).execute
-    println(s"response for GET request for $url $response")
-    response.code
-    val json = Json.parse(response.body.string)
-    ResponseWrapper(json, response.code)
+    import response._
+    val resInfo = Map(
+      "status-code" -> response.code.toString,
+      "message" -> response.message
+    )
+    println(s"GET $url response: $resInfo")
+    val json = if (code == 200) Json.parse(body.string) else Json.obj()
+    ResponseWrapper(json, code)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import PlayKeys._
+import play.sbt.PlayImport.PlayKeys._
+
 import scala.sys.process._
 
 val commonSettings = Seq(
@@ -121,22 +122,21 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
 lazy val adminToolsLib = project("admin-tools-lib", Some("admin-tools/lib"))
   .settings(
     excludeDependencies ++= Seq(
-      ExclusionRule("com.amazonaws", "aws-java-sdk-iam"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-s3"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-ec2"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-cloudwatch"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-cloudfront"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-sqs"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-sns"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-sts"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-dynamodb"),
-      ExclusionRule("com.amazonaws", "aws-java-sdk-kinesis"),
-      ExclusionRule("org.elasticsearch", "elasticsearch"),
-      ExclusionRule("com.sksamuel.elastic4s", "elastic4s-core"),
-      ExclusionRule("com.sksamuel.elastic4s", "elastic4s-http"),
+      ExclusionRule("com.amazonaws"),
+      ExclusionRule("org.elasticsearch"),
+      ExclusionRule("com.sksamuel.elastic4s"),
+      ExclusionRule("com.drewnoakes", "metadata-extractor"),
+      ExclusionRule("org.codehaus.janino"),
+      //      ExclusionRule("com.typesafe.play"),
+      ExclusionRule("org.scalaz.stream"),
+      ExclusionRule("org.im4java"),
+      ExclusionRule("org.scalacheck"),
     ),
     libraryDependencies ++= Seq(
-      "com.squareup.okhttp3" % "okhttp" % okHttpVersion
+      "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
+      //      "com.typesafe.play" %% "play-json" % "2.6.9",
+      //      "com.typesafe.play" %% "play-json-joda" % "2.6.9",
+      //      "com.typesafe.play" %% "filters-helpers" % "2.6.20",
     )
   ).dependsOn(commonLib)
 

--- a/build.sbt
+++ b/build.sbt
@@ -119,19 +119,34 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
 )
 
 lazy val adminToolsLib = project("admin-tools-lib", Some("admin-tools/lib"))
-  .dependsOn(commonLib).settings {
-  libraryDependencies ++= Seq(
-    "com.squareup.okhttp3" % "okhttp" % okHttpVersion
-  )
-}
+  .settings(
+    excludeDependencies ++= Seq(
+      ExclusionRule("com.amazonaws", "aws-java-sdk-iam"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-s3"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-ec2"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-cloudwatch"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-cloudfront"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-sqs"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-sns"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-sts"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-dynamodb"),
+      ExclusionRule("com.amazonaws", "aws-java-sdk-kinesis"),
+      ExclusionRule("org.elasticsearch", "elasticsearch"),
+      ExclusionRule("com.sksamuel.elastic4s", "elastic4s-core"),
+      ExclusionRule("com.sksamuel.elastic4s", "elastic4s-http"),
+    ),
+    libraryDependencies ++= Seq(
+      "com.squareup.okhttp3" % "okhttp" % okHttpVersion
+    )
+  ).dependsOn(commonLib)
 
 lazy val adminToolsLambda = project("admin-tools-lambda", Some("admin-tools/lambda"))
-  .dependsOn(adminToolsLib).settings {
-  assemblyMergeStrategy in assembly := {
-    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-    case x => MergeStrategy.first
-  }
-}
+  .settings {
+    assemblyMergeStrategy in assembly := {
+      case PathList("META-INF", xs@_*) => MergeStrategy.discard
+      case x => MergeStrategy.first
+    }
+  }.dependsOn(adminToolsLib)
 
 lazy val adminToolsDev = playProject("admin-tools-dev", 9013, Some("admin-tools/dev"))
   .dependsOn(adminToolsLib)

--- a/build.sbt
+++ b/build.sbt
@@ -127,16 +127,16 @@ lazy val adminToolsLib = project("admin-tools-lib", Some("admin-tools/lib"))
       ExclusionRule("com.sksamuel.elastic4s"),
       ExclusionRule("com.drewnoakes", "metadata-extractor"),
       ExclusionRule("org.codehaus.janino"),
-      //      ExclusionRule("com.typesafe.play"),
+      ExclusionRule("com.typesafe.play"),
       ExclusionRule("org.scalaz.stream"),
       ExclusionRule("org.im4java"),
       ExclusionRule("org.scalacheck"),
     ),
     libraryDependencies ++= Seq(
       "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
-      //      "com.typesafe.play" %% "play-json" % "2.6.9",
-      //      "com.typesafe.play" %% "play-json-joda" % "2.6.9",
-      //      "com.typesafe.play" %% "filters-helpers" % "2.6.20",
+      "com.typesafe.play" %% "play-json" % "2.6.9",
+      "com.typesafe.play" %% "play-json-joda" % "2.6.9",
+      "com.typesafe.play" %% "play-functional" % "2.6.9",
     )
   ).dependsOn(commonLib)
 

--- a/build.sbt
+++ b/build.sbt
@@ -118,16 +118,20 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
   )
 )
 
-lazy val adminToolsLib =  project("admin-tools-lib", Some("admin-tools/lib"))
+lazy val adminToolsLib = project("admin-tools-lib", Some("admin-tools/lib"))
   .dependsOn(commonLib).settings {
   libraryDependencies ++= Seq(
-    "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
     "com.squareup.okhttp3" % "okhttp" % okHttpVersion
   )
 }
 
 lazy val adminToolsLambda = project("admin-tools-lambda", Some("admin-tools/lambda"))
-  .dependsOn(adminToolsLib)
+  .dependsOn(adminToolsLib).settings {
+  assemblyMergeStrategy in assembly := {
+    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+    case x => MergeStrategy.first
+  }
+}
 
 lazy val adminToolsDev = playProject("admin-tools-dev", 9013, Some("admin-tools/dev"))
   .dependsOn(adminToolsLib)
@@ -171,7 +175,7 @@ def project(projectName: String, path: Option[String] = None): Project =
 val buildInfo = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,
-    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse(try {
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse (try {
       "git rev-parse HEAD".!!.trim
     } catch {
       case e: Exception => "unknown"


### PR DESCRIPTION
## What does this change?
admin-tool lambda execution boilerplate
- that code enables execution `ImageDataMerger.getMergedImageData(mediaId: String)` in a aws lambda function
- makes jar for `adminToolsLambda` project independent form Play web framework it uses only Play json steriliser
- configure jar creation of `adminToolsLambda` artefact like merge strategy 

proper logger will be added in next PR

## How can success be measured?
manual execution of `grid-admin-tools-lambda-DEV` lambda in media service AWS account logs expected results

## Tested?
- [x] locally
- [x] on TEST
