### PR TITLE
Introduce GC logging and file rotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -238,6 +238,12 @@ def playProject(projectName: String, port: Int, path: Option[String] = None): Pr
       javaOptions in Universal ++= Seq(
         "-Dpidfile.path=/dev/null",
         s"-Dconfig.file=/usr/share/$projectName/conf/application.conf",
-        s"-Dlogger.file=/usr/share/$projectName/conf/logback.xml"
+        s"-Dlogger.file=/usr/share/$projectName/conf/logback.xml",
+        "-J-XX:+PrintGCDetails",
+        "-J-XX:+PrintGCDateStamps",
+        s"-J-Xloggc:/var/log/$projectName/gc.log",
+        "-J-XX:+UseGCLogFileRotation",
+        "-J-XX:NumberOfGCLogFiles=5",
+        "-J-XX:GCLogFileSize=2M"
       )
     ))


### PR DESCRIPTION
this won't take more than 10Mb of disk space so should be safe everywhere

## What does this change?
We are currently unable to see GC data from grid instances and this turns on logging for that.

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [x] on TEST
