### PR TITLE
mime type fallback

### DIFF
--- a/image-loader/app/lib/imaging/MimeTypeDetection.scala
+++ b/image-loader/app/lib/imaging/MimeTypeDetection.scala
@@ -1,19 +1,39 @@
 package lib.imaging
 
-import java.io.File
+import java.io.{BufferedInputStream, File, FileInputStream}
 
+import com.drew.imaging.FileTypeDetector
+import com.gu.mediaservice.lib.logging._
 import com.gu.mediaservice.model.{MimeType, UnsupportedMimeTypeException}
 import org.apache.tika.Tika
-import com.gu.mediaservice.lib.logging._
+import play.api.Logger
 
 import scala.util.{Failure, Success, Try}
 
 object MimeTypeDetection {
-  val tika = new Tika()
-
-  def guessMimeType(file: File): Either[UnsupportedMimeTypeException, MimeType] = Try(MimeType(tika.detect(file))) match {
+  def guessMimeType(file: File): Either[UnsupportedMimeTypeException, MimeType] = Try(usingTika(file)) match {
     case Success(mimeType) => Right(mimeType)
-    case Failure(exception: UnsupportedMimeTypeException) => Left(exception)
+    case Failure(tikaAttempt: UnsupportedMimeTypeException) => {
+      Try(usingMetadataExtractor(file)) match {
+        case Success(mimeType) => {
+          Logger.info(s"Using mime type from metadata extractor as tika mime type is unsupported (${tikaAttempt.mimeType})")
+          Right(mimeType)
+        }
+        case Failure(metadataExtractorAttempt: UnsupportedMimeTypeException) => {
+          Logger.warn(s"Unsupported mime type: tika was ${tikaAttempt.mimeType}, metadata extractor was ${metadataExtractorAttempt.mimeType}")
+          Left(metadataExtractorAttempt)
+        }
+        case Failure(_: Throwable) => Left(new UnsupportedMimeTypeException(FALLBACK))
+      }
+    }
     case Failure(_: Throwable) => Left(new UnsupportedMimeTypeException(FALLBACK))
+  }
+
+  private def usingTika(file: File): MimeType = MimeType(new Tika().detect(file))
+
+  private def usingMetadataExtractor(file: File) : MimeType = {
+    val stream = new BufferedInputStream(new FileInputStream(file))
+    val fileType = FileTypeDetector.detectFileType(stream)
+    MimeType(fileType.getMimeType)
   }
 }


### PR DESCRIPTION
## What does this change?
For some files, Tika detects the mime type as `message/rfc822`. This change falls back to metadata extractor when this happens.

This code path is executed on file upload (or projection) and we've somehow landed in a situation where we have 52 images in PROD with mime type `message/rfc822`. I think the flow was:
- In 2015, upload images
- In 2015, mime type was detected as `image/jpeg`
- In 2019, update mime type detection to use tika only (tika recognises these images as `message/rfc822`)
- In 2020, reingest the images as part of the great image restoration and mime type updated to `message/rfc822`

We should be able to convert these 52 images back to `image/jpeg` by reingesting them.

It's a little hard to write a test for this as we cannot checkin the offending image due to copyright and crafting a file of the correct shape requires using a hex editor - I've tried for the last 30 mins with no luck.

Requires https://github.com/guardian/grid/pull/2753.

## How can success be measured?
Part one of solving the 5XX alarm in media-api.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
