### PR TITLE
add more context to logs produced by image-loader

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/RequestLoggingContext.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/RequestLoggingContext.scala
@@ -1,0 +1,13 @@
+package com.gu.mediaservice.lib.logging
+
+import java.util.UUID
+
+import net.logstash.logback.marker.{LogstashMarker, Markers}
+
+import scala.collection.JavaConverters._
+
+case class RequestLoggingContext(requestId: UUID = UUID.randomUUID(), initialMarkers: Map[String, String] = Map.empty) {
+  def toMarker(extraMarkers: Map[String, String] = Map.empty): LogstashMarker = Markers.appendEntries(
+    (initialMarkers ++ extraMarkers + ("requestId" -> requestId)).asJava
+  )
+}

--- a/image-loader/test/scala/model/ImageUploadProjectorTest.scala
+++ b/image-loader/test/scala/model/ImageUploadProjectorTest.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.net.URI
 
 import com.gu.mediaservice.lib.imaging.ImageOperations
+import com.gu.mediaservice.lib.logging.RequestLoggingContext
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.LeasesByMedia
 import lib.DigestedFile
@@ -157,7 +158,9 @@ class ImageUploadProjectorTest extends FunSuite with Matchers with ScalaFutures 
       picdarUrn = None,
     )
 
-    val actualFuture = projector.projectImage(fileDigest, extractedS3Meta)
+    val requestLoggingContext = RequestLoggingContext()
+    
+    val actualFuture = projector.projectImage(fileDigest, extractedS3Meta, requestLoggingContext)
 
     whenReady(actualFuture) { actual =>
       actual shouldEqual expected


### PR DESCRIPTION
## What does this change?
There are three entrypoints to image-loader, this change adds an additional `requestType` marker to the logs so we can more easily group logs together by entrypoint.

Furthermore, adds `RequestLoggingContext` to more places which adds a `requestId` marker which allows us to group logs by the initial request.

## How can success be measured?
Logs help us understand behaviour. Grouping logs together in these new ways help us tell a story.

## Screenshots (if applicable)
![img](https://media.giphy.com/media/8dYmJ6Buo3lYY/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
