### PR TITLE
Add admin-tools to the list of grid services

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -67,6 +67,7 @@ trait CommonConfig {
     stringDefault("hosts.apiPrefix", s"api.$rootAppName."),
     stringDefault("hosts.loaderPrefix", s"loader.$rootAppName."),
     stringDefault("hosts.cropperPrefix", s"cropper.$rootAppName."),
+    stringDefault("hosts.adminToolsPrefix", s"admin-tools.$rootAppName."),
     stringDefault("hosts.metadataPrefix", s"$rootAppName-metadata."),
     stringDefault("hosts.imgopsPrefix", s"$rootAppName-imgops."),
     stringDefault("hosts.usagePrefix", s"$rootAppName-usage."),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -5,6 +5,7 @@ case class ServiceHosts(
   apiPrefix: String,
   loaderPrefix: String,
   cropperPrefix: String,
+  adminToolsPrefix: String,
   metadataPrefix: String,
   imgopsPrefix: String,
   usagePrefix: String,
@@ -24,6 +25,7 @@ object ServiceHosts {
       apiPrefix = s"api.$rootAppName.",
       loaderPrefix = s"loader.$rootAppName.",
       cropperPrefix = s"cropper.$rootAppName.",
+      adminToolsPrefix = s"admin-tools.$rootAppName.",
       metadataPrefix = s"$rootAppName-metadata.",
       imgopsPrefix = s"$rootAppName-imgops.",
       usagePrefix = s"$rootAppName-usage.",
@@ -45,6 +47,7 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
   val collectionsHost: String = s"${hosts.collectionsPrefix}$domainRoot"
   val leasesHost: String      = s"${hosts.leasesPrefix}$domainRoot"
   val authHost: String        = s"${hosts.authPrefix}$domainRoot"
+  val adminToolsHost: String  = s"${hosts.adminToolsPrefix}$domainRoot"
 
   val kahunaBaseUri      = baseUri(kahunaHost)
   val apiBaseUri         = baseUri(apiHost)
@@ -56,6 +59,7 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
   val collectionsBaseUri = baseUri(collectionsHost)
   val leasesBaseUri      = baseUri(leasesHost)
   val authBaseUri        = baseUri(authHost)
+  val adminToolsBaseUri  = baseUri(adminToolsHost)
 
   val guardianWitnessBaseUri: String = "https://n0ticeapis.com"
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -66,7 +66,8 @@ class MediaApi(
       Link("witness-report",  s"${config.services.guardianWitnessBaseUri}/2/report/{id}"),
       Link("collections",     config.collectionsUri),
       Link("permissions",     s"${config.rootUri}/permissions"),
-      Link("leases",          config.leasesUri)
+      Link("leases",          config.leasesUri),
+      Link("admin-tools",     config.adminToolsUri)
     )
     respond(indexData, indexLinks)
   }

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -59,6 +59,7 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   lazy val authUri: String = services.authBaseUri
   lazy val loginUriTemplate: String = services.loginUriTemplate
   lazy val collectionsUri: String = services.collectionsBaseUri
+  lazy val adminToolsUri: String = services.adminToolsBaseUri
 
   lazy val requiredMetadata = List("credit", "description", "usageRights")
 


### PR DESCRIPTION
## What does this change?

This adds admin-tools to the list of grid services.

## How can success be measured?

Go to the root media-api endpoint. You should see a URL for admin-tools present. This URL should  resolve for the routes in the admin-tools project.

## Tested?
- [x] locally
- [ ] on TEST
