### PR TITLE
more detail in log markers in Thrall

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -50,14 +50,16 @@ case class UpdateMessage(
   syndicationRights: Option[SyndicationRights] = None,
   bulkIndexRequest: Option[BulkIndexRequest] = None
 ) extends LogMarker {
-  override def toLogMarker: LogstashMarker = {
+  override def markerContents = {
     val message = Json.stringify(Json.toJson(this))
-
-    MarkerMap(Map (
+    Map (
       "subject" -> subject,
       "id" -> id.getOrElse(image.map(_.id).getOrElse("none")),
       "size" -> message.getBytes.length,
       "length" -> message.length
-    )).toLogMarker
+    )
+  }
+  override def toLogMarker: LogstashMarker = {
+    MarkerMap(markerContents).toLogMarker
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -59,7 +59,4 @@ case class UpdateMessage(
       "length" -> message.length
     )
   }
-  override def toLogMarker: LogstashMarker = {
-    MarkerMap(markerContents).toLogMarker
-  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -1,17 +1,18 @@
 package com.gu.mediaservice.lib.elasticsearch
 
+import com.gu.mediaservice.lib.logging.MarkerMap
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.http.JavaClient
 import com.sksamuel.elastic4s.{ElasticClient, ElasticProperties, Response}
 import com.sksamuel.elastic4s.requests.common.HealthStatus
 import com.sksamuel.elastic4s.requests.analysis.{Analysis, AnalysisBuilder}
-
 import com.sksamuel.elastic4s.requests.analyzers.PatternAnalyzerDefinition
 import com.sksamuel.elastic4s.requests.indexes.CreateIndexResponse
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexExistsResponse
-
+import net.logstash.logback.marker.Markers.appendEntries
 import play.api.Logger
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -64,12 +65,14 @@ trait ElasticSearchClient extends ElasticSearchExecutions {
   }
 
   def healthCheck(): Future[Boolean] = {
+    implicit val logMarker = MarkerMap()
     val request = search(imagesAlias) limit 0
     executeAndLog(request, "Healthcheck").map { _ => true}.recover { case _ => false}
   }
 
 
   def countImages(): Future[ElasticSearchImageCounts] = {
+    implicit val logMarker = MarkerMap()
     val queryCatCount = catCount("images") // document count only of index including live documents, not deleted documents which have not yet been removed by the merge process
     val queryImageSearch = search("images") limit 0 // hits that match the query defined in the request
     val queryStats = indexStats("images") // total accumulated values of an index for both primary and replica shards
@@ -147,9 +150,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions {
   // Elastic only allows one index in an alias set to be the write index.
   // To mirror index updates to all indexes in the alias group, the grid queries the alias set and explicitly executes
   // each update on every aliased index.
-  def getCurrentIndices: List[String] = {
-    ???
-  }
+  def getCurrentIndices: List[String] = ???
 
   def assignAliasTo(index: String): Unit = {
     Logger.info(s"Assigning alias $imagesAlias to $index")
@@ -172,8 +173,6 @@ trait ElasticSearchClient extends ElasticSearchExecutions {
     Logger.info("Got alias action response: " + aliasActionResponse)
   }
 
-  def removeAliasFrom(index: String) = {
-    ???
-  }
+ def removeAliasFrom(index: String) = ???
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
@@ -1,0 +1,40 @@
+package com.gu.mediaservice.lib.elasticsearch
+
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
+import com.sksamuel.elastic4s.ElasticError
+import net.logstash.logback.marker.LogstashMarker
+
+trait ElasticSearchError {
+  self: Throwable =>
+  def error: ElasticError
+
+  def markerContents: Map[String, Any]
+}
+
+object ElasticSearchException {
+  def apply(e: ElasticError): Exception with ElasticSearchError = {
+    e match {
+      case ElasticError(t, r, _, _, _, Seq(), _, _, _, _) => // No root causes provided.
+        new Exception(s"query failed because: $r type: $t") with ElasticSearchError {
+          override def error: ElasticError = e
+
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t)
+        }
+      case ElasticError(t, r, _, _, _, s, _, _, _, _) =>
+        new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}") with ElasticSearchError {
+          override def error: ElasticError = e
+
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "))
+        }
+      case _ => new Exception(s"query failed because: unknown error") with ElasticSearchError {
+        override def error: ElasticError = e
+
+        override def markerContents: Map[String, Any] = Map("reason" -> "unknown Elastic Search error")
+      }
+    }
+  }
+
+  def unapply(arg: ElasticSearchError): Option[(ElasticError, LogMarker)] = Some((arg.error, MarkerMap(arg.markerContents)))
+}
+
+case object ElasticNotFoundException extends Exception(s"Elastic Search Document Not Found")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
@@ -1,15 +1,13 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Executor, Functor, Handler, Response}
-import net.logstash.logback.marker.LogstashMarker
-import net.logstash.logback.marker.Markers.appendEntries
-import play.api.{Logger, MarkerContext}
+import com.gu.mediaservice.lib.logging._
+import com.sksamuel.elastic4s._
+import play.api.Logger
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-trait ElasticSearchExecutions {
+trait ElasticSearchExecutions  {
 
   def client: ElasticClient
 
@@ -18,8 +16,10 @@ trait ElasticSearchExecutions {
                                                        executor: Executor[Future],
                                                        handler: Handler[T, U],
                                                        manifest: Manifest[U],
-                                                       executionContext: ExecutionContext): Future[Response[U]] = {
-    val start = System.currentTimeMillis()
+                                                       executionContext: ExecutionContext,
+                                                       logMarkers: LogMarker
+  ): Future[Response[U]] = {
+    val stopwatch = Stopwatch.start
 
     val result = client.execute(request).transform {
       case Success(r) =>
@@ -27,41 +27,30 @@ trait ElasticSearchExecutions {
           case true => Success(r)
           case false => r.status match {
             case 404 => Failure(ElasticNotFoundException)
-            case _ => Failure(ElasticException(r.error))
+            case _ => Failure(ElasticSearchException(r.error))
           }
         }
       case Failure(f) => Failure(f)
     }
 
     result.foreach { r =>
-      val elapsed = System.currentTimeMillis() - start
-      val markers = MarkerContext(durationMarker(elapsed))
-      Logger.info(s"$message - query returned successfully in $elapsed ms")(markers)
+      val elapsed = stopwatch.elapsed
+      Logger.info(s"$message - query returned successfully in ${elapsed.toMillis} ms")(combineMarkers(logMarkers, elapsed))
     }
 
     result.failed.foreach { e =>
-      val elapsed = System.currentTimeMillis() - start
-      val markers = MarkerContext(durationMarker(elapsed))
+      val elapsed = stopwatch.elapsed
       e match {
-        case ElasticNotFoundException => Logger.error(s"$message - query failed: Document not Found")(markers)
-        case ElasticException(error) => error match {
-          case ElasticError(t, r, _, _, _, Seq(), _, _, _, _) => // No root causes provided.
-            Logger.error(s"$message - query failed because: $r type: $t")(markers)
-          case ElasticError(t, r, _, _, _, s, _, _, _, _) =>
-            Logger.error(
-              s"$message - query failed because: $r type: $t; root cause ${s.mkString(", ")}"
-            )(markers)
-        }
-        case _ => Logger.error(s"$message - query failed: ${e.getMessage} cs: ${e.getCause}")(markers)
+        case ElasticNotFoundException => Logger.error(s"$message - query failed: Document not Found")(
+          combineMarkers(logMarkers, elapsed, MarkerMap(Map("reason" -> "ElasticNotFoundException"))))
+        case ElasticSearchException(error, marker) =>
+          Logger.error(s"$message - query failed: ${e.getMessage}")(combineMarkers(logMarkers, elapsed, marker))
+        case _ => Logger.error(s"$message - query failed: ${e.getMessage} cs: ${e.getCause}")(
+          combineMarkers(logMarkers, elapsed, MarkerMap(Map("reason" -> "unknown es error"))))
       }
     }
-
     result
   }
 
-  private def durationMarker(elapsed: Long): LogstashMarker = appendEntries(Map("duration" -> elapsed).asJava)
 
 }
-
-case class ElasticException(error: ElasticError) extends Exception(s"Elastic Search Error ${error.`type`} ${error.reason}")
-case object ElasticNotFoundException  extends Exception(s"Elastic Search Document Not Found")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/MarkerUtils.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/MarkerUtils.scala
@@ -2,15 +2,28 @@ package com.gu.mediaservice.lib.logging
 
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
+import play.api.MarkerContext
+import scala.language.implicitConversions
+
 import scala.collection.JavaConverters._
 
-trait LogMarker { def toLogMarker: LogstashMarker }
+trait LogMarker {
+  def toLogMarker: LogstashMarker
+  def markerContents: Map[String, Any]
+}
 
-case class MarkerMap(values: Map[String, Any]) extends LogMarker {
-  override def toLogMarker: LogstashMarker = appendEntries(values.asJava)
+
+
+case class MarkerMap(markerContents: Map[String, Any]) extends LogMarker {
+  override def toLogMarker: LogstashMarker = appendEntries(markerContents.asJava)
+}
+
+object MarkerMap {
+  def apply(entries: (String, Any)*):MarkerMap = MarkerMap(entries.toMap)
 }
 
 trait MarkerUtils {
   val FALLBACK: String = "unknown"
-  def combineMarkers(markers: LogMarker*): LogstashMarker = markers.map(_.toLogMarker).reduce((first, second) => first.and[LogstashMarker](second))
+  def combineMarkers(markers: LogMarker*): LogMarker = MarkerMap(markers.flatMap(_.markerContents.toSeq).toMap)
+  implicit def fromLogMarker(logMarker: LogMarker):MarkerContext = MarkerContext(logMarker.toLogMarker)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/MarkerUtils.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/MarkerUtils.scala
@@ -8,15 +8,11 @@ import scala.language.implicitConversions
 import scala.collection.JavaConverters._
 
 trait LogMarker {
-  def toLogMarker: LogstashMarker
+  def toLogMarker: LogstashMarker = appendEntries(markerContents.asJava)
   def markerContents: Map[String, Any]
 }
 
-
-
-case class MarkerMap(markerContents: Map[String, Any]) extends LogMarker {
-  override def toLogMarker: LogstashMarker = appendEntries(markerContents.asJava)
-}
+case class MarkerMap(markerContents: Map[String, Any]) extends LogMarker
 
 object MarkerMap {
   def apply(entries: (String, Any)*):MarkerMap = MarkerMap(entries.toMap)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/Stopwatch.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/Stopwatch.scala
@@ -5,8 +5,8 @@ import scala.concurrent.duration._
 
 case class DurationForLogging(duration: Duration) extends LogMarker {
   def toMillis: Long = duration.toMillis
-
-  override def toLogMarker: LogstashMarker = MarkerMap(Map("duration" -> toMillis)).toLogMarker
+  def markerContents = Map("duration" -> toMillis)
+  override def toLogMarker: LogstashMarker = MarkerMap(markerContents).toLogMarker
 }
 
 class Stopwatch {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/Stopwatch.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/Stopwatch.scala
@@ -6,7 +6,6 @@ import scala.concurrent.duration._
 case class DurationForLogging(duration: Duration) extends LogMarker {
   def toMillis: Long = duration.toMillis
   def markerContents = Map("duration" -> toMillis)
-  override def toLogMarker: LogstashMarker = MarkerMap(markerContents).toLogMarker
 }
 
 class Stopwatch {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/logging/MarkerUtilsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/logging/MarkerUtilsTest.scala
@@ -1,0 +1,17 @@
+package com.gu.mediaservice.lib.logging
+
+import org.scalatest.{FunSpec, Matchers}
+
+class MarkerUtilsTest extends FunSpec with Matchers {
+  it("should combine markers") {
+    val marker1 = MarkerMap("a" -> "b")
+    val marker2 = MarkerMap("c" -> "d")
+    val combined = combineMarkers(marker1, marker2)
+    combined.markerContents.toSeq should contain("a" -> "b")
+    combined.markerContents.toSeq should contain("c" -> "d")
+
+    val markerString = combined.toLogMarker.toString
+
+    markerString should be("{a=b, c=d}")
+  }
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/logging/StopwatchTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/logging/StopwatchTest.scala
@@ -3,12 +3,25 @@ package com.gu.mediaservice.lib.logging
 import org.scalatest.{FunSpec, Matchers}
 
 class StopwatchTest extends FunSpec with Matchers {
-  it ("should return the elapsed time") {
+  it("should return the elapsed time") {
     val fiveSeconds: Long = 5 * 1000
-    def doWork = Thread.sleep(fiveSeconds)
+    val durationRegex = """\{duration=(\d*)\}""".r
 
+    def doWork = Thread.sleep(fiveSeconds)
     val stopwatch = Stopwatch.start
     doWork
-    stopwatch.elapsed.duration.toMillis should be >= fiveSeconds // >= as time is needed to call the function
+
+    val marker = stopwatch.elapsed.toLogMarker
+    val map = stopwatch.elapsed.markerContents
+
+
+    map("duration") should be >= fiveSeconds
+
+    (marker.toString match {
+      case durationRegex(duration) => {
+        duration.toLong
+      }
+      case _ => 0
+    }) should be >= fiveSeconds // >= as time is needed to call the function
   }
 }

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -116,7 +116,10 @@ setupLocalKinesis() {
   # ignore stream already exists error
   set +e
   stream_name='media-service-DEV-ThrallMessageQueue-1N0T2UXYNUIC9'
+<<<<<<< HEAD
   export AWS_PAGER=""
+=======
+>>>>>>> dont change dev-start in this pr
   aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis create-stream --shard-count 1 --stream-name "${stream_name}"
   aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis list-streams
 }

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -3,6 +3,7 @@ package lib.elasticsearch
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchConfig, ElasticSearchExecutions}
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.DenySyndicationLease
 import com.gu.mediaservice.model.usage.PublishedUsageStatus
@@ -26,6 +27,7 @@ import scala.concurrent.{Await, Future}
 class ElasticSearchTest extends ElasticSearchTestBase with Eventually with ElasticSearchExecutions with MockitoSugar {
 
   implicit val request = mock[AuthenticatedRequest[AnyContent, Principal]]
+
 
   private val index = "images"
 
@@ -430,6 +432,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
   }
 
   private def saveImages(images: Seq[Image]) = {
+    implicit val logMarker: LogMarker = MarkerMap()
+
     Future.sequence(images.map { i =>
       executeAndLog(indexInto(index) id i.id source Json.stringify(Json.toJson(i)), s"Indexing test image")
     })
@@ -438,6 +442,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
   private def totalImages: Long = Await.result(ES.totalImages(), oneHundredMilliseconds)
 
   private def purgeTestImages = {
+    implicit val logMarker: LogMarker = MarkerMap()
+
     def deleteImages = executeAndLog(deleteByQuery(index, matchAllQuery()), s"Deleting images")
 
     Await.result(deleteImages, fiveSeconds)

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch
 
 import java.util.UUID
 
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.whisk.docker.impl.spotify.DockerKitSpotify
 import com.whisk.docker.scalatest.DockerTestKit
@@ -17,6 +18,7 @@ import scala.concurrent.duration._
 import scala.util.Properties
 
 trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with DockerKit with DockerTestKit with DockerKitSpotify with ConditionFixtures {
+
 
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))

--- a/thrall/app/lib/RetryHandler.scala
+++ b/thrall/app/lib/RetryHandler.scala
@@ -3,6 +3,7 @@ package lib
 
 import akka.actor.ActorSystem
 import akka.pattern.{after, retry}
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap, combineMarkers}
 import play.api.{Logger, MarkerContext}
 
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
@@ -10,50 +11,52 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
 object RetryHandler {
-  def handleWithRetryAndTimeout[T](f: () => Future[T],
+  type WithMarkers[T] = (LogMarker) => Future[T]
+
+  def handleWithRetryAndTimeout[T](f: WithMarkers[T],
                                    retries: Int,
                                    timeout: FiniteDuration,
-                                   delay: FiniteDuration
+                                   delay: FiniteDuration,
+                                   marker: LogMarker
                                   )(implicit actorSystem: ActorSystem,
                                     executionContext: ExecutionContext,
-                                    mc: MarkerContext
-                                  ): () => Future[T] = {
-    def logFailures[T](f: () => Future[T])(
-      implicit executionContext: ExecutionContext, mc: MarkerContext
-    ): () => Future[T] = {
-      () => {
-        f().transform {
+                                  ): Future[T] = {
+    def logFailures[T](f: WithMarkers[T]):WithMarkers[T]  = {
+      (marker: LogMarker) => {
+        f(marker).transform {
           case Success(x) => Success(x)
           case Failure(t: TimeoutException) => {
-            Logger.error("Failed with timeout. Will retry")
+            Logger.error("Failed with timeout. Will retry")(marker.toLogMarker)
             Failure(t)
           }
           case Failure(exception) => {
-            Logger.error("Failed with exception.", exception)
+            Logger.error("Failed with exception.", exception)(marker.toLogMarker)
             Failure(exception)
           }
         }
       }
     }
 
-    def handleWithTimeout[T](f: () => Future[T], attemptTimeout: FiniteDuration): () => Future[T] = () => {
+    def handleWithTimeout[T](f: WithMarkers[T], attemptTimeout: FiniteDuration): WithMarkers[T] = ( marker ) => {
       val timeout = after(attemptTimeout, using = actorSystem.scheduler)(Future.failed(
         new TimeoutException(s"Timeout of $attemptTimeout reached.")
       ))
-      Future.firstCompletedOf(Seq(timeout, f()))
+      Future.firstCompletedOf(Seq(timeout, f(marker)))
     }
 
-    def handleWithRetry[T](f: () => Future[T], retries: Int, delay: FiniteDuration): () => Future[T] = () => {
+    def handleWithRetry[T](f: WithMarkers[T], retries: Int, delay: FiniteDuration): WithMarkers[T] = (marker) => {
       implicit val scheduler = actorSystem.scheduler
       var count = 0
 
       def attempt = () => {
         count = count + 1
-        Logger.info(s"Attempt $count of $retries")
-        f()
+        val markerWithRetry = combineMarkers(marker, MarkerMap("retryCount" -> count))
+        Logger.info(s"Attempt $count of $retries")(markerWithRetry)
+
+        f(markerWithRetry)
       }
       retry(attempt, retries, delay)
     }
-    handleWithRetry(handleWithTimeout(logFailures(f), timeout), retries, delay)
+    handleWithRetry(handleWithTimeout(logFailures(f), timeout), retries, delay)(marker)
   }
 }

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch
 
 import java.util.UUID
 
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
@@ -15,6 +16,8 @@ import scala.concurrent.{Await, Future}
 
 class ElasticSearchTest extends ElasticSearchTestBase {
   "Elasticsearch" - {
+   implicit val logMarker: LogMarker = MarkerMap()
+
 
     "images" - {
 
@@ -290,7 +293,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         Await.result(Future.sequence(ES.indexImage(id, Json.toJson(imageWithExports))), fiveSeconds)
         reloadedImage(id).get.exports.nonEmpty shouldBe true
 
-        Await.result(Future.sequence(ES.deleteImageExports(id)), fiveSeconds)
+        Await.result(Future.sequence(ES.deleteImageExports(id, logMarker)), fiveSeconds)
 
         reloadedImage(id).get.exports.isEmpty shouldBe true
       }

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,10 +1,9 @@
 package lib.elasticsearch
 
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.ElasticDsl
-
-
 import com.whisk.docker.impl.spotify.DockerKitSpotify
 import com.whisk.docker.scalatest.DockerTestKit
 import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}
@@ -65,10 +64,12 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
 
 
   def reloadedImage(id: String) = {
+    implicit val logMarker: LogMarker = MarkerMap()
     Await.result(ES.getImage(id), fiveSeconds)
   }
 
   def indexedImage(id: String) = {
+    implicit val logMarker: LogMarker = MarkerMap()
     Thread.sleep(1000) // TODO use eventually clause
     Await.result(ES.getImage(id), fiveSeconds)
   }

--- a/thrall/test/lib/elasticsearch/SyndicationRightsOpsTest.scala
+++ b/thrall/test/lib/elasticsearch/SyndicationRightsOpsTest.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch
 
 import java.util.UUID
 
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model.{Image, Photoshoot, SyndicationRights}
 import org.joda.time.DateTime
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -12,12 +13,16 @@ class SyndicationRightsOpsTest extends ElasticSearchTestBase {
   lazy val syndRightsOps = new SyndicationRightsOps(ES)
 
   def withImage(image: Image)(test: Image => Unit): Unit = {
+    implicit val logMarker: LogMarker = MarkerMap()
+
     ES.indexImage(image.id, Json.toJson(image))
     Thread.sleep(1000)
     test(image)
   }
 
   def withPhotoshoot(photoshoot: Photoshoot)(test: List[Image] => Unit): Unit = {
+    implicit val logMarker: LogMarker = MarkerMap()
+
     val images = (1 to 5).map { _ =>
       val image = imageWithPhotoshoot(photoshoot)
       ES.indexImage(image.id, Json.toJson(image))
@@ -31,6 +36,7 @@ class SyndicationRightsOpsTest extends ElasticSearchTestBase {
 
   private def makeSyndicationRightsInferred(imageWithRights: Image): Option[SyndicationRights] = imageWithRights.syndicationRights.map(_.copy(isInferred = true))
 
+  implicit val logMarker = MarkerMap()
   implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 
   "SyndicationRightsOps" - {

--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -3,6 +3,7 @@ package lib.kinesis
 import java.util.UUID
 
 import com.gu.mediaservice.lib.aws.{BulkIndexRequest, UpdateMessage}
+import com.gu.mediaservice.lib.logging.MarkerMap
 import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
 import com.gu.mediaservice.model.{Collection, Crop, Edits, Image, ImageMetadata, SyndicationRights}
@@ -17,6 +18,7 @@ import scala.util.{Success, Try}
 
 
 class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
+  implicit val logMarker = MarkerMap()
   "MessageProcessor" - {
     val messageProcessor = new MessageProcessor(
       es = ES,
@@ -62,7 +64,7 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
             syndicationRights = None,
             bulkIndexRequest = None
           )
-          (Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds))  ) shouldBe expected
+          (Try(Await.result(messageProcessor.updateImageUsages(message, logMarker), fiveSeconds))  ) shouldBe expected
         }
         "not crash for an image that doesn't exist 👻🖼" in {
           val expected: Success[List[ElasticSearchUpdateResponse]] = Success(List(ElasticSearchUpdateResponse()))
@@ -83,7 +85,7 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
             syndicationRights = None,
             bulkIndexRequest = None
           )
-         Try(Await.result(messageProcessor.updateImageUsages(message), fiveSeconds))  shouldBe expected
+         Try(Await.result(messageProcessor.updateImageUsages(message, logMarker), fiveSeconds))  shouldBe expected
         }
       }
     }


### PR DESCRIPTION

## What does this change?

Every place where previously we'd created a new log marker in thrall, I've created a new `MarkerContext` and passed that down. 

We create new `MarkerContext`s from an existing (explicit) `MarkerContext` and a `Map[String,Any]`- use the map to create a brand new Marker, add any Marker present in the existing context and then create and return a new `MarkerContext`. 

We've agreed that this should be as explicit as possible, so I'm going through and making it so.

I think it's currently functional, but I'm going to go and make it explicit when it creates the initial context from the message. 

Where we have a function which doesn't do anything to a `MarkerContext` I've just left it implicit. 
 
## How can success be measured?

More details in logs!

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
