### PR TITLE
Update grid imaging ami to latest ubuntu (not ESR)

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -91,7 +91,7 @@ deployments:
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-imaging
+          Recipe: grid-imaging-eoan
         ImgOpsAmiId:
           BuiltBy: amigo
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?
This updates Ubuntu to Ubuntu 19.10 (Eoan Ermine) which brings in the GraphicsMagick package 1.4+really1.3.33.

Not the most reassuring package name, but it fixes the bug we've been experiencing with 1.3.28 in Bionic.

## How can success be measured?
Fewer image load errors in the reingest. 

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
