### PR TITLE
add image-loader-projection to prout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -4,6 +4,7 @@
     "collections": { "url": "https://media-collections.gutools.co.uk/management/manifest", "overdue": "30M" },
     "cropper": { "url": "https://cropper.media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "image-loader": { "url": "https://loader.media.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "image-loader-projection": { "url": "https://loader-projection.media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "kahuna": { "url": "https://media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "leases": { "url": "https://media-leases.gutools.co.uk/management/manifest", "overdue": "30M" },
     "media-api": { "url": "https://api.media.gutools.co.uk/management/manifest", "overdue": "30M" },


### PR DESCRIPTION
## What does this change?
PRout will add a label to a PR once it has been seen on PROD. Add `image-loader-projection` config to close the loop on the new stack.

Related to https://github.com/guardian/grid/pull/2836.

## How can success be measured?
PRout will tell us when a PR is on PROD in all the places.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [ ] locally
- [ ] on TEST
