### PR TITLE
Add `batch-index` message processing to thrall

### DIFF
--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -26,8 +26,10 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
   val es6 = new ElasticSearch(es6Config, Some(thrallMetrics))
   es6.ensureAliasAssigned()
 
+  val bulkIndexS3Client = new BulkIndexS3Client(config)
+
   val thrallKinesisMessageConsumer = new kinesis.ThrallMessageConsumer(
-    config, es6, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es6), config.from
+    config, es6, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es6), config.from, bulkIndexS3Client
   )
   thrallKinesisMessageConsumer.start()
 

--- a/thrall/app/lib/BulkIndexS3Client.scala
+++ b/thrall/app/lib/BulkIndexS3Client.scala
@@ -1,0 +1,23 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.{BulkIndexRequest, S3}
+import com.gu.mediaservice.model.Image
+import play.api.Logger
+import play.api.libs.json._
+
+class BulkIndexS3Client(config: ThrallConfig) extends S3(config){
+  def getImages(request: BulkIndexRequest): List[Image] = {
+    getObjectAsString(request.bucket, request.key)
+      .map(content => {
+        Json.parse(content).validate[List[Image]] match {
+          case images: JsSuccess[List[Image]] => images.get
+          case _ => {
+            val message = s"failed to parse S3 file ${request.bucket}/${request.key} as a list of images"
+            Logger.error(message)
+            throw new Exception(message)
+          }
+        }
+      })
+      .getOrElse(List.empty)
+  }
+}

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -24,5 +24,4 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   lazy val metadataTopicArn: String = properties("indexed.image.sns.topic.arn")
 
   lazy val from: Option[DateTime] = properties.get("rewind.from").map(ISODateTimeFormat.dateTime.parseDateTime)
-
 }

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -1,6 +1,5 @@
 package lib.kinesis
 
-import java.nio.charset.StandardCharsets
 import java.util
 import java.util.concurrent.Executors
 
@@ -17,16 +16,17 @@ import play.api.Logger
 import play.api.libs.json.{JodaReads, Json, Reads}
 
 import scala.concurrent.duration.{Duration, SECONDS}
-import scala.concurrent.{Await, ExecutionContext, Future, TimeoutException}
+import scala.concurrent.{Await, ExecutionContext, TimeoutException}
 import scala.util.{Failure, Success, Try}
 
 class ThrallEventConsumer(es: ElasticSearch,
                           thrallMetrics: ThrallMetrics,
                           store: ThrallStore,
                           metadataEditorNotifications: MetadataEditorNotifications,
-                          syndicationRightsOps: SyndicationRightsOps) extends IRecordProcessor with PlayJsonHelpers {
+                          syndicationRightsOps: SyndicationRightsOps,
+                          bulkIndexS3Client: BulkIndexS3Client) extends IRecordProcessor with PlayJsonHelpers {
 
-  private val messageProcessor = new MessageProcessor(es, store, metadataEditorNotifications, syndicationRightsOps)
+  private val messageProcessor = new MessageProcessor(es, store, metadataEditorNotifications, syndicationRightsOps, bulkIndexS3Client)
   private val Timeout = Duration(30, SECONDS)
 
   private implicit val ctx: ExecutionContext =

--- a/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallMessageConsumer.scala
@@ -16,12 +16,13 @@ class ThrallMessageConsumer(config: ThrallConfig,
                             store: ThrallStore,
                             metadataEditorNotifications: MetadataEditorNotifications,
                             syndicationRightsOps: SyndicationRightsOps,
-                            from: Option[DateTime]) {
+                            from: Option[DateTime],
+                            bulkIndexS3Client: BulkIndexS3Client) {
 
   private val workerId = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
   private val thrallEventProcessorFactory = new IRecordProcessorFactory {
-    override def createProcessor(): IRecordProcessor = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, syndicationRightsOps)
+    override def createProcessor(): IRecordProcessor = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, syndicationRightsOps, bulkIndexS3Client)
   }
 
   private def createKinesisWorker(cfg: KinesisClientLibConfiguration): Worker = {


### PR DESCRIPTION
## What does this change?
This message will have a `s3Path` property which is a path to an object in S3. We'll take that file, read as string and parse it as `List[Image]` and then bulk insert into elasticsearch (see https://github.com/guardian/grid/pull/2765).

If we're unable to parse the file to the correct type, we throw.

## How can success be measured?
We can process a `batch-index` message.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
