### PR TITLE
Add reindex route to admin-tools

### DIFF
--- a/admin-tools/dev/app/AdminToolsComponents.scala
+++ b/admin-tools/dev/app/AdminToolsComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.aws.ThrallMessageSender
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.AdminToolsCtr
 import lib.AdminToolsConfig
@@ -10,7 +11,9 @@ class AdminToolsComponents(context: Context) extends GridComponents(context) {
 
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val controller = new AdminToolsCtr(config, controllerComponents)
+  val notifications = new ThrallMessageSender(config)
+
+  val controller = new AdminToolsCtr(config, controllerComponents, notifications)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management)
 }

--- a/admin-tools/dev/app/lib/AdminToolsConfig.scala
+++ b/admin-tools/dev/app/lib/AdminToolsConfig.scala
@@ -8,7 +8,6 @@ class AdminToolsConfig(override val configuration: Configuration) extends Common
 
   // hardcoded for dev
   override lazy val domainRoot: String = "local.dev-gutools.co.uk"
-  override lazy val properties = Map("auth.keystore.bucket" -> "not-used")
 
   // hardcoded for dev
   val apiKey: String = "dev-"

--- a/admin-tools/dev/conf/routes
+++ b/admin-tools/dev/conf/routes
@@ -1,5 +1,6 @@
 GET     /                           controllers.AdminToolsCtr.index
 GET     /images/projection/:id      controllers.AdminToolsCtr.project(id: String)
+POST    /images/reindex/:id         controllers.AdminToolsCtr.reindex(id: String)
 
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck

--- a/admin-tools/dev/conf/routes
+++ b/admin-tools/dev/conf/routes
@@ -1,6 +1,5 @@
 GET     /                           controllers.AdminToolsCtr.index
-GET     /images/projection/:id      controllers.AdminToolsCtr.project(id: String)
-POST    /images/reindex/:id         controllers.AdminToolsCtr.reindex(id: String)
+GET     /images/projection/:id      controllers.AdminToolsCtr.project(id: String, reingest: Boolean ?= false)
 
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
@@ -6,10 +6,11 @@ import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.model.Image
 import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json.{Json}
+import play.api.libs.json.Json
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
 
 class ImageProjectionLambdaHandler extends LazyLogging {
   private val domainRoot = sys.env("DOMAIN_ROOT")
@@ -18,7 +19,8 @@ class ImageProjectionLambdaHandler extends LazyLogging {
   private val imageLoaderEndpoint = sys.env.get("IMAGE_LOADER_ENDPOINT")
 
   def handleRequest(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
-    val shouldReingest = event.getPathParameters.getOrDefault("reingest", "false").asInstanceOf[Boolean]
+    val shouldReingestStr = event.getPathParameters.getOrDefault("reingest", "false")
+    val shouldReingest = Try(shouldReingestStr.toBoolean).getOrElse(false)
     val mediaId = event.getPath.stripPrefix("/images/projection/")
 
     getConfigFromRequestEvent(event) match {

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.{Json}
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ImageReingestLambdaHandler extends LazyLogging {
+class ImageProjectionLambdaHandler extends LazyLogging {
   private val domainRoot = sys.env("DOMAIN_ROOT")
   private val streamName = sys.env("KINESIS_STREAM")
   // if we want to release the load from main grid image-loader we can pass a dedicated endpoint

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
@@ -19,9 +19,11 @@ class ImageProjectionLambdaHandler extends LazyLogging {
   private val imageLoaderEndpoint = sys.env.get("IMAGE_LOADER_ENDPOINT")
 
   def handleRequest(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
-    val shouldReingestStr = event.getQueryStringParameters.getOrDefault("reingest", "false")
-    val shouldReingest = Try(shouldReingestStr.toBoolean).getOrElse(false)
     val mediaId = event.getPath.stripPrefix("/images/projection/")
+    val shouldReingest = if (event.getQueryStringParameters != null) {
+      val shouldReingestStr = event.getQueryStringParameters.getOrDefault("reingest", "false")
+      Try(shouldReingestStr.toBoolean).getOrElse(false)
+    } else false
 
     getConfigFromRequestEvent(event) match {
       case Some(config) => projectImage(mediaId, config, reingest = shouldReingest)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -78,8 +78,6 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
         val start = System.currentTimeMillis()
         val result = getImages(mediaIds, imagesEndpoint, InputIdsStore)
 
-
-
         logger.info(s"foundImagesIds: ${result.found}")
         logger.info(s"notFoundImagesIds: ${result.notFound}")
         logger.info(s"failedImageIds: ${result.failed}")

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -115,15 +115,10 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
   }
 
   def processImages(): Unit = {
-
     if (AwsHelpers.checkKinesisIsNiceAndFast(stage, threshold))
       processImagesOnlyIfKinesisIsNiceAndFast()
     else
       logger.info("Kinesis is too busy; leaving it for now")
-  }
-
-  def processSingleImage(id: string) = {
-
   }
 
   def processImagesOnlyIfKinesisIsNiceAndFast(): Unit = {

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -122,6 +122,10 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
       logger.info("Kinesis is too busy; leaving it for now")
   }
 
+  def processSingleImage(id: string) = {
+
+  }
+
   def processImagesOnlyIfKinesisIsNiceAndFast(): Unit = {
     if (!validApiKey(projectionEndpoint)) throw new IllegalStateException("invalid api key")
     val stateProgress = scala.collection.mutable.ArrayBuffer[ProduceProgress]()


### PR DESCRIPTION
## What does this change?

Adds the option to reingest images when projecting them. Reingestion is a destructive reindex – it'll stomp on anything that is already there in ES.

Intended to be used with the upcoming CLI tool.

## How can success be measured?

Call `POST admin-tools.{local|test}.dev-gutools.co.uk/images/project/:id?reingest=true` for an image that is present everywhere but Elasticsearch.  You should receive a 204 response. The image should reappear in ES with other data (e.g. leases, collections) restored.

## Tested?
- [x] locally
- [ ] on TEST
