### PR TITLE
use more explicit naming of authentication

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.{EmbeddedEntity, Link}
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.lib.auth.Authentication.getEmail
+import com.gu.mediaservice.lib.auth.Authentication.getIdentity
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.model.{ActionData, Collection}
 import lib.CollectionsConfig
@@ -119,7 +119,7 @@ class CollectionsController(authenticated: Authentication, config: CollectionsCo
     (req.body \ "data").asOpt[String] map { child =>
       if (isValidPathBit(child)) {
         val path = collectionPathId.map(uriToPath).getOrElse(Nil) :+ child
-        val collection = Collection.build(path, ActionData(getEmail(req.user), DateTime.now))
+        val collection = Collection.build(path, ActionData(getIdentity(req.user), DateTime.now))
 
         store.add(collection).map { collection =>
           val node = Node(collection.path.last, Nil, collection.path, collection.path, Some(collection))

--- a/collections/app/controllers/ImageCollectionsController.scala
+++ b/collections/app/controllers/ImageCollectionsController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.lib.auth.Authentication.getEmail
+import com.gu.mediaservice.lib.auth.Authentication.getIdentity
 import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound, UpdateMessage}
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.lib.net.{URI => UriOps}
@@ -34,7 +34,7 @@ class ImageCollectionsController(authenticated: Authentication, config: Collecti
 
   def addCollection(id: String) = authenticated.async(parse.json) { req =>
     (req.body \ "data").asOpt[List[String]].map { path =>
-      val collection = Collection.build(path, ActionData(getEmail(req.user), DateTime.now()))
+      val collection = Collection.build(path, ActionData(getIdentity(req.user), DateTime.now()))
       dynamo.listAdd(id, "collections", collection)
         .map(publish(id))
         .map(cols => respond(collection))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/ApiAccessor.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/ApiAccessor.scala
@@ -17,18 +17,18 @@ object Tier {
   }
 }
 
-case class ApiKey(name: String, tier: Tier)
-object ApiKey extends ArgoHelpers {
+case class ApiAccessor(identity: String, tier: Tier)
+object ApiAccessor extends ArgoHelpers {
   val unauthorizedResult: Result = respondError(Forbidden, "forbidden", "Unauthorized - the API key is not allowed to perform this operation", List.empty)
 
-  def apply(content: String): ApiKey = {
+  def apply(content: String): ApiAccessor = {
     val rows = content.split("\n")
     val name = rows.headOption.getOrElse("")
     val tier = rows.tail.headOption.map(Tier(_)).getOrElse(Internal)
-    ApiKey(name, tier)
+    ApiAccessor(name, tier)
   }
 
-  def hasAccess(apiKey: ApiKey, request: Request[Any], services: Services): Boolean = apiKey.tier match {
+  def hasAccess(apiKey: ApiAccessor, request: Request[Any], services: Services): Boolean = apiKey.tier match {
     case Internal => true
     case ReadOnly => request.method == "GET"
     case Syndication => request.method == "GET" && request.host == services.apiHost && request.path.startsWith("/images")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/KeyStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/KeyStore.scala
@@ -8,9 +8,9 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 class KeyStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext)
-  extends BaseStore[String, ApiKey](bucket, config)(ec) {
+  extends BaseStore[String, ApiAccessor](bucket, config)(ec) {
 
-  def lookupIdentity(key: String): Option[ApiKey] = store.get().get(key)
+  def lookupIdentity(key: String): Option[ApiAccessor] = store.get().get(key)
 
   def findKey(prefix: String): Option[String] = s3.syncFindKey(bucket, prefix)
 
@@ -19,8 +19,8 @@ class KeyStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionConte
     store.send(_ => fetchAll)
   }
 
-  private def fetchAll: Map[String, ApiKey] = {
+  private def fetchAll: Map[String, ApiAccessor] = {
     val keys = s3.client.listObjects(bucket).getObjectSummaries.asScala.map(_.getKey)
-    keys.flatMap(k => getS3Object(k).map(k -> ApiKey(_))).toMap
+    keys.flatMap(k => getS3Object(k).map(k -> ApiAccessor(_))).toMap
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/PermissionsHandler.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/PermissionsHandler.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.auth
 
-import com.gu.mediaservice.lib.auth.Authentication.{AuthenticatedService, PandaUser, Principal}
+import com.gu.mediaservice.lib.auth.Authentication.{ApiKeyAccessor, PandaUser, Principal}
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 
@@ -21,7 +21,7 @@ trait PermissionsHandler {
     user match {
       case PandaUser(u) => permissions.hasPermission(permission, u.email)
       // think about only allowing certain services i.e. on `service.name`?
-      case service: AuthenticatedService if service.apiKey.tier == Internal => true
+      case service: ApiKeyAccessor if service.accessor.tier == Internal => true
       case _ => false
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/GridLogger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/GridLogger.scala
@@ -1,5 +1,5 @@
 package com.gu.mediaservice.lib.logging
-import com.gu.mediaservice.lib.auth.ApiKey
+import com.gu.mediaservice.lib.auth.ApiAccessor
 import net.logstash.logback.marker.Markers
 
 import scala.collection.JavaConverters._
@@ -13,15 +13,15 @@ object GridLogger {
 
   def error(message: String, markers: Map[String, Any] = Map()): Unit = logger.error(Markers.appendEntries(markers.asJava), message)
 
-  def info(message: String, apiKey: ApiKey): Unit = info(message, apiKeyMarkers(apiKey))
+  def info(message: String, apiKey: ApiAccessor): Unit = info(message, apiKeyMarkers(apiKey))
 
-  def info(message: String, apiKey: ApiKey, imageId: String): Unit = info(message, apiKeyMarkers(apiKey) ++ imageIdMarker(imageId))
+  def info(message: String, apiKey: ApiAccessor, imageId: String): Unit = info(message, apiKeyMarkers(apiKey) ++ imageIdMarker(imageId))
 
   def info(message: String, imageId: String): Unit = info(message, imageIdMarker(imageId))
 
-  private def apiKeyMarkers(apiKey: ApiKey) = Map(
+  private def apiKeyMarkers(apiKey: ApiAccessor) = Map(
     "key-tier" -> apiKey.tier.toString,
-    "key-name" -> apiKey.name
+    "key-name" -> apiKey.identity
   )
 
   private def imageIdMarker(imageId: String) = Map("image-id" -> imageId)

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -121,11 +121,11 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
           "requestType" -> "import-image"
         )
       )
-      val apiKey = request.user.apiKey
+      val apiKey = request.user.accessor
 
       Logger.info("importImage request start")(requestContext.toMarker(Map(
         "key-tier" -> apiKey.tier.toString,
-        "key-name" -> apiKey.name
+        "key-name" -> apiKey.identity
       )))
       Try(URI.create(uri)) map { validUri =>
         val tmpFile = createTempFile("download", requestContext)
@@ -141,14 +141,14 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
         result onComplete (_ => tmpFile.delete())
         Logger.info("importImage request end")(requestContext.toMarker(Map(
           "key-tier" -> apiKey.tier.toString,
-          "key-name" -> apiKey.name
+          "key-name" -> apiKey.identity
         )))
         result
 
       } getOrElse {
         Logger.info("importImage request end")(requestContext.toMarker(Map(
           "key-tier" -> apiKey.tier.toString,
-          "key-name" -> apiKey.name
+          "key-name" -> apiKey.identity
         )))
         Future.successful(FailureResponse.invalidUri)
       }
@@ -184,7 +184,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
 
     val uploadedBy_ = uploadedBy match {
       case Some(by) => by
-      case None => Authentication.getEmail(user)
+      case None => Authentication.getIdentity(user)
     }
 
     // TODO: should error if the JSON parsing failed

--- a/leases/app/controllers/MediaLeaseController.scala
+++ b/leases/app/controllers/MediaLeaseController.scala
@@ -84,7 +84,7 @@ class MediaLeaseController(auth: Authentication, store: LeaseStore, config: Leas
   def postLease = auth.async(parse.json) { implicit request =>
     request.body.validate[MediaLease] match {
       case JsSuccess(mediaLease, _) =>
-        addLease(mediaLease, Some(Authentication.getEmail(request.user))).map(_ => Accepted)
+        addLease(mediaLease, Some(Authentication.getIdentity(request.user))).map(_ => Accepted)
 
       case JsError(errors) =>
         Future.successful(badRequest(errors))
@@ -124,7 +124,7 @@ class MediaLeaseController(auth: Authentication, store: LeaseStore, config: Leas
       badRequest,
       mediaLeases => {
         if (validateLeases(mediaLeases)) {
-          replaceLeases(mediaLeases, id, Some(Authentication.getEmail(request.user)))
+          replaceLeases(mediaLeases, id, Some(Authentication.getIdentity(request.user)))
           Accepted
         } else {
           respondError(BadRequest, "validation-error", "No more than one syndication lease per image")

--- a/media-api/app/lib/MediaApiMetrics.scala
+++ b/media-api/app/lib/MediaApiMetrics.scala
@@ -1,7 +1,7 @@
 package lib
 
 import com.amazonaws.services.cloudwatch.model.Dimension
-import com.gu.mediaservice.lib.auth.{ApiKey, Syndication}
+import com.gu.mediaservice.lib.auth.{ApiAccessor, Syndication}
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 
 class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${config.stage}/MediaApi", config) {
@@ -21,13 +21,13 @@ class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${conf
     val metricName = "OptimisedImageDownload"
   }
 
-  def incrementImageDownload(apiKey: ApiKey, downloadType: DownloadType) = {
+  def incrementImageDownload(apiKey: ApiAccessor, downloadType: DownloadType) = {
     val metric = new CountMetric(apiKey.tier.toString)
 
     // CW Metrics have a maximum of 10 dimensions per metric.
     // Create a separate dimension per syndication partner and group other Tier types together.
     val dimensionValue: String = apiKey.tier match {
-      case Syndication => apiKey.name
+      case Syndication => apiKey.identity
       case _ => apiKey.tier.toString
     }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -151,7 +151,7 @@ object SearchParams {
       request.getQueryString("persisted") flatMap parseBooleanFromQuery,
       commaSep("usageStatus").map(UsageStatus(_)),
       commaSep("usagePlatform"),
-      request.user.apiKey.tier,
+      request.user.accessor.tier,
       request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus
     )
   }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -159,7 +159,7 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
         errorMessage = JsError.toJson(e).toString
       ),
       sur => {
-        GridLogger.info("recording syndication usage", req.user.apiKey, sur.mediaId)
+        GridLogger.info("recording syndication usage", req.user.accessor, sur.mediaId)
         val group = usageGroup.build(sur)
         usageRecorder.usageSubject.onNext(group)
         Accepted
@@ -176,7 +176,7 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
         errorMessage = JsError.toJson(e).toString
       ),
       fur => {
-        GridLogger.info("recording front usage", req.user.apiKey, fur.mediaId)
+        GridLogger.info("recording front usage", req.user.accessor, fur.mediaId)
         val group = usageGroup.build(fur)
         usageRecorder.usageSubject.onNext(group)
         Accepted


### PR DESCRIPTION
## What does this change?
Some routes have an `uploadedBy` param, however they also require a cookie, which has a user associated with it already. Renaming the auth schema is the first step to simplifying this process.

## How can success be measured?
More explicit naming makes more easier to understand code.

## Screenshots (if applicable)
![img](https://media.giphy.com/media/l2Jejt7O03eXaRQre/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
