### PR TITLE
allow riffraff to deploy to the new isolated image-loader-projection app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,8 @@ lazy val root = project("grid", path = Some("."))
       (packageBin in Debian in collections).value -> s"${(name in collections).value}/${(name in collections).value}.deb",
       (packageBin in Debian in cropper).value -> s"${(name in cropper).value}/${(name in cropper).value}.deb",
       (packageBin in Debian in imageLoader).value -> s"${(name in imageLoader).value}/${(name in imageLoader).value}.deb",
+      // image-loader-projection uses the same deb as image-loader, we're running it for isolation of traffic in batch reindexing
+      (packageBin in Debian in imageLoader).value -> s"${(name in imageLoader).value}-projection/${(name in imageLoader).value}-projection.deb",
       (packageBin in Debian in leases).value -> s"${(name in leases).value}/${(name in leases).value}.deb",
       (packageBin in Debian in thrall).value -> s"${(name in thrall).value}/${(name in thrall).value}.deb",
       (packageBin in Debian in kahuna).value -> s"${(name in kahuna).value}/${(name in kahuna).value}.deb",

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -39,6 +39,9 @@ deployments:
   image-loader:
     template: autoscaling
 
+  image-loader-projection:
+    template: autoscaling
+
   kahuna:
     template: autoscaling
 


### PR DESCRIPTION
## What does this change?
We have recently created a duplicated stack of `image-loader` called `image-loader-projection` to isolate network traffic from the batch reingest process.

Update `riff-raff.yaml` to add this new stack to CD.

## How can success be measured?
RiffRaff will deploy to `image-loader-projection` in CD.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/75374016-64ba0100-58c3-11ea-8e23-699a67cc93a1.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
