### PR TITLE
Log image bigness when it's too big for ingest params

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -25,7 +25,7 @@ class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duratio
       val notFoundOrImage: Future[Option[Either[Image, String]]] = responseFuture.map { response =>
         response.statusCode match {
           case 200 if response.bodyAsString.size > maxSize => {
-            InputIdsStore.setStateToTooBig(id)
+            InputIdsStore.setStateToTooBig(id, response.bodyAsString.size)
             None
           }
           case 200 => {


### PR DESCRIPTION
## What does this change?
Adds a log marker with the image size when it's too big for the current reingest params. This should give us an idea of the composition of image metadata, to better help us understand how to tweak reingestion params.

## How can success be measured?

A log marker with the image size should be present when images are too large to be reingested.

## Tested?
- [x] locally
- [ ] on TEST
