### PR TITLE
ship logs to a local ELK stack

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -53,6 +53,8 @@ trait CommonConfig {
   val isProd: Boolean = stage == "PROD"
   val isDev: Boolean = stage == "DEV"
 
+  val localLogShipping: Boolean = sys.env.getOrElse("LOCAL_LOG_SHIPPING", "false").toBoolean
+
   lazy val thrallKinesisStream = properties("thrall.kinesis.stream.name")
 
   lazy val thrallKinesisEndpoint: String = properties.getOrElse("thrall.local.kinesis.url", kinesisAWSEndpoint)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridAppLoader.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridAppLoader.scala
@@ -10,6 +10,7 @@ abstract class GridAppLoader(loadFn: Context => GridComponents) extends Applicat
 
     val gridApp = loadFn(context)
     LogConfig.initKinesisLogging(gridApp.config)
+    LogConfig.initLocalLogShipping(gridApp.config)
 
     gridApp.application
   }

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -13,6 +13,11 @@ do
         IS_DEBUG=true
         shift
     fi
+
+    if [ "$arg" == "--ship-logs" ]; then
+        export LOCAL_LOG_SHIPPING=true
+        shift
+    fi
 done
 
 isInstalled() {


### PR DESCRIPTION
## What does this change?
Ship logs over TCP to a Logstash instance running locally with https://github.com/guardian/local-elk. This makes the observation of markers a lot easier and provides a smaller feedback loop as we don't need to deploy to TEST to confirm a marker is being written correctly.

Adds a new `--ship-logs` flag to `dev-start.sh` to conditionally ship logs. By default, logs are not shipped. Logs are only shipped when `stage=DEV` and the `--ship-logs` flag is provided.

Logs continue to get written to disk too.

Alternatives to this could be:
- Writing to a Kinesis stream (like PROD) that is running with [localstack](https://github.com/localstack/localstack) in local-elk. However, this is a lot of infrastructure.
- Use the [File input plugin](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-file.html). However this would mean mounting the log file of each service into local-elk, which isn't scalable.
- Run an ELK stack in Grid. However this isn't scalable to other Tools and apps. Writing to a standalone, local, ELK stack closely matches PROD; we can even ship ES logs to it, if needed, for example.

## How can success be measured?
Simpler interrogation of logs and a smaller feedback loop.

## Screenshots (if applicable)
Note the URL.

![image](https://user-images.githubusercontent.com/836140/76700560-9f3be000-66b0-11ea-9be0-4a06b8d23115.png)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
