### PR TITLE
Remove the complex gubbins from the file upload

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -7287,520 +7287,390 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
               }
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
               }
             },
             "chownr": {
               "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "debug": {
               "version": "4.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.1"
               }
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.3.5"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.3"
               }
             },
             "glob": {
               "version": "7.1.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
               }
             },
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.3"
               }
             },
             "minizlib": {
               "version": "1.2.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.3.5"
               }
             },
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
             },
             "ms": {
               "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "needle": {
               "version": "2.3.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
+                "debug": "4.1.1",
+                "iconv-lite": "0.4.24",
+                "sax": "1.2.4"
               }
             },
             "nopt": {
               "version": "4.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
               }
             },
             "npm-bundled": {
               "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.6"
               }
             },
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.5",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               }
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "osenv": {
               "version": "0.1.5",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "rc": {
               "version": "1.2.8",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.6.0",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
               },
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
+                  "bundled": true
                 }
               }
             },
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "rimraf": {
               "version": "2.6.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "glob": "^7.1.3"
+                "glob": "7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "semver": {
               "version": "5.7.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "tar": {
               "version": "4.4.8",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
+                "chownr": "1.1.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.3.5",
+                "minizlib": "1.2.1",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.3"
               }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "wide-align": {
               "version": "1.1.3",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
-                "string-width": "^1.0.2 || 2"
+                "string-width": "1.0.2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -74,24 +74,11 @@ upload.factory('fileUploader',
                 function($q, loaderApi) {
 
     function upload(file) {
-        return readFile(file).then(fileData => {
-            return uploadFile(fileData, { filename: file.name });
-        });
+      return uploadFile(file, {filename: file.name});
     }
 
-    function readFile(file) {
-        var reader = new FileReader();
-        var def = $q.defer();
-
-        reader.addEventListener('load',  event => def.resolve(event.target.result));
-        reader.addEventListener('error', def.reject);
-        reader.readAsArrayBuffer(file);
-
-        return def.promise;
-    }
-
-    function uploadFile(fileData, uploadInfo) {
-        return loaderApi.load(new Uint8Array(fileData), uploadInfo);
+    function uploadFile(file, uploadInfo) {
+        return loaderApi.load(file, uploadInfo);
     }
 
     function loadUriImage(fileUri) {

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -40,7 +40,7 @@ upload.factory('uploadManager',
         $q.all(promises).finally(() => {
           jobs.delete(job);
           job.map(jobItem => {
-            $window.revokeObjectURL(jobItem.dataUrl);
+            $window.URL.revokeObjectURL(jobItem.dataUrl);
           });
         });
     }


### PR DESCRIPTION
## What does this change?

This stops wrapping uploaded images in an array, which reduces the amount of memory our javascript is requesting- and allows the browser to manage the upload. thanks @mbarton 

This also corrects the method call which frees the object url.

We've managed to upload 250mb images, but 700mb is above the limit as image-loader seems to have some issues handling really big files

## How can success be measured?

Able to upload big images.

## Screenshots (if applicable)


## Who should look at this?
@akash1810 


## Tested?
- [X] locally
- [X] on TEST
