### PR TITLE
bump metadata-extractor to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.gu" %% "box" % "0.2.0",
     "com.gu" %% "thrift-serializer" % "4.0.0",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
-    "com.drewnoakes" % "metadata-extractor" % "2.11.0",
+    "com.drewnoakes" % "metadata-extractor" % "2.13.0",
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -3,7 +3,7 @@ package lib.imaging
 import java.io.File
 import java.util.concurrent.Executors
 
-import com.adobe.xmp.XMPMetaFactory
+import com.adobe.internal.xmp.XMPMetaFactory
 import com.drew.imaging.ImageMetadataReader
 import com.drew.metadata.exif.{ExifDirectoryBase, ExifIFD0Directory, ExifSubIFDDirectory}
 import com.drew.metadata.icc.IccDirectory

--- a/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
+++ b/image-loader/test/scala/lib/imaging/FileMetadataReaderTest.scala
@@ -558,7 +558,7 @@ class FileMetadataReaderTest extends FunSpec with Matchers with ScalaFutures {
       "Custom Rendered" -> "Normal process",
       "Exif Image Height" -> "3840 pixels",
       "Lens Serial Number" -> "000043c4bb",
-      "Flash" -> "Flash did not fire, auto",
+      "Flash" -> "Flash did not fire",
       "Focal Length" -> "88 mm",
       "Date/Time Original" -> "2015:04:15 01:08:44",
       "Date/Time Original Composite" -> "2015-04-15T01:08:44.880Z",


### PR DESCRIPTION
## What does this change?
Bump metadata-extractor to [latest version](https://github.com/drewnoakes/metadata-extractor/releases).

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
