### PR TITLE
Add "reason" for error in logs

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
@@ -39,7 +39,10 @@ trait ElasticSearchExecutions {
 
     result.failed.foreach { e =>
       val elapsed = System.currentTimeMillis() - start
-      val markers = MarkerContext(durationMarker(elapsed))
+      val markers = MarkerContext(appendEntries(Map(
+        "duration" -> elapsed,
+        "reason" -> e.getClass.getName
+      ).asJava))
       Logger.error(s"$message - query failed after $elapsed ms: ${e.getMessage} cs: ${e.getCause}")(markers)
     }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/ElasticSearchSyntax.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/ElasticSearchSyntax.scala
@@ -44,7 +44,8 @@ trait ElasticSearchSyntax {
       result.failed.foreach { e =>
         val elapsed = System.currentTimeMillis() - start
         val markers = MarkerContext(appendEntries(Map(
-          "duration" -> elapsed
+          "duration" -> elapsed,
+          "reason" -> e.getClass.getName
         ).asJava))
 
         Logger.error(s"$message - query failed after $elapsed ms: ${e.getMessage} cs: ${e.getCause}")(markers)


### PR DESCRIPTION
## What does this change?
When logging at ERROR level, there isn't an easily identifiable field for what _type_ of error is occurring, making it hard to visualise the frequency of it happening.

This adds a field called `reason` to the logs, which will add the class name of the error in order to allow it to be grouped in visualisation metrics.

## How can success be measured?
The `reason` key is seen as part of error logs in ELK.

## Screenshots (if applicable)


## Who should look at this?
@guardian/digital-cms 


## Tested?
- [X] locally
- [X] on TEST
