### PR TITLE
 dont update phantom usages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ val commonSettings = Seq(
   version := "0.1",
   scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings"),
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.0.5"
+    "org.scalatest" %% "scalatest" % "3.0.5",
+    "org.mockito" % "mockito-core" % "2.18.0"
   )
 )
 
@@ -83,8 +84,8 @@ lazy val commonLib = project("common-lib").settings(
     // needed to parse conditional statements in `logback.xml`
     // i.e. to only log to disk in DEV
     // see: https://logback.qos.ch/setup.html#janino
-    "org.codehaus.janino" % "janino" % "3.0.6"
-  ),
+    "org.codehaus.janino" % "janino" % "3.0.6",
+),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 )
 
@@ -114,7 +115,6 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
     "org.apache.commons" % "commons-email" % "1.5",
     "org.parboiled" %% "parboiled" % "2.1.5",
     "org.http4s" %% "http4s-core" % "0.18.7",
-    "org.mockito" % "mockito-core" % "2.18.0",
     "com.softwaremill.quicklens" %% "quicklens" % "1.4.11",
     "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
     "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
@@ -44,7 +44,7 @@ trait ElasticSearchExecutions {
       val markers = MarkerContext(durationMarker(elapsed))
       e match {
         case ElasticNotFoundException => Logger.error(s"$message - query failed: Document not Found")(markers)
-        case ElasticException(error) => Logger.error(s"$message - query failed after: ${error.reason} type: ${error.`type`}")(markers)
+        case ElasticException(error) => Logger.error(s"$message - query failed because: ${error.reason} type: ${error.`type`}")(markers)
         case _ => Logger.error(s"$message - query failed: ${e.getMessage} cs: ${e.getCause}")(markers)
 
       }

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -94,7 +94,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
     }
   }
 
-  def updateImageUsages(id: String, usages: List[Usage], lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
+  def updateImageUsages(id: String, usages: Seq[Usage], lastModified: JsLookupResult)(implicit ex: ExecutionContext): List[Future[ElasticSearchUpdateResponse]] = {
     val replaceUsagesScript = """
       | def dtf = DateTimeFormatter.ISO_DATE_TIME;
       | def updateDate = Date.from(Instant.from(dtf.parse(params.lastModified)));

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -652,15 +652,5 @@ class ElasticSearchTest extends ElasticSearchTestBase {
     }
   }
 
-  private def reloadedImage(id: String) = {
-    Await.result(ES.getImage(id), fiveSeconds)
-  }
-
-  private def indexedImage(id: String) = {
-    Thread.sleep(1000) // TODO use eventually clause
-    Await.result(ES.getImage(id), fiveSeconds)
-  }
-
-  private def asJsLookup(d: DateTime): JsLookupResult = JsDefined(Json.toJson(d.toString))
 
 }

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -5,7 +5,6 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.ElasticDsl
 
 
-// import com.sksamuel.elastic4s.ElasticDsl._  This brings in the handler. Don't optimise imports.
 import com.whisk.docker.impl.spotify.DockerKitSpotify
 import com.whisk.docker.scalatest.DockerTestKit
 import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,14 +1,19 @@
 package lib.elasticsearch
 
-import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchConfig, Mappings}
+import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.ElasticDsl
+
+
+// import com.sksamuel.elastic4s.ElasticDsl._  This brings in the handler. Don't optimise imports.
 import com.whisk.docker.impl.spotify.DockerKitSpotify
 import com.whisk.docker.scalatest.DockerTestKit
 import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}
 import helpers.Fixtures
+import org.joda.time.DateTime
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FreeSpec, Matchers}
-import com.sksamuel.elastic4s.ElasticDsl
-import com.sksamuel.elastic4s.ElasticDsl._
+import play.api.libs.json.{JsDefined, JsLookupResult, Json}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -58,4 +63,16 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
     esContainer.toList ++ super.dockerContainers
 
   final override val StartContainersTimeout = 1.minute
+
+
+  def reloadedImage(id: String) = {
+    Await.result(ES.getImage(id), fiveSeconds)
+  }
+
+  def indexedImage(id: String) = {
+    Thread.sleep(1000) // TODO use eventually clause
+    Await.result(ES.getImage(id), fiveSeconds)
+  }
+
+  def asJsLookup(d: DateTime): JsLookupResult = JsDefined(Json.toJson(d.toString))
 }

--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -7,13 +7,13 @@ import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
 import com.gu.mediaservice.model.{Collection, Crop, Edits, Image, ImageMetadata, SyndicationRights}
 import lib.{BulkIndexS3Client, MetadataEditorNotifications, ThrallStore}
-import lib.elasticsearch.{ElasticSearchTestBase, SyndicationRightsOps}
+import lib.elasticsearch.{ElasticSearchTestBase, ElasticSearchUpdateResponse, SyndicationRightsOps}
 import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.{JsArray, Json}
 
 import scala.concurrent.{Await, Future}
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 
 class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
@@ -29,6 +29,7 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
 
       "adds usages" - {
         "for an image that exists" in {
+          val expected: Success[List[ElasticSearchUpdateResponse]] = Success(List(ElasticSearchUpdateResponse()))
 
           val id = UUID.randomUUID().toString
 
@@ -61,13 +62,10 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
             syndicationRights = None,
             bulkIndexRequest = None
           )
-          (Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)) match {
-            case Success(responses) if responses.length == 1 => true
-            case _ => false
-          }) shouldBe true
+          (Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds))  ) shouldBe expected
         }
         "not crash for an image that doesn't exist 👻🖼" in {
-
+          val expected: Success[List[ElasticSearchUpdateResponse]] = Success(List(ElasticSearchUpdateResponse()))
           val id = UUID.randomUUID().toString
 
           val message = UpdateMessage(
@@ -85,11 +83,7 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
             syndicationRights = None,
             bulkIndexRequest = None
           )
-         val result=  (Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)) match {
-            case Success(responses) if responses.length == 0 => true
-            case _ => false
-          })
-         result shouldBe true
+         Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds))  shouldBe expected
         }
       }
     }

--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -13,6 +13,7 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.{JsArray, Json}
 
 import scala.concurrent.{Await, Future}
+import scala.util.{Try, Success}
 
 
 class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
@@ -60,7 +61,10 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
             syndicationRights = None,
             bulkIndexRequest = None
           )
-          noException should be thrownBy Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)
+          (Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)) match {
+            case Success(responses) if responses.length == 1 => true
+            case _ => false
+          }) shouldBe true
         }
         "not crash for an image that doesn't exist 👻🖼" in {
 
@@ -81,7 +85,11 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
             syndicationRights = None,
             bulkIndexRequest = None
           )
-          noException should be thrownBy Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)
+         val result=  (Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)) match {
+            case Success(responses) if responses.length == 0 => true
+            case _ => false
+          })
+         result shouldBe true
         }
       }
     }

--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -1,0 +1,89 @@
+package lib.kinesis
+
+import java.util.UUID
+
+import com.gu.mediaservice.lib.aws.{BulkIndexRequest, UpdateMessage}
+import com.gu.mediaservice.model.leases.MediaLease
+import com.gu.mediaservice.model.usage.UsageNotice
+import com.gu.mediaservice.model.{Collection, Crop, Edits, Image, ImageMetadata, SyndicationRights}
+import lib.{BulkIndexS3Client, MetadataEditorNotifications, ThrallStore}
+import lib.elasticsearch.{ElasticSearchTestBase, SyndicationRightsOps}
+import org.joda.time.DateTime
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.{JsArray, Json}
+
+import scala.concurrent.{Await, Future}
+
+
+class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
+  "MessageProcessor" - {
+    val messageProcessor = new MessageProcessor(
+      es = ES,
+      store = mock[ThrallStore],
+      metadataEditorNotifications = mock[MetadataEditorNotifications],
+      syndicationRightsOps = mock[SyndicationRightsOps],
+      bulkIndexS3Client = mock[BulkIndexS3Client])
+
+    "usages" - {
+
+      "adds usages" - {
+        "for an image that exists" in {
+
+          val id = UUID.randomUUID().toString
+
+          val userMetadata = Some(Edits(metadata = ImageMetadata(
+            description = Some("My boring image"),
+            title = Some("User supplied title"),
+            subjects = List("foo", "bar"),
+            specialInstructions = Some("Testing")
+          )))
+
+          val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(DateTime.now()), None).
+            copy(userMetadata = userMetadata)
+
+          Await.result(Future.sequence(ES.indexImage(id, Json.toJson(image))), fiveSeconds)
+
+          eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(image.id))
+
+          val message = UpdateMessage(
+            "update-image-usages",
+            image = None,
+            id = Some(id),
+            usageNotice = Some(UsageNotice(id, JsArray())),
+            edits = None,
+            lastModified = Some(new DateTime()),
+            collections = None,
+            leaseId = None,
+            crops = None,
+            mediaLease = None,
+            leases = None,
+            syndicationRights = None,
+            bulkIndexRequest = None
+          )
+          noException should be thrownBy Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)
+        }
+        "not crash for an image that doesn't exist 👻🖼" in {
+
+          val id = UUID.randomUUID().toString
+
+          val message = UpdateMessage(
+            "update-image-usages",
+            image = None,
+            id = Some(id),
+            usageNotice = Some(UsageNotice(id, JsArray())),
+            edits = None,
+            lastModified = Some(new DateTime()),
+            collections = None,
+            leaseId = None,
+            crops = None,
+            mediaLease = None,
+            leases = None,
+            syndicationRights = None,
+            bulkIndexRequest = None
+          )
+          noException should be thrownBy Await.result(messageProcessor.updateImageUsages(message), fiveSeconds)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

ElasticSearch queries can now return typed errors for es failures, exposing more detail about what went wrong. Now for updates, we can catch these specific errors and not cause a retry.

## How can success be measured?

Able to take usages for non-existent images without crashing.


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
