### PR TITLE
add bulk insert ability to thrall

### DIFF
--- a/thrall/app/lib/elasticsearch/ElasticSearchResponse.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearchResponse.scala
@@ -2,3 +2,4 @@ package lib.elasticsearch
 
 case class ElasticSearchUpdateResponse()
 case class ElasticSearchDeleteResponse()
+case class ElasticSearchBulkUpdateResponse()


### PR DESCRIPTION
## What does this change?
Updates the elasticsearch client in thrall with the ability bulk insert images. We're not linked to the message processor yet, so this is just a preliminary PR to add the tests.

## How can success be measured?
Thrall can bulk insert images.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
