### PR TITLE
Make lambda helper stateless for ease of re-use

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/AwsHelpers.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/AwsHelpers.scala
@@ -22,7 +22,7 @@ import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.Json
 import scala.collection.JavaConverters._
 
-object BatchIndexHandlerAwsFunctions extends LazyLogging {
+object AwsHelpers extends LazyLogging {
   val AwsRegion: String = "eu-west-1"
 
   lazy val awsCredentials = new AWSCredentialsProviderChain(

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandlerAwsFunctions.scala
@@ -22,8 +22,7 @@ import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.Json
 import scala.collection.JavaConverters._
 
-object BatchIndexHandlerAwsFunctions {
-
+object BatchIndexHandlerAwsFunctions extends LazyLogging {
   val AwsRegion: String = "eu-west-1"
 
   lazy val awsCredentials = new AWSCredentialsProviderChain(
@@ -31,25 +30,9 @@ object BatchIndexHandlerAwsFunctions {
     new EnvironmentVariableCredentialsProvider()
   )
 
-  def buildDynamoTableClient(dynamoTableName: String): Table = {
-    val builder = AmazonDynamoDBClient.builder()
-      .withRegion(AwsRegion)
-      .withCredentials(awsCredentials)
-    val dynamo = new AwsDynamoDB(builder.build())
-    dynamo.getTable(dynamoTableName)
-  }
-
-}
-
-class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLogging {
-
   private val s3client = buildS3Client
-  private val kinesis = buildKinesisClient
 
-  import BatchIndexHandlerAwsFunctions.{awsCredentials, AwsRegion}
-  import cfg._
-
-  def putToS3(imageBlobs: List[Image]): BulkIndexRequest = {
+  def putToS3(imageBlobs: List[Image], batchIndexBucket: String): BulkIndexRequest = {
     import Json.{stringify, toJson}
     val imagesJsonArray = stringify(toJson(imageBlobs))
     val bArr = imagesJsonArray.getBytes
@@ -62,20 +45,20 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
     BulkIndexRequest(batchIndexBucket, key)
   }
 
-  def putToKinesis(message: UpdateMessage): Unit = {
+  def putToKinesis(message: UpdateMessage, streamName: String, client: AmazonKinesis): Unit = {
     logger.info("attempting to put message to kinesis")
     val payload = JsonByteArrayUtil.toByteArray(message)
     val partitionKey = UUID.randomUUID().toString
     val putReq = new PutRecordRequest()
-      .withStreamName(kinesisStreamName)
+      .withStreamName(streamName)
       .withPartitionKey(partitionKey)
       .withData(ByteBuffer.wrap(payload))
 
-    val res = kinesis.putRecord(putReq)
-    logger.info(s"PUT [$message] message to kinesis stream: $kinesisStreamName response: $res")
+    val res = client.putRecord(putReq)
+    logger.info(s"PUT [$message] message to kinesis stream: $streamName response: $res")
   }
 
-  def checkKinesisIsNiceAndFast: Boolean = {
+  def checkKinesisIsNiceAndFast(stage: Option[String], threshold: Option[Integer]): Boolean = {
     stage match {
       case None => true // did not get a stage. presume it's not prod and go ahead.
       case Some(actualStage) =>
@@ -90,7 +73,7 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
 
             val dimensionValue = s"media-service-thrall-${actualStage.toUpperCase}"
             val endTime: Date = new Date() // now!
-            val startTime: Date = new Date(endTime.getTime - 5 * 60 * 1000L) // five minutes ago
+          val startTime: Date = new Date(endTime.getTime - 5 * 60 * 1000L) // five minutes ago
 
             val dimension = new Dimension()
               .withName("StreamName")
@@ -121,16 +104,7 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
     }
   }
 
-  private def buildS3Client = {
-    val builder = AmazonS3ClientBuilder.standard().withRegion(AwsRegion)
-    builder.withCredentials(awsCredentials).build()
-  }
-
-  def buildDynamoTableClient: Table = {
-    BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTableName)
-  }
-
-  private def buildKinesisClient: AmazonKinesis = {
+  def buildKinesisClient(kinesisEndpoint: Option[String] = None): AmazonKinesis = {
     val baseBuilder = AmazonKinesisClientBuilder.standard()
     val builder = kinesisEndpoint match {
       case Some(uri) =>
@@ -143,9 +117,23 @@ class BatchIndexHandlerAwsFunctions(cfg: BatchIndexHandlerConfig) extends LazyLo
     builder.withCredentials(awsCredentials).build()
   }
 
+  def buildDynamoTableClient(dynamoTableName: String): Table = {
+    val builder = AmazonDynamoDBClient.builder()
+      .withRegion(AwsRegion)
+      .withCredentials(awsCredentials)
+    val dynamo = new AwsDynamoDB(builder.build())
+    dynamo.getTable(dynamoTableName)
+  }
+
   private def buildCloudWatchClient: AmazonCloudWatch = AmazonCloudWatchAsyncClientBuilder
     .standard()
     .withRegion(AwsRegion)
     .withCredentials(awsCredentials)
     .build()
+
+
+  private def buildS3Client = {
+    val builder = AmazonS3ClientBuilder.standard().withRegion(AwsRegion)
+    builder.withCredentials(awsCredentials).build()
+  }
 }

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -12,7 +12,7 @@ object ImagesGroupByProgressState extends App with LazyLogging {
   import InputIdsStore._
 
   private val dynamoTable = args(0)
-  private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
+  private val ddbClient = AwsHelpers.buildDynamoTableClient(dynamoTable)
   private val stateIndex = ddbClient.getIndex(StateField)
 
   def execute() = {

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetImageBatchIndexTable.scala
@@ -11,7 +11,7 @@ object ResetImageBatchIndexTable extends App with LazyLogging {
   if (args.isEmpty) throw new IllegalArgumentException("please provide dynamo table name")
 
   private val dynamoTable = args(0)
-  private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
+  private val ddbClient = AwsHelpers.buildDynamoTableClient(dynamoTable)
 
   def execute(batchSize: Int) = {
     val InputIdsStore = new InputIdsStore(ddbClient, batchSize)

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ResetKnownErrors.scala
@@ -14,7 +14,7 @@ object ResetKnownErrors extends App with LazyLogging {
   import InputIdsStore._
 
   private val dynamoTable = args(0)
-  private val ddbClient = BatchIndexHandlerAwsFunctions.buildDynamoTableClient(dynamoTable)
+  private val ddbClient = AwsHelpers.buildDynamoTableClient(dynamoTable)
   private val stateIndex = ddbClient.getIndex(StateField)
 
   def execute() = {


### PR DESCRIPTION
## What does this change?

A quick refactor to make the lambda helper stateless, passing in only what's needed for configuration for each call.

This decouples it from large config objects, which makes it easier to use elsewhere – for example, in the upcoming single image ingest lambda.

## How can success be measured?

It should be easier for developers to use this object outside of the BatchIndexLambdaHandler context for which it was first created.

## Tested?
- [x] locally
- [ ] on TEST
