### PR TITLE
log encounters of unsupported mime types

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -12,6 +12,7 @@ import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.model._
 import org.joda.time.{DateTime, Duration}
 import org.slf4j.LoggerFactory
+import play.api.Logger
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -49,7 +50,10 @@ class S3(config: CommonConfig) {
       case Some("image/jpeg") => "jpg"
       case Some("image/png") => "png"
       case Some("image/tiff") => "tif"
-      case _ => throw new Exception("Unsupported mime type")
+      case _ => {
+        Logger.error("Unsupported mime type")(image.toLogMarker)
+        throw new Exception("Unsupported mime type")
+      }
     }
 
     val baseFilename: String = image.uploadInfo.filename match {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -1,5 +1,6 @@
 package com.gu.mediaservice.model
 
+import com.gu.mediaservice.lib.logging._
 import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease, LeasesByMedia}
 import com.gu.mediaservice.model.usage.{SyndicationUsage, Usage}
 import org.joda.time.DateTime
@@ -28,7 +29,7 @@ case class Image(
   leases:              LeasesByMedia    = LeasesByMedia.empty,
   collections:         List[Collection] = Nil,
   syndicationRights:   Option[SyndicationRights] = None,
-  userMetadataLastModified: Option[DateTime] = None) {
+  userMetadataLastModified: Option[DateTime] = None) extends LogMarker {
 
   def hasExports = exports.nonEmpty
 
@@ -64,6 +65,11 @@ case class Image(
       }
     }
   }
+
+  override def markerContents: Map[String, Any] = Map(
+    "imageId" -> id,
+    "mimeType" -> source.mimeType.getOrElse(FALLBACK)
+  )
 }
 
 object Image {


### PR DESCRIPTION
## What does this change?
Logs (with image id and mime type markers) when we encounter an unsupported mime type. Currently, we have a 5XX alarm sounding in media api (eg this search `/images?q=&offset=1176&length=14&orderBy=-uploadTime&since=2020-03-29T23%3A00%3A00.000Z&until=2020-03-30T11%3A11%3A11.681Z`), this will help us identify the images affected and fix them.

## How can success be measured?
Higher visibility of the system allow a 5XX alarm to be triaged.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [ ] locally
- [ ] on TEST
