### PR TITLE
add LoggingMarker trait for more consistent function naming

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -37,7 +37,7 @@ class Kinesis(config: CommonConfig) {
 
     val payload = JsonByteArrayUtil.toByteArray(message)
 
-    val markers: LogstashMarker = message.toLogMarker.and(Markers.append("compressed-size", payload.length))
+    val markers: LogstashMarker = message.toLogMarker(Map("compressed-size" -> payload.length))
     Logger.info("Publishing message to kinesis")(markers)
 
     val data = ByteBuffer.wrap(payload)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -1,16 +1,13 @@
 package com.gu.mediaservice.lib.aws
 
-import java.nio.ByteBuffer
-
 import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.logging.{FALLBACK, LoggingMarker}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
-import net.logstash.logback.marker.{LogstashMarker, Markers}
+import net.logstash.logback.marker.LogstashMarker
 import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, Json}
-
-import scala.collection.JavaConverters._
 
 // TODO MRB: replace this with the simple Kinesis class once we migrate off SNS
 class ThrallMessageSender(config: CommonConfig) {
@@ -52,17 +49,17 @@ case class UpdateMessage(
   leases: Option[Seq[MediaLease]] = None,
   syndicationRights: Option[SyndicationRights] = None,
   bulkIndexRequest: Option[BulkIndexRequest] = None
-) {
-  def toLogMarker: LogstashMarker = {
+) extends LoggingMarker {
+  override def toLogMarker: LogstashMarker = {
     val message = Json.stringify(Json.toJson(this))
 
     val markers = Map (
       "subject" -> subject,
-      "id" -> id.getOrElse(image.map(_.id).getOrElse("none")),
+      "id" -> id.getOrElse(image.map(_.id).getOrElse(FALLBACK)),
       "size" -> message.getBytes.length,
       "length" -> message.length
     )
 
-    Markers.appendEntries(markers.asJava)
+    super.toLogMarker(markers)
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LoggingMarker.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LoggingMarker.scala
@@ -1,0 +1,10 @@
+package com.gu.mediaservice.lib.logging
+
+import net.logstash.logback.marker.{LogstashMarker, Markers}
+import scala.collection.JavaConverters._
+
+trait LoggingMarker {
+  def toLogMarker: LogstashMarker
+
+  def toLogMarker(extraMarkers: Map[String, Any]): LogstashMarker = Markers.appendEntries(extraMarkers.asJava)
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/RequestLoggingContext.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/RequestLoggingContext.scala
@@ -4,16 +4,14 @@ import java.util.UUID
 
 import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.auth.Authentication.Principal
-import net.logstash.logback.marker.{LogstashMarker, Markers}
-
-import scala.collection.JavaConverters._
+import net.logstash.logback.marker.LogstashMarker
 
 case class RequestLoggingContext(
   requestId: UUID = UUID.randomUUID(),
   requestType: String,
   principal: Principal,
   initialMarkers: Map[String, String] = Map.empty
-) {
+) extends LoggingMarker {
   private val coreMarkers: Map[String, String] = Map(
     "requestId" -> requestId.toString,
     "requestType" -> requestType,
@@ -21,9 +19,9 @@ case class RequestLoggingContext(
     "authTier" -> Authentication.getTier(principal).toString
   )
 
-  def toMarker: LogstashMarker = toMarker(Map.empty)
+  override def toLogMarker: LogstashMarker = toLogMarker(Map.empty)
 
-  def toMarker(extraMarkers: Map[String, String]): LogstashMarker = Markers.appendEntries(
-    (coreMarkers ++ initialMarkers ++ extraMarkers).asJava
+  override def toLogMarker(extraMarkers: Map[String, Any]): LogstashMarker = super.toLogMarker(
+    coreMarkers ++ initialMarkers ++ extraMarkers
   )
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -1,10 +1,9 @@
 package com.gu.mediaservice.model
 
-import net.logstash.logback.marker.Markers
-import play.api.libs.json._
+import com.gu.mediaservice.lib.logging.LoggingMarker
+import net.logstash.logback.marker.LogstashMarker
 import play.api.libs.functional.syntax._
-
-import scala.collection.JavaConverters._
+import play.api.libs.json._
 
 case class FileMetadata(
   iptc: Map[String, String]                     = Map(),
@@ -15,8 +14,8 @@ case class FileMetadata(
   getty: Map[String, String]                    = Map(),
   colourModel: Option[String]                   = None,
   colourModelInformation: Map[String, String]   = Map()
-) {
-  def toLogMarker = {
+) extends LoggingMarker {
+  override def toLogMarker: LogstashMarker = {
     val fieldCountMarkers = Map (
       "iptcFieldCount" -> iptc.size,
       "exifFieldCount" -> exif.size,
@@ -30,7 +29,7 @@ case class FileMetadata(
     val totalFieldCount = fieldCountMarkers.foldLeft(0)(_ + _._2)
     val markers = fieldCountMarkers + ("totalFieldCount" -> totalFieldCount)
 
-    Markers.appendEntries(markers.asJava)
+    super.toLogMarker(markers)
   }
 }
 

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -174,7 +174,7 @@ object ImageUploadOps {
 
     import deps._
 
-    val initialMarkers: LogstashMarker = uploadRequest.toLogMarker.and(requestLoggingContext.toMarker)
+    val initialMarkers: LogstashMarker = uploadRequest.toLogMarker.and(requestLoggingContext.toLogMarker)
 
     Logger.info("Starting image ops")(initialMarkers)
     val uploadedFile = uploadRequest.tempFile

--- a/image-loader/app/model/UploadRequest.scala
+++ b/image-loader/app/model/UploadRequest.scala
@@ -3,12 +3,11 @@ package model
 import java.io.File
 import java.util.UUID
 
+import com.gu.mediaservice.lib.logging.{FALLBACK, LoggingMarker}
 import com.gu.mediaservice.model.UploadInfo
-import net.logstash.logback.marker.{LogstashMarker, Markers}
+import net.logstash.logback.marker.LogstashMarker
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
-
-import scala.collection.JavaConverters._
 
 case class UploadRequest(
   requestId: UUID,
@@ -19,22 +18,18 @@ case class UploadRequest(
   uploadedBy: String,
   identifiers: Map[String, String],
   uploadInfo: UploadInfo
-) {
+) extends LoggingMarker {
   val identifiersMeta: Map[String, String] = identifiers.map { case (k, v) => (s"identifier!$k", v) }
 
-  def toLogMarker: LogstashMarker = {
-    val fallback = "none"
-
-    val markers = Map (
+  override def toLogMarker: LogstashMarker = super.toLogMarker(
+    Map (
       "requestId" -> requestId,
       "imageId" -> imageId,
-      "mimeType" -> mimeType.getOrElse(fallback),
+      "mimeType" -> mimeType.getOrElse(FALLBACK),
       "uploadTime" -> ISODateTimeFormat.dateTime.print(uploadTime.withZone(DateTimeZone.UTC)),
       "uploadedBy" -> uploadedBy,
-      "filename" -> uploadInfo.filename.getOrElse(fallback),
+      "filename" -> uploadInfo.filename.getOrElse(FALLBACK),
       "filesize" -> tempFile.length
     ) ++ identifiersMeta
-
-    Markers.appendEntries(markers.asJava)
-  }
+  )
 }


### PR DESCRIPTION
Depends on https://github.com/guardian/grid/pull/2826

## What does this change?
traits allow for consistent naming of functions.

## How can success be measured?
n/a

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
