### PR TITLE
Allow remembering Metadata Panel state between sessions

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -89,6 +89,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             ctrl.metadataPanel = panels.metadataPanel;
 
             panelService.setAndSaveState($scope, 'collections', ctrl.collectionsPanel);
+            panelService.setAndSaveState($scope, 'metadata', ctrl.metadataPanel);
 
             keyboardShortcut.bindTo($scope).add({
                 combo: shortcutKeys.get('metadataPanel'),


### PR DESCRIPTION
## What does this change?
I always wanted to do this, but this is for discussion. It makes Metadata panel behave like Collections panel: its state (shown/hidden, locked/unlocked) is kept between reloads/sessions in localstorage.

For: consistency of UI; useful for heavy users of this panel
Against: may be annoying to occasional or involuntary users of the panel as it stayes empty until something is selected (maybe it should always show on selection, I bet that would make for a good onboarding?)

## How can success be measured?
Whether it’s more helpful and less annoying. Whether long-term it promotes editing metadata in the browser (including batch edits).

## Who should look at this?
Interested in @akash1810’s opinion, will ask users around (maybe @JonnyWeeks?)

## Tested?
- [x] locally
- [ ] on TEST
