### PR TITLE
don't throw when encountering an unrecognised mime type

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -46,19 +46,19 @@ class S3(config: CommonConfig) {
       case OptimisedPng => image.optimisedPng.getOrElse(image.source)
     }
 
-    val extension = asset.mimeType match {
-      case Some("image/jpeg") => "jpg"
-      case Some("image/png") => "png"
-      case Some("image/tiff") => "tif"
+    val extension: String = asset.mimeType match {
+      case Some("image/jpeg") => ".jpg"
+      case Some("image/png") => ".png"
+      case Some("image/tiff") => ".tif"
       case _ => {
-        Logger.error("Unsupported mime type")(image.toLogMarker)
-        throw new Exception("Unsupported mime type")
+        Logger.warn("Unrecognised mime type")(image.toLogMarker)
+        ""
       }
     }
 
     val baseFilename: String = image.uploadInfo.filename match {
-      case Some(f) => s"${removeExtension(f)} (${image.id}).$extension"
-      case _ => s"${image.id}.$extension"
+      case Some(f) => s"${removeExtension(f)} (${image.id})$extension"
+      case _ => s"${image.id}$extension"
     }
 
     charset.displayName() match {


### PR DESCRIPTION
## What does this change?
We've managed to create a number of documents in ES with mime type `message/rfc822`. We use the mime type to create the filename for the content disposition property of the file download link.

Currently, we're throwing (and causing a 5XX response) when we encounter an unsupported mime type. This doesn't make sense at this point - we've already ingested the image, so there's no reason to break downloading the file again.

This changes the behaviour: rather than throwing, we return an empty string which results in the downloaded file having no file extension.

## How can success be measured?
No more 5XX alarms when a search response contains an unsupported mime type.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
![img](https://media.giphy.com/media/U86dK3B1QK7eg/giphy.gif)

## Tested?
- [x] locally
- [ ] on TEST
