### PR TITLE
Test Kinesis GetRecords.IteratorAgeMilliseconds threshold

### DIFF
--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
@@ -9,7 +9,9 @@ class BatchIndexLambdaHandler {
     kinesisStreamName = sys.env("KINESIS_STREAM"),
     dynamoTableName = sys.env("IMAGES_TO_INDEX_DYNAMO_TABLE"),
     batchSize = sys.env("BATCH_SIZE").toInt,
-    maxIdleConnections = sys.env("MAX_IDLE_CONNECTIONS").toInt
+    maxIdleConnections = sys.env("MAX_IDLE_CONNECTIONS").toInt,
+    stage = sys.env.get("STAGE"),
+    threshold = sys.env.get("LATENCY_THRESHOLD").map(t => Integer.parseInt(t))
   )
 
   private val batchIndex = new BatchIndexHandler(cfg)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
@@ -101,7 +101,7 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
               .withEndTime(endTime)
               .withMetricName("GetRecords.IteratorAgeMilliseconds")
               .withNamespace("AWS/Kinesis")
-              .withPeriod(3)
+              .withPeriod(300)
               .withStartTime(startTime)
               .withStatistics("Maximum")
               .withUnit("Milliseconds")

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
@@ -88,7 +88,7 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
 
             logger.info("Checking kinesis is nice and fast")
 
-            val dimensionValue = s"media-service-thrall-${actualStage.toLowerCase}"
+            val dimensionValue = s"media-service-thrall-${actualStage.toUpperCase}"
             val endTime: Date = new Date() // now!
             val startTime: Date = new Date(endTime.getTime - 5 * 60 * 1000L) // five minutes ago
 

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
@@ -88,7 +88,7 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
 
             logger.info("Checking kinesis is nice and fast")
 
-            val dimensionValue = s"media-service-thrall-$actualStage"
+            val dimensionValue = s"media-service-thrall-${actualStage.toLowerCase}"
             val endTime: Date = new Date() // now!
             val startTime: Date = new Date(endTime.getTime - 5 * 60 * 1000L) // five minutes ago
 
@@ -115,7 +115,7 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
             logger.info(s"Got ${dataPoints.size} data points")
 
             val fastEnough = dataPoints.nonEmpty && ! dataPoints.exists(d => d.getMaximum > actualThreshold)
-            logger.info(s"Kinesis stream is fast enough: ${fastEnough}")
+            logger.info(s"Kinesis stream is fast enough: $fastEnough")
             fastEnough
         }
     }


### PR DESCRIPTION
## What does this change?
This changes adds a test that the configured Kinesis stream for this stage is currently returning all low values for GetRecords.IteratorAgeMilliseconds

## How can success be measured?
If the kinesis stream runs slowly, lambda will log a refusal to process images until the stream runs quickly again.

## Who should look at this?
All of Ed Tools

## Tested?
- [ ] locally
- [ ] on TEST
