### PR TITLE
refactor ServiceHosts

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -77,7 +77,7 @@ trait CommonConfig {
 
   lazy val corsAllowedOrigins: Set[String] = getStringSetFromProperties("security.cors.allowedOrigins")
 
-  lazy val services = new Services(domainRoot, isProd, serviceHosts, corsAllowedOrigins)
+  lazy val services = new Services(domainRoot, serviceHosts, corsAllowedOrigins)
 
   final def getStringSetFromProperties(key: String): Set[String] = Try(
     properties(key).split(",").map(_.trim).toSet

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -1,11 +1,40 @@
 package com.gu.mediaservice.lib.config
 
-case class ServiceHosts(kahunaPrefix: String, apiPrefix: String, loaderPrefix: String,
-                        cropperPrefix: String, metadataPrefix: String, imgopsPrefix: String,
-                        usagePrefix: String, collectionsPrefix: String, leasesPrefix: String,
-                        authPrefix: String)
+case class ServiceHosts(
+  kahunaPrefix: String,
+  apiPrefix: String,
+  loaderPrefix: String,
+  cropperPrefix: String,
+  metadataPrefix: String,
+  imgopsPrefix: String,
+  usagePrefix: String,
+  collectionsPrefix: String,
+  leasesPrefix: String,
+  authPrefix: String
+)
 
-class Services(val domainRoot: String, isProd: Boolean, hosts: ServiceHosts, corsAllowedOrigins: Set[String]) {
+object ServiceHosts {
+  // this is tightly coupled to the Guardian's deployment.
+  // TODO make more generic but w/out relying on Play config
+  def guardianPrefixes: ServiceHosts = {
+    val rootAppName: String = "media"
+
+    ServiceHosts(
+      kahunaPrefix = s"$rootAppName.",
+      apiPrefix = s"api.$rootAppName.",
+      loaderPrefix = s"loader.$rootAppName.",
+      cropperPrefix = s"cropper.$rootAppName.",
+      metadataPrefix = s"$rootAppName-metadata.",
+      imgopsPrefix = s"$rootAppName-imgops.",
+      usagePrefix = s"$rootAppName-usage.",
+      collectionsPrefix = s"$rootAppName-collections.",
+      leasesPrefix = s"$rootAppName-leases.",
+      authPrefix = s"$rootAppName-auth."
+    )
+  }
+}
+
+class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: Set[String]) {
   val kahunaHost: String      = s"${hosts.kahunaPrefix}$domainRoot"
   val apiHost: String         = s"${hosts.apiPrefix}$domainRoot"
   val loaderHost: String      = s"${hosts.loaderPrefix}$domainRoot"


### PR DESCRIPTION
## What does this change?
Add a simple apply method that doesn't rely on config. This is very Guardian specific...

This is so we can re-use it in the admin-tools project and not have to bring in Play just for reading Play config. Not the best solution, however a temporary one.

[This](https://github.com/guardian/grid/blob/master/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala#L15-L23) can now be replaced with something like:

```scala
val domainRoot = "foo" // value obtained from config or similar
val services = Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
```

The base URI for a service can now be accessed on `services`.


## How can success be measured?
n/a

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
