### PR TITLE
Clear root of images S3 bucket

### DIFF
--- a/scripts/cleanup-s3/README.md
+++ b/scripts/cleanup-s3/README.md
@@ -1,0 +1,40 @@
+# Cheap and cheerful scripts to clean up our grid imagebuckets
+
+## Delete function
+```
+delete-images-by-prefix.sh
+```
+Deletes images, if found, which match the provided prefix.
+
+Takes parameters:
+  * size
+  * prefix
+  * stage
+  * profile
+  * region
+
+Not intended to be invoked directly.
+
+## Wrapper function to delete images in the root
+```
+images-in-root.sh
+```
+
+Takes parameters:
+  * size
+  * stage
+  * profile
+  * region
+
+## Wrapper function to delete images with a null first prefix (ie key beginning with /)
+```
+images-with-empty-prefix.sh
+```
+
+Takes parameters:
+  * size
+  * stage
+  * profile
+  * region
+
+Continues until it successfully deletes something or runs out of prefixes to check.

--- a/scripts/cleanup-s3/delete-images-by-prefix.sh
+++ b/scripts/cleanup-s3/delete-images-by-prefix.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+size=${1:-10}; shift
+prefix=${1:00}; shift
+stage=${1:-test}; shift
+profile=${1:-media-service}; shift
+region=${1:-eu-west-1}; shift
+
+creds="--profile $profile --region $region"
+s3cmd="aws $creds s3 "
+s3apicmd="aws $creds s3api "
+
+function getBucket {
+   $s3cmd ls | grep media-service-$stage-imagebucket | awk '{print $3}'
+}
+
+function getImages {
+   $s3apicmd list-objects --bucket $bucket --page-size $size --max-items $size --prefix $prefix
+}
+
+function constructAwsJson {
+   cat | jq '
+[
+   .Contents[]
+   | 
+   { "Key": .Key }
+]
+| 
+{
+  "Objects": .,
+  "Quiet": false
+}
+'
+}
+
+bucket=$(getBucket)
+
+echo "Deleting up to $size images in root of $bucket using profile $profile in region $region"
+
+tempFile=$(mktemp)
+echo "Using temp file $tempFile"
+
+getImages | constructAwsJson > $tempFile
+
+empty=$(find $(dirname $tempFile) -empty -name $(basename $tempFile) | wc -l)
+if [[ $empty -eq 1 ]]; then
+  echo "No images found to match prefix $prefix"
+  rc=1
+else
+  $s3apicmd delete-objects --bucket $bucket --delete file://$tempFile
+  rc=$?
+fi
+
+rm $tempFile
+exit $rc

--- a/scripts/cleanup-s3/images-in-root.sh
+++ b/scripts/cleanup-s3/images-in-root.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+size=${1:-10}; shift
+stage=${1:-test}; shift
+profile=${1:-media-service}; shift
+region=${1:-eu-west-1}; shift
+
+cd $(dirname $0)
+
+for a in 0 1 2 3 4 5 6 7 8 9 a b c d e f; do
+   for b in 0 1 2 3 4 5 6 7 8 9 a b c d e f; do
+     ./delete-images-by-prefix.sh $size $a$b $stage $profile $region
+     if [[ $? -eq 0 ]]; then
+        exit
+     fi
+   done
+done

--- a/scripts/cleanup-s3/images-with-empty-prefix.sh
+++ b/scripts/cleanup-s3/images-with-empty-prefix.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+size=${1:-10}; shift
+stage=${1:-test}; shift
+profile=${1:-media-service}; shift
+region=${1:-eu-west-1}; shift
+
+cd $(dirname $0)
+
+./delete-images-by-prefix.sh $size '/' $stage $profile $region


### PR DESCRIPTION
## What does this change?
Provides cheap and cheerful functionality for deleting the images in 
https://trello.com/c/CphkaF1Y/1710-clear-root-of-images-s3-bucket

## How can success be measured?
No more images in root of image bucket, no images stored with a null prefix.

## Screenshots (if applicable)
N/A

## Who should look at this?
People planning on deleting images.

## Tested?
- [ ] locally
- [X] on TEST
