### PR TITLE
Add integration test for message processor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,7 +165,8 @@ lazy val thrall = playProject("thrall", 9002).settings(
     "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
     "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
-    "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test
+    "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test,
+    "org.mockito" % "mockito-core" % "2.18.0"
   )
 )
 

--- a/thrall/test/lib/ElasticSearchTest.scala
+++ b/thrall/test/lib/ElasticSearchTest.scala
@@ -621,15 +621,5 @@ class ElasticSearchTest extends ElasticSearchTestBase {
     }
   }
 
-  private def reloadedImage(id: String) = {
-    Await.result(ES.getImage(id), fiveSeconds)
-  }
-
-  private def indexedImage(id: String) = {
-    Thread.sleep(1000) // TODO use eventually clause
-    Await.result(ES.getImage(id), fiveSeconds)
-  }
-
   private def asJsLookup(d: DateTime): JsLookupResult = JsDefined(Json.toJson(d.toString))
-
 }

--- a/thrall/test/lib/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/ElasticSearchTestBase.scala
@@ -8,6 +8,7 @@ import helpers.Fixtures
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Properties
 
@@ -43,4 +44,13 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
     esContainer.toList ++ super.dockerContainers
 
   final override val StartContainersTimeout = 1.minute
+
+  protected def reloadedImage(id: String) = {
+    Await.result(ES.getImage(id), fiveSeconds)
+  }
+
+  protected def indexedImage(id: String) = {
+    Thread.sleep(1000) // TODO use eventually clause
+    Await.result(ES.getImage(id), fiveSeconds)
+  }
 }

--- a/thrall/test/lib/MessageProcessorTest.scala
+++ b/thrall/test/lib/MessageProcessorTest.scala
@@ -5,17 +5,17 @@ import java.util.UUID
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import lib.kinesis.MessageProcessor
 import org.joda.time.DateTime
-import play.api.Configuration
+import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
 
 import scala.concurrent.Await
 
 
-class MessageProcessorTest extends ElasticSearchTestBase {
-  val config = Configuration()
-  val thrallConfig = new ThrallConfig(config)
-  val thrallStore = new ThrallStore(thrallConfig)
-  val metadataEditorNotifications = new MetadataEditorNotifications(thrallConfig)
-  val syndicationRightsOps = new SyndicationRightsOps(ES)
+class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
+  val thrallConfig = mock[ThrallConfig]
+  val thrallStore = mock[ThrallStore]
+  val metadataEditorNotifications = mock[MetadataEditorNotifications]
+  val syndicationRightsOps =mock[SyndicationRightsOps]
 
   "MessageProcessor" - {
     "chooses the correct handler function given a subject" in {


### PR DESCRIPTION
## What does this change?

Adds a simple integration test for one kind of message processor.

We can expand on this as we move towards a more typesafe route for future message types.

## How can success be measured?

The tests should pass.

## Tested?
- [x] locally
- [ ] on TEST
