### PR TITLE
be able to project picdarURN from s3 file metadata

### DIFF
--- a/image-loader/app/model/ImageUploadProjector.scala
+++ b/image-loader/app/model/ImageUploadProjector.scala
@@ -9,7 +9,7 @@ import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.model.{Image, UploadInfo}
 import lib.imaging.MimeTypeDetection
 import lib.{DigestedFile, ImageLoaderConfig}
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -21,12 +21,15 @@ object ImageUploadProjector {
   = new ImageUploadProjector(toImageUploadOpsCfg(config), imageOps)(ec)
 }
 
+case class S3FileExtractedMetadata(uploadedBy: String, uploadTime: DateTime, uploadFileName: Option[String], picdarUrn: Option[String])
+
 class ImageUploadProjector(config: ImageUploadOpsCfg, imageOps: ImageOperations)
                           (implicit val ec: ExecutionContext) {
 
   private val imageUploadProjectionOps = new ImageUploadProjectionOps(config, imageOps)
 
-  def projectImage(srcFileDigest: DigestedFile, uploadedBy: String, uploadedTime: DateTime, uploadFileName: Option[String]): Future[Image] = {
+  def projectImage(srcFileDigest: DigestedFile, extractedS3Meta: S3FileExtractedMetadata): Future[Image] = {
+    import extractedS3Meta._
     val DigestedFile(tempFile_, id_) = srcFileDigest
     // TODO identifiers_ to rehydrate
     val identifiers_ = Map[String, String]()
@@ -39,7 +42,7 @@ class ImageUploadProjector(config: ImageUploadOpsCfg, imageOps: ImageOperations)
       imageId = id_,
       tempFile = tempFile_,
       mimeType = mimeType_,
-      uploadedTime,
+      uploadTime = uploadTime,
       uploadedBy,
       identifiers = identifiers_,
       uploadInfo = uploadInfo_

--- a/image-loader/app/model/ImageUploadProjector.scala
+++ b/image-loader/app/model/ImageUploadProjector.scala
@@ -31,8 +31,11 @@ class ImageUploadProjector(config: ImageUploadOpsCfg, imageOps: ImageOperations)
   def projectImage(srcFileDigest: DigestedFile, extractedS3Meta: S3FileExtractedMetadata): Future[Image] = {
     import extractedS3Meta._
     val DigestedFile(tempFile_, id_) = srcFileDigest
-    // TODO identifiers_ to rehydrate
-    val identifiers_ = Map[String, String]()
+    // TODO more identifiers_ to rehydrate
+    val identifiers_ = picdarUrn match {
+      case Some(value) => Map[String, String]("picdarURN" -> value)
+      case _ => Map[String, String]()
+    }
     val uploadInfo_ = UploadInfo(filename = uploadFileName)
     //  Abort early if unsupported mime-type
     val mimeType_ = MimeTypeDetection.guessMimeType(tempFile_)

--- a/image-loader/test/scala/model/ImageUploadProjectorTest.scala
+++ b/image-loader/test/scala/model/ImageUploadProjectorTest.scala
@@ -7,7 +7,7 @@ import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.LeasesByMedia
 import lib.DigestedFile
-import model.{ImageUploadOpsCfg, ImageUploadProjector}
+import model.{ImageUploadOpsCfg, ImageUploadProjector, S3FileExtractedMetadata}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
@@ -150,7 +150,14 @@ class ImageUploadProjectorTest extends FunSuite with Matchers with ScalaFutures 
       userMetadataLastModified = None
     )
 
-    val actualFuture = projector.projectImage(fileDigest, uploadedBy, uploadTime, uploadFileName)
+    val extractedS3Meta = S3FileExtractedMetadata(
+      uploadedBy = uploadedBy,
+      uploadTime = uploadTime,
+      uploadFileName = uploadFileName,
+      picdarUrn = None,
+    )
+
+    val actualFuture = projector.projectImage(fileDigest, extractedS3Meta)
 
     whenReady(actualFuture) { actual =>
       actual shouldEqual expected


### PR DESCRIPTION
## What does this change?
be able to project picdarURN from s3 file metadata

## How can success be measured?
if file in s3 have custom metadata: `x-amz-meta-identifier!picdarurn`

it should be projected as `identifiers: { picdarURN: "..."}`

## Tested?
- [x] locally
- [x] on TEST
