### PR TITLE
More accurate count in ES7

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -150,7 +150,9 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
       case _ => sorts.createSort(params.orderBy)
     }
 
-    val searchRequest = prepareSearch(withFilter) from params.offset size params.length sortBy sort
+    // We need to set trackHits to ensure that the total number of hits we return to users is accurate.
+    // See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response
+    val searchRequest = prepareSearch(withFilter).copy(trackHits = Some(true)) from params.offset size params.length sortBy sort
 
     executeAndLog(searchRequest, "image search").
       toMetric(Some(mediaApiMetrics.searchQueries), List(mediaApiMetrics.searchTypeDimension("results")))(_.result.took).map { r =>


### PR DESCRIPTION
## What does this change?

The Grid is currently telling users:

<img width="285" alt="Screenshot 2020-03-03 at 14 36 02" src="https://user-images.githubusercontent.com/7767575/75798924-35960a80-5d6f-11ea-9431-ff3ad0c17027.png">

This is ... not correct.

This PR updates the query to accurately reflect the count in the search, re: [these docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response)

## How can success be measured?

The number of images returned on a default search should number ~10m, not 10,000.

## Tested?
- [x] locally
- [x] on TEST
