### PR TITLE
Handle unknown errors as seperate state and too big metadatas

### DIFF
--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
@@ -1,5 +1,7 @@
 package com.gu.mediaservice
 
+import com.gu.mediaservice.indexing.IndexInputCreation
+
 class BatchIndexLambdaHandler {
 
   private val cfg = BatchIndexHandlerConfig(
@@ -12,17 +14,20 @@ class BatchIndexLambdaHandler {
     batchSize = sys.env("BATCH_SIZE").toInt,
     maxIdleConnections = sys.env("MAX_IDLE_CONNECTIONS").toInt,
     stage = sys.env.get("STAGE"),
-    threshold = sys.env.get("LATENCY_THRESHOLD").map(t => Integer.parseInt(t))
+    threshold = sys.env.get("LATENCY_THRESHOLD").map(t => Integer.parseInt(t)),
+    maxSize = 5000,
+    startState = IndexInputCreation.NotStarted
   )
 
   private val batchIndex = new BatchIndexHandler(cfg)
+
 
   def handleRequest() = {
     batchIndex.processImages()
   }
 
   def handleCheckRequest() = {
-    batchIndex.processImages()
+    batchIndex.checkImages()
   }
 
 }

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
@@ -15,8 +15,8 @@ class BatchIndexLambdaHandler {
     maxIdleConnections = sys.env("MAX_IDLE_CONNECTIONS").toInt,
     stage = sys.env.get("STAGE"),
     threshold = sys.env.get("LATENCY_THRESHOLD").map(t => Integer.parseInt(t)),
-    maxSize = 5000,
-    startState = IndexInputCreation.NotStarted
+    maxSize = sys.env("MAX_SIZE").toInt,
+    startState = IndexInputCreation.get(sys.env("START_STATE").toInt)
   )
 
   private val batchIndex = new BatchIndexHandler(cfg)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -52,7 +52,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
   private val ImagesProjectionTimeout = new FiniteDuration(ProjectionTimeoutInSec, TimeUnit.MINUTES)
   private val gridClient = GridClient(maxIdleConnections, debugHttpResponse = false)
 
-  private val ImagesBatchProjector = new ImagesBatchProjection(apiKey, projectionEndpoint, ImagesProjectionTimeout, gridClient)
+  private val ImagesBatchProjector = new ImagesBatchProjection(apiKey, projectionEndpoint, ImagesProjectionTimeout, gridClient, maxSize)
   private val AwsFunctions = new BatchIndexHandlerAwsFunctions(cfg)
   private val InputIdsStore = new InputIdsStore(AwsFunctions.buildDynamoTableClient, batchSize)
 
@@ -124,7 +124,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
     if (!validApiKey(projectionEndpoint)) throw new IllegalStateException("invalid api key")
     val stateProgress = scala.collection.mutable.ArrayBuffer[ProduceProgress]()
     stateProgress += NotStarted
-    val mediaIdsFuture = getUnprocessedMediaIdsBatch
+    val mediaIdsFuture = getUnprocessedMediaIdsBatch(startState)
     val mediaIds = Await.result(mediaIdsFuture, GetIdsTimeout)
     logger.info(s"got ${mediaIds.size}, unprocessed mediaIds, $mediaIds")
     Try {
@@ -194,11 +194,11 @@ class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
 
   import InputIdsStore._
 
-  def getUnprocessedMediaIdsBatch(implicit ec: ExecutionContext): Future[List[String]] = Future {
+  def getUnprocessedMediaIdsBatch(unprocessedState: ProduceProgress)(implicit ec: ExecutionContext): Future[List[String]] = Future {
     logger.info("attempt to get mediaIds batch from dynamo")
     val querySpec = new QuerySpec()
       .withKeyConditionExpression(s"$StateField = :sub")
-      .withValueMap(new ValueMap().withNumber(":sub", NotStarted.stateId))
+      .withValueMap(new ValueMap().withNumber(":sub", unprocessedState.stateId))
       .withMaxResultSize(batchSize)
     val mediaIds = table.getIndex(StateField).query(querySpec).asScala.toList.map(it => {
       val json = Json.parse(it.toJSON).as[JsObject]

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -29,7 +29,9 @@ case class BatchIndexHandlerConfig(
                                     kinesisMaximumMetric: Option[(String, Integer)] = None,
                                     maxIdleConnections: Int,
                                     stage: Option[String],
-                                    threshold: Option[Integer]
+                                    threshold: Option[Integer],
+                                    startState: ProduceProgress,
+                                    maxSize: Int
                                   )
 
 case class SuccessResult(foundImagesCount: Int, notFoundImagesCount: Int, progressHistory: String, projectionTookInSec: Long)
@@ -288,10 +290,22 @@ class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
   }
 
   // used in situation if something failed in a expected way and we want to ignore that file in next batch
-  def setStateToKnownError(id: String): ProduceProgress = {
+   def setStateToKnownError(id: String): ProduceProgress = {
     logger.info("setting item to KnownError state to ignore it next time")
     updateItemSate(id, KnownError.stateId)
     KnownError
+  }
+
+  def setStateToUnknownError(id: String): ProduceProgress = {
+    logger.info("setting item to UnknownError state to ignore it next time")
+    updateItemSate(id, UnknownError.stateId)
+    UnknownError
+  }
+
+  def setStateToTooBig(id: String): ProduceProgress = {
+    logger.info("setting item to TooBig state to ignore it next time")
+    updateItemSate(id, TooBig.stateId)
+    TooBig
   }
 
   private def updateItemSate(id: String, state: Int) = {

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -23,20 +23,27 @@ class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duratio
       val projectionUrl = new URL(s"$projectionEndpoint/$id")
       val responseFuture: Future[ResponseWrapper] = gridClient.makeGetRequestAsync(projectionUrl, apiKey)
       val notFoundOrImage: Future[Option[Either[Image, String]]] = responseFuture.map { response =>
-        if (response.statusCode == 200) {
-          val img = response.body.as[Image]
-          Some(Left(img))
-        } else if (response.statusCode == 404) {
-          InputIdsStore.updateStateToNotFoundImage(id)
-          Some(Right(id))
-        } else {
-          if (isAKnownError(response)) {
-            InputIdsStore.setStateToKnownError(id)
-          } else {
-            // for example server temporary inaccessible
-            InputIdsStore.resetItemState(id)
+        response.statusCode match {
+          case 200 if response.bodyAsString.size > 5000 => {
+            InputIdsStore.setStateToTooBig(id)
+            None
           }
-          None
+          case 200 => {
+            val img = response.body.as[Image]
+            Some(Left(img))
+          }
+          case 404 => {
+            InputIdsStore.updateStateToNotFoundImage(id)
+            Some(Right(id))
+          }
+          case _ if (isAKnownError(response)) => {
+            InputIdsStore.setStateToKnownError(id)
+            None
+          }
+          case _ => {
+            InputIdsStore.setStateToUnknownError(id)
+            None
+          }
         }
       }
       notFoundOrImage
@@ -78,7 +85,8 @@ class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duratio
   }
 
   private val KnownErrors = List(
-    "org.im4java.core.CommandException"
+    "org.im4java.core.CommandException",
+    "End of data reached."
   )
 
   private def isAKnownError(res: ResponseWrapper): Boolean =

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -7,7 +7,7 @@ import com.gu.mediaservice.model.Image
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duration, gridClient: GridClient) {
+class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duration, gridClient: GridClient, maxSize: Int) {
 
   private implicit val ThrottledExecutionContext = ExecutionContext.fromExecutor(java.util.concurrent.Executors.newFixedThreadPool(5))
 
@@ -24,7 +24,7 @@ class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duratio
       val responseFuture: Future[ResponseWrapper] = gridClient.makeGetRequestAsync(projectionUrl, apiKey)
       val notFoundOrImage: Future[Option[Either[Image, String]]] = responseFuture.map { response =>
         response.statusCode match {
-          case 200 if response.bodyAsString.size > 5000 => {
+          case 200 if response.bodyAsString.size > maxSize => {
             InputIdsStore.setStateToTooBig(id)
             None
           }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
@@ -15,6 +15,9 @@ package object indexing {
     val Locating = ProduceProgress("looking for image",5)
     val Found = ProduceProgress("image found", 6)
     val Inconsistent = ProduceProgress("re-ingested image not found in media-api", 7)
+    val UnknownError = ProduceProgress("blacklisted because of unknown failure", 8)
+    val TooBig = ProduceProgress("too big, putting back down", 9001)
+
   }
 
 }

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
@@ -18,6 +18,22 @@ package object indexing {
     val UnknownError = ProduceProgress("blacklisted because of unknown failure", 8)
     val TooBig = ProduceProgress("too big, putting back down", 9001)
 
+    val all = List(
+      NotStarted,
+      InProgress,
+      NotFound,
+      Finished,
+      Reset,
+      KnownError,
+      Locating,
+      Found,
+      Inconsistent,
+      UnknownError,
+      TooBig
+    )
+
+    def get(id: Int) = all.find(_.stateId == id).getOrElse(NotStarted)
+
   }
 
 }


### PR DESCRIPTION
## What does this change?

This adds two new statuses for images that have big projections or failed for an unknown reasons.
This also adds `End of data reached.` as a known error.

Todo: add new params as stack params
## How can success be measured?

Not gumming up thrall.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
