### PR TITLE
inferring lastModified date on image projection

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -81,13 +81,21 @@ object ImageProjectionOverrides extends LazyLogging {
   }
 
   private def overrideInferredLastModifiedDate(img: Image) = {
-    val lastModifiedFinal = projectFinalLastModifiedDate(img)
+    val lastModifiedFinal = inferLastModifiedDate(img)
     img.copy(
       lastModified = lastModifiedFinal
     )
   }
 
-  private def projectFinalLastModifiedDate(image: Image): Option[DateTime] = {
+  private def inferLastModifiedDate(image: Image): Option[DateTime] = {
+
+    /**
+      * TODO
+      * it is using userMetadataLastModified field now
+      * because it is not persisted now anywhere else then ElasticSearch
+      * and projection is initially created to be able to project records that are missing in ElasticSearch
+      * so TODO userMetadataLastModified should be stored in dynamo additionally
+      * */
 
     val dtOrdering = Ordering.by((_: DateTime).getMillis())
 

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -30,9 +30,9 @@ case class ImageDataMergerConfig(apiKey: String, services: Services, gridClient:
   }
 }
 
-object ImageMetadataOverrides extends LazyLogging {
+object ImageProjectionOverrides extends LazyLogging {
 
-  def overrideMetadata(img: Image): Image = {
+  def overrideSelectedFields(img: Image): Image = {
     logger.info(s"applying metadata overrides")
 
     val metadataEdits: Option[ImageMetadata] = img.userMetadata.map(_.metadata)
@@ -125,7 +125,7 @@ class ImageDataMerger(config: ImageDataMergerConfig) extends LazyLogging {
     maybeImage match {
       case Some(img) =>
         aggregate(img).map { aggImg =>
-          Some(ImageMetadataOverrides.overrideMetadata(aggImg))
+          Some(ImageProjectionOverrides.overrideSelectedFields(aggImg))
         }
       case None => Future(None)
     }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -38,13 +38,13 @@ object ImageProjectionOverrides extends LazyLogging {
     val metadataEdits: Option[ImageMetadata] = img.userMetadata.map(_.metadata)
     val usageRightsEdits: Option[UsageRights] = img.userMetadata.flatMap(_.usageRights)
 
-    val chain = overrideWithMetadataEditsIfExists(metadataEdits) _ compose
-      overrideWithUsageEditsIfExists(usageRightsEdits) compose overrideInferredLastModifiedDate
+    val chain = overrideMetadataWithUserEditsIfExists(metadataEdits) _ compose
+      overrideUsageRightsWithUserEditsIfExists(usageRightsEdits) compose overrideWithInferredLastModifiedDate
 
     chain.apply(img)
   }
 
-  private def overrideWithMetadataEditsIfExists(metadataEdits: Option[ImageMetadata])(img: Image) = {
+  private def overrideMetadataWithUserEditsIfExists(metadataEdits: Option[ImageMetadata])(img: Image) = {
     metadataEdits match {
       case Some(metadataEdits) =>
         val origMetadata = img.metadata
@@ -80,7 +80,7 @@ object ImageProjectionOverrides extends LazyLogging {
     }
   }
 
-  private def overrideInferredLastModifiedDate(img: Image) = {
+  private def overrideWithInferredLastModifiedDate(img: Image) = {
     val lastModifiedFinal = inferLastModifiedDate(img)
     img.copy(
       lastModified = lastModifiedFinal
@@ -113,7 +113,7 @@ object ImageProjectionOverrides extends LazyLogging {
 
   private def handleEmptyString(entry: Option[String]): Option[String] = entry.collect { case x if x.trim.nonEmpty => x }
 
-  private def overrideWithUsageEditsIfExists(usageRightsEdits: Option[UsageRights])(img: Image) = {
+  private def overrideUsageRightsWithUserEditsIfExists(usageRightsEdits: Option[UsageRights])(img: Image) = {
     usageRightsEdits match {
       case Some(usrR) => img.copy(usageRights = usrR)
       case _ => img

--- a/admin-tools/lib/src/test/scala/com/gu/mediaservice/ImageProjectionOverridesTest.scala
+++ b/admin-tools/lib/src/test/scala/com/gu/mediaservice/ImageProjectionOverridesTest.scala
@@ -9,7 +9,7 @@ import com.gu.mediaservice.model._
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 
-class ImageMetadataOverridesTest extends FlatSpec with Matchers {
+class ImageProjectionOverridesTest extends FlatSpec with Matchers {
 
   private val Deletion = Some("")
 
@@ -35,7 +35,7 @@ class ImageMetadataOverridesTest extends FlatSpec with Matchers {
     image.metadata shouldEqual initialImgMetadata
     image.usageRights shouldEqual initialUsageRights
 
-    val actual = ImageMetadataOverrides.overrideMetadata(image)
+    val actual = ImageProjectionOverrides.overrideSelectedFields(image)
 
     val metadataExpected = ImageMetadata(
       dateTaken = Some(new DateTime("2014-01-01T00:00:00.000Z")),
@@ -50,14 +50,14 @@ class ImageMetadataOverridesTest extends FlatSpec with Matchers {
   }
 
   it should "override image metadata with the latest lastModified picked form sub fields" in {
-    import ImageMetadataOverrides.overrideMetadata
+    import ImageProjectionOverrides.overrideSelectedFields
     val date = new DateTime("2014-01-01T00:00:00.000Z")
 
     val imageWithNoDates = createImage()
-    overrideMetadata(imageWithNoDates).lastModified shouldEqual None
+    overrideSelectedFields(imageWithNoDates).lastModified shouldEqual None
 
     val imageWithMainLastModOnly = createImage().copy(lastModified = Some(date))
-    overrideMetadata(imageWithMainLastModOnly).lastModified.get shouldEqual date
+    overrideSelectedFields(imageWithMainLastModOnly).lastModified.get shouldEqual date
 
     val imageWithCrops = createImage().copy(
       lastModified = Some(date),
@@ -73,7 +73,7 @@ class ImageMetadataOverridesTest extends FlatSpec with Matchers {
       ),
     )
 
-    overrideMetadata(imageWithCrops).lastModified.get shouldEqual date.plusHours(1)
+    overrideSelectedFields(imageWithCrops).lastModified.get shouldEqual date.plusHours(1)
 
     val imageWithAllDates = createImage().copy(
       lastModified = Some(date),
@@ -96,7 +96,7 @@ class ImageMetadataOverridesTest extends FlatSpec with Matchers {
       ))
     )
 
-    overrideMetadata(imageWithAllDates).lastModified.get shouldEqual date.plusHours(4)
+    overrideSelectedFields(imageWithAllDates).lastModified.get shouldEqual date.plusHours(4)
   }
 
 


### PR DESCRIPTION
## What does this change?
inferring lastModified date on image projection

## How can success be measured?
on image projection
lastModified date  should be more recent then uploadDate
if there were events happening on the image like:
usages, crops, ...

it is not covering metadata edits as `userMetadataLastModified` is not persisted now anywhere else then ElasticSearch


## Tested?
- [x] locally
- [x] on TEST
