### PR TITLE
use consistent spelling of healthcheck

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -65,7 +65,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions {
 
   def healthCheck(): Future[Boolean] = {
     val request = search(imagesAlias) limit 0
-    executeAndLog(request, "Health check").map { _ => true}.recover { case _ => false}
+    executeAndLog(request, "Healthcheck").map { _ => true}.recover { case _ => false}
   }
 
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/management/Management.scala
@@ -51,7 +51,7 @@ class ElasticSearchHealthCheck(override val controllerComponents: ControllerComp
     elasticHealth.map {
       case None => Ok("Ok")
       case Some(err) => {
-        Logger.warn(s"Health check failed with problems: $err")
+        Logger.warn(s"Healthcheck failed with problems: $err")
         ServiceUnavailable(err)
       }
     }

--- a/thrall/app/controllers/HealthCheck.scala
+++ b/thrall/app/controllers/HealthCheck.scala
@@ -18,7 +18,7 @@ class HealthCheck(elasticsearch: ElasticSearch, messageConsumer: ThrallMessageCo
       val problems = Seq(esHealth, actorSystemHealth).flatten
       if (problems.nonEmpty) {
         val problemsMessage = problems.mkString(",")
-        Logger.warn("Health check failed with problems: " + problemsMessage)
+        Logger.warn("Healthcheck failed with problems: " + problemsMessage)
         ServiceUnavailable(problemsMessage)
       } else {
         Ok("Ok")


### PR DESCRIPTION
## What does this change?
Removes the "health check" variant to make log filtering easier.

## How can success be measured?
Filtering of logs becomes easier.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
