### PR TITLE
Exclude flick from Getty

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -170,7 +170,7 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
       "S&G and Barratts/EMPICS Sport", "EMPICS Sport", "EMPICS SPORT", "EMPICS Sports Photo Agency",
       "Empics Sports Photography Ltd.", "EMPICS Entertainment", "Empics Entertainment", "MatchDay Images Limited",
       "S&G and Barratts/EMPICS Archive", "PPAUK", "SWNS.COM", "Euan Cherry", "Plumb Images", "Mercury Press", "SWNS",
-      "Athena Pictures"
+      "Athena Pictures", "Flick.digital"
     )
 
     val excludedSource = List(


### PR DESCRIPTION
We are finally in a position to finally start recognising Getty properly, because of recent XMP work, so that these wouldn’t be necessary… for now… go, rabbit, go!