### PR TITLE
don't create kinesis stream in cloudformation DEV stack

### DIFF
--- a/cloud-formation/dev-template.yaml
+++ b/cloud-formation/dev-template.yaml
@@ -109,15 +109,6 @@ Resources:
         ProvisionedThroughput:
           ReadCapacityUnits: '1'
           WriteCapacityUnits: '1'
-
-  ThrallMessageQueue:
-    Type: AWS::Kinesis::Stream
-    Properties:
-      ShardCount: 1
-      RetentionPeriodHours: 168
-      Tags:
-      - { Key: Stack, Value: media-service }
-      - { Key: Stage, Value: DEV }
   IndexedImageTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -278,5 +269,3 @@ Outputs:
     Value: !Ref 'LiveContentPollTable'
   PreviewContentPollTable:
     Value: !Ref 'PreviewContentPollTable'
-  ThrallMessageQueue:
-    Value: !Ref 'ThrallMessageQueue'

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -117,13 +117,19 @@ setupLocalKinesis() {
   # java sdk use CBOR protocol
   # which does not work with localstack kinesis which use kinesislite
   export AWS_CBOR_DISABLE=true
-  echo 'creating local kinesis streams'
-  stream_name='media-service-DEV-ThrallMessageQueue-1N0T2UXYNUIC9'
-  stream_count=$(aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis list-streams | jq -r .StreamNames[] | grep -c "${stream_name}" || true)
-  if [ "$stream_count" -eq 0 ]; then
-    export AWS_PAGER=""
-    aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis create-stream --shard-count 1 --stream-name "${stream_name}"
-  fi
+  export AWS_PAGER=""
+
+  streams=(
+    'media-service-DEV-thrall'
+  )
+
+  for stream_name in "${streams[@]}"; do
+    stream_count=$(aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis list-streams | jq -r '.StreamNames[]' | grep -c "${stream_name}" || true)
+    if [ "$stream_count" -eq 0 ]; then
+      echo "creating local kinesis stream ${stream_name}"
+      aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis create-stream --shard-count 1 --stream-name "${stream_name}"
+    fi
+  done
 }
 
 main() {

--- a/scripts/generate-dot-properties/config.json5
+++ b/scripts/generate-dot-properties/config.json5
@@ -21,6 +21,10 @@
     replicas: 0
   },
 
+  thrall: {
+    streamName: 'media-service-DEV-thrall',
+  },
+
   // Guardian specific properties for the Usage service
   capi: {
     poll:  5,

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -25,7 +25,7 @@ function getCollectionsConfig(config) {
         |s3.collections.bucket=${config.stackProps.CollectionsBucket}
         |dynamo.table.collections=${config.stackProps.CollectionsDynamoTable}
         |dynamo.table.imageCollections=${config.stackProps.ImageCollectionsDynamoTable}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
@@ -39,7 +39,7 @@ function getCropperConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |publishing.image.bucket=${config.stackProps.ImageOriginBucket}
         |publishing.image.host=${config.stackProps.ImageOriginBucket}.s3.amazonaws.com
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
@@ -54,7 +54,7 @@ function getImageLoaderConfig(config) {
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
@@ -86,7 +86,7 @@ function getLeasesConfig(config) {
         |domain.root=${config.domainRoot}
         |aws.region=${config.aws.region}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |dynamo.tablename.leasesTable=${config.stackProps.LeasesDynamoTable}
@@ -101,7 +101,7 @@ function getMediaApiConfig(config) {
         |s3.image.bucket=${config.stackProps.ImageBucket}
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
@@ -123,7 +123,7 @@ function getMetadataEditorConfig(config) {
         |aws.region=${config.aws.region}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.collections.bucket=${config.stackProps.CollectionsBucket}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |dynamo.table.edits=${config.stackProps.EditsDynamoTable}
@@ -157,7 +157,7 @@ function getThrallConfig(config) {
         |es6.cluster=${config.es6.cluster}
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |`;
@@ -172,7 +172,7 @@ function getUsageConfig(config) {
         |capi.apiKey=${config.capi.live.key}
         |dynamo.tablename.usageRecordTable=${config.stackProps.UsageRecordTable}
         |composer.baseUrl=${config.composer.url}
-        |thrall.kinesis.stream.name=${config.stackProps.ThrallMessageQueue}
+        |thrall.kinesis.stream.name=${config.thrall.streamName}
         |thrall.local.kinesis.url=${localKinesisURL}
         |thrall.local.dynamodb.url=${localDynamoURL}
         |crier.live.arn=${config.crier.live.roleArn}


### PR DESCRIPTION
## What does this change?
We're using localstack in DEV now, so we do not need this AWS resource.

Also use a more generic stream name for thrall.

Related to https://github.com/guardian/grid/pull/2896

## How can success be measured?
Cheaper AWS bill?

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
