### PR TITLE
ability to pass isolated endpoint for image-loader for projection

### DIFF
--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -2,19 +2,18 @@ package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
-import com.gu.mediaservice.model.Image
 import com.gu.mediaservice.model.Image._
 import com.gu.mediaservice.{FullImageProjectionFailed, FullImageProjectionSuccess, ImageDataMerger, ImageDataMergerConfig}
 import lib.AdminToolsConfig
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
-  private val cfg = ImageDataMergerConfig(apiKey = config.apiKey, domainRoot = config.domainRoot)
+  private val cfg = ImageDataMergerConfig(apiKey = config.apiKey, domainRoot = config.domainRoot, imageLoaderEndpointOpt = None)
 
   private val merger = new ImageDataMerger(cfg)
 

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
@@ -19,13 +19,15 @@ class ImageProjectionLambdaHandler extends LazyLogging {
     val mediaId = event.getPath.stripPrefix("/images/projection/")
 
     val domainRoot = sys.env("DOMAIN_ROOT")
+    // if we want to release the load from main grid image-loader we can pass a dedicated endpoint
+    val imageLoaderEndpoint = sys.env.get("IMAGE_LOADER_ENDPOINT")
     val headers = event.getHeaders.asScala.toMap
 
     val apiKey = getAuthKeyFrom(headers)
 
     apiKey match {
       case Some(key) =>
-        val cfg: ImageDataMergerConfig = ImageDataMergerConfig(apiKey = key, domainRoot = domainRoot)
+        val cfg: ImageDataMergerConfig = ImageDataMergerConfig(apiKey = key, domainRoot = domainRoot, imageLoaderEndpointOpt = imageLoaderEndpoint)
         if (!cfg.isValidApiKey()) return getUnauthorisedResponse
 
         logger.info(s"starting handleImageProjection for mediaId=$mediaId")


### PR DESCRIPTION
## What does this change?
- ability to pass isolated endpoint for image-loader for projection to not to disrupt usual grid usage
- when calling projection endpoint we want to be able to switch to a isolated image-loader endpoint

## How can success be measured?
when calling projection endpoint we call different instance of image-loader  the the that is used by most users

## Tested?
- [x] locally
- [x] on TEST
