### PR TITLE
A checker for the batch image processor.

### DIFF
--- a/admin-tools/lambda/riff-raff.yaml
+++ b/admin-tools/lambda/riff-raff.yaml
@@ -10,3 +10,4 @@ deployments:
       functionNames:
         - "admin-tools-image-projection-lambda-"
         - "admin-tools-image-batch-index-lambda-"
+        - "admin-tools-image-batch-index-checker-lambda-"

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
@@ -5,6 +5,7 @@ class BatchIndexLambdaHandler {
   private val cfg = BatchIndexHandlerConfig(
     apiKey = sys.env("API_KEY"),
     projectionEndpoint = sys.env("PROJECTION_ENDPOINT"),
+    imagesEndpoint = sys.env("IMAGES_ENDPOINT"),
     batchIndexBucket = sys.env("BATCH_INDEX_BUCKET"),
     kinesisStreamName = sys.env("KINESIS_STREAM"),
     dynamoTableName = sys.env("IMAGES_TO_INDEX_DYNAMO_TABLE"),
@@ -17,6 +18,10 @@ class BatchIndexLambdaHandler {
   private val batchIndex = new BatchIndexHandler(cfg)
 
   def handleRequest() = {
+    batchIndex.processImages()
+  }
+
+  def handleCheckRequest() = {
     batchIndex.processImages()
   }
 

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
@@ -12,7 +12,9 @@ package object indexing {
     val Finished = ProduceProgress("finished", 3)
     val Reset = ProduceProgress("reset because of failure", 0)
     val KnownError = ProduceProgress("blacklisted because of known failure", 4)
-
+    val Locating = ProduceProgress("looking for image",5)
+    val Found = ProduceProgress("image found", 6)
+    val Inconsistent = ProduceProgress("re-ingested image not found in media-api", 7)
   }
 
 }

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -19,7 +19,7 @@ object ImagesGroupByProgressState extends App with LazyLogging {
 
     def stateNameToCount(progressType: ProduceProgress): (String, Int) = {
       logger.info(s"calculating stateNameToCount for $progressType")
-      val queryRes = stateIndex.query(getAllMediaIdsWithinStateQuery(progressType.stateId))
+      val queryRes = stateIndex.query(getAllMediaIdsWithinProgressQuery(progressType))
       val result = progressType.name -> queryRes.iterator.asScala.length
       logger.info(s"result=$result")
       result

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
@@ -21,7 +21,7 @@ object ResetKnownErrors extends App with LazyLogging {
     val ignoredAtThisScript = 100
     val InputIdsStore = new InputIdsStore(ddbClient, ignoredAtThisScript)
 
-    val mediaIDsWithKnownErrors = stateIndex.query(getAllMediaIdsWithinStateQuery(KnownError.stateId))
+    val mediaIDsWithKnownErrors = stateIndex.query(getAllMediaIdsWithinProgressQuery(KnownError))
       .asScala.toList.map { it =>
       val json = Json.parse(it.toJSON).as[JsObject]
       (json \ PKField).as[String]


### PR DESCRIPTION
## What does this change?

This allows us to batch check the images restored to grid.

This adds another lambda that runs alongside the reingestion lambda to check the images successfully ingested. It checks to see if the image is in the grid and then updates the status in the table.

## How can success be measured?

More images!

## Screenshots (if applicable)


## Who should look at this?
  @guardian/digital-cms 


## Tested?
- [ ] locally
- [ ] on TEST
