### PR TITLE
Thrall dual lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,31 @@ jobs:
         # Wait for elasticsearch to report healthy before continuing.
         # see https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L28
         options: -e "discovery.type=single-node" --expose 9200 --health-cmd "curl localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 10
+      localstack:
+        image: localstack/localstack:0.10.8
+        env:
+          SERVICES: kinesis:4568,dynamodb:4569
+          DEFAULT_REGION: eu-west-1
+          KINESIS_ERROR_PROBABILITY: 0.0
+          PORT_WEB_UI: 5050
+        ports:
+          - 5050:5050
+          - 4568:4568
+          - 4569:4569
+        options: >-
+          --health-cmd "curl localhost:5050/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     steps:
     - uses: actions/checkout@v1
     - name: SBT
       uses: ./.github/actions/sbt
       env:
-        ES6_USE_DOCKER: false
+        USE_DOCKER_FOR_TESTS: false
         ES6_TEST_URL: http://elasticsearch:9200
+        AWS_CBOR_DISABLE: true
+        KINESIS_ENDPOINT: http://localstack:4568
+        DYNAMODB_ENDPOINT: http://localstack:4569
       with:
         args: clean compile test

--- a/collections/app/lib/Notifications.scala
+++ b/collections/app/lib/Notifications.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 
-class Notifications(config: CollectionsConfig) extends ThrallMessageSender(config)
+class Notifications(config: CollectionsConfig) extends ThrallMessageSender(config.thrallKinesisStreamConfig)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -14,14 +14,14 @@ import play.api.Logger
 import play.api.libs.json.{JodaWrites, Json}
 import com.amazonaws.auth.AWSCredentialsProvider
 
-case class KinesisConfig(
+case class KinesisSenderConfig(
   awsRegion: String,
   awsCredentials: AWSCredentialsProvider,
   kinesisEndpoint: String,
   streamName: String
 )
 
-class Kinesis(config: KinesisConfig) {
+class Kinesis(config: KinesisSenderConfig) {
 
   private val builder = AmazonKinesisClientBuilder.standard()
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -12,18 +12,24 @@ import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 import play.api.Logger
 import play.api.libs.json.{JodaWrites, Json}
+import com.amazonaws.auth.AWSCredentialsProvider
 
-class Kinesis(config: CommonConfig) {
+case class KinesisConfig(
+  awsRegion: String,
+  awsCredentials: AWSCredentialsProvider,
+  kinesisEndpoint: String,
+  streamName: String
+)
+
+class Kinesis(config: KinesisConfig) {
 
   private val builder = AmazonKinesisClientBuilder.standard()
 
-  import config.{awsRegion, awsCredentials, thrallKinesisEndpoint, thrallKinesisStream}
-
   private def getKinesisClient: AmazonKinesis = {
-    Logger.info(s"creating kinesis publisher with endpoint=$thrallKinesisEndpoint , region=$awsRegion")
+    Logger.info(s"creating kinesis publisher with endpoint=${config.kinesisEndpoint}, region=${config.awsRegion}")
    builder
-     .withEndpointConfiguration(new EndpointConfiguration(thrallKinesisEndpoint, awsRegion))
-     .withCredentials(awsCredentials)
+     .withEndpointConfiguration(new EndpointConfiguration(config.kinesisEndpoint, config.awsRegion))
+     .withCredentials(config.awsCredentials)
      .build()
   }
 
@@ -42,7 +48,7 @@ class Kinesis(config: CommonConfig) {
 
     val data = ByteBuffer.wrap(payload)
     val request = new PutRecordRequest()
-      .withStreamName(thrallKinesisStream)
+      .withStreamName(config.streamName)
       .withPartitionKey(partitionKey)
       .withData(data)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, Json}
 
 // TODO MRB: replace this with the simple Kinesis class once we migrate off SNS
-class ThrallMessageSender(config: KinesisConfig) {
+class ThrallMessageSender(config: KinesisSenderConfig) {
   private val kinesis = new Kinesis(config)
 
   def publish(updateMessage: UpdateMessage): Unit = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, Json}
 
 // TODO MRB: replace this with the simple Kinesis class once we migrate off SNS
-class ThrallMessageSender(config: CommonConfig) {
+class ThrallMessageSender(config: KinesisConfig) {
   private val kinesis = new Kinesis(config)
 
   def publish(updateMessage: UpdateMessage): Unit = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -7,10 +7,10 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.client.builder.AwsClientBuilder
 import play.api.Configuration
+import com.gu.mediaservice.lib.aws.KinesisSenderConfig
 
 import scala.io.Source._
 import scala.util.Try
-import com.gu.mediaservice.lib.aws.KinesisConfig
 
 
 trait CommonConfig {
@@ -86,7 +86,7 @@ trait CommonConfig {
 
   lazy val services = new Services(domainRoot, serviceHosts, corsAllowedOrigins)
 
-  private def getKinesisConfigForStream(streamName: String) = KinesisConfig(awsRegion, awsCredentials, thrallKinesisEndpoint, streamName)
+  private def getKinesisConfigForStream(streamName: String) = KinesisSenderConfig(awsRegion, awsCredentials, thrallKinesisEndpoint, streamName)
 
   final def getStringSetFromProperties(key: String): Set[String] = Try(
     properties(key).split(",").map(_.trim).toSet

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -10,6 +10,7 @@ import play.api.Configuration
 
 import scala.io.Source._
 import scala.util.Try
+import com.gu.mediaservice.lib.aws.KinesisConfig
 
 
 trait CommonConfig {
@@ -58,8 +59,10 @@ trait CommonConfig {
   lazy val thrallKinesisStream = properties("thrall.kinesis.stream.name")
   lazy val thrallKinesisLowPriorityStream = properties("thrall.kinesis.lowPriorityStream.name")
 
-  lazy val thrallKinesisEndpoint: String = properties.getOrElse("thrall.local.kinesis.url", kinesisAWSEndpoint)
+  lazy val thrallKinesisStreamConfig = getKinesisConfigForStream(thrallKinesisStream)
+  lazy val thrallKinesisLowPriorityStreamConfig = getKinesisConfigForStream(thrallKinesisLowPriorityStream)
 
+  lazy val thrallKinesisEndpoint: String = properties.getOrElse("thrall.local.kinesis.url", kinesisAWSEndpoint)
   lazy val thrallKinesisDynamoEndpoint: String = properties.getOrElse("thrall.local.dynamodb.url", dynamodbAWSEndpoint)
 
   // Note: had to make these lazy to avoid init order problems ;_;
@@ -82,6 +85,8 @@ trait CommonConfig {
   lazy val corsAllowedOrigins: Set[String] = getStringSetFromProperties("security.cors.allowedOrigins")
 
   lazy val services = new Services(domainRoot, serviceHosts, corsAllowedOrigins)
+
+  private def getKinesisConfigForStream(streamName: String) = KinesisConfig(awsRegion, awsCredentials, thrallKinesisEndpoint, streamName)
 
   final def getStringSetFromProperties(key: String): Set[String] = Try(
     properties(key).split(",").map(_.trim).toSet

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -56,6 +56,7 @@ trait CommonConfig {
   val localLogShipping: Boolean = sys.env.getOrElse("LOCAL_LOG_SHIPPING", "false").toBoolean
 
   lazy val thrallKinesisStream = properties("thrall.kinesis.stream.name")
+  lazy val thrallKinesisLowPriorityStream = properties("thrall.kinesis.lowPriorityStream.name")
 
   lazy val thrallKinesisEndpoint: String = properties.getOrElse("thrall.local.kinesis.url", kinesisAWSEndpoint)
 

--- a/cropper/app/lib/Notifications.scala
+++ b/cropper/app/lib/Notifications.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 
-class Notifications(config: CropperConfig) extends ThrallMessageSender(config)
+class Notifications(config: CropperConfig) extends ThrallMessageSender(config.thrallKinesisStreamConfig)

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -121,6 +121,7 @@ setupLocalKinesis() {
 
   streams=(
     'media-service-DEV-thrall'
+    'media-service-DEV-thrall-low-priority'
   )
 
   for stream_name in "${streams[@]}"; do

--- a/image-loader/app/lib/Notifications.scala
+++ b/image-loader/app/lib/Notifications.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 
-class Notifications(config: ImageLoaderConfig) extends ThrallMessageSender(config)
+class Notifications(config: ImageLoaderConfig) extends ThrallMessageSender(config.thrallKinesisStreamConfig)

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -4,7 +4,7 @@ import com.gu.mediaservice.lib.aws.{ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.model.leases.MediaLease
 import org.joda.time.DateTime
 
-class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends ThrallMessageSender(config) {
+class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends ThrallMessageSender(config.thrallKinesisStreamConfig) {
   def sendReindexLeases(mediaId: String) = {
     val replaceImageLeases = "replace-image-leases"
     val leases = store.getForMedia(mediaId)

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -16,7 +16,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
-  val messageSender = new ThrallMessageSender(config)
+  val messageSender = new ThrallMessageSender(config.thrallKinesisStreamConfig)
   val mediaApiMetrics = new MediaApiMetrics(config)
 
   val es6Config: ElasticSearchConfig = ElasticSearchConfig(

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -23,7 +23,7 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))
 
-  val useEsDocker = Properties.envOrElse("ES6_USE_DOCKER", "true").toBoolean
+  val useEsDocker = Properties.envOrElse("USE_DOCKER_FOR_TESTS", "true").toBoolean
   val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
 
   def esContainer: Option[DockerContainer]

--- a/metadata-editor/app/lib/Notifications.scala
+++ b/metadata-editor/app/lib/Notifications.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 
-class Notifications(config: EditsConfig) extends ThrallMessageSender(config)
+class Notifications(config: EditsConfig) extends ThrallMessageSender(config.thrallKinesisStreamConfig)

--- a/scripts/ci/grid.sh
+++ b/scripts/ci/grid.sh
@@ -4,6 +4,10 @@ set -e
 
 SCRIPT_DIR=$(dirname ${0})
 
+# The Java SDK uses CBOR protocol
+# Kinesis in localstack uses kinesislite which requires CBOR to be disabled
+export AWS_CBOR_DISABLE=true
+
 setupNvm() {
     export NVM_DIR="$HOME/.nvm"
     [[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -1,4 +1,5 @@
 import akka.Done
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{HealthCheck, ThrallController}
@@ -32,11 +33,11 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
 
   val bulkIndexS3Client = new BulkIndexS3Client(config)
 
-  val highPriortyKinesisConfig = KinesisConfig.kinesisConfig(config.kinesisConfig)
-  val lowPriorityKinesisConfig = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)
+  val highPriorityKinesisConfig: KinesisClientLibConfiguration = KinesisConfig.kinesisConfig(config.kinesisConfig)
+  val lowPriorityKinesisConfig: KinesisClientLibConfiguration = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)
 
   val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es), bulkIndexS3Client, actorSystem)
-  val thrallStreamProcessor = new ThrallStreamProcessor(highPriortyKinesisConfig, lowPriorityKinesisConfig, thrallEventConsumer, actorSystem, materializer)
+  val thrallStreamProcessor = new ThrallStreamProcessor(highPriorityKinesisConfig, lowPriorityKinesisConfig, thrallEventConsumer, actorSystem, materializer)
   val streamRunning: Future[Done] = thrallStreamProcessor.run()
 
   val thrallController = new ThrallController(controllerComponents)

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -32,10 +32,11 @@ class ThrallComponents(context: Context) extends GridComponents(context) {
 
   val bulkIndexS3Client = new BulkIndexS3Client(config)
 
-  val kinesisConfig = KinesisConfig.kinesisConfig(config)
+  val highPriortyKinesisConfig = KinesisConfig.kinesisConfig(config.kinesisConfig)
+  val lowPriorityKinesisConfig = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)
 
   val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es), bulkIndexS3Client, actorSystem)
-  val thrallStreamProcessor = new ThrallStreamProcessor(kinesisConfig, thrallEventConsumer, actorSystem, materializer)
+  val thrallStreamProcessor = new ThrallStreamProcessor(highPriortyKinesisConfig, lowPriorityKinesisConfig, thrallEventConsumer, actorSystem, materializer)
   val streamRunning: Future[Done] = thrallStreamProcessor.run()
 
   val thrallController = new ThrallController(controllerComponents)

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -6,7 +6,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import play.api.Configuration
 
-case class ThrallKinesisConfig(
+case class KinesisReceiverConfig(
   streamName: String,
   rewindFrom: Option[DateTime],
   thrallKinesisEndpoint: String,
@@ -15,8 +15,8 @@ case class ThrallKinesisConfig(
   awsCredentials: AWSCredentialsProvider
 )
 
-object ThrallKinesisConfig {
-  def apply(streamName: String, rewindFrom: Option[DateTime], thrallConfig: ThrallConfig): ThrallKinesisConfig = ThrallKinesisConfig(
+object KinesisReceiverConfig {
+  def apply(streamName: String, rewindFrom: Option[DateTime], thrallConfig: ThrallConfig): KinesisReceiverConfig = KinesisReceiverConfig(
     streamName,
     rewindFrom,
     thrallConfig.thrallKinesisEndpoint,
@@ -47,6 +47,6 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   lazy val rewindFrom: Option[DateTime] = properties.get("thrall.kinesis.stream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
   lazy val lowPriorityRewindFrom: Option[DateTime] = properties.get("thrall.kinesis.lowPriorityStream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
 
-  def kinesisConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisStream, rewindFrom, this)
-  def kinesisLowPriorityConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)
+  def kinesisConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisStream, rewindFrom, this)
+  def kinesisLowPriorityConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)
 }

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -7,13 +7,24 @@ import org.joda.time.format.ISODateTimeFormat
 import play.api.Configuration
 
 case class ThrallKinesisConfig(
-  thrallKinesisStream: String,
+  streamName: String,
+  rewindFrom: Option[DateTime],
   thrallKinesisEndpoint: String,
   thrallKinesisDynamoEndpoint: String,
   awsRegion: String,
-  rewindFrom: Option[DateTime],
   awsCredentials: AWSCredentialsProvider
 )
+
+object ThrallKinesisConfig {
+  def apply(streamName: String, rewindFrom: Option[DateTime], thrallConfig: ThrallConfig): ThrallKinesisConfig = ThrallKinesisConfig(
+    streamName,
+    rewindFrom,
+    thrallConfig.thrallKinesisEndpoint,
+    thrallConfig.thrallKinesisDynamoEndpoint,
+    thrallConfig.awsRegion,
+    thrallConfig.awsCredentials
+  )
+}
 
 class ThrallConfig(override val configuration: Configuration) extends CommonConfig {
   final override lazy val appName = "thrall"
@@ -36,7 +47,6 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   lazy val rewindFrom: Option[DateTime] = properties.get("thrall.kinesis.stream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
   lazy val lowPriorityRewindFrom: Option[DateTime] = properties.get("thrall.kinesis.lowPriorityStream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
 
-  def kinesisConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisStream, thrallKinesisEndpoint,thrallKinesisDynamoEndpoint, awsRegion, rewindFrom, awsCredentials)
-  def kinesisLowPriorityConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisLowPriorityStream, thrallKinesisEndpoint,thrallKinesisDynamoEndpoint, awsRegion, lowPriorityRewindFrom, awsCredentials)
-
+  def kinesisConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisStream, rewindFrom, this)
+  def kinesisLowPriorityConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)
 }

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -1,9 +1,19 @@
 package lib
 
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.mediaservice.lib.config.CommonConfig
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import play.api.Configuration
+
+case class ThrallKinesisConfig(
+  thrallKinesisStream: String,
+  thrallKinesisEndpoint: String,
+  thrallKinesisDynamoEndpoint: String,
+  awsRegion: String,
+  rewindFrom: Option[DateTime],
+  awsCredentials: AWSCredentialsProvider
+)
 
 class ThrallConfig(override val configuration: Configuration) extends CommonConfig {
   final override lazy val appName = "thrall"
@@ -23,5 +33,10 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
 
   lazy val metadataTopicArn: String = properties("indexed.image.sns.topic.arn")
 
-  lazy val from: Option[DateTime] = properties.get("rewind.from").map(ISODateTimeFormat.dateTime.parseDateTime)
+  lazy val rewindFrom: Option[DateTime] = properties.get("thrall.kinesis.stream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
+  lazy val lowPriorityRewindFrom: Option[DateTime] = properties.get("thrall.kinesis.lowPriorityStream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
+
+  def kinesisConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisStream, thrallKinesisEndpoint,thrallKinesisDynamoEndpoint, awsRegion, rewindFrom, awsCredentials)
+  def kinesisLowPriorityConfig: ThrallKinesisConfig = ThrallKinesisConfig(thrallKinesisLowPriorityStream, thrallKinesisEndpoint,thrallKinesisDynamoEndpoint, awsRegion, lowPriorityRewindFrom, awsCredentials)
+
 }

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -1,6 +1,7 @@
 package lib
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.gu.mediaservice.lib.config.CommonConfig
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
@@ -12,7 +13,8 @@ case class KinesisReceiverConfig(
   thrallKinesisEndpoint: String,
   thrallKinesisDynamoEndpoint: String,
   awsRegion: String,
-  awsCredentials: AWSCredentialsProvider
+  awsCredentials: AWSCredentialsProvider,
+  metricsLevel: MetricsLevel = MetricsLevel.DETAILED
 )
 
 object KinesisReceiverConfig {

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -49,8 +49,6 @@ class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfigura
     SourceShape(mergePreferred.out)
   })
 
-
-  // Test prioritisation
   def createStream(): Source[(TaggedRecord, Stopwatch, Option[UpdateMessage]), NotUsed] = {
     mergedKinesisSource.map{ taggedRecord =>
       taggedRecord -> consumer.parseRecord(taggedRecord.record.data.toArray, taggedRecord.record.approximateArrivalTimestamp)
@@ -66,7 +64,6 @@ class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfigura
     }
   }
 
-  // Run the thing
   def run(): Future[Done] = {
     val stream = this.createStream().runForeach {
       case (taggedRecord, stopwatch, maybeUpdateMessage) =>

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -39,10 +39,10 @@ class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfigura
         TaggedRecord(r, LowPriority)
       }
 
-    val mergePreferred = g.add(MergePreferred.create[TaggedRecord[KinesisRecord]](2))
+    val mergePreferred = g.add(MergePreferred.create[TaggedRecord[KinesisRecord]](1))
 
-    highPriorityKinesisSource ~> mergePreferred.in(0)
-    lowPriorityKinesisSource  ~> mergePreferred.in(1)
+    highPriorityKinesisSource ~> mergePreferred.preferred
+    lowPriorityKinesisSource  ~> mergePreferred.in(0)
 
     SourceShape(mergePreferred.out)
   })

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -58,11 +58,10 @@ class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfigura
       val stopwatch = Stopwatch.start
       result match {
         case (record, Some(updateMessage)) =>
-          println(updateMessage)
           consumer.processUpdateMessage(updateMessage)
             .recover { case _ => () }
             .map(_ => (record, stopwatch, Some(updateMessage)))
-        case (record, None) => Future.successful((record, stopwatch, None))
+        case (record, _) => Future.successful((record, stopwatch, None))
       }
     }
   }

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -1,9 +1,10 @@
 package lib
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import akka.stream.{Materializer, SourceShape}
+import akka.stream.javadsl.MergePreferred
+import akka.stream.scaladsl.{GraphDSL, MergePrioritized, Source}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.contxt.kinesis.{KinesisRecord, KinesisSource}
 import lib.kinesis.ThrallEventConsumer
@@ -12,16 +13,32 @@ import play.api.Logger
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-class ThrallStreamProcessor(config: KinesisClientLibConfiguration, consumer: ThrallEventConsumer, actorSystem: ActorSystem, materializer: Materializer) {
+class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfiguration, lowPriorityKinesisConfig: KinesisClientLibConfiguration, consumer: ThrallEventConsumer, actorSystem: ActorSystem, materializer: Materializer) {
 
   implicit val mat = materializer
 
-  val kinesisSource: Source[KinesisRecord, Future[Done]] = KinesisSource(config)
+
 
   implicit val dispatcher = actorSystem.getDispatcher
 
+
+  val mergedKinesisSource: Source[KinesisRecord, NotUsed] = Source.fromGraph(GraphDSL.create() { implicit g =>
+    import GraphDSL.Implicits._
+
+    val highPriorityKinesisSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
+    val lowPriorityKinesisSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
+
+    val mergePreferred = g.add(MergePreferred.create[KinesisRecord](2))
+
+    highPriorityKinesisSource ~> mergePreferred.in(0)
+    lowPriorityKinesisSource  ~> mergePreferred.in(1)
+
+    SourceShape(mergePreferred.out)
+  })
+
+
   def run(): Future[Done] = {
-    val streamRunning = kinesisSource.map{ record =>
+    val streamRunning = mergedKinesisSource.map{ record =>
       record -> consumer.parseRecord(record.data.toArray, record.approximateArrivalTimestamp)
     }.mapAsync(1) {
       case (record, Some(updateMessage)) => consumer.processUpdateMessage(updateMessage).recover{case _ => ()}.map(_ => record)

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -7,6 +7,7 @@ import akka.stream.{Materializer, SourceShape}
 import akka.{Done, NotUsed}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.contxt.kinesis.{KinesisRecord, KinesisSource}
+import com.gu.mediaservice.lib.DateTimeUtils
 import lib.kinesis.ThrallEventConsumer
 import play.api.Logger
 import com.gu.mediaservice.lib.logging._
@@ -21,9 +22,10 @@ case object LowPriority extends Priority {
 case object HighPriority extends Priority {
   override def toString = "high"
 }
-case class TaggedRecord[T](record: T, priority: Priority) extends LogMarker {
-  def markerContents = Map(
-    "priority" -> priority
+case class TaggedRecord(record: KinesisRecord, priority: Priority) extends LogMarker {
+  override def markerContents = Map(
+    "recordPriority" -> priority.toString,
+    "recordArrivalTime" -> DateTimeUtils.toString(record.approximateArrivalTimestamp)
   )
 }
 
@@ -32,13 +34,13 @@ class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfigura
   implicit val mat = materializer
   implicit val dispatcher = actorSystem.getDispatcher
 
-  val mergedKinesisSource: Source[TaggedRecord[KinesisRecord], NotUsed] = Source.fromGraph(GraphDSL.create() { implicit g =>
+  val mergedKinesisSource: Source[TaggedRecord, NotUsed] = Source.fromGraph(GraphDSL.create() { implicit g =>
     import GraphDSL.Implicits._
 
     val highPriorityKinesisSource = KinesisSource(highPriorityKinesisConfig).map(TaggedRecord(_, HighPriority))
     val lowPriorityKinesisSource = KinesisSource(lowPriorityKinesisConfig).map(TaggedRecord(_, LowPriority))
 
-    val mergePreferred = g.add(MergePreferred.create[TaggedRecord[KinesisRecord]](1))
+    val mergePreferred = g.add(MergePreferred.create[TaggedRecord](1))
 
     highPriorityKinesisSource ~> mergePreferred.preferred
     lowPriorityKinesisSource  ~> mergePreferred.in(0)
@@ -48,23 +50,24 @@ class ThrallStreamProcessor(highPriorityKinesisConfig: KinesisClientLibConfigura
 
 
   def run(): Future[Done] = {
-    val streamRunning = mergedKinesisSource.map{ record =>
-      record -> consumer.parseRecord(record.record.data.toArray, record.record.approximateArrivalTimestamp)
+    val streamRunning = mergedKinesisSource.map{ taggedRecord =>
+      taggedRecord -> consumer.parseRecord(taggedRecord.record.data.toArray, taggedRecord.record.approximateArrivalTimestamp)
     }.mapAsync(1) { result =>
       val stopwatch = Stopwatch.start
       result match {
         case (record, Some(updateMessage)) =>
           consumer.processUpdateMessage(updateMessage)
             .recover { case _ => () }
-            .map(_ => (record, stopwatch))
-        case (record, None) =>
-          Future.successful((record, stopwatch))
+            .map(_ => (record, stopwatch, Some(updateMessage)))
+        case (record, None) => Future.successful((record, stopwatch, None))
       }
     }.runForeach {
-      case ((record, stopwatch)) =>
-        record.record.markProcessed()
-        val arrivalMarkers = MarkerMap(("kinesisArrivalTime" -> record.record.approximateArrivalTimestamp.getEpochSecond()))
-        Logger.info("Record processed")(combineMarkers(record, stopwatch.elapsed, arrivalMarkers))
+      case (taggedRecord, stopwatch, maybeUpdateMessage) =>
+        val basicMakers = combineMarkers(taggedRecord, stopwatch.elapsed)
+        val markers = maybeUpdateMessage.map(combineMarkers(basicMakers, _)).getOrElse(basicMakers)
+
+        Logger.info("Record processed")(markers)
+        taggedRecord.record.markProcessed()
     }
 
     streamRunning.onComplete {

--- a/thrall/app/lib/kinesis/KinesisConfig.scala
+++ b/thrall/app/lib/kinesis/KinesisConfig.scala
@@ -15,8 +15,8 @@ object KinesisConfig {
 
     Logger.info(s"creating kinesis consumer with endpoint=${config.thrallKinesisEndpoint}, region=${config.awsRegion}")
     kinesisClientLibConfig(
-      kinesisAppName = config.thrallKinesisStream,
-      streamName = config.thrallKinesisStream,
+      kinesisAppName = config.streamName,
+      streamName = config.streamName,
       config,
       from = config.rewindFrom
     ).withKinesisEndpoint(config.thrallKinesisEndpoint)

--- a/thrall/app/lib/kinesis/KinesisConfig.scala
+++ b/thrall/app/lib/kinesis/KinesisConfig.scala
@@ -4,7 +4,8 @@ import java.net.InetAddress
 import java.util.UUID
 
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
-import lib.{ThrallConfig, KinesisReceiverConfig}
+import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
+import lib.KinesisReceiverConfig
 import org.joda.time.DateTime
 import play.api.Logger
 
@@ -18,12 +19,13 @@ object KinesisConfig {
       kinesisAppName = config.streamName,
       streamName = config.streamName,
       config,
-      from = config.rewindFrom
+      from = config.rewindFrom,
+      config.metricsLevel
     ).withKinesisEndpoint(config.thrallKinesisEndpoint)
       .withDynamoDBEndpoint(config.thrallKinesisDynamoEndpoint)
   }
 
-  private def kinesisClientLibConfig(kinesisAppName: String, streamName: String, config: KinesisReceiverConfig, from: Option[DateTime]): KinesisClientLibConfiguration = {
+  private def kinesisClientLibConfig(kinesisAppName: String, streamName: String, config: KinesisReceiverConfig, from: Option[DateTime], metricsLevel: MetricsLevel): KinesisClientLibConfiguration = {
     val credentialsProvider = config.awsCredentials
 
     val kinesisConfig = new KinesisClientLibConfiguration(
@@ -37,7 +39,8 @@ object KinesisConfig {
       withMaxRecords(100).
       withIdleMillisBetweenCalls(1000).
       withIdleTimeBetweenReadsInMillis(250).
-      withCallProcessRecordsEvenForEmptyRecordList(true)
+      withCallProcessRecordsEvenForEmptyRecordList(true).
+      withMetricsLevel(metricsLevel)
 
     from.fold(
       kinesisConfig.withInitialPositionInStream(InitialPositionInStream.TRIM_HORIZON)

--- a/thrall/app/lib/kinesis/KinesisConfig.scala
+++ b/thrall/app/lib/kinesis/KinesisConfig.scala
@@ -4,26 +4,26 @@ import java.net.InetAddress
 import java.util.UUID
 
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
-import lib.ThrallConfig
+import lib.{ThrallConfig, ThrallKinesisConfig}
 import org.joda.time.DateTime
 import play.api.Logger
 
 object KinesisConfig {
   private val workerId = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
-  def kinesisConfig(config: ThrallConfig) = {
-    import config.{thrallKinesisEndpoint, thrallKinesisDynamoEndpoint, awsRegion}
-    Logger.info(s"creating kinesis consumer with endpoint=$thrallKinesisEndpoint, region=$awsRegion")
+  def kinesisConfig(config: ThrallKinesisConfig) = {
+
+    Logger.info(s"creating kinesis consumer with endpoint=${config.thrallKinesisEndpoint}, region=${config.awsRegion}")
     kinesisClientLibConfig(
       kinesisAppName = config.thrallKinesisStream,
       streamName = config.thrallKinesisStream,
       config,
-      from = config.from
-    ).withKinesisEndpoint(thrallKinesisEndpoint)
-      .withDynamoDBEndpoint(thrallKinesisDynamoEndpoint)
+      from = config.rewindFrom
+    ).withKinesisEndpoint(config.thrallKinesisEndpoint)
+      .withDynamoDBEndpoint(config.thrallKinesisDynamoEndpoint)
   }
 
-  private def kinesisClientLibConfig(kinesisAppName: String, streamName: String, config: ThrallConfig, from: Option[DateTime]): KinesisClientLibConfiguration = {
+  private def kinesisClientLibConfig(kinesisAppName: String, streamName: String, config: ThrallKinesisConfig, from: Option[DateTime]): KinesisClientLibConfiguration = {
     val credentialsProvider = config.awsCredentials
 
     val kinesisConfig = new KinesisClientLibConfiguration(

--- a/thrall/app/lib/kinesis/KinesisConfig.scala
+++ b/thrall/app/lib/kinesis/KinesisConfig.scala
@@ -4,14 +4,14 @@ import java.net.InetAddress
 import java.util.UUID
 
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
-import lib.{ThrallConfig, ThrallKinesisConfig}
+import lib.{ThrallConfig, KinesisReceiverConfig}
 import org.joda.time.DateTime
 import play.api.Logger
 
 object KinesisConfig {
   private val workerId = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
-  def kinesisConfig(config: ThrallKinesisConfig) = {
+  def kinesisConfig(config: KinesisReceiverConfig) = {
 
     Logger.info(s"creating kinesis consumer with endpoint=${config.thrallKinesisEndpoint}, region=${config.awsRegion}")
     kinesisClientLibConfig(
@@ -23,7 +23,7 @@ object KinesisConfig {
       .withDynamoDBEndpoint(config.thrallKinesisDynamoEndpoint)
   }
 
-  private def kinesisClientLibConfig(kinesisAppName: String, streamName: String, config: ThrallKinesisConfig, from: Option[DateTime]): KinesisClientLibConfiguration = {
+  private def kinesisClientLibConfig(kinesisAppName: String, streamName: String, config: KinesisReceiverConfig, from: Option[DateTime]): KinesisClientLibConfiguration = {
     val credentialsProvider = config.awsCredentials
 
     val kinesisConfig = new KinesisClientLibConfiguration(

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -19,7 +19,7 @@ import scala.util.Properties
 
 trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with BeforeAndAfterAll with BeforeAndAfterEach with Eventually with ScalaFutures with DockerKit with DockerTestKit with DockerKitSpotify {
 
-  val useEsDocker = Properties.envOrElse("ES6_USE_DOCKER", "true").toBoolean
+  val useEsDocker = Properties.envOrElse("USE_DOCKER_FOR_TESTS", "true").toBoolean
   val esTestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
 
   val oneHundredMilliseconds = Duration(100, MILLISECONDS)

--- a/thrall/test/lib/kinesis/KinesisTest.scala
+++ b/thrall/test/lib/kinesis/KinesisTest.scala
@@ -38,10 +38,10 @@ class KinesisTest extends KinesisTestBase {
       val stream = streamProcessor.createStream()
       val future = stream.runWith(Sink.seq)
       for (i <- 1 to 10) {
-        highPrioritySender.publish(UpdateMessage("image"))
+        highPrioritySender.publish(UpdateMessage("image", id = Some(s"image-id-$i")))
       }
       for (i <- 1 to 10) {
-        lowPrioritySender.publish(UpdateMessage("update-image-usages"))
+        lowPrioritySender.publish(UpdateMessage("update-image-usages", id = Some(s"image-id-$i")))
       }
       val result = Await.result(future, 5.seconds)
       println(result)

--- a/thrall/test/lib/kinesis/KinesisTest.scala
+++ b/thrall/test/lib/kinesis/KinesisTest.scala
@@ -1,0 +1,10 @@
+package lib.kinesis
+
+class KinesisTest extends KinesisTestBase {
+  describe("Example test") {
+    it("should run once everything is ready") {
+      println("Executing tests")
+      true shouldBe true
+    }
+  }
+}

--- a/thrall/test/lib/kinesis/KinesisTest.scala
+++ b/thrall/test/lib/kinesis/KinesisTest.scala
@@ -1,6 +1,43 @@
 package lib.kinesis
 
+import com.gu.mediaservice.lib.aws.ThrallMessageSender
+import com.gu.mediaservice.lib.aws.Kinesis
+import com.gu.mediaservice.lib.aws.KinesisSenderConfig
+import lib.ThrallStreamProcessor
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import lib.KinesisReceiverConfig
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
+
 class KinesisTest extends KinesisTestBase {
+  private implicit val actorSystem = ActorSystem()
+  private val materializer = ActorMaterializer()
+
+  val lowPrioritySender = getSenderConfig(lowPriorityStreamName)
+  val hightPrioritySender = getSenderConfig(highPriorityStreamName)
+
+  def getSenderConfig(streamName: String): ThrallMessageSender = {
+    val config = new KinesisSenderConfig(region, staticCredentials, kinesisTestUrl, streamName)
+    new ThrallMessageSender(config)
+  }
+
+  def getReceiverConfig(streamName: String): KinesisClientLibConfiguration  = {
+    val config = new KinesisReceiverConfig(
+      streamName,
+      None,
+      "eu-west-1",
+      "stream-endpoint",
+      "dynamo-endpoint",
+      staticCredentials
+    )
+    KinesisConfig.kinesisConfig(config)
+  }
+
+  val highPriorityKinesisConfig = getReceiverConfig(highPriorityStreamName)
+  val lowPriorityKinesisConfig = getReceiverConfig(lowPriorityStreamName)
+  val mockConsumer = mock[ThrallEventConsumer]
+  val streamProcessor = new ThrallStreamProcessor(highPriorityKinesisConfig, lowPriorityKinesisConfig, mockConsumer, actorSystem, materializer)
+
   describe("Example test") {
     it("should run once everything is ready") {
       println("Executing tests")

--- a/thrall/test/lib/kinesis/KinesisTest.scala
+++ b/thrall/test/lib/kinesis/KinesisTest.scala
@@ -30,7 +30,7 @@ class KinesisTest extends KinesisTestBase {
   }
 
   describe("Example test") {
-    it("should take high-priority events from the stream") {
+    it("should process high priority events first") {
       val stream = streamProcessor.createStream()
       val future = stream.take(20).runWith(Sink.seq)
 
@@ -39,7 +39,7 @@ class KinesisTest extends KinesisTestBase {
       publishFiveMessages(highPrioritySender, UpdateMessage("image", id = Some(s"image-id")))
       publishFiveMessages(lowPrioritySender, UpdateMessage("update-image-usages", id = Some(s"image-id")))
 
-      val result = Await.result(future, 2.minutes).map { case (record, _, _) => record.priority }
+      val result = Await.result(future, 5.minutes).map { case (record, _, _) => record.priority }
 
       result.length shouldBe 20
 

--- a/thrall/test/lib/kinesis/KinesisTestBase.scala
+++ b/thrall/test/lib/kinesis/KinesisTestBase.scala
@@ -7,9 +7,6 @@ import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}
 import com.gu.mediaservice.model._
 import org.scalatest.time.{Second, Seconds, Span}
 
-import scala.concurrent.duration._
-import scala.util.Properties
-import scala.concurrent.{Await, Future}
 import lib.KinesisReceiverConfig
 import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
@@ -28,10 +25,17 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.dynamodbv2.model.ListStreamsRequest
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.util.Properties
+import scala.concurrent.{Await, Future}
+import com.gu.mediaservice.lib.aws.ThrallMessageSender
+import com.gu.mediaservice.lib.aws.KinesisSenderConfig
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 
 trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with DockerKit with DockerTestKit with DockerKitSpotify with MockitoSugar {
   val highPriorityStreamName = "thrall-test-stream-high-priority"
   val lowPriorityStreamName = "thrall-test-stream-low-priority"
+  val streamNames = List(highPriorityStreamName, lowPriorityStreamName)
   val kinesisTestUrl = Properties.envOrElse("KINESIS_TEST_URL", "http://localhost:4568/")
   val region = "eu-west-1"
   val staticCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials("stub", "creds"))
@@ -69,6 +73,22 @@ trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with 
     client.createStream(createStreamRequest)
   }
 
+  private def ensureStreamExistsAndIsActive(client: AmazonKinesis, streamNames: List[String]) = {
+    val streamListResult = client.listStreams()
+    streamNames.forall(streamName =>
+      streamListResult.getStreamNames.contains(streamName) &&
+        client.describeStream(highPriorityStreamName).getStreamDescription().getStreamStatus() == "ACTIVE")
+  }
+
+  private def checkStreams(client: AmazonKinesis): Boolean = {
+    if (ensureStreamExistsAndIsActive(client, streamNames)) {
+      true
+    } else {
+      Thread.sleep(1000)
+      checkStreams(client)
+    }
+  }
+
   override def beforeAll {
     super.beforeAll()
     Await.ready(kinesisContainer.isReady(), 1.minute)
@@ -81,6 +101,26 @@ trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with 
     assert(streamNames.contains(highPriorityStreamName))
     assert(streamNames.contains(lowPriorityStreamName))
 
-    println("Local kinesis streams are ready")
+    // We must wait for the stream to be ready – see https://github.com/localstack/localstack/issues/231
+    Await.result(Future { checkStreams(client) }, 10.seconds)
+
+    println(s"Local kinesis streams are ready: ${streamNames}")
+  }
+
+  def getSenderConfig(streamName: String): ThrallMessageSender = {
+    val config = new KinesisSenderConfig(region, staticCredentials, kinesisTestUrl, streamName)
+    new ThrallMessageSender(config)
+  }
+
+  def getReceiverConfig(streamName: String): KinesisClientLibConfiguration  = {
+    val config = new KinesisReceiverConfig(
+      streamName,
+      None,
+      "eu-west-1",
+      "stream-endpoint",
+      "dynamo-endpoint",
+      staticCredentials
+    )
+    KinesisConfig.kinesisConfig(config)
   }
 }

--- a/thrall/test/lib/kinesis/KinesisTestBase.scala
+++ b/thrall/test/lib/kinesis/KinesisTestBase.scala
@@ -10,15 +10,38 @@ import org.scalatest.time.{Second, Seconds, Span}
 import scala.concurrent.duration._
 import scala.util.Properties
 import scala.concurrent.{Await, Future}
+import lib.ThrallKinesisConfig
+import org.mockito.Mockito
+import org.scalatest.mockito.MockitoSugar
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.kinesis.AmazonKinesis
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.kinesis.model.CreateStreamRequest
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.internal.StaticCredentialsProvider
+import org.apache.http.impl.client.BasicCredentialsProvider
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.dynamodbv2.model.ListStreamsRequest
 
-trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with DockerKit with DockerTestKit with DockerKitSpotify {
-  val kinesisTestUrl = Properties.envOrElse("KINESIS_TEST_URL", "http://localhost:4566")
-  val kinesisPort = 4566
+import scala.collection.JavaConverters._
+
+trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with DockerKit with DockerTestKit with DockerKitSpotify with MockitoSugar {
+  val kinesisTestUrl = Properties.envOrElse("KINESIS_TEST_URL", "http://localhost:4568/")
+  val kinesisPort = 4568
   val webUiPort = 5050
-  val kinesisImage = "localstack/localstack:0.11.0"
+  val region = "eu-west-1"
+  val kinesisImage = "localstack/localstack:0.10.8"
   val kinesisContainer = DockerContainer(kinesisImage)
     .withPorts(kinesisPort -> Some(kinesisPort), webUiPort -> Some(webUiPort))
-    .withEnv(s"PORT_WEB_UI=$webUiPort")
+    .withEnv(
+      "SERVICES=kinesis",
+      s"PORT_WEB_UI=$webUiPort",
+      "KINESIS_ERROR_PROBABILITY=0"
+    )
     .withReadyChecker(
       DockerReadyChecker.HttpResponseCode(webUiPort, "health").within(1.minutes).looped(40, 1250.millis)
     )
@@ -28,10 +51,36 @@ trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with 
   final override def dockerContainers: List[DockerContainer] =
     kinesisContainer :: super.dockerContainers
 
+  val highPriorityStreamName = "thrall-test-stream-high-priority"
+  val lowPriorityStreamName = "thrall-test-stream-low-priority"
+
+  def createKinesisClient(): AmazonKinesis = {
+    val clientBuilder = AmazonKinesisClientBuilder.standard()
+    val staticCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials("stub", "creds"))
+    clientBuilder.setCredentials(staticCredentials)
+    clientBuilder.setEndpointConfiguration(new EndpointConfiguration(kinesisTestUrl, region))
+    clientBuilder.build()
+  }
+
+  private def createStream(client: AmazonKinesis, name: String) = {
+    val createStreamRequest = new CreateStreamRequest()
+    createStreamRequest.setStreamName(name)
+    createStreamRequest.setShardCount(1)
+    client.createStream(createStreamRequest)
+  }
+
   override def beforeAll {
     super.beforeAll()
     Await.ready(kinesisContainer.isReady(), 1.minute)
+
+    val client = createKinesisClient()
+    createStream(client, highPriorityStreamName)
+    createStream(client, lowPriorityStreamName)
+
+    val streamNames = client.listStreams().getStreamNames().asScala
+    assert(streamNames.contains(highPriorityStreamName))
+    assert(streamNames.contains(lowPriorityStreamName))
+
     println("Local kinesis image is ready")
   }
 }
-

--- a/thrall/test/lib/kinesis/KinesisTestBase.scala
+++ b/thrall/test/lib/kinesis/KinesisTestBase.scala
@@ -1,0 +1,37 @@
+package lib.kinesis
+
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import com.whisk.docker.impl.spotify.DockerKitSpotify
+import com.whisk.docker.scalatest.DockerTestKit
+import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}
+import com.gu.mediaservice.model._
+import org.scalatest.time.{Second, Seconds, Span}
+
+import scala.concurrent.duration._
+import scala.util.Properties
+import scala.concurrent.{Await, Future}
+
+trait KinesisTestBase extends FunSpec with BeforeAndAfterAll with Matchers with DockerKit with DockerTestKit with DockerKitSpotify {
+  val kinesisTestUrl = Properties.envOrElse("KINESIS_TEST_URL", "http://localhost:4566")
+  val kinesisPort = 4566
+  val webUiPort = 5050
+  val kinesisImage = "localstack/localstack:0.11.0"
+  val kinesisContainer = DockerContainer(kinesisImage)
+    .withPorts(kinesisPort -> Some(kinesisPort), webUiPort -> Some(webUiPort))
+    .withEnv(s"PORT_WEB_UI=$webUiPort")
+    .withReadyChecker(
+      DockerReadyChecker.HttpResponseCode(webUiPort, "health").within(1.minutes).looped(40, 1250.millis)
+    )
+
+  final override val StartContainersTimeout = 1.minute
+
+  final override def dockerContainers: List[DockerContainer] =
+    kinesisContainer :: super.dockerContainers
+
+  override def beforeAll {
+    super.beforeAll()
+    Await.ready(kinesisContainer.isReady(), 1.minute)
+    println("Local kinesis image is ready")
+  }
+}
+

--- a/usage/app/lib/Notifications.scala
+++ b/usage/app/lib/Notifications.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 
-class Notifications(config: UsageConfig) extends ThrallMessageSender(config)
+class Notifications(config: UsageConfig) extends ThrallMessageSender(config.thrallKinesisStreamConfig)

--- a/usage/app/lib/UsageNotifier.scala
+++ b/usage/app/lib/UsageNotifier.scala
@@ -11,7 +11,7 @@ import rx.lang.scala.Observable
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class UsageNotifier(config: UsageConfig, usageTable: UsageTable) extends ThrallMessageSender(config) {
+class UsageNotifier(config: UsageConfig, usageTable: UsageTable) extends ThrallMessageSender(config.thrallKinesisStreamConfig) {
   def build(mediaId: String) = Observable.from(
     usageTable.queryByImageId(mediaId).map((usages: Set[MediaUsage]) => {
       val usageJson = Json.toJson(usages.map(UsageBuilder.build)).as[JsArray]


### PR DESCRIPTION
## What does this change?
Implements high and low priority lanes in thrall. The high priority lane will get processed first and the low priority will get processed eventually.

## How can success be measured?
When there is a record on the high priority stream, it get's processed first, regardless of what's on the low priority stream.
- Let logs with `subject=image` be A
- Let logs with `subject=update-image-usages` be B
- A with have `recordPriority` `high`
- B with have `recordPriority` `low`
- A's `recordArrivalTime` and `start` will be close
- B's `recordArrivalTime` and `start` will vary
- Some Bs will have `recordArrivalTime` close to A's, A will be started first as it is higher priority

We can confirm this with [this script](https://gist.github.com/akash1810/7dcc81004022f3e2349c0750ebf30ca0).

View logs [here](https://logs.gutools.co.uk/goto/d5654cf2be4f65d66bc1ccb8b601aa8c).

## Screenshots (if applicable)
Column 4 is `recordArrivalTime`. Column 5 is `start`.
![image](https://user-images.githubusercontent.com/836140/78455595-26201f00-7697-11ea-83f0-f136ce39edbf.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
