### PR TITLE
Overlap thrall timeout (now 20s) with client timeout (now 30s)

### DIFF
--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -90,7 +90,7 @@ async.factory('poll',
 async.factory('apiPoll', ['poll', function(poll) {
 
   const pollFrequency = 500; // ms
-  const pollTimeout   = 20 * 1000; // ms
+  const pollTimeout   = 30 * 1000; // ms
 
   return func => poll(func, pollFrequency, pollTimeout);
 }]);

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -29,7 +29,7 @@ class ThrallEventConsumer(es: ElasticSearch,
                           bulkIndexS3Client: BulkIndexS3Client,
                           actorSystem: ActorSystem) extends IRecordProcessor with PlayJsonHelpers {
 
-  private val attemptTimeout = FiniteDuration(30, SECONDS)
+  private val attemptTimeout = FiniteDuration(20, SECONDS)
   private val delay = FiniteDuration(5, SECONDS)
   private val attempts = 2
   private val timeout = attemptTimeout * attempts + delay * (attempts - 1)


### PR DESCRIPTION
## What does this change?

This reduces the thrall task timeout from 30s to 20s, and increases the client timeout from 20s to 30s. ↩️ 

Thrall reads block the queue for longer than we poll for. By having the polling time overlap the maximum queue block time, we hope that the client will pick up successful writes more often.

## How can success be measured?

Users experience fewer problems in production as large messages are processed. This is difficult to measure precisely – any ideas, please let me know!

## Tested?
- [x] locally
- [ ] on TEST
