### PR TITLE
Remove log to prevent double counting

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -71,15 +71,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
         val (foundImages, notFoundImagesIds) = partitionToSuccessAndNotFound(maybeBlobsFuture)
         val end = System.currentTimeMillis()
         val projectionTookInSec = (end - start) / 1000
-        val message = s"Projections received in $projectionTookInSec seconds. Found ${foundImages.size} images, could not find ${notFoundImagesIds.size} images"
-        val jsonMsg = Json.obj(
-          "batchSize" -> mediaIds.size,
-          "foundImagesCount" -> foundImages.size,
-          "notFoundImagesCount" -> notFoundImagesIds.size,
-          "projectionTookInSec" -> projectionTookInSec,
-          "message" -> message
-        )
-        logger.info(jsonMsg.toString())
+        logger.info(s"Projections received in $projectionTookInSec seconds. Found ${foundImages.size} images, could not find ${notFoundImagesIds.size} images")
 
         if (foundImages.nonEmpty) {
           logger.info("attempting to store blob to s3")


### PR DESCRIPTION
## What does this change?

Remove log to prevent double counting

## How can success be measured?

Single count of relevant log lines in logs – e.g. foundImagesCount.

## Tested?
- [x] locally
- [ ] on TEST
