### PR TITLE
document the flags available for dev-start.sh

### DIFF
--- a/docs/03-running.md
+++ b/docs/03-running.md
@@ -6,6 +6,13 @@ Once all the requirements have been installed and you have configuration files, 
 ./dev-start.sh
 ```
 
+`./dev-start.sh` has two flags:
+
+- `--debug` which will make port `5005` available for [debugging in IntelliJ](https://www.jetbrains.com/help/idea/attaching-to-local-process.html)
+- `--ship-logs` which will ship logs to a [local elk](https://github.com/guardian/local-elk) stack over tcp on port `5000`.
+Grid decorates log lines with markers which allow dashboards to be made to observe the health of the microservices.
+Pushing these logs to a local ELK stack provides a nicer experience than tailing log files.
+
 ## Client Side code
 Grid uses webpack to bundle client side code. Run the following from the `kahuna` directory to watch for changes:
 
@@ -14,13 +21,13 @@ npm run watch
 ```
 
 ## `the_pingler.sh`
-Grid consists of many micro-services. Some services don't compile until you hit them for the first time. 
+Grid consists of many micro-services. Some services don't compile until you hit them for the first time.
 There is a script included that will do this for you called [the_pingler.sh](../the_pingler.sh).
 
 This is a simple shell script that keeps pinging the healthcheck endpoints of the various
 services and reports it via the colour of the URL.  This is needed because some services do
 not start to function correctly until they have been contacted at least once.
-It's recommended to keep this running in the background while you have the stack started up 
+It's recommended to keep this running in the background while you have the stack started up
 and keep it running in a background terminal.
 
 ```bash


### PR DESCRIPTION
## What does this change?
Since https://github.com/guardian/grid/pull/2861 we have the ability to view logs in a local ELK stack, which is useful for ensuring your markers are correct, or even just for searching through logs.

This PR adds some documentation for this.

## How can success be measured?
More obvious how to view local logs in a local ELK stack.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
