### PR TITLE
group image loader failure responses together

### DIFF
--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -1,0 +1,23 @@
+package lib
+
+import play.api.mvc.Result
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.logging.FALLBACK
+import model.UploadRequest
+import play.api.Logger
+
+object FailureResponse extends ArgoHelpers {
+  val invalidUri: Result = respondError(BadRequest, "invalid-uri", s"The provided 'uri' is not valid")
+  val failedUriDownload: Result = respondError(BadRequest, "failed-uri-download", s"The provided 'uri' could not be downloaded")
+
+  def unsupportedMimeType(uploadRequest: UploadRequest, supportedMimeTypes: List[String]): Result = {
+    Logger.info(s"Rejected request to load file: mime-type is not supported")(uploadRequest.toLogMarker)
+    val mimeType = uploadRequest.mimeType getOrElse FALLBACK
+
+    respondError(
+      UnsupportedMediaType,
+      "unsupported-type",
+      s"Unsupported mime-type: $mimeType. Supported: ${supportedMimeTypes.mkString(", ")}"
+    )
+  }
+}

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -23,6 +23,6 @@ class ImageLoaderConfig(override val configuration: Configuration) extends Commo
   val loginUriTemplate: String = services.loginUriTemplate
 
   val transcodedMimeTypes = properties.getOrElse("transcoded.mime.types", "").split(",").toList
-  val supportedMimeTypes = List("image/jpeg", "image/png") ::: transcodedMimeTypes
+  val supportedMimeTypes: List[String] = List("image/jpeg", "image/png") ::: transcodedMimeTypes
 
 }


### PR DESCRIPTION
## What does this change?
This simplifies the controller a little.

Follows https://github.com/guardian/grid/pull/2821.

## How can success be measured?
n/a

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
