### PR TITLE
change signature of loadImage to use stricter types

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/DateTimeUtils.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/DateTimeUtils.scala
@@ -1,0 +1,9 @@
+package com.gu.mediaservice.lib
+
+import org.joda.time.DateTime
+
+import scala.util.Try
+
+object DateTimeUtils {
+  def fromValueOrNow(value: Option[String]): DateTime = Try{new DateTime(value.get)}.getOrElse(DateTime.now)
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/DateTimeUtilsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/DateTimeUtilsTest.scala
@@ -1,0 +1,23 @@
+package com.gu.mediaservice.lib
+
+import org.joda.time.DateTime
+import org.scalatest.{FunSpec, Matchers}
+
+class DateTimeUtilsTest extends FunSpec with Matchers {
+  it ("should convert a string to a DateTime") {
+    val dateString = "2020-01-01T12:34:56.000Z"
+    val actual = DateTimeUtils.fromValueOrNow(Some(dateString))
+    actual shouldBe a[DateTime]
+    actual.toString shouldBe dateString
+  }
+
+  it ("should handle an invalid date string input and return a DateTime") {
+    val actual = DateTimeUtils.fromValueOrNow(Some("nonsense"))
+    actual shouldBe a[DateTime]
+  }
+
+  it ("should return a date with no input") {
+    val actual = DateTimeUtils.fromValueOrNow(None)
+    actual shouldBe a[DateTime]
+  }
+}

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -176,7 +176,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
     }
   }
 
-  def loadFile(digestedFile: DigestedFile, user: Principal,
+  private def loadFile(digestedFile: DigestedFile, user: Principal,
                uploadedBy: Option[String], identifiers: Option[String],
                uploadTime: Option[String], filename: Option[String], requestLoggingContext: RequestLoggingContext): Future[Result] = {
     val DigestedFile(tempFile_, id_) = digestedFile

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -72,7 +72,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
     Logger.info("body parsed")(requestContext.toMarker(markers))
 
     auth.async(parsedBody) { req =>
-      val result = loadFile(req.body, req.user, uploadedBy, identifiers, uploadTime, filename, requestContext)
+      val result = loadFile(req.body, req.user, uploadedBy, identifiers, dateTimeFromValueOrNow(uploadTime), filename, requestContext)
       Logger.info("loadImage request end")(requestContext.toMarker(markers))
       result
     }
@@ -130,7 +130,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
         val tmpFile = createTempFile("download", requestContext)
 
         val result = downloader.download(validUri, tmpFile).flatMap { digestedFile =>
-          loadFile(digestedFile, request.user, uploadedBy, identifiers, uploadTime, filename, requestContext)
+          loadFile(digestedFile, request.user, uploadedBy, identifiers, dateTimeFromValueOrNow(uploadTime), filename, requestContext)
         } recover {
           case NonFatal(e) =>
             Logger.error(s"Unable to download image $uri", e)
@@ -176,9 +176,11 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
     }
   }
 
+  private def dateTimeFromValueOrNow(value: Option[String]): DateTime = Try{new DateTime(value)}.getOrElse(DateTime.now)
+
   private def loadFile(digestedFile: DigestedFile, user: Principal,
                uploadedBy: Option[String], identifiers: Option[String],
-               uploadTime: Option[String], filename: Option[String], requestLoggingContext: RequestLoggingContext): Future[Result] = {
+               uploadTime: DateTime, filename: Option[String], requestLoggingContext: RequestLoggingContext): Future[Result] = {
     val DigestedFile(tempFile_, id_) = digestedFile
 
     val uploadedBy_ = uploadedBy match {
@@ -191,13 +193,6 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
 
     val uploadInfo_ = UploadInfo(filename.flatMap(_.trim.nonEmptyOpt))
 
-    // TODO: handle the error thrown by an invalid string to `DateTime`
-    // only allow uploadTime to be set by AuthenticatedService
-    val uploadTime_ = uploadTime match {
-      case Some(time) => new DateTime(time)
-      case None => DateTime.now
-    }
-
     Logger.info("Detecting mimetype")(requestLoggingContext.toMarker())
     // Abort early if unsupported mime-type
     val mimeType_ = MimeTypeDetection.guessMimeType(tempFile_)
@@ -208,7 +203,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
       imageId = id_,
       tempFile = tempFile_,
       mimeType = mimeType_,
-      uploadTime = uploadTime_,
+      uploadTime = uploadTime,
       uploadedBy = uploadedBy_,
       identifiers = identifiers_,
       uploadInfo = uploadInfo_


### PR DESCRIPTION
## What does this change?
Rather than accepting an `Option[String]` as a param and then converting it to a DateTime in the function body, have a stricter signature.

This is part of a refactor to make the ImageLoaderController easier to follow. The ambition is to make the controller a transforming layer, going from an http request into a strictly typed set of objects that can be pushed into other functions.

Also makes `loadImage` private, because it is!

## How can success be measured?
Simpler code.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
