### PR TITLE
use stricter types for usages

### DIFF
--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -53,12 +53,11 @@ class MessageProcessor(es: ElasticSearch,
 
   def updateImageUsages(message: UpdateMessage)(implicit ec: ExecutionContext) = {
     implicit val unw = Json.writes[UsageNotice]
-    def asJsLookup(us: Seq[Usage]): JsLookupResult = JsDefined(Json.toJson(us))
     withId(message) { id =>
       withUsageNotice(message) { usageNotice =>
         withLastModified(message) { lastModifed =>
-          val usages = usageNotice.usageJson.as[Seq[Usage]]
-          Future.sequence(es.updateImageUsages(id, asJsLookup(usages), dateTimeAsJsLookup(lastModifed)))
+          val usages = usageNotice.usageJson.as[List[Usage]]
+          Future.sequence(es.updateImageUsages(id, usages, dateTimeAsJsLookup(lastModifed)))
         }
       }
     }

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -402,7 +402,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), None)
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
 
-        Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(usage()))), asJsLookup(DateTime.now))), fiveSeconds)
+        Await.result(Future.sequence(ES.updateImageUsages(id, List(usage()), asJsLookup(DateTime.now))), fiveSeconds)
 
         reloadedImage(id).get.usages.size shouldBe 1
       }
@@ -413,11 +413,11 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
 
         val existingUsage = usage(id = "existing")
-        Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(existingUsage))), asJsLookup(DateTime.now))), fiveSeconds)
+        Await.result(Future.sequence(ES.updateImageUsages(id, List(existingUsage), asJsLookup(DateTime.now))), fiveSeconds)
         reloadedImage(id).get.usages.head.id shouldEqual ("existing")
 
         val moreRecentUsage = usage(id = "most-recent")
-        Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(moreRecentUsage))), asJsLookup(DateTime.now))), fiveSeconds)
+        Await.result(Future.sequence(ES.updateImageUsages(id, List(moreRecentUsage), asJsLookup(DateTime.now))), fiveSeconds)
 
         reloadedImage(id).get.usages.size shouldBe 1
         reloadedImage(id).get.usages.head.id shouldEqual ("most-recent")
@@ -429,11 +429,11 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
 
         val mostRecentUsage = usage(id = "recent")
-        Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(mostRecentUsage))), asJsLookup(DateTime.now))), fiveSeconds)
+        Await.result(Future.sequence(ES.updateImageUsages(id, List(mostRecentUsage), asJsLookup(DateTime.now))), fiveSeconds)
 
         val staleUsage = usage(id = "stale")
         val staleLastModified = DateTime.now.minusWeeks(1)
-        Await.result(Future.sequence(ES.updateImageUsages(id, JsDefined(Json.toJson(List(staleUsage))), asJsLookup(staleLastModified))), fiveSeconds)
+        Await.result(Future.sequence(ES.updateImageUsages(id, List(staleUsage), asJsLookup(staleLastModified))), fiveSeconds)
 
         reloadedImage(id).get.usages.head.id shouldEqual ("recent")
       }


### PR DESCRIPTION
## What does this change?
It's easier to reason about strict types instead of a `JsLookupResult`.

## How can success be measured?
The usage-stream app is still scaled down from the incident on Tuesday 18 Feb where a Tag merge caused a flood of messages to be seen on the CAPI firehose. These messages related to old articles with image ids that do not exist in Grid.

As thrall is FIFO and now retries, the sudden flood of usage messages meant thrall was blocking other message types for a period.

We should do [this work](https://trello.com/c/GR1aywwr/1699-handle-404-responses-from-es-more-gracefully-in-grid-when-updating-by-id) before re-enabling usage-stream. That is, success cannot be measured for this card... unless code simplicity is a metric?

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
