### PR TITLE
Decode URI-encoded filenames when we're reading them from S3 metadata

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -12,6 +12,7 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth._
+import com.gu.mediaservice.lib.net.{URI => MediaURI}
 import com.gu.mediaservice.lib.aws.{S3Ops, UpdateMessage}
 import com.gu.mediaservice.model.{Image, UploadInfo}
 import lib._
@@ -158,7 +159,10 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
     val uploadedBy = fileUserMetadata.getOrElse("uploaded_by", "re-ingester")
     val uploadedTimeRaw = fileUserMetadata.getOrElse("upload_time", lastModified)
     val uploadTime = new DateTime(uploadedTimeRaw).withZone(DateTimeZone.UTC)
-    val uploadFileName = fileUserMetadata.get("file_name")
+
+    val uploadFileNameRaw = fileUserMetadata.get("file_name")
+    // The file name is URL encoded in  S3 metadata
+    val uploadFileName = uploadFileNameRaw.map(MediaURI.decode)
 
     val finalImage = imageUploadProjector.projectImage(digestedFile, uploadedBy, uploadTime, uploadFileName)
 


### PR DESCRIPTION
## What does this change?

For the projection endpoint, decode the URI-encoded filename we receive from S3 metadata. It's encoded for storage, but written to Elasticsearch in its original form, so this restores it to its original state.

NB: I've written a version with tests that pushes the relevant code into `imageUploadProjector.projectImage` but I wasn't sure that filename-mangling code belonged there -- let me know if that approach would be preferable.

## How can success be measured?

Requests for images with filenames affected by encoding, e.g.

```
"uploadInfo": {
        "filename": "Frederike+Kaltheuner.+Circular+panelist+byline.+DO+NOT+USE+FOR+ANY+OTHER+PURPOSE%21.png"
}
```

are now decoded correctly, e.g.

```
"uploadInfo": {
        "filename": "Frederike Kaltheuner. Circular panelist byline. DO NOT USE FOR ANY OTHER PURPOSE!.png"
}
```

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
