### PR TITLE
execute admin tools lambda via api gateway (lambda handler code)

### DIFF
--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -23,7 +23,7 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
       "description" -> "This is Admin tools API"
     )
     val indexLinks = List(
-      Link("image-projection", s"${config.rootUri}/images/{id}/project")
+      Link("image-projection", s"${config.rootUri}/images/projection/{id}")
     )
     respond(indexData, indexLinks)
   }

--- a/admin-tools/dev/conf/routes
+++ b/admin-tools/dev/conf/routes
@@ -1,5 +1,5 @@
 GET     /                           controllers.AdminToolsCtr.index
-GET     /images/:id/project         controllers.AdminToolsCtr.project(id: String)
+GET     /images/projection/:id      controllers.AdminToolsCtr.project(id: String)
 
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
@@ -17,9 +17,7 @@ class LambdaHandler {
 
     println(s"handleImageProjection event: $event")
 
-    val queryParams: Map[String, String] = event.getQueryStringParameters.asScala.toMap
-
-    val mediaId = queryParams.getOrElse("media_id", "")
+    val mediaId = event.getPath.stripPrefix("/images/projection/")
 
     val domainRoot = sys.env("DOMAIN_ROOT")
     // TODO consider using parameter store with KMS for API_KEY

--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,10 @@ lazy val adminToolsLambda = project("admin-tools-lambda", Some("admin-tools/lamb
       case PathList("META-INF", xs@_*) => MergeStrategy.discard
       case x => MergeStrategy.first
     }
+    libraryDependencies ++= Seq(
+      "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+      "com.amazonaws" % "aws-lambda-java-events" % "2.2.7",
+    )
   }.dependsOn(adminToolsLib)
 
 lazy val adminToolsDev = playProject("admin-tools-dev", 9013, Some("admin-tools/dev"))


### PR DESCRIPTION
## What does this change?
Introduce possibility to execute admin tools lambda via api gateway 
this PR have only changes for (lambda handler code)

- code for infra for lambda and API gateway will be introduced in next PRs
- logger improvements will be introduced in next PR

## How can success be measured?
example test projection API request with manually created lambda and api gateway: https://l86cq520x1.execute-api.eu-west-1.amazonaws.com/dev/images/projection/96fd3df8031b6f20a00bf05cd8c7aa5dedc5dc99


it uses test grid apis (loader, leases ...)


## Tested?
- [x] locally
- [x] on TEST
