### PR TITLE
[Single image reingest]: Check images aren't already present before reingesting

### DIFF
--- a/thrall/app/lib/elasticsearch/ElasticSearchResponse.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearchResponse.scala
@@ -3,3 +3,4 @@ package lib.elasticsearch
 case class ElasticSearchUpdateResponse()
 case class ElasticSearchDeleteResponse()
 case class ElasticSearchBulkUpdateResponse()
+case class ElasticSearchNoopResponse()


### PR DESCRIPTION
## What does this change?

Adds a check to ensure images aren't already present in Elasticsearch before they're reingested. If they're already there, this is a no-op.

## How can success be measured?

It should be impossible to reingest images already present in Elasticsearch.

It will be fairly difficult to check this as a user, as the cli tool will run its own checks before attempting reingestion, but the tests should confirm the logic.

## Tested?
- [x] locally
- [ ] on TEST
