### PR TITLE
add a cheat to the bulk insert test

### DIFF
--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -29,13 +29,19 @@ class ElasticSearchTest extends ElasticSearchTestBase {
 
           val images: List[Image] = List(imageOne, imageTwo)
 
+          // Ideally, before we bulk insert we would assert document count is 0 and after, it is 2.
+          // However there is a race condition in the tests (only seen in GH Actions) which results in state being shared between tests,
+          // so we're just checking the document count has increased by the correct amount.
+          val initialDocumentCount = ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count
+          val expectedDocumentCount = initialDocumentCount + images.length
+
           Await.result(Future.sequence(ES.bulkInsert(images)), fiveSeconds)
 
           // force ES to refresh https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
           Await.result(ES.client.execute(ElasticDsl.refreshIndex(ES.initialImagesIndex)), fiveSeconds)
 
           // after bulk inserting, we should have 2 documents
-          ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count shouldBe images.length
+          ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count shouldBe expectedDocumentCount
 
           Json.toJson(reloadedImage("batman").get) shouldBe Json.toJson(imageOne)
           Json.toJson(reloadedImage("superman").get) shouldBe Json.toJson(imageTwo)


### PR DESCRIPTION
## What does this change?
The issue raised in https://github.com/guardian/grid/pull/2785 is still being witnessed. This is a cheating solution.

Ideally, before we bulk insert we would assert document count is 0 and after, it is 2. However there is a race condition in the tests (only seen in GH Actions) which results in state being shared between tests, so we're just checking the document count has increased by the correct amount.

## How can success be measured?
More reliable CI.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
