### PR TITLE
Change search help flyout from defunct staff to under-quota

### DIFF
--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -167,10 +167,10 @@
         </dl>
         <dl class="advanced-search-example">
           <dt class="advanced-search-example__field">
-            <gr-chip-example gr:filter-field="is" gr:example-search="staff"></gr-chip-example>
+            <gr-chip-example gr:filter-field="is" gr:example-search="under-quota"></gr-chip-example>
           </dt>
           <dd class="advanced-search-example__explanation">
-            Returns images that are staff.
+            Returns images from suppliers with free usage quota.
           </dd>
         </dl>
     </div>

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -162,7 +162,7 @@
                 <gr-chip-example gr:filter-field="has" gr:example-search="crops"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
-                Checks for the existence of a field. For example crops, xmp metadata, location etc.
+                Checks for the existence of a field, eg. usageRights, crops, location.
             </dd>
         </dl>
         <dl class="advanced-search-example">


### PR DESCRIPTION
We peddle a lie:

![image](https://user-images.githubusercontent.com/6032869/74334414-bde94700-4d91-11ea-9064-857a207647bc.png)

while trying to be helpful:

![image](https://user-images.githubusercontent.com/6032869/74334450-ce012680-4d91-11ea-8102-c5d952a18050.png)

this changes it to give example of `is:under-quota` search instead.

Also, rewords `has:` search suggestions to not suggest a serch that brakes the app, but mostly, so that it doesn’t wrap text so badly ;-).

- [x] on TEST
