### PR TITLE
Move RedundantTokenRemover before BylineCreditReorganise

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -15,8 +15,8 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
   val allCleaners: List[MetadataCleaner] = List(
     CleanRubbishLocation,
     StripCopyrightPrefix,
-    BylineCreditReorganise,
     RedundantTokenRemover,
+    BylineCreditReorganise,
     UseCanonicalGuardianCredit,
     ExtractGuardianCreditFromByline
   ) ++ attrCreditFromBylineCleaners ++ List(


### PR DESCRIPTION
## What does this change?
Changes the order of the cleaners, so that the one stripping redundant tokens runs before reorganise.

## How can success be measured?
`"By-line": "STRINGER/MEXICO"`
`"Credit": "REUTERS"`
won’t get cleaned to
`byline: [empty]`
`"credit": "MEXICO/REUTERS"`
preventing Reuters pic from being recognised.

## Tested?
- [ ] locally
- [ ] on TEST
