### PR TITLE
throw away update-image-usages messages

### DIFF
--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -30,7 +30,7 @@ class MessageProcessor(es: ElasticSearch,
       case "delete-image-exports" => deleteImageExports
       case "update-image-exports" => updateImageExports
       case "update-image-user-metadata" => updateImageUserMetadata
-      case "update-image-usages" => updateImageUsages
+      case "update-image-usages" => noop
       case "replace-image-leases" => replaceImageLeases
       case "add-image-lease" => addImageLease
       case "remove-image-lease" => removeImageLease
@@ -40,6 +40,11 @@ class MessageProcessor(es: ElasticSearch,
       case "update-image-photoshoot" => updateImagePhotoshoot
       case "batch-index" => batchIndex
     }
+  }
+
+  def noop(message: UpdateMessage) = {
+    Logger.info("Valid message, but ignoring it")(message.toLogMarker)
+    Future.successful(s"Ignoring ${message.subject} message")
   }
 
   def batchIndex(message: UpdateMessage)(implicit ec: ExecutionContext): Future[List[ElasticSearchBulkUpdateResponse]] = {


### PR DESCRIPTION
## What does this change?
This is temporary, whilst we deal with an ongoing incident. This will drop all `update-image-usages` messages regardless of their validity. We can replay the good (and dropped) `update-image-usages` messages at a later date once we've unblocked the queue (and the picture desk).

Not the best solution, and definitely a temporary one.

I think the exhaustive set of options for this incident are:
1. Wait
1. Move the checkpoint to hopefully skip the batch of bad messages
1. Make a change to thrall to immediately drop update-image-usages messages (for now)
1. Update thrall to not retry on ES 404 responses

This is number 3 which I think is the fastest and safest as 1. is taking a long time, 2. We'd miss a bunch of real messages and 4. Long term solution, but is a bigger PR.

## How can success be measured?
We drop the bad batch of `update-image-usages` messages.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
