### PR TITLE
add riffraff to admin-tools lambdas

### DIFF
--- a/admin-tools/lambda/riff-raff.yaml
+++ b/admin-tools/lambda/riff-raff.yaml
@@ -1,0 +1,12 @@
+stacks: [media-service]
+regions: [eu-west-1]
+deployments:
+  admin-tools-lambda:
+    type: aws-lambda
+    parameters:
+      bucket: media-service-dist
+      fileName: admin-tools-lambda.jar
+      prefixStack: false
+      functionNames:
+        - "admin-tools-image-projection-lambda-"
+        - "admin-tools-image-batch-index-lambda-"

--- a/build.sbt
+++ b/build.sbt
@@ -143,6 +143,7 @@ lazy val adminToolsLib = project("admin-tools-lib", Some("admin-tools/lib"))
   ).dependsOn(commonLib)
 
 lazy val adminToolsLambda = project("admin-tools-lambda", Some("admin-tools/lambda"))
+  .enablePlugins(RiffRaffArtifact)
   .settings(
     assemblyMergeStrategy in assembly := {
       case PathList("META-INF", xs@_*) => MergeStrategy.discard
@@ -153,9 +154,15 @@ lazy val adminToolsLambda = project("admin-tools-lambda", Some("admin-tools/lamb
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
       "com.amazonaws" % "aws-lambda-java-events" % "2.2.7",
     )
-  ).dependsOn(adminToolsLib).settings(
-  assemblyJarName in assembly := "admin-tools-lambda.jar"
-)
+  )
+  .dependsOn(adminToolsLib)
+  .settings(
+    assemblyJarName := s"${name.value}.jar",
+    riffRaffPackageType := assembly.value,
+    riffRaffUploadArtifactBucket := Some("riffraff-artifact"),
+    riffRaffUploadManifestBucket := Some("riffraff-builds"),
+    riffRaffManifestProjectName := s"media-service::grid::admin-tools-lambda"
+  )
 
 lazy val adminToolsDev = playProject("admin-tools-dev", 9013, Some("admin-tools/dev"))
   .dependsOn(adminToolsLib)

--- a/scripts/ci/admin-tools-lambda-build.sh
+++ b/scripts/ci/admin-tools-lambda-build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+sbt ";project admin-tools-lambda; assembly; riffRaffUpload"


### PR DESCRIPTION
## What does this change?
Add RiffRaff to the admin-tools lambdas to bring the deployment in line with other apps and we can also start having CD on it too.

## How can success be measured?
Easier deployment strategy.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@mkuzdowicz 
@jonathonherbert 

## Tested?
- [ ] locally
- [ ] on TEST
