### PR TITLE
Update scan to query and http calls debug logs refinement

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -65,7 +65,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) {
         val start = System.currentTimeMillis()
         val maybeBlobsFuture: List[Either[Image, String]] = getImagesProjection(mediaIds, projectionEndpoint, InputIdsStore)
         val (foundImages, notFoundImagesIds) = partitionToSuccessAndNotFound(maybeBlobsFuture)
-        println(s"foundImages size: $foundImages, notFoundImagesIds size: $notFoundImagesIds")
+        println(s"foundImages size: ${foundImages.size}, notFoundImagesIds size: ${notFoundImagesIds.size}")
         val end = System.currentTimeMillis()
         val projectionTookInSec = (end - start) / 1000
         println(s"projection of ${mediaIds.length} images took: $projectionTookInSec seconds")

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -80,6 +80,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) {
           stateProgress += updateStateToFinished(foundImages.map(_.id))
         } else {
           println("all was empty terminating current batch")
+          stateProgress += NotFound
         }
         stateProgress.map(_.name).toList
       }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -112,12 +112,11 @@ class InputIdsStore(table: Table, batchSize: Int) {
 
   def getUnprocessedMediaIdsBatch(implicit ec: ExecutionContext): Future[List[String]] = Future {
     println("attempt to get mediaIds batch from dynamo")
-
     val querySpec = new QuerySpec()
       .withKeyConditionExpression(s"$StateField = :sub")
       .withValueMap(new ValueMap().withNumber(":sub", 0))
       .withMaxResultSize(batchSize)
-    val mediaIds = table.query(querySpec).asScala.toList.map(it => {
+    val mediaIds = table.getIndex(StateField).query(querySpec).asScala.toList.map(it => {
       val json = Json.parse(it.toJSON).as[JsObject]
       (json \ PKField).as[String]
     })

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -59,7 +59,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) {
     val mediaIds = Await.result(mediaIdsFuture, GetIdsTimeout)
     Try {
       val processImagesFuture: Future[List[String]] = Future {
-        println(s"number of mediaIDs to index ${mediaIds.length}, $mediaIds")
+        println(s"number of mediaIDs to index ${mediaIds.length}")
         stateProgress += updateStateToItemsInProgress(mediaIds)
         println(s"get images projection started, projectionEndpoint: $projectionEndpoint")
         val start = System.currentTimeMillis()

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -35,10 +35,10 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) {
   private val ProjectionTimoutInMins = 11
   private val GetIdsTimoutInMins = 1
   private val OthersTimoutInMins = 1
-  private val GlobalTimoutInMins = ProjectionTimoutInMins + GetIdsTimoutInMins + OthersTimoutInMins
+  private val MainProcessingTimoutInMins = ProjectionTimoutInMins + OthersTimoutInMins
 
   private val GetIdsTimeout = new FiniteDuration(GetIdsTimoutInMins, TimeUnit.MINUTES)
-  private val GlobalTimeout = new FiniteDuration(GlobalTimoutInMins, TimeUnit.MINUTES)
+  private val GlobalTimeout = new FiniteDuration(MainProcessingTimoutInMins, TimeUnit.MINUTES)
   private val ImagesProjectionTimeout = new FiniteDuration(ProjectionTimoutInMins, TimeUnit.MINUTES)
   private val gridClient = GridClient(maxIdleConnections, debugHttpResponse = false)
 

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -64,6 +64,9 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) {
       val json = if (code == 200) Json.parse(body.string) else Json.obj()
       response.close()
       ResponseWrapper(json, code)
+    } catch {
+      case e: Exception =>
+        throw e
     } finally {
       body.close()
     }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -66,6 +66,7 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) {
       ResponseWrapper(json, code)
     } catch {
       case e: Exception =>
+        // propagating exception
         throw e
     } finally {
       body.close()

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -25,10 +25,10 @@ case class ImageDataMergerConfig(apiKey: String, services: Services, gridClient:
 case class ResponseWrapper(body: JsValue, statusCode: Int)
 
 object GridClient {
-  def apply(maxIdleConnections: Int): GridClient = new GridClient(maxIdleConnections)
+  def apply(maxIdleConnections: Int, debugHttpResponse: Boolean = true): GridClient = new GridClient(maxIdleConnections, debugHttpResponse)
 }
 
-class GridClient(maxIdleConnections: Int) {
+class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) {
 
   import java.util.concurrent.TimeUnit
 
@@ -60,7 +60,7 @@ class GridClient(maxIdleConnections: Int) {
         "status-code" -> code.toString,
         "message" -> response.message()
       )
-      println(s"GET $url response: $resInfo")
+      if (debugHttpResponse) println(s"GET $url response: $resInfo")
       val json = if (code == 200) Json.parse(body.string) else Json.obj()
       response.close()
       ResponseWrapper(json, code)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -2,7 +2,6 @@ package com.gu.mediaservice
 
 import java.net.URL
 
-import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
 import com.gu.mediaservice.model.Image
 
 import scala.concurrent.duration.Duration
@@ -24,14 +23,6 @@ class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duratio
     }
     Await.result(f, timeout)
   }
-
-  private def createImageProjector = {
-    val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
-    val cfg = ImageDataMergerConfig(apiKey, services, gridClient)
-    if (!cfg.isValidApiKey()) throw new IllegalArgumentException("provided api_key is invalid")
-    new ImageDataMerger(cfg, gridClient)
-  }
-
 }
 
 


### PR DESCRIPTION
## What does this change?

- Change the query for images currently being indexed from a scan to a query, as an index was added to the appropriate key.
- And http calls debug logs refinement
- update item state to not found instantly, not after all projections
## How can success be measured?

This code should work against a database with the appropriate index.

## Tested?
- [x] locally
- [x] on TEST
