### PR TITLE
Reduce retry delay

### DIFF
--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -17,7 +17,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaReads, Json, Reads}
 import play.api.{Logger, MarkerContext}
 
-import scala.concurrent.duration.{FiniteDuration, SECONDS}
+import scala.concurrent.duration.{FiniteDuration, SECONDS, MILLISECONDS}
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.util.{Failure, Success, Try}
 
@@ -30,7 +30,7 @@ class ThrallEventConsumer(es: ElasticSearch,
                           actorSystem: ActorSystem) extends IRecordProcessor with PlayJsonHelpers {
 
   private val attemptTimeout = FiniteDuration(20, SECONDS)
-  private val delay = FiniteDuration(5, SECONDS)
+  private val delay = FiniteDuration(1, MILLISECONDS)
   private val attempts = 2
   private val timeout = attemptTimeout * attempts + delay * (attempts - 1)
 


### PR DESCRIPTION
## What does this change?

Reduce the retry delay, which we hope will stop the queue blocking for long durations on retry.

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

## Tested?
- [ ] locally
- [ ] on TEST
