### PR TITLE
Mkuzdowicz/ DynamoDB scripts use-full while Re-ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ imgops/dev/nginx.conf
 /stress-test/test-files/
 
 LOGS_LOCATION_IS_UNDEFINED
+re_ingestion_stats.txt

--- a/admin-tools/README.md
+++ b/admin-tools/README.md
@@ -2,11 +2,11 @@
 
 ## indexed Image projection
 
-    GET /images/:id/project
+    GET /images/projection/:id
 
 ### Example
 
-https://admin-tools.media.local.dev-gutools.co.uk/images/7b749a7acbd19590af928243f701e3929adef11e/project
+https://admin-tools.media.local.dev-gutools.co.uk/images/projection/7b749a7acbd19590af928243f701e3929adef11e
 
 See the [routes file](https://github.com/guardian/media-service/blob/master/admin-tools/conf/routes) for more API
 "documentation".

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -132,7 +132,7 @@ class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
   }
 
   def getProcessedMediaIdsBatch(implicit ec: ExecutionContext): Future[List[String]] = Future {
-    logger.info("attempt to get mediaIds batch from dynamo")
+    logger.info(s"attempt to get mediaIds batch from dynamo: ${table.getTableName}")
     val scanSpec = new ScanSpec()
       .withFilterExpression(s"$StateField in (:finished, :not_found, :in_progress)")
       .withValueMap(new ValueMap()

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -117,12 +117,6 @@ object InputIdsStore {
   val PKField: String = "id"
   val StateField: String = "progress_state"
 
-  def getAllMediaIdsWithinStateScan(state: Int) = {
-    new ScanSpec()
-      .withFilterExpression(s"$StateField = :sub")
-      .withValueMap(new ValueMap().withNumber(":sub", state))
-  }
-
   def getAllMediaIdsWithinStateQuery(state: Int) = {
     new QuerySpec()
       .withKeyConditionExpression(s"$StateField = :sub")

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -113,10 +113,20 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
 
 }
 
+object InputIdsStore {
+  val PKField: String = "id"
+  val StateField: String = "progress_state"
+
+  def getAllMediaIdsWithinState(state: Int) = {
+    new ScanSpec()
+      .withFilterExpression(s"$StateField = :sub")
+      .withValueMap(new ValueMap().withNumber(":sub", state))
+  }
+}
+
 class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
 
-  private val PKField: String = "id"
-  private val StateField: String = "progress_state"
+  import InputIdsStore._
 
   def getUnprocessedMediaIdsBatch(implicit ec: ExecutionContext): Future[List[String]] = Future {
     logger.info("attempt to get mediaIds batch from dynamo")

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -117,9 +117,15 @@ object InputIdsStore {
   val PKField: String = "id"
   val StateField: String = "progress_state"
 
-  def getAllMediaIdsWithinState(state: Int) = {
+  def getAllMediaIdsWithinStateScan(state: Int) = {
     new ScanSpec()
       .withFilterExpression(s"$StateField = :sub")
+      .withValueMap(new ValueMap().withNumber(":sub", state))
+  }
+
+  def getAllMediaIdsWithinStateQuery(state: Int) = {
+    new QuerySpec()
+      .withKeyConditionExpression(s"$StateField = :sub")
       .withValueMap(new ValueMap().withNumber(":sub", state))
   }
 }

--- a/admin-tools/scripts/README.md
+++ b/admin-tools/scripts/README.md
@@ -6,3 +6,7 @@
 ## get stats
 
 `sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ImagesGroupByProgressState <table name>"`
+
+## reset known errors
+
+`sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ResetKnownErrors <table name>"`

--- a/admin-tools/scripts/README.md
+++ b/admin-tools/scripts/README.md
@@ -1,5 +1,7 @@
 
-## reset dynamo batch index table items state local run
+# Scripts execution
+
+## reset dynamo batch index table items state
 
 `sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ResetImageBatchIndexTable <table name>"`
 

--- a/admin-tools/scripts/README.md
+++ b/admin-tools/scripts/README.md
@@ -1,0 +1,4 @@
+
+## reset dynamo batch index table items state local run
+
+`sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ResetImageBatchIndexTable <table name>"`

--- a/admin-tools/scripts/README.md
+++ b/admin-tools/scripts/README.md
@@ -9,6 +9,6 @@
 
 `sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ImagesGroupByProgressState <table name>"`
 
-## reset known errors
+## reset known errors state
 
 `sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ResetKnownErrors <table name>"`

--- a/admin-tools/scripts/README.md
+++ b/admin-tools/scripts/README.md
@@ -2,3 +2,7 @@
 ## reset dynamo batch index table items state local run
 
 `sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ResetImageBatchIndexTable <table name>"`
+
+## get stats
+
+`sbt "project admin-tools-scripts" "runMain com.gu.mediaservice.ImagesGroupByProgressState <table name>"`

--- a/admin-tools/scripts/src/main/resources/logback.xml
+++ b/admin-tools/scripts/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5relative %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -1,0 +1,61 @@
+package com.gu.mediaservice
+
+import com.gu.mediaservice.indexing.{IndexInputCreation, ProduceProgress}
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.collection.JavaConverters._
+
+
+object ImagesGroupByProgressState extends App with LazyLogging {
+
+  if (args.isEmpty) throw new IllegalArgumentException("please provide dynamo table name")
+
+  import InputIdsStore._
+
+  private val dynamoTable = args(0)
+  private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
+  private val stateIndex = ddbClient.getIndex(StateField)
+
+  def execute() = {
+
+    def stateNameToCount(progressType: ProduceProgress) = {
+      val result = stateIndex.scan(getAllMediaIdsWithinState(progressType.stateId))
+      result.asScala.foreach { _ =>
+        // done to initialize lazy result
+      }
+      val pages = result.pages().asScala.size
+      logger.info(s"calculating stateNameToCount for $progressType")
+      logger.info(s"pages=$pages")
+      val ans = progressType.name -> result.getAccumulatedItemCount
+      logger.info(s"result=$ans")
+      ans
+    }
+
+    def writeResult(content: String) = {
+      import java.io.PrintWriter
+      new PrintWriter("stats.txt") {
+        write(content);
+        close
+      }
+    }
+
+    import IndexInputCreation._
+
+    logger.info(s"starting to calculate stats at dynamoTable=$dynamoTable")
+
+    val result = Map(
+      stateNameToCount(Finished),
+      stateNameToCount(NotFound),
+      stateNameToCount(KnownError),
+      stateNameToCount(NotStarted),
+    ).mkString("\n")
+
+    logger.info(s"results from dynamoTable=$dynamoTable")
+    logger.info(result)
+
+    writeResult(result)
+
+  }
+
+  execute()
+}

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -31,7 +31,7 @@ object ImagesGroupByProgressState extends App with LazyLogging {
 
     def writeResult(content: String) = {
       import java.io.PrintWriter
-      new PrintWriter("stats.txt") {
+      new PrintWriter("re_ingestion_stats.txt") {
         write(content);
         close
       }

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -3,6 +3,8 @@ package com.gu.mediaservice
 import com.gu.mediaservice.indexing.{IndexInputCreation, ProduceProgress}
 import com.typesafe.scalalogging.LazyLogging
 
+import scala.collection.JavaConverters._
+
 object ImagesGroupByProgressState extends App with LazyLogging {
 
   if (args.isEmpty) throw new IllegalArgumentException("please provide dynamo table name")
@@ -15,18 +17,12 @@ object ImagesGroupByProgressState extends App with LazyLogging {
 
   def execute() = {
 
-    def stateNameToCount(progressType: ProduceProgress) = {
+    def stateNameToCount(progressType: ProduceProgress): (String, Int) = {
       logger.info(s"calculating stateNameToCount for $progressType")
-      val result = stateIndex.query(getAllMediaIdsWithinStateQuery(progressType.stateId))
-      val iterator = result.iterator()
-      var count: Long = 0
-      while (iterator.hasNext) {
-        count += 1
-        iterator.next()
-      }
-      val ans = progressType.name -> count
-      logger.info(s"result=$ans")
-      ans
+      val queryRes = stateIndex.query(getAllMediaIdsWithinStateQuery(progressType.stateId))
+      val result = progressType.name -> queryRes.iterator.asScala.length
+      logger.info(s"result=$result")
+      result
     }
 
     def writeResult(content: String) = {

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -3,9 +3,6 @@ package com.gu.mediaservice
 import com.gu.mediaservice.indexing.{IndexInputCreation, ProduceProgress}
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.collection.JavaConverters._
-
-
 object ImagesGroupByProgressState extends App with LazyLogging {
 
   if (args.isEmpty) throw new IllegalArgumentException("please provide dynamo table name")
@@ -19,14 +16,15 @@ object ImagesGroupByProgressState extends App with LazyLogging {
   def execute() = {
 
     def stateNameToCount(progressType: ProduceProgress) = {
-      val result = stateIndex.scan(getAllMediaIdsWithinState(progressType.stateId))
-      result.asScala.foreach { _ =>
-        // done to initialize lazy result
-      }
-      val pages = result.pages().asScala.size
       logger.info(s"calculating stateNameToCount for $progressType")
-      logger.info(s"pages=$pages")
-      val ans = progressType.name -> result.getAccumulatedItemCount
+      val result = stateIndex.query(getAllMediaIdsWithinStateQuery(progressType.stateId))
+      val iterator = result.iterator()
+      var count: Long = 0
+      while (iterator.hasNext) {
+        count += 1
+        iterator.next()
+      }
+      val ans = progressType.name -> count
       logger.info(s"result=$ans")
       ans
     }

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -52,7 +52,6 @@ object ImagesGroupByProgressState extends App with LazyLogging {
     logger.info(result)
 
     writeResult(result)
-
   }
 
   execute()

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
@@ -17,10 +17,10 @@ object ResetImageBatchIndexTable extends App with LazyLogging {
     val InputIdsStore = new InputIdsStore(ddbClient, batchSize)
     val mediaIdsFuture = InputIdsStore.getProcessedMediaIdsBatch
     val mediaIds = Await.result(mediaIdsFuture, Duration.Inf)
-    logger.info(s"got ${mediaIds.size}, unprocessed mediaIds, $mediaIds")
+    logger.info(s"got ${mediaIds.size}, processed mediaIds")
     InputIdsStore.resetItemsState(mediaIds)
   }
 
-  execute(1000)
+  execute(10000)
 
 }

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
@@ -8,6 +8,8 @@ import scala.concurrent.duration.Duration
 
 object ResetImageBatchIndexTable extends App with LazyLogging {
 
+  if (args.isEmpty) throw new IllegalArgumentException("please provide dynamo table name")
+
   private val dynamoTable = args(0)
   private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
 

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
@@ -1,0 +1,24 @@
+package com.gu.mediaservice
+
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+object ResetImageBatchIndexTable extends App with LazyLogging {
+
+  private val dynamoTable = args(0)
+  private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
+
+  def execute(batchSize: Int) = {
+    val InputIdsStore = new InputIdsStore(ddbClient, batchSize)
+    val mediaIdsFuture = InputIdsStore.getProcessedMediaIdsBatch
+    val mediaIds = Await.result(mediaIdsFuture, Duration.Inf)
+    logger.info(s"got ${mediaIds.size}, unprocessed mediaIds, $mediaIds")
+    InputIdsStore.resetItemsState(mediaIds)
+  }
+
+  execute(1000)
+
+}

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
@@ -1,0 +1,33 @@
+package com.gu.mediaservice
+
+import com.gu.mediaservice.indexing.IndexInputCreation
+import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.json.{JsObject, Json}
+
+import scala.collection.JavaConverters._
+
+object ResetKnownErrors extends App with LazyLogging {
+
+  if (args.isEmpty) throw new IllegalArgumentException("please provide dynamo table name")
+
+  import IndexInputCreation._
+  import InputIdsStore._
+
+  private val dynamoTable = args(0)
+  private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
+  private val stateIndex = ddbClient.getIndex(StateField)
+
+  def execute(batchSize: Int) = {
+    val InputIdsStore = new InputIdsStore(ddbClient, batchSize)
+
+    val mediaIDsWithKnownErrors = stateIndex.query(getAllMediaIdsWithinStateQuery(KnownError.stateId)).asScala.toList.map(it => {
+      val json = Json.parse(it.toJSON).as[JsObject]
+      (json \ PKField).as[String]
+    })
+
+    logger.info(s"got ${mediaIDsWithKnownErrors.size}, mediaIds blacklisted as KnownError")
+    InputIdsStore.resetItemsState(mediaIDsWithKnownErrors)
+  }
+
+  execute(10000)
+}

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
@@ -17,8 +17,9 @@ object ResetKnownErrors extends App with LazyLogging {
   private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
   private val stateIndex = ddbClient.getIndex(StateField)
 
-  def execute(batchSize: Int) = {
-    val InputIdsStore = new InputIdsStore(ddbClient, batchSize)
+  def execute() = {
+    val ignoredAtThisScript = 100
+    val InputIdsStore = new InputIdsStore(ddbClient, ignoredAtThisScript)
 
     val mediaIDsWithKnownErrors = stateIndex.query(getAllMediaIdsWithinStateQuery(KnownError.stateId))
       .asScala.toList.map { it =>
@@ -30,5 +31,5 @@ object ResetKnownErrors extends App with LazyLogging {
     InputIdsStore.resetItemsState(mediaIDsWithKnownErrors)
   }
 
-  execute(10000)
+  execute()
 }

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
@@ -20,10 +20,11 @@ object ResetKnownErrors extends App with LazyLogging {
   def execute(batchSize: Int) = {
     val InputIdsStore = new InputIdsStore(ddbClient, batchSize)
 
-    val mediaIDsWithKnownErrors = stateIndex.query(getAllMediaIdsWithinStateQuery(KnownError.stateId)).asScala.toList.map(it => {
+    val mediaIDsWithKnownErrors = stateIndex.query(getAllMediaIdsWithinStateQuery(KnownError.stateId))
+      .asScala.toList.map { it =>
       val json = Json.parse(it.toJSON).as[JsObject]
       (json \ PKField).as[String]
-    })
+    }
 
     logger.info(s"got ${mediaIDsWithKnownErrors.size}, mediaIds blacklisted as KnownError")
     InputIdsStore.resetItemsState(mediaIDsWithKnownErrors)

--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,15 @@ lazy val adminToolsLambda = project("admin-tools-lambda", Some("admin-tools/lamb
     riffRaffManifestProjectName := s"media-service::grid::admin-tools-lambda"
   )
 
+lazy val adminToolsScripts = project("admin-tools-scripts", Some("admin-tools/scripts"))
+  .settings(
+    assemblyMergeStrategy in assembly := {
+      case PathList("META-INF", xs@_*) => MergeStrategy.discard
+      case "logback.xml" => MergeStrategy.first
+      case x => MergeStrategy.first
+    }
+  ).dependsOn(adminToolsLib)
+
 lazy val adminToolsDev = playProject("admin-tools-dev", 9013, Some("admin-tools/dev"))
   .dependsOn(adminToolsLib)
 

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -10,8 +10,7 @@ import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.aws.{S3Ops, UpdateMessage}
-import com.gu.mediaservice.lib.logging.FALLBACK
-import com.gu.mediaservice.lib.logging.RequestLoggingContext
+import com.gu.mediaservice.lib.logging.{FALLBACK, RequestLoggingContext}
 import com.gu.mediaservice.model.{Image, UploadInfo}
 import lib._
 import lib.imaging.MimeTypeDetection
@@ -102,7 +101,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
               Ok(Json.toJson(img)).as(ArgoMediaType)
             }
             case None =>
-              val s3Path = "s3://" + config.imageBucket + ImageIngestOperations.fileKeyFromId(imageId)
+              val s3Path = "s3://" + config.imageBucket + "/" + ImageIngestOperations.fileKeyFromId(imageId)
               Logger.info("image not found")(requestContext.toMarker())
               respondError(NotFound, "image-not-found", s"Could not find image: $imageId in s3 at $s3Path")
           }


### PR DESCRIPTION
## What does this change?
adding  DynamoDB scripts use-full while Re-ingestion
- reset state of images to re-ingest in dynamodb
- get stats about re-ingestion `pregress_state`
- reset known errors

## Tested?
- [x] locally
- [ ] on TEST
