### PR TITLE
add skeleton for processing a batch index

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -21,6 +21,16 @@ class ThrallMessageSender(config: CommonConfig) {
   }
 }
 
+case class BulkIndexRequest(
+  bucket: String,
+  key: String
+)
+
+object BulkIndexRequest {
+  implicit val reads = Json.reads[BulkIndexRequest]
+  implicit val writes = Json.writes[BulkIndexRequest]
+}
+
 object UpdateMessage {
   implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
   implicit val unw = Json.writes[UsageNotice]
@@ -40,7 +50,8 @@ case class UpdateMessage(
   crops: Option[Seq[Crop]] = None,
   mediaLease: Option[MediaLease] = None,
   leases: Option[Seq[MediaLease]] = None,
-  syndicationRights: Option[SyndicationRights] = None
+  syndicationRights: Option[SyndicationRights] = None,
+  bulkIndexRequest: Option[BulkIndexRequest] = None
 ) {
   def toLogMarker: LogstashMarker = {
     val message = Json.stringify(Json.toJson(this))

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -1,6 +1,6 @@
 package lib.kinesis
 
-import com.gu.mediaservice.lib.aws.{EsResponse, UpdateMessage}
+import com.gu.mediaservice.lib.aws.{BulkIndexRequest, EsResponse, UpdateMessage}
 import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
@@ -36,7 +36,14 @@ class MessageProcessor(es: ElasticSearch,
       case "delete-usages" => deleteAllUsages
       case "upsert-rcs-rights" => upsertSyndicationRights
       case "update-image-photoshoot" => updateImagePhotoshoot
+      case "batch-index" => batchIndex
     }
+  }
+
+  def batchIndex(message: UpdateMessage)(implicit ec: ExecutionContext): Future[BulkIndexRequest] = {
+    val request = message.bulkIndexRequest.get
+    Logger.info(s"Batch Indexing from ${request.bucket}/${request.key}")
+    Future.successful(request)
   }
 
   def updateImageUsages(message: UpdateMessage)(implicit ec: ExecutionContext) = {


### PR DESCRIPTION
## What does this change?
Includes the deserialising of the message into values that can be used to get the S3 object.

## How can success be measured?
We can read `batch-index` messages.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@mkuzdowicz 

## Tested?
- [ ] locally
- [ ] on TEST
