### PR TITLE
Add drag-data to image thumbnail

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -34,7 +34,8 @@
                         <div class="image-crop"
                              ng:class="{'image-crop--selected': !ctrl.crop}">
                             <a draggable="true"
-                                ui:sref="{ crop: null }">
+                                ui:sref="{ crop: null }"
+                                ui:drag-data="ctrl.image | asImageDragData">
                                 <img class="image-crop__image"
                                      alt="original image thumbnail"
                                      ng:src="{{:: ctrl.image.data.thumbnail | assetFile }}" />


### PR DESCRIPTION
## What does this change?
One can drag an image to InDesign from the browser, from viewer’s main image and from crop thumbs. This change allows doing it also from image (top) thumb in the viewer. Dragging a selection of multiple images to InDesign from the browser I intend to attend to in the next 5–10 years. Watch this space. Intently.

## How can success be measured?
I can drag to InDesign from wherever I want.

## Screenshots
![image](https://user-images.githubusercontent.com/6032869/77127360-0dcbc580-6a44-11ea-82f2-17e7e7049550.png)

## Tested?
- [x] locally
- [ ] on TEST
