### PR TITLE
Remove Barcroft as a Supplier

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -16,7 +16,6 @@ object SupplierProcessors {
     AlamyParser,
     AllStarParser,
     ApParser,
-    BarcroftParser,
     CorbisParser,
     EpaParser,
     PaParser,
@@ -137,14 +136,6 @@ object ApParser extends ImageProcessor {
     )
     case _ => image
   }
-}
-
-object BarcroftParser extends ImageProcessor {
-  def apply(image: Image): Image =
-    // We search the credit and the source here as Barcroft seems to use both
-    if(List(image.metadata.credit, image.metadata.source).flatten.map(_.toLowerCase).exists { s =>
-      List("barcroft media", "barcroft images", "barcroft india", "barcroft usa", "barcroft cars").exists(s.contains)
-    }) image.copy(usageRights = Agency("Barcroft Media")) else image
 }
 
 object CorbisParser extends ImageProcessor {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -71,7 +71,6 @@ object UsageRightsConfig {
     "Alamy",
     "Allstar Picture Library",
     "AP",
-    "Barcroft Media",
     "EPA",
     "Getty Images",
     "PA",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -10,9 +10,6 @@ object UsageRightsConfig {
     "Alinari",
     "Arnold Newman Collection",
     "ASAblanca",
-    // Note: Even though we have a deal directly with Barcroft, it
-    // does not apply to images sourced through Getty. Silly, I know.
-    "Barcroft Media",
     "Bob Thomas Sports Photography",
     "Carnegie Museum of Art",
     "Catwalking",

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -169,40 +169,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     }
   }
 
-
-  describe("Barcroft Media") {
-    it("should match Barcroft Media credit") {
-      val image = createImageFromMetadata("credit" -> "Barcroft Media")
-      val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("Barcroft Media"))
-
-      processedImage.metadata.credit should be(Some("Barcroft Media"))
-    }
-
-    it("should match other Barcroft offices credit") {
-      val image = createImageFromMetadata("credit" -> "Barcroft India")
-      val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("Barcroft Media"))
-      processedImage.metadata.credit should be(Some("Barcroft India"))
-    }
-
-    it("should match Barcroft Media source") {
-      val image = createImageFromMetadata("source" -> "Barcroft Media")
-      val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("Barcroft Media"))
-
-      processedImage.metadata.source should be(Some("Barcroft Media"))
-    }
-
-    it("should match other Barcroft offices source") {
-      val image = createImageFromMetadata("source" -> "Barcroft India")
-      val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("Barcroft Media"))
-      processedImage.metadata.source should be(Some("Barcroft India"))
-    }
-  }
-
-
+  
   describe("Corbis") {
     it("should match Corbis source") {
       val image = createImageFromMetadata("credit" -> "Demotix/Corbis", "source" -> "Corbis")


### PR DESCRIPTION
## What does this change?
Removes Barcroft as a Supplier and related tests etc.

## How can success be measured?
Barcroft images are now to come via Getty. They should be successfully recognised as Getty (with Barcroft as a Supplier’s Collection), eg. d28cce45c1d47172f9734e18ce3c190bf2159597.

@guardian/digital-cms

## Tested?
- [x] on TEST
