### PR TITLE
ensure we delete files through all code paths in image-loader

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -80,7 +80,6 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
 
     auth.async(parsedBody) { req =>
       val result = loadFile(req.body, req.user, uploadedBy, identifiers, uploadTime, filename, requestContext)
-      result.onComplete { _ => req.body.file.delete() }
       Logger.info("loadImage request end")(requestContext.toMarker(markers))
       result
     }

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -221,6 +221,9 @@ object ImageUploadOps {
             uploadRequest
           )
 
+          Logger.info(s"Deleting temp file ${uploadedFile.getAbsolutePath}")(uploadRequest.toLogMarker)
+          uploadedFile.delete()
+
           finalImage
         }
       })


### PR DESCRIPTION
## What does this change?
There are 3 ways to interact with image loader:
- POST a file, which will create a temp file from the request body
- POST a url, which will download the file from the url into a temp file
- GET a projection, which will create temp files from a file in S3

Each of these paths need to clean up after themselves. We were not doing this on the projection path.

[`fromUploadRequestShared`](https://github.com/guardian/grid/blob/21841aaf13239ae764bd00c0bd11b628f90cc89a/image-loader/app/model/ImageUpload.scala#L172) is shared between all three paths, so it makes sense to do the deletion there to keep things DRY.

This has been tested by:
- watching the temp directory (`watch -n 0.1 /tmp`)
- uploading a file through the browser
- observing temp files being created and removed
- projecting an image
- observing temp files being created and removed

Prior to this change, the last step was failing.

## How can success be measured?
Disks do not fill up!

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
