### PR TITLE
force a refresh between tests

### DIFF
--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -29,6 +29,9 @@ class ElasticSearchTest extends ElasticSearchTestBase {
 
           val images: List[Image] = List(imageOne, imageTwo)
 
+          // in a clean index, we should have 0 documents
+          ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count shouldBe 0
+
           Await.result(Future.sequence(ES.bulkInsert(images)), fiveSeconds)
 
           // force ES to refresh https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -29,19 +29,13 @@ class ElasticSearchTest extends ElasticSearchTestBase {
 
           val images: List[Image] = List(imageOne, imageTwo)
 
-          // Ideally, before we bulk insert we would assert document count is 0 and after, it is 2.
-          // However there is a race condition in the tests (only seen in GH Actions) which results in state being shared between tests,
-          // so we're just checking the document count has increased by the correct amount.
-          val initialDocumentCount = ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count
-          val expectedDocumentCount = initialDocumentCount + images.length
-
           Await.result(Future.sequence(ES.bulkInsert(images)), fiveSeconds)
 
           // force ES to refresh https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
           Await.result(ES.client.execute(ElasticDsl.refreshIndex(ES.initialImagesIndex)), fiveSeconds)
 
           // after bulk inserting, we should have 2 documents
-          ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count shouldBe expectedDocumentCount
+          ES.client.execute(ElasticDsl.count(ES.initialImagesIndex)).await.result.count shouldBe images.length
 
           Json.toJson(reloadedImage("batman").get) shouldBe Json.toJson(imageOne)
           Json.toJson(reloadedImage("superman").get) shouldBe Json.toJson(imageTwo)

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,17 +1,20 @@
 package lib.elasticsearch
 
-import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
+import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchConfig, Mappings}
+import com.sksamuel.elastic4s.http.ElasticDsl
 import com.whisk.docker.impl.spotify.DockerKitSpotify
 import com.whisk.docker.scalatest.DockerTestKit
 import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}
 import helpers.Fixtures
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FreeSpec, Matchers}
+import com.sksamuel.elastic4s.http.ElasticDsl._
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Properties
 
-trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with Eventually with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
+trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with BeforeAndAfterEach with Eventually with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
 
   val useEsDocker = Properties.envOrElse("ES6_USE_DOCKER", "true").toBoolean
   val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
@@ -33,6 +36,14 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
   override def beforeAll {
     super.beforeAll()
     ES.ensureAliasAssigned()
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    Await.ready(
+      ES.client.execute(
+        ElasticDsl.deleteByQuery(ES.initialImagesIndex, Mappings.dummyType, ElasticDsl.matchAllQuery())
+      ), fiveSeconds)
   }
 
   override def afterAll: Unit = {

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -40,10 +40,14 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
   override protected def afterEach(): Unit = {
     super.afterEach()
+    // Ensure to reset the state of ES between tests by deleting all documents...
     Await.ready(
       ES.client.execute(
         ElasticDsl.deleteByQuery(ES.initialImagesIndex, Mappings.dummyType, ElasticDsl.matchAllQuery())
       ), fiveSeconds)
+
+    // ...and then forcing a refresh. These operations need to be done in serial.
+    Await.result(ES.client.execute(ElasticDsl.refreshIndex(ES.initialImagesIndex)), fiveSeconds)
   }
 
   override def afterAll: Unit = {


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/grid/pull/2802, but better!

We have a scenario where state persists between tests in elasticsearch. This change updates the `afterEach` step of a test, to clear the index and force a refresh. This is in the hope of forcing independent state.

## How can success be measured?
More reliable CI.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
