### PR TITLE
add more context to default RequestLoggingContext

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -111,6 +111,7 @@ object Authentication {
   val originalServiceHeaderName = "X-Gu-Original-Service"
 
   def getIdentity(principal: Principal): String = principal.accessor.identity
+  def getTier(principal: Principal): Tier = principal.accessor.tier
 
   def validateUser(authedUser: AuthenticatedUser, userValidationEmailDomain: String, multifactorChecker: Option[Google2FAGroupChecker]): Boolean = {
     val isValidDomain = authedUser.user.email.endsWith("@" + userValidationEmailDomain)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/RequestLoggingContext.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/RequestLoggingContext.scala
@@ -2,12 +2,28 @@ package com.gu.mediaservice.lib.logging
 
 import java.util.UUID
 
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.Principal
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 
 import scala.collection.JavaConverters._
 
-case class RequestLoggingContext(requestId: UUID = UUID.randomUUID(), initialMarkers: Map[String, String] = Map.empty) {
-  def toMarker(extraMarkers: Map[String, String] = Map.empty): LogstashMarker = Markers.appendEntries(
-    (initialMarkers ++ extraMarkers + ("requestId" -> requestId)).asJava
+case class RequestLoggingContext(
+  requestId: UUID = UUID.randomUUID(),
+  requestType: String,
+  principal: Principal,
+  initialMarkers: Map[String, String] = Map.empty
+) {
+  private val coreMarkers: Map[String, String] = Map(
+    "requestId" -> requestId.toString,
+    "requestType" -> requestType,
+    "authIdentity" -> Authentication.getIdentity(principal),
+    "authTier" -> Authentication.getTier(principal).toString
+  )
+
+  def toMarker: LogstashMarker = toMarker(Map.empty)
+
+  def toMarker(extraMarkers: Map[String, String]): LogstashMarker = Markers.appendEntries(
+    (coreMarkers ++ initialMarkers ++ extraMarkers).asJava
   )
 }

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -174,7 +174,7 @@ object ImageUploadOps {
 
     import deps._
 
-    val initialMarkers: LogstashMarker = uploadRequest.toLogMarker.and(requestLoggingContext.toMarker())
+    val initialMarkers: LogstashMarker = uploadRequest.toLogMarker.and(requestLoggingContext.toMarker)
 
     Logger.info("Starting image ops")(initialMarkers)
     val uploadedFile = uploadRequest.tempFile

--- a/image-loader/test/scala/model/ImageUploadProjectorTest.scala
+++ b/image-loader/test/scala/model/ImageUploadProjectorTest.scala
@@ -3,6 +3,8 @@ package test.model
 import java.io.File
 import java.net.URI
 
+import com.gu.mediaservice.lib.auth.Authentication.ApiKeyAccessor
+import com.gu.mediaservice.lib.auth.{ApiAccessor, ReadOnly, Tier}
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.RequestLoggingContext
 import com.gu.mediaservice.model._
@@ -158,7 +160,7 @@ class ImageUploadProjectorTest extends FunSuite with Matchers with ScalaFutures 
       picdarUrn = None,
     )
 
-    val requestLoggingContext = RequestLoggingContext()
+    val requestLoggingContext = RequestLoggingContext(requestType = "test", principal = ApiKeyAccessor(ApiAccessor("test", ReadOnly)))
 
     val actualFuture = projector.projectImage(fileDigest, extractedS3Meta, requestLoggingContext)
 


### PR DESCRIPTION
Depends on https://github.com/guardian/grid/pull/2825

## What does this change?
Every request logs:
- request id
- request type
- user identity (email or api key name)
- api tier

## How can success be measured?
More detailed and structured logs.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
