### PR TITLE
thin out Image Loader Controller a bit more

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/Files.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/Files.scala
@@ -6,16 +6,23 @@ import java.nio.channels.Channels
 import java.util.concurrent.Executors
 
 import scala.concurrent.{ExecutionContext, Future}
-
+import _root_.play.api.Logger
 
 object Files {
 
   private implicit val ctx = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
 
-  def createTempFile(prefix: String, suffix: String, tempDir: File): Future[File] =
+  def createTempFileSync(prefix: String, suffix: String, tempDir: File): File = {
+    Logger.info(s"creating temp file in ${tempDir}")
+    File.createTempFile(prefix, prefix, tempDir)
+  }
+
+  def createTempFile(prefix: String, suffix: String, tempDir: File): Future[File] = {
+    Logger.info(s"creating temp file in ${tempDir}")
     Future {
       File.createTempFile(prefix, suffix, tempDir)
     }
+  }
 
   def transferFromURL(from: URL, to: File): Future[Unit] =
     Future {


### PR DESCRIPTION
## What does this change?
Co-locating file operations for better organisation. I suspect we don't need both a sync and async version of temp file creation, however I couldn't get the compiler to like me, so doing this in the mean time.

## How can success be measured?
Thin controllers are easier to read.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
