### PR TITLE
Clicking new images ticker scrolls to top

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -248,7 +248,7 @@ results.controller('SearchResultsCtrl', [
             // FIXME: should ideally be able to just call $state.reload(),
             // but there seems to be a bug (alluded to in the docs) when
             // notify is false, so forcing to true explicitly instead:
-            window.scrollTo(0,0);
+            $window.scrollTo(0,0);
             $state.transitionTo($state.current, $stateParams, {
                 reload: true, inherit: false, notify: true
             });

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -248,6 +248,7 @@ results.controller('SearchResultsCtrl', [
             // FIXME: should ideally be able to just call $state.reload(),
             // but there seems to be a bug (alluded to in the docs) when
             // notify is false, so forcing to true explicitly instead:
+            window.scrollTo(0,0);
             $state.transitionTo($state.current, $stateParams, {
                 reload: true, inherit: false, notify: true
             });


### PR DESCRIPTION
## What does this change?
It makes clicking ticker scroll to top to see these new arrivals. Took me three days of blindly pasting half the internets in between random parentheses.
Now, we need to have a better way of *always* keeping current view (of specific images): when images disappear because of deletion, on coming back from the viewer to the browser that loaded more images at the top or, as much as we can, even on search changes. But clicking this ticker is a clear declaration of intent: _I want to see them_. Once we have a good way of keeping current view, we could debate if we should scroll to the top like here or, maybe, to where new arrivals meet what one already have seen. For now, this will do. 

## How can success be measured?
Success is for the weak.

![2020-03-22 20 50 11](https://user-images.githubusercontent.com/6032869/77260380-7e125b00-6c7f-11ea-8ce1-91b1d24c45af.gif)

## Who should look at this?
Mr. Bot.

## Tested?
- [x] locally
- [ ] on TEST
