### PR TITLE
adding error handling when projection endpoint is in error state or api_key is invalid

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -53,6 +53,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) {
   private implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   def processImages(): List[String] = {
+    if (!validApiKey(projectionEndpoint)) throw new IllegalStateException("invalid api key")
     val stateProgress = scala.collection.mutable.ArrayBuffer[ProduceProgress]()
     stateProgress += NotStarted
     val mediaIdsFuture = getUnprocessedMediaIdsBatch

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -61,6 +61,7 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) {
         "message" -> response.message()
       )
       if (debugHttpResponse) println(s"GET $url response: $resInfo")
+      if (serverErrorType(code)) throw new IllegalStateException(s"projection server error, calling $url return statusCode: $code")
       val json = if (code == 200) Json.parse(body.string) else Json.obj()
       response.close()
       ResponseWrapper(json, code)
@@ -72,6 +73,8 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) {
       body.close()
     }
   }
+
+  private def serverErrorType(code: Int): Boolean = (code / 100) == 5
 
   private def makeRequestAsync(url: URL, apiKey: String): Future[Response] = {
     val request = new Request.Builder().url(url).header(Authentication.apiKeyHeaderName, apiKey).build

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -9,6 +9,11 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duration, gridClient: GridClient) {
 
+  def validApiKey(projectionEndpoint: String) = {
+    val projectionUrl = new URL(s"$projectionEndpoint/not-exists")
+    gridClient.makeGetRequestSync(projectionUrl, apiKey).statusCode == 404
+  }
+
   def getImagesProjection(mediaIds: List[String], projectionEndpoint: String,
                           InputIdsStore: InputIdsStore)(implicit ec: ExecutionContext): List[Either[Image, String]] = {
     val f = Future.traverse(mediaIds) { id =>


### PR DESCRIPTION
## What does this change?
adding error handling:
- when projection endpoint is in error state
- api_key is invalid
## How can success be measured?
lambda fail when projection endpoint is in error state
and reset items state to 0


## Tested?
- [ ] locally
- [x] on TEST
