### PR TITLE
handle issue with http headers case sensitivity and refactoring

### DIFF
--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/LambdaHandler.scala
@@ -13,14 +13,6 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
 class LambdaHandler {
-  private def getUnauthorisedResponse = {
-    val res = Json.obj("message" -> s"missing or invalid api key header").toString
-
-    new APIGatewayProxyResponseEvent()
-      .withStatusCode(401)
-      .withHeaders(Map("content-type" -> "application/json").asJava)
-      .withBody(res)
-  }
 
   def handleImageProjection(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
 
@@ -31,48 +23,63 @@ class LambdaHandler {
     val domainRoot = sys.env("DOMAIN_ROOT")
     val headers = event.getHeaders.asScala.toMap
 
-    println(s"headers are $headers")
-
-    // API Gateway lowercases header names, yay!
-    val apiKey = headers.get(Authentication.apiKeyHeaderName.toLowerCase)
+    val apiKey = getAuthKeyFrom(headers)
 
     apiKey match {
-      case Some(key) => {
-        println(s"api key is $apiKey")
-        // DO work
+      case Some(key) =>
         val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
 
         val cfg: ImageDataMergerConfig = ImageDataMergerConfig(key, services)
-
-        if(!cfg.isValidApiKey()) return getUnauthorisedResponse
+        if (!cfg.isValidApiKey()) return getUnauthorisedResponse
 
         println(s"starting handleImageProjection for mediaId=$mediaId")
         println(s"with config: $cfg")
 
         val merger = new ImageDataMerger(cfg)
-
         val maybeImageFuture: Future[Option[Image]] = merger.getMergedImageData(mediaId.asInstanceOf[String])
-
         val mayBeImage: Option[Image] = Await.result(maybeImageFuture, Duration.Inf)
 
         mayBeImage match {
           case Some(img) =>
             println(s"image projected \n $img")
-            val body = Json.toJson(img).toString
-            new APIGatewayProxyResponseEvent()
-              .withStatusCode(200)
-              .withHeaders(Map("content-type" -> "application/json").asJava)
-              .withBody(body)
+            getSuccessResponse(img)
           case _ =>
-            val emptyRes = Json.obj("message" -> s"image with id=$mediaId not-found").toString
-            println(s"image not projected \n $emptyRes")
-            new APIGatewayProxyResponseEvent()
-              .withStatusCode(404)
-              .withHeaders(Map("content-type" -> "application/json").asJava)
-              .withBody(emptyRes)
+            getNotFoundResponse(mediaId)
         }
-      }
       case _ => getUnauthorisedResponse
     }
+  }
+
+  private def getSuccessResponse(img: Image) = {
+    val body = Json.toJson(img).toString
+    new APIGatewayProxyResponseEvent()
+      .withStatusCode(200)
+      .withHeaders(Map("content-type" -> "application/json").asJava)
+      .withBody(body)
+  }
+
+  private def getNotFoundResponse(mediaId: String) = {
+    val emptyRes = Json.obj("message" -> s"image with id=$mediaId not-found").toString
+    println(s"image not projected \n $emptyRes")
+    new APIGatewayProxyResponseEvent()
+      .withStatusCode(404)
+      .withHeaders(Map("content-type" -> "application/json").asJava)
+      .withBody(emptyRes)
+  }
+
+  private def getUnauthorisedResponse = {
+    val res = Json.obj("message" -> s"missing or invalid api key header").toString
+
+    new APIGatewayProxyResponseEvent()
+      .withStatusCode(401)
+      .withHeaders(Map("content-type" -> "application/json").asJava)
+      .withBody(res)
+  }
+
+  private def getAuthKeyFrom(headers: Map[String, String]) = {
+    // clients like curl or API gateway may lowerCases custom header names, yay!
+    headers.find {
+      case (k, _) => k.equalsIgnoreCase(Authentication.apiKeyHeaderName)
+    }.map(_._2)
   }
 }


### PR DESCRIPTION
## What does this change?
- handle issue with http headers case sensitivity
- refactoring

clients like curl or API gateway may lowerCases custom header names


## Tested?
- [x] locally
- [x] on TEST
