### PR TITLE
Add _elasticsearch endpoint

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -130,7 +130,7 @@ class MediaApi(
   /**
     * Get the raw response from ElasticSearch.
     */
-  def getImageRaw(id: String) = auth.async { request =>
+  def getImageFromElasticSearch(id: String) = auth.async { request =>
     getImageResponseFromES(id, request) map {
       case Some((source, _, imageLinks, imageActions)) =>
         respond(source, imageLinks, imageActions)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -13,6 +13,7 @@ GET     /images/aggregations/date/:field              controllers.AggregationCon
 
 # Images
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
+GET     /images/:id/raw                               controllers.MediaApi.getImageRaw(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -13,7 +13,7 @@ GET     /images/aggregations/date/:field              controllers.AggregationCon
 
 # Images
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
-GET     /images/:id/raw                               controllers.MediaApi.getImageRaw(id: String)
+GET     /images/:id/_elasticsearch                    controllers.MediaApi.getImageFromElasticSearch(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)


### PR DESCRIPTION
## What does this change?

This adds a `GET /images/:id/_elasticsearch` endpoint, which returns the raw output from ElasticSearch.

Useful when we'd like to examine the contents of ES directly, for example to checking reingestion dry runs against existing data.

### Why  _elasticsearch?

`_` indicates the method is something that isn't intended for public consumption. (It's also an Elasticsearch convention!) `elasticsearch` is as unambiguous as we can be 👍 

Tested on CODE.

## How can success be measured?

Make a request to `GET /images/:id/_elasticsearch`. The result (in the `data` envelope) should be identical to the response from ES.

## Who should look at this?

@akash1810 
@mkuzdowicz 

## Tested?
- [x] locally
- [x] on TEST
