### PR TITLE
Ensure temp file removed when image load fails

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -134,6 +134,8 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
         } recover {
           case NonFatal(e) =>
             Logger.error(s"Unable to download image $uri", e)
+            // Need to delete this here as a failure response will never have its onComplete method called.
+            tmpFile.delete()
             FailureResponse.failedUriDownload
         }
 


### PR DESCRIPTION
## What does this change?
When we have a failure, we do not delete the temp file.

## How can success be measured?
Temp file always deleted.

## Tested?
- [ ] locally
- [ ] on TEST
