### PR TITLE
use mozilla sbt docker image

### DIFF
--- a/.github/actions/sbt/Dockerfile
+++ b/.github/actions/sbt/Dockerfile
@@ -1,15 +1,9 @@
-FROM adoptopenjdk:8-jdk-openj9
+FROM mozilla/sbt
 
 RUN apt-get -y update
 
-RUN apt-get -y install gnupg
 RUN apt-get -y install graphicsmagick
 RUN apt-get -y install graphicsmagick-imagemagick-compat
 RUN apt-get -y install exiftool
-
-RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
-RUN apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-RUN apt-get -y update
-RUN apt-get -y install sbt
 
 ENTRYPOINT ["sbt"]


### PR DESCRIPTION
## What does this change?
Hopefully it results in a faster GitHub Actions build.

Reference https://github.com/mozilla/docker-sbt.

## How can success be measured?
Green build. Faster build.

This should yield a faster build as we're not adding `sbt` to the base image, it has it already. We could further improve the build time by publishing an image with the imaging libraries and using that (a la AMIgo).

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
