### PR TITLE
Revert "Revert "Improve image-loader controller structure"" and fix the response code.

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -145,7 +145,7 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
         .map {
           r => {
             Logger.info("importImage request end")
-            Ok(r)
+            Accepted(r)
           }
         }
         .recover {

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -1,40 +1,35 @@
 package controllers
 
-import java.io.{File, FileOutputStream}
+import java.io.File
 import java.net.URI
 
-import com.amazonaws.services.s3.model.S3Object
-import com.gu.mediaservice.lib.{DateTimeUtils, ImageIngestOperations}
+import com.gu.mediaservice.lib.{DateTimeUtils , ImageIngestOperations}
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
-import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth._
-import com.gu.mediaservice.lib.aws.{S3Ops, UpdateMessage}
 import com.gu.mediaservice.lib.logging.{FALLBACK, RequestLoggingContext}
-import com.gu.mediaservice.model.{Image, UploadInfo}
 import lib._
-import lib.imaging.MimeTypeDetection
+import lib.imaging.{ImageLoaderException, Importer, NoSuchImageExistsInS3, Projector, UserImageLoaderException}
 import lib.storage.ImageLoaderStore
-import model.{ImageUploadOps, ImageUploadProjector, S3FileExtractedMetadata, UploadRequest}
-import net.logstash.logback.marker.LogstashMarker
-import org.apache.tika.io.IOUtils
-import org.joda.time.DateTime
+import model.{ImageUploadOps, ImageUploadProjector}
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success, Try}
 
 class ImageLoaderController(auth: Authentication, downloader: Downloader, store: ImageLoaderStore, notifications: Notifications,
                             config: ImageLoaderConfig, imageUploadOps: ImageUploadOps, imageUploadProjector: ImageUploadProjector,
                             override val controllerComponents: ControllerComponents, wSClient: WSClient)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
-  val indexResponse: Result = {
+  private val imageProjector = new Projector(config)
+  private val imageImporter = new Importer(config, imageUploadOps, notifications, store)
+
+  private lazy val indexResponse: Result = {
     val indexData = Map("description" -> "This is the Loader Service")
     val indexLinks = List(
       Link("load", s"${config.rootUri}/images{?uploadedBy,identifiers,uploadTime,filename}"),
@@ -43,213 +38,149 @@ class ImageLoaderController(auth: Authentication, downloader: Downloader, store:
     respond(indexData, indexLinks)
   }
 
-  def index = auth {
-    indexResponse
-  }
+  def index: Action[AnyContent] = auth { indexResponse }
 
-  private def createTempFile(prefix: String, requestContext: RequestLoggingContext) = {
-    Logger.info(s"creating temp file in ${config.tempDir}")(requestContext.toMarker())
-    File.createTempFile(prefix, "", config.tempDir)
-  }
-
-  def loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]) = {
-    val requestContext = RequestLoggingContext(
+  def loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]): Action[DigestedFile] = {
+    implicit val context: RequestLoggingContext = RequestLoggingContext(
       initialMarkers = Map(
-        "requestType" -> "load-image"
+        "requestType" -> "load-image",
+        "uploadedBy" -> uploadedBy.getOrElse(FALLBACK),
+        "identifiers" -> identifiers.getOrElse(FALLBACK),
+        "uploadTime" -> uploadTime.getOrElse(FALLBACK),
+        "filename" -> filename.getOrElse(FALLBACK)
       )
     )
 
-    val markers = Map(
-      "uploadedBy" -> uploadedBy.getOrElse(FALLBACK),
-      "identifiers" -> identifiers.getOrElse(FALLBACK),
-      "uploadTime" -> uploadTime.getOrElse(FALLBACK),
-      "filename" -> filename.getOrElse(FALLBACK)
-    )
+    Logger.info("loadImage request start")
 
-    Logger.info("loadImage request start")(requestContext.toMarker(markers))
+    // synchronous write to file
+    val tempFile = createTempFile("requestBody")
+    Logger.info("body parsed")
+    val parsedBody = DigestBodyParser.create(tempFile)
 
-    val parsedBody = DigestBodyParser.create(createTempFile("requestBody", requestContext))
-    Logger.info("body parsed")(requestContext.toMarker(markers))
-
+    // asynchronous load, store and delete
     auth.async(parsedBody) { req =>
-      val result = loadFile(req.body, req.user, uploadedBy, identifiers, DateTimeUtils.fromValueOrNow(uploadTime), filename, requestContext)
-      Logger.info("loadImage request end")(requestContext.toMarker(markers))
-      result
+      val result = for {
+        uploadRequest <- imageImporter.loadFile(
+          req.body,
+          req.user,
+          uploadedBy,
+          identifiers,
+          DateTimeUtils.fromValueOrNow(uploadTime),
+          filename.flatMap(_.trim.nonEmptyOpt),
+          context)
+        result <- imageImporter.storeFile(uploadRequest)
+      } yield result
+
+      result.onComplete( _ => Try { deleteTempFile(tempFile) } )
+
+      result map { r =>
+        Ok(r)
+      } recover {
+        case e: ImageLoaderException => InternalServerError(Json.obj("error" -> e.getMessage))
+      }
     }
   }
 
-  private def getSrcFileDigestForProjection(s3Src: S3Object, imageId: String, requestLoggingContext: RequestLoggingContext) = {
-    val uploadedFile = createTempFile(s"projection-${imageId}", requestLoggingContext)
-    IOUtils.copy(s3Src.getObjectContent, new FileOutputStream(uploadedFile))
-    DigestedFile(uploadedFile, imageId)
-  }
-
-  def projectImageBy(imageId: String) = {
-    val requestContext = RequestLoggingContext(
+  // Fetch
+  def projectImageBy(imageId: String): Action[AnyContent] = {
+    implicit val requestContext: RequestLoggingContext = RequestLoggingContext(
       initialMarkers = Map(
         "imageId" -> imageId,
         "requestType" -> "image-projection"
       )
     )
 
-    auth { _ =>
-      projectS3ImageById(imageId, requestContext) match {
-        case Success(maybeImage) =>
-          maybeImage match {
-            case Some(img) => {
-              Logger.info("image found")(requestContext.toMarker())
-              Ok(Json.toJson(img)).as(ArgoMediaType)
-            }
-            case None =>
-              val s3Path = "s3://" + config.imageBucket + "/" + ImageIngestOperations.fileKeyFromId(imageId)
-              Logger.info("image not found")(requestContext.toMarker())
-              respondError(NotFound, "image-not-found", s"Could not find image: $imageId in s3 at $s3Path")
-          }
-        case Failure(error) => {
-          Logger.error(s"image projection failed", error)(requestContext.toMarker())
-          respondError(InternalServerError, "image-projection-failed", error.getMessage)
-        }
+    val tempFile = createTempFile(s"projection-$imageId")
+    auth.async { _ =>
+      val result= imageProjector.projectS3ImageById(imageUploadProjector, imageId, requestContext, tempFile)
+
+      result.onComplete( _ => Try { deleteTempFile(tempFile) } )
+
+      result.map {
+        case Some(img) =>
+          Logger.info("image found")
+          Ok(Json.toJson(img)).as(ArgoMediaType)
+        case None =>
+          val s3Path = "s3://" + config.imageBucket + "/" + ImageIngestOperations.fileKeyFromId(imageId)
+          Logger.info("image not found")
+          respondError(NotFound, "image-not-found", s"Could not find image: $imageId in s3 at $s3Path")
+      } recover {
+        case _: NoSuchImageExistsInS3 => NotFound(Json.obj("imageId" -> imageId))
+        case _ => InternalServerError(Json.obj("imageId" -> imageId))
       }
+
     }
   }
 
-  def importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]) = {
+  def importImage(
+                   uri: String,
+                   uploadedBy: Option[String],
+                   identifiers: Option[String],
+                   uploadTime: Option[String],
+                   filename: Option[String]
+                 ): Action[AnyContent] = {
     auth.async { request =>
-      val requestContext = RequestLoggingContext(
+      implicit val requestContext: RequestLoggingContext = RequestLoggingContext(
         initialMarkers = Map(
-          "requestType" -> "import-image"
+          "requestType" -> "import-image",
+          "key-tier" -> request.user.accessor.tier.toString,
+          "key-name" -> request.user.accessor.identity
         )
       )
-      val apiKey = request.user.accessor
 
-      Logger.info("importImage request start")(requestContext.toMarker(Map(
-        "key-tier" -> apiKey.tier.toString,
-        "key-name" -> apiKey.identity
-      )))
-      Try(URI.create(uri)) map { validUri =>
-        val tmpFile = createTempFile("download", requestContext)
+      Logger.info("importImage request start")
 
-        val result = downloader.download(validUri, tmpFile).flatMap { digestedFile =>
-          loadFile(digestedFile, request.user, uploadedBy, identifiers, DateTimeUtils.fromValueOrNow(uploadTime), filename, requestContext)
-        } recover {
-          case NonFatal(e) =>
-            Logger.error(s"Unable to download image $uri", e)
-            // Need to delete this here as a failure response will never have its onComplete method called.
-            tmpFile.delete()
-            FailureResponse.failedUriDownload
+      val tempFile = createTempFile("download")
+      val result = for {
+        validUri <- Future { URI.create(uri) }
+        digestedFile <- downloader.download(validUri, tempFile)
+        uploadRequest <- imageImporter.loadFile(digestedFile, request.user, uploadedBy, identifiers, DateTimeUtils.fromValueOrNow(uploadTime), filename.flatMap(_.trim.nonEmptyOpt), requestContext)
+        result <- imageImporter.storeFile(uploadRequest)
+      } yield result
+
+      result.onComplete( _ => Try { deleteTempFile(tempFile) } )
+
+      result
+        .map {
+          r => {
+            Logger.info("importImage request end")
+            Ok(r)
+          }
         }
-
-        result onComplete (_ => tmpFile.delete())
-        Logger.info("importImage request end")(requestContext.toMarker(Map(
-          "key-tier" -> apiKey.tier.toString,
-          "key-name" -> apiKey.identity
-        )))
-        result
-
-      } getOrElse {
-        Logger.info("importImage request end")(requestContext.toMarker(Map(
-          "key-tier" -> apiKey.tier.toString,
-          "key-name" -> apiKey.identity
-        )))
-        Future.successful(FailureResponse.invalidUri)
+        .recover {
+        case _: IllegalArgumentException =>
+          Logger.warn("importImage request failed; invalid uri")
+          FailureResponse.invalidUri
+        case e: UserImageLoaderException =>
+          Logger.warn("importImage request failed; bad user input")
+          BadRequest(e.getMessage)
+        case NonFatal(_) =>
+          Logger.warn("importImage request failed")
+          FailureResponse.failedUriDownload
       }
-    }
-  }
-
-  private def projectS3ImageById(imageId: String, requestLoggingContext: RequestLoggingContext): Try[Option[Image]] = {
-    Logger.info(s"projecting image: $imageId")(requestLoggingContext.toMarker())
-
-    import ImageIngestOperations.fileKeyFromId
-    val s3Key = fileKeyFromId(imageId)
-    val s3 = S3Ops.buildS3Client(config)
-
-    if (!s3.doesObjectExist(config.imageBucket, s3Key)) return Try(None)
-
-    Logger.info(s"object exists, getting s3 object at s3://${config.imageBucket}/$s3Key to perform Image projection")(requestLoggingContext.toMarker())
-
-    val s3Source = s3.getObject(config.imageBucket, s3Key)
-    val digestedFile = getSrcFileDigestForProjection(s3Source, imageId, requestLoggingContext)
-    val extractedS3Meta = S3FileExtractedMetadata(s3Source.getObjectMetadata)
-
-    Try {
-      val finalImageFuture = imageUploadProjector.projectImage(digestedFile, extractedS3Meta, requestLoggingContext)
-      val finalImage = Await.result(finalImageFuture, Duration.Inf)
-      Some(finalImage)
-    }
-  }
-
-  private def loadFile(digestedFile: DigestedFile, user: Principal,
-               uploadedBy: Option[String], identifiers: Option[String],
-               uploadTime: DateTime, filename: Option[String], requestLoggingContext: RequestLoggingContext): Future[Result] = {
-    val DigestedFile(tempFile_, id_) = digestedFile
-
-    val uploadedBy_ = uploadedBy match {
-      case Some(by) => by
-      case None => Authentication.getIdentity(user)
-    }
-
-    // TODO: should error if the JSON parsing failed
-    val identifiers_ = identifiers.map(Json.parse(_).as[Map[String, String]]) getOrElse Map()
-
-    val uploadInfo_ = UploadInfo(filename.flatMap(_.trim.nonEmptyOpt))
-
-    Logger.info("Detecting mimetype")(requestLoggingContext.toMarker())
-    // Abort early if unsupported mime-type
-    val mimeType_ = MimeTypeDetection.guessMimeType(tempFile_)
-    Logger.info(s"Detected mimetype as ${mimeType_.getOrElse(FALLBACK)}")(requestLoggingContext.toMarker())
-
-    val uploadRequest = UploadRequest(
-      requestId = requestLoggingContext.requestId,
-      imageId = id_,
-      tempFile = tempFile_,
-      mimeType = mimeType_,
-      uploadTime = uploadTime,
-      uploadedBy = uploadedBy_,
-      identifiers = identifiers_,
-      uploadInfo = uploadInfo_
-    )
-
-    val supportedMimeType = config.supportedMimeTypes.exists(mimeType_.contains(_))
-
-    if (supportedMimeType) {
-      storeFile(uploadRequest, requestLoggingContext)
-    } else {
-      Future {
-        FailureResponse.unsupportedMimeType(uploadRequest, config.supportedMimeTypes)
-      }
-    }
-  }
-
-  def storeFile(uploadRequest: UploadRequest, requestLoggingContext: RequestLoggingContext): Future[Result] = {
-    val completeMarkers: LogstashMarker = requestLoggingContext.toMarker().and(uploadRequest.toLogMarker)
-
-    Logger.info("Storing file")(completeMarkers)
-    val result = for {
-      imageUpload <- imageUploadOps.fromUploadRequest(uploadRequest, requestLoggingContext)
-      image = imageUpload.image
-    } yield {
-      val updateMessage = UpdateMessage(subject = "image", image = Some(image))
-      notifications.publish(updateMessage)
-
-      // TODO: centralise where all these URLs are constructed
-      Accepted(Json.obj("uri" -> s"${config.apiUri}/images/${uploadRequest.imageId}")).as(ArgoMediaType)
-    }
-
-    result recover {
-      case e =>
-        Logger.warn(s"Failed to store file: ${e.getMessage}.", e)(completeMarkers)
-
-        store.deleteOriginal(uploadRequest.imageId).onComplete {
-          case Failure(err) => Logger.error(s"Failed to delete image for ${uploadRequest.imageId}: $err")(completeMarkers)
-          case _ =>
-        }
-        respondError(BadRequest, "upload-error", e.getMessage)
     }
   }
 
   // Find this a better home if used more widely
   implicit class NonEmpty(s: String) {
     def nonEmptyOpt: Option[String] = if (s.isEmpty) None else Some(s)
+  }
+
+  // To avoid Future _madness_, it is better to make temp files at the controller and pass them down,
+  // then clear them up again at the end.  This avoids leaks.
+  def createTempFile(prefix: String)(implicit requestContext: RequestLoggingContext): File = {
+    val tempFile = File.createTempFile(prefix, "", config.tempDir)
+    Logger.info(s"Created temp file ${tempFile.getName} in ${config.tempDir}")(requestContext.toMarker())
+    tempFile
+  }
+
+  def deleteTempFile(tempFile: File)(implicit requestContext: RequestLoggingContext): Future[Unit] = Future {
+    if (tempFile.delete()) {
+      Logger.info(s"Deleted temp file $tempFile")
+    } else {
+      Logger.warn(s"Unable to delete temp file $tempFile in ${config.tempDir}")
+    }
   }
 
 }

--- a/image-loader/app/lib/imaging/Importer.scala
+++ b/image-loader/app/lib/imaging/Importer.scala
@@ -1,0 +1,78 @@
+package lib.imaging
+
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.Principal
+import com.gu.mediaservice.lib.aws.UpdateMessage
+import com.gu.mediaservice.lib.logging.{FALLBACK, RequestLoggingContext}
+import com.gu.mediaservice.model.UploadInfo
+import lib.{DigestedFile, ImageLoaderConfig, Notifications}
+import model.{ImageUploadOps, UploadRequest}
+import net.logstash.logback.marker.LogstashMarker
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.{JsObject, Json}
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import lib.storage.ImageLoaderStore
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class Importer(
+                val config: ImageLoaderConfig,
+                val imageUploadOps: ImageUploadOps,
+                val notifications: Notifications,
+                val store: ImageLoaderStore) extends ArgoHelpers {
+
+  def loadFile(digestedFile: DigestedFile,
+               user: Principal,
+               uploadedBy: Option[String],
+               identifiers: Option[String],
+               uploadTime: DateTime,
+               filename: Option[String],
+               requestLoggingContext:
+               RequestLoggingContext)(implicit ec:ExecutionContext): Future[UploadRequest] = {
+    val DigestedFile(tempFile_, id_) = digestedFile
+
+    // Abort early if unsupported mime-type
+    val guessedMimeType = MimeTypeDetection.guessMimeType(tempFile_)
+    Logger.info(s"Detected mimetype as ${guessedMimeType.getOrElse(FALLBACK)}")(requestLoggingContext.toMarker())
+    val supportedMimeType = config.supportedMimeTypes.exists(guessedMimeType.contains(_))
+    if (!supportedMimeType)
+      throw new UnsupportedMimeTypeException(guessedMimeType.getOrElse("Not Provided"))
+
+    val uploadedBy_ = uploadedBy match {
+      case Some(by) => by
+      case None => Authentication.getIdentity(user)
+    }
+
+    // TODO: should error if the JSON parsing failed
+    val identifiersMap = identifiers.map(Json.parse(_).as[Map[String, String]]) getOrElse Map()
+
+    Future.successful(UploadRequest(
+      requestId = requestLoggingContext.requestId,
+      imageId = id_,
+      tempFile = tempFile_,
+      mimeType = guessedMimeType,
+      uploadTime = uploadTime,
+      uploadedBy = uploadedBy_,
+      identifiers = identifiersMap,
+      uploadInfo = UploadInfo(filename)
+    ))
+
+  }
+
+  def storeFile(uploadRequest: UploadRequest)(implicit requestLoggingContext: RequestLoggingContext, ec:ExecutionContext): Future[JsObject] = {
+    val completeMarkers: LogstashMarker = requestLoggingContext.toMarker().and(uploadRequest.toLogMarker)
+
+    Logger.info("Storing file")(completeMarkers)
+    for {
+      imageUpload <- imageUploadOps.fromUploadRequest(uploadRequest, requestLoggingContext)
+      updateMessage = UpdateMessage(subject = "image", image = Some(imageUpload.image))
+      _ <- Future { notifications.publish(updateMessage) }
+      // TODO: centralise where all these URLs are constructed
+      uri = s"${config.apiUri}/images/${uploadRequest.imageId}"
+    } yield {
+      Json.obj("uri" -> uri)
+    }
+
+  }
+}

--- a/image-loader/app/lib/imaging/Projector.scala
+++ b/image-loader/app/lib/imaging/Projector.scala
@@ -1,0 +1,47 @@
+package lib.imaging
+
+import java.io.{File, FileOutputStream}
+
+import com.amazonaws.services.s3.model.S3Object
+import com.gu.mediaservice.lib.ImageIngestOperations
+import com.gu.mediaservice.lib.aws.S3Ops
+import com.gu.mediaservice.lib.logging.RequestLoggingContext
+import com.gu.mediaservice.model.Image
+import lib.{DigestedFile, ImageLoaderConfig}
+import model.{ImageUploadProjector, S3FileExtractedMetadata}
+import org.apache.tika.io.IOUtils
+import play.api.Logger
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+
+class Projector(val config: ImageLoaderConfig) {
+
+  def projectS3ImageById(imageUploadProjector: ImageUploadProjector, imageId: String, requestLoggingContext: RequestLoggingContext, tempFile: File)(implicit ex: ExecutionContext): Future[Option[Image]] = {
+    Logger.info(s"Projecting image: $imageId")(requestLoggingContext.toMarker())
+    Future {
+      import ImageIngestOperations.fileKeyFromId
+      val s3Key = fileKeyFromId(imageId)
+      val s3 = S3Ops.buildS3Client(config)
+
+      if (!s3.doesObjectExist(config.imageBucket, s3Key))
+        throw new NoSuchImageExistsInS3(config.imageBucket, s3Key)
+
+      Logger.info(s"object exists, getting s3 object at s3://${config.imageBucket}/$s3Key to perform Image projection")(requestLoggingContext.toMarker())
+
+      val s3Source = s3.getObject(config.imageBucket, s3Key)
+      val digestedFile = getSrcFileDigestForProjection(s3Source, imageId, requestLoggingContext, tempFile)
+      val extractedS3Meta = S3FileExtractedMetadata(s3Source.getObjectMetadata)
+
+      val finalImageFuture = imageUploadProjector.projectImage(digestedFile, extractedS3Meta, requestLoggingContext)
+      val finalImage = Await.result(finalImageFuture, Duration.Inf)
+      Some(finalImage)
+    }
+  }
+
+  private def getSrcFileDigestForProjection(s3Src: S3Object, imageId: String, requestLoggingContext: RequestLoggingContext, tempFile: File) = {
+    IOUtils.copy(s3Src.getObjectContent, new FileOutputStream(tempFile))
+    DigestedFile(tempFile, imageId)
+  }
+}
+

--- a/image-loader/app/lib/imaging/exceptions.scala
+++ b/image-loader/app/lib/imaging/exceptions.scala
@@ -1,0 +1,11 @@
+package lib.imaging
+
+class ImageLoaderException(val message: String) extends RuntimeException(message)
+
+class UserImageLoaderException(override val message: String) extends ImageLoaderException(message)
+class UnsupportedMimeTypeException(val mimeType: String)
+  extends UserImageLoaderException(s"Mime type value '$mimeType' is not supported")
+
+class ServerImageLoaderException(override val message: String) extends ImageLoaderException(message)
+class NoSuchImageExistsInS3(val bucket: String, val key: String)
+  extends ServerImageLoaderException(s"Could not find image in $bucket with key $key")

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -222,9 +222,6 @@ object ImageUploadOps {
             uploadRequest
           )
 
-          Logger.info(s"Deleting temp file ${uploadedFile.getAbsolutePath}")(initialMarkers)
-          uploadedFile.delete()
-
           finalImage
         }
       })


### PR DESCRIPTION
## What does this change?
Improves the structure of image loader, which is currently quite overloaded.
Fix cases where a temp file is left behind.

## How can success be measured?
Code is clearer, behaviour is unchanged except that temp files are cleared down.

## Screenshots (if applicable)
N/A

## Who should look at this?
@guardian/digital-cms 


## Tested?
- [X] locally
- [X] on TEST

Uploading and projecting work fine.