### PR TITLE
Better log error messages for the batch reingest lambda

### DIFF
--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -41,8 +41,11 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
           case _ =>
             respondError(NotFound, "not-found", s"image with mediaId: $mediaId not found")
         }
-      case FullImageProjectionFailed(expMessage) =>
-        respondError(InternalServerError, "image-projection-failed", expMessage)
+      case FullImageProjectionFailed(expMessage, downstreamMessage) =>
+        respondError(InternalServerError, "image-projection-failed", Json.obj(
+          "errorMessage" -> expMessage,
+          "downstreamErrorMessage" -> downstreamMessage
+        ).toString)
     }
   }
 }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -52,10 +52,21 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends La
       )
       if (debugHttpResponse) logger.info(s"GET $url response: $resInfo")
       if (code != 200 && code != 404) {
+        // Parse error messages from the response body JSON, if there are any
+        val bodyAsJson = Json.parse(bodyAsString)
+        val errorMessage = (bodyAsJson \ "message" \ "errorMessage").asOpt[String].getOrElse("No error message found")
+        val maybeDownstreamErrorAsString = (bodyAsJson \ "message" \ "downstreamErrorMessage").asOpt[String]
+        val downstreamErrorMessage = maybeDownstreamErrorAsString.flatMap(downstreamError => {
+          val errorAsJson = Json.parse(downstreamError)
+          (errorAsJson \ "errorMessage").asOpt[String]
+        }).getOrElse("No downstream error message found")
+
         val errorJson = Json.obj(
           "errorStatusCode" -> code,
           "responseMessage" -> message,
           "responseBody" -> bodyAsString,
+          "errorMessage" -> errorMessage,
+          "downstreamErrorMessage" -> downstreamErrorMessage,
           "url" -> url.toString,
         )
         logger.error(errorJson.toString())

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -131,7 +131,7 @@ trait FullImageProjectionResult
 
 case class FullImageProjectionSuccess(image: Option[Image]) extends FullImageProjectionResult
 
-case class FullImageProjectionFailed(exception: String) extends FullImageProjectionResult
+case class FullImageProjectionFailed(message: String, downstreamErrorMessage: String) extends FullImageProjectionResult
 
 class ImageDataMerger(config: ImageDataMergerConfig) extends LazyLogging {
 
@@ -145,8 +145,8 @@ class ImageDataMerger(config: ImageDataMergerConfig) extends LazyLogging {
       val mayBeImage: Option[Image] = Await.result(maybeImageFuture, Duration.Inf)
       FullImageProjectionSuccess(mayBeImage)
     } catch {
-      case e: DownstreamApiInBadSateException =>
-        FullImageProjectionFailed(e.getMessage)
+      case e: DownstreamApiInBadStateException =>
+        FullImageProjectionFailed(e.getMessage, e.getDownstreamMessage)
     }
   }
 
@@ -243,18 +243,22 @@ class ImageDataMerger(config: ImageDataMergerConfig) extends LazyLogging {
   private def validateResponse(res: ResponseWrapper, url: URL): Unit = {
     import res._
     if (statusCode != 200 && statusCode != 404) {
-      val message = Json.obj(
-        "errorMessage" -> s"breaking the circuit of full image projection, downstream API: $url is in a bad state, code: $statusCode",
-        "downstreamErrorMessage" -> res.bodyAsString
-      )
+      val errorMessage = s"breaking the circuit of full image projection, downstream API: $url is in a bad state, code: $statusCode"
+      val downstreamErrorMessage = res.bodyAsString
+
       val errorJson = Json.obj(
         "errorStatusCode" -> statusCode,
-        "message" -> message
+        "message" -> Json.obj(
+          "errorMessage" -> errorMessage,
+          "downstreamErrorMessage" -> downstreamErrorMessage
+        )
       )
       logger.error(errorJson.toString())
-      throw new DownstreamApiInBadSateException(message.toString())
+      throw new DownstreamApiInBadStateException(errorMessage, downstreamErrorMessage)
     }
   }
 }
 
-class DownstreamApiInBadSateException(message: String) extends IllegalStateException(message)
+class DownstreamApiInBadStateException(message: String, downstreamMessage: String) extends IllegalStateException(message) {
+  def getDownstreamMessage = downstreamMessage
+}

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -247,6 +247,7 @@ class ImageDataMerger(config: ImageDataMergerConfig) extends LazyLogging {
       val downstreamErrorMessage = res.bodyAsString
 
       val errorJson = Json.obj(
+        "level" -> "ERROR",
         "errorStatusCode" -> statusCode,
         "message" -> Json.obj(
           "errorMessage" -> errorMessage,


### PR DESCRIPTION
## What does this change?

This adds better error message logging to the batch reingest lambda.

Beforehand, we just logged everything we received from the image projection response body. Here, we extract error messages and log them as separate keys, to help us visualise error types and their frequencies.

## How can success be measured?

We should see the `errorMessage` and `downstreamErrorMessage` fields populated in logs.

## Tested?
- [x] locally
- [ ] on TEST
