### PR TITLE
use an agnostic AMIgo recipe name

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -91,7 +91,7 @@ deployments:
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-xenial
+          Recipe: grid-imaging
         ImgOpsAmiId:
           BuiltBy: amigo
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?
We're moving to bionic now for a later version of graphicsmagic `grid-imaging` is a more generic name (plus we've updated AMIgo already!)

## How can success be measured?
noop

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
