### PR TITLE
log when Content-Length header isn't present

### DIFF
--- a/image-loader/app/lib/Downloader.scala
+++ b/image-loader/app/lib/Downloader.scala
@@ -8,10 +8,13 @@ import com.google.common.hash.HashingOutputStream
 import com.google.common.io.ByteStreams
 import com.gu.mediaservice.DeprecatedHashWrapper
 import okhttp3.{OkHttpClient, Request}
+import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 case object TruncatedDownload extends Exception
+case object InvalidDownload extends Exception
 
 //TODO Revisit this logic
 class Downloader(implicit ec: ExecutionContext) {
@@ -22,25 +25,34 @@ class Downloader(implicit ec: ExecutionContext) {
     val request = new Request.Builder().url(uri.toString).build()
     val response = client.newCall(request).execute()
 
-    val expectedSize = response.header("Content-Length").toInt
-    val input = response.body().byteStream()
+    val maybeExpectedSize = Try{response.header("Content-Length").toInt}.toOption
 
-    val output = new FileOutputStream(file)
-    val hashedOutput = new HashingOutputStream(digester, output)
+    maybeExpectedSize match {
+      case None => {
+        Logger.error(s"Missing content-length header from $uri")
+        throw InvalidDownload
+      }
+      case Some(expectedSize) => {
+        val input = response.body().byteStream()
 
-    ByteStreams.copy(input, hashedOutput)
+        val output = new FileOutputStream(file)
+        val hashedOutput = new HashingOutputStream(digester, output)
 
-    val hash = hashedOutput.hash().asBytes()
+        ByteStreams.copy(input, hashedOutput)
 
-    input.close()
-    hashedOutput.close()
+        val hash = hashedOutput.hash().asBytes()
 
-    val actualSize = Files.size(file.toPath)
+        input.close()
+        hashedOutput.close()
 
-    if (actualSize != expectedSize) {
-      throw TruncatedDownload
+        val actualSize = Files.size(file.toPath)
+
+        if (actualSize != expectedSize) {
+          throw TruncatedDownload
+        }
+
+        DigestedFile(file, hash)
+      }
     }
-
-    DigestedFile(file, hash)
   }
 }


### PR DESCRIPTION
## What does this change?
The alarm `Sum FailedUploads GreaterThanOrEqualToThreshold 50.0` is tripping fairly often. The logs have some suspicious entries around the time they trip:

```
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:542)
	at java.lang.Integer.parseInt(Integer.java:615)
	at scala.collection.immutable.StringLike.toInt(StringLike.scala:304)
	at scala.collection.immutable.StringLike.toInt$(StringLike.scala:304)
	at scala.collection.immutable.StringOps.toInt(StringOps.scala:33)
	at lib.Downloader.$anonfun$download$1(Downloader.scala:25)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:658)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:91)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:91)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:44)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

Improve the handling of a missing `Content-Length` header and log to understand how often it happens.

## How can success be measured?
More insight into behaviour.

## Screenshots (if applicable)
![img](https://media.giphy.com/media/26FfiEIgbcoXfFeLu/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [ ] locally
- [ ] on TEST
