### PR TITLE
Remove Redundant Bylines and Credits

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -15,6 +15,7 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
   val allCleaners: List[MetadataCleaner] = List(
     CleanRubbishLocation,
     StripCopyrightPrefix,
+    RedundantTokenRemover,
     BylineCreditReorganise,
     UseCanonicalGuardianCredit,
     ExtractGuardianCreditFromByline

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -15,8 +15,8 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
   val allCleaners: List[MetadataCleaner] = List(
     CleanRubbishLocation,
     StripCopyrightPrefix,
-    RedundantTokenRemover,
     BylineCreditReorganise,
+    RedundantTokenRemover,
     UseCanonicalGuardianCredit,
     ExtractGuardianCreditFromByline
   ) ++ attrCreditFromBylineCleaners ++ List(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -1,0 +1,41 @@
+package com.gu.mediaservice.lib.cleanup
+import com.gu.mediaservice.model.ImageMetadata
+
+object RedundantTokenRemover extends MetadataCleaner {
+  val toRemove = List(
+    "Handout",
+    "HANDOUT",
+    "HO",
+    "HO HANDOUT",
+    "Pool",
+    "POOL",
+    "POOL New",
+    "STRINGER",
+    "stringer",
+    "Stringer",
+    "STR",
+    "-",
+    "UNCREDITED",
+    "Uncredited",
+    "uncreadited",
+    "XXSTRINGERXX xxxxx"
+  )
+
+  override def clean(metadata: ImageMetadata): ImageMetadata = metadata.copy(
+    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty),
+    credit = metadata.credit.map(removeHandoutTokens).flatMap { c =>
+      if (c.isEmpty) {
+        metadata.credit.flatMap(c => c.split("/").lastOption)
+      } else {
+        Some(c)
+      }
+    },
+  )
+
+  def removeHandoutTokens(text: String): String = {
+    text.split("/").filter { tok =>
+      val trimmedToken = tok.trim
+      toRemove.contains(trimmedToken)
+    }.mkString("/")
+  }
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -22,20 +22,20 @@ object RedundantTokenRemover extends MetadataCleaner {
   )
 
   override def clean(metadata: ImageMetadata): ImageMetadata = metadata.copy(
-    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty).map(_.trim),
+    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty),
     credit = metadata.credit.map(removeHandoutTokens).flatMap { c =>
       if (c.isEmpty) {
         metadata.credit.flatMap(c => c.split("/").lastOption)
       } else {
         Some(c)
       }
-    }.map(_.trim),
+    },
   )
 
   def removeHandoutTokens(text: String): String = {
     text.split("/").filter { tok =>
       val trimmedToken = tok.trim
       !toRemove.contains(trimmedToken)
-    }.mkString("/")
+    }.mkString("/").trim
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -17,7 +17,7 @@ object RedundantTokenRemover extends MetadataCleaner {
     "-",
     "UNCREDITED",
     "Uncredited",
-    "uncreadited",
+    "uncredited",
     "XXSTRINGERXX xxxxx"
   )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -22,14 +22,14 @@ object RedundantTokenRemover extends MetadataCleaner {
   )
 
   override def clean(metadata: ImageMetadata): ImageMetadata = metadata.copy(
-    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty),
+    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty).map(_.trim),
     credit = metadata.credit.map(removeHandoutTokens).flatMap { c =>
       if (c.isEmpty) {
         metadata.credit.flatMap(c => c.split("/").lastOption)
       } else {
         Some(c)
       }
-    },
+    }.map(_.trim),
   )
 
   def removeHandoutTokens(text: String): String = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -35,7 +35,7 @@ object RedundantTokenRemover extends MetadataCleaner {
   def removeHandoutTokens(text: String): String = {
     text.split("/").filter { tok =>
       val trimmedToken = tok.trim
-      toRemove.contains(trimmedToken)
+      !toRemove.contains(trimmedToken)
     }.mkString("/")
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -22,20 +22,20 @@ object RedundantTokenRemover extends MetadataCleaner {
   )
 
   override def clean(metadata: ImageMetadata): ImageMetadata = metadata.copy(
-    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty),
+    byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty).map(_.trim),
     credit = metadata.credit.map(removeHandoutTokens).flatMap { c =>
       if (c.isEmpty) {
         metadata.credit.flatMap(c => c.split("/").lastOption)
       } else {
         Some(c)
       }
-    },
+    }.map(_.trim),
   )
 
   def removeHandoutTokens(text: String): String = {
     text.split("/").filter { tok =>
       val trimmedToken = tok.trim
       !toRemove.contains(trimmedToken)
-    }.mkString("/").trim
+    }.mkString("/")
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemoverTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemoverTest.scala
@@ -3,29 +3,39 @@ package com.gu.mediaservice.lib.cleanup
 import org.scalatest.{FunSpec, Matchers}
 
 class RedundantTokenRemoverTest extends FunSpec with Matchers with MetadataHelper {
-  it ("Remove redundant byline, keep redundant credit") {
-    BylineCredit("HANDOUT", "HANDOUT")
-      .whenCleaned(None, "HANDOUT")
-  }
+  // We've seen both "/" and " / " in the wild so test with both
+  val separators = List("/", " / ")
 
-  it ("Keep good byline, clean partially redundant credit") {
-    BylineCredit("Byline Person", "POOL/Credit")
-      .whenCleaned(Some("Byline Person"), "Credit")
-  }
+  separators.foreach { s =>
+    it (s"Remove redundant byline, keep redundant credit - '$s' separator") {
+      BylineCredit("HANDOUT", "HANDOUT")
+        .whenCleaned(None, "HANDOUT")
+    }
 
-  it ("Keep good byline, simplify redundant credit") {
-    BylineCredit("Byline Person", "POOL/HANDOUT")
-      .whenCleaned(Some("Byline Person"), "HANDOUT")
-  }
+    it (s"Clean partially redundant byline, clean partially redundant credit - '$s' separator") {
+      BylineCredit(s"HANDOUT${s}Byline", s"POOL${s}Credit")
+        .whenCleaned(Some("Byline"), "Credit")
+    }
 
-  it ("Remove redundant byline, keep good credit") {
-    BylineCredit("HANDOUT", "Credit")
-      .whenCleaned(None, "Credit")
-  }
+    it (s"Keep good byline, clean partially redundant credit - '$s' separator") {
+      BylineCredit("Byline", s"POOL${s}Credit")
+        .whenCleaned(Some("Byline"), "Credit")
+    }
 
-  it ("Keep good byline, keep good credit") {
-    BylineCredit("Byline Person", "Credit")
-      .whenCleaned(Some("Byline Person"), "Credit")
+    it (s"Keep good byline, simplify redundant credit (use the rightmost) - '$s' separator") {
+      BylineCredit("Byline", s"POOL${s}HANDOUT")
+        .whenCleaned(Some("Byline"), "HANDOUT")
+    }
+
+    it (s"Remove redundant byline, keep good credit - '$s' separator") {
+      BylineCredit("HANDOUT", "Credit")
+        .whenCleaned(None, "Credit")
+    }
+
+    it (s"Keep good byline, keep good credit - '$s' separator") {
+      BylineCredit("Byline", "Credit")
+        .whenCleaned(Some("Byline"), "Credit")
+    }
   }
 
   case class BylineCredit(byline: String, credit: String) {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemoverTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemoverTest.scala
@@ -1,0 +1,43 @@
+package com.gu.mediaservice.lib.cleanup
+
+import org.scalatest.{FunSpec, Matchers}
+
+class RedundantTokenRemoverTest extends FunSpec with Matchers with MetadataHelper {
+  it ("Remove redundant byline, keep redundant credit") {
+    BylineCredit("HANDOUT", "HANDOUT")
+      .whenCleaned(None, "HANDOUT")
+  }
+
+  it ("Keep good byline, clean partially redundant credit") {
+    BylineCredit("Byline Person", "POOL/Credit")
+      .whenCleaned(Some("Byline Person"), "Credit")
+  }
+
+  it ("Keep good byline, simplify redundant credit") {
+    BylineCredit("Byline Person", "POOL/HANDOUT")
+      .whenCleaned(Some("Byline Person"), "HANDOUT")
+  }
+
+  it ("Remove redundant byline, keep good credit") {
+    BylineCredit("HANDOUT", "Credit")
+      .whenCleaned(None, "Credit")
+  }
+
+  it ("Keep good byline, keep good credit") {
+    BylineCredit("Byline Person", "Credit")
+      .whenCleaned(Some("Byline Person"), "Credit")
+  }
+
+  case class BylineCredit(byline: String, credit: String) {
+    def whenCleaned(cByline: Option[String], cCredit: String) = {
+      val metadata = createImageMetadata(
+        "byline" -> byline,
+        "credit" -> credit
+      )
+      val cleanMetadata = RedundantTokenRemover.clean(metadata)
+
+      cleanMetadata.byline should be (cByline)
+      cleanMetadata.credit should be (Some(cCredit))
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Sometimes the byline and credits contain "redundant" values. A few of these have been found in the wild, values such as `HANDOUT`, `stringer`, `Uncredited`, etc. etc.

These should be removed!

In the case of the byline field these can be removed completely but it's not valid for there to be no credit field. In the case of a credit having on or more of these redundant values we either keep the redundant value (if there's one) or choose the right-most.

Added tests with both`"/"` and `" / "` as the token separator

## Tested?
- [x] locally
- [x] on TEST
