### PR TITLE
proxy the api key from Gateway to the Grid APIs

### DIFF
--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
@@ -2,16 +2,25 @@ package com.gu.mediaservice
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
 import com.gu.mediaservice.model.Image
 import play.api.libs.json.Json
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
-import scala.collection.JavaConverters._
 
 class LambdaHandler {
+  private def getUnauthorisedResponse = {
+    val res = Json.obj("message" -> s"missing or invalid api key header").toString
+
+    new APIGatewayProxyResponseEvent()
+      .withStatusCode(401)
+      .withHeaders(Map("content-type" -> "application/json").asJava)
+      .withBody(res)
+  }
 
   def handleImageProjection(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
 
@@ -20,36 +29,50 @@ class LambdaHandler {
     val mediaId = event.getPath.stripPrefix("/images/projection/")
 
     val domainRoot = sys.env("DOMAIN_ROOT")
-    // TODO consider using parameter store with KMS for API_KEY
-    val apiKey = sys.env("API_KEY")
-    val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
+    val headers = event.getHeaders.asScala.toMap
 
-    val cfg = ImageDataMergerConfig(apiKey, services)
+    println(s"headers are $headers")
 
-    println(s"starting handleImageProjection for mediaId=$mediaId")
-    println(s"with config: $cfg")
+    // API Gateway lowercases header names, yay!
+    val apiKey = headers.get(Authentication.apiKeyHeaderName.toLowerCase)
 
-    val merger = new ImageDataMerger(cfg)
+    apiKey match {
+      case Some(key) => {
+        println(s"api key is $apiKey")
+        // DO work
+        val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
 
-    val maybeImageFuture: Future[Option[Image]] = merger.getMergedImageData(mediaId.asInstanceOf[String])
+        val cfg: ImageDataMergerConfig = ImageDataMergerConfig(key, services)
 
-    val mayBeImage: Option[Image] = Await.result(maybeImageFuture, Duration.Inf)
+        if(!cfg.isValidApiKey()) return getUnauthorisedResponse
 
-    mayBeImage match {
-      case Some(img) =>
-        println(s"image projected \n $img")
-        val body = Json.toJson(img).toString
-        new APIGatewayProxyResponseEvent()
-          .withStatusCode(200)
-          .withHeaders(Map("content-type" -> "application/json").asJava)
-          .withBody(body)
-      case _ =>
-        val emptyRes = Json.obj("message" -> s"image with id=$mediaId not-found").toString
-        println(s"image not projected \n $emptyRes")
-        new APIGatewayProxyResponseEvent()
-          .withStatusCode(404)
-          .withHeaders(Map("content-type" -> "application/json").asJava)
-          .withBody(emptyRes)
+        println(s"starting handleImageProjection for mediaId=$mediaId")
+        println(s"with config: $cfg")
+
+        val merger = new ImageDataMerger(cfg)
+
+        val maybeImageFuture: Future[Option[Image]] = merger.getMergedImageData(mediaId.asInstanceOf[String])
+
+        val mayBeImage: Option[Image] = Await.result(maybeImageFuture, Duration.Inf)
+
+        mayBeImage match {
+          case Some(img) =>
+            println(s"image projected \n $img")
+            val body = Json.toJson(img).toString
+            new APIGatewayProxyResponseEvent()
+              .withStatusCode(200)
+              .withHeaders(Map("content-type" -> "application/json").asJava)
+              .withBody(body)
+          case _ =>
+            val emptyRes = Json.obj("message" -> s"image with id=$mediaId not-found").toString
+            println(s"image not projected \n $emptyRes")
+            new APIGatewayProxyResponseEvent()
+              .withStatusCode(404)
+              .withHeaders(Map("content-type" -> "application/json").asJava)
+              .withBody(emptyRes)
+        }
+      }
+      case _ => getUnauthorisedResponse
     }
   }
 }


### PR DESCRIPTION
## What does this change?
We want to have authentication on the admin-tools project. This could be achieved in a few ways:
- Like other Grid services, polling the S3 bucket where API keys live
- Acting as a proxy

The former brings a lot of Play dependencies into the lambda so we opted for the second. This change means:
- we fail fast of the api key header is empty
- if the api key is provided, we make a call to the leases api, if the response is a 200 we know the key is valid

API Gateway seems to lowercase headers, so we're doing a lowercase comparison, which is a bit gross!

## How can success be measured?
admin-tools lambda has auth

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
![img](https://media.giphy.com/media/3o7TKEdVH8csXxKDO8/giphy.gif)

## Tested?
- [x] locally
- [x] on TEST
