### PR TITLE
rel="noopener" on  target="_blank""

### DIFF
--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -5,8 +5,8 @@
         <gr-icon>more_vert</gr-icon>
     </button>
     <ul class="drop-menu__items drop-menu__items--right" ng:if="showUserActions">
-        <li><a href="/quotas" target="_blank">Quotas</a></li>
-        <li><a href="{{ctrl.feedbackFormLink}}" target="_blank" rel="noopener noreferrer">Feedback</a></li>
+        <li><a href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
+        <li><a href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
         <li><a href="/logout" target="_self">Logout</a></li>
     </ul>
 </nav>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -10,7 +10,7 @@
     </button>
 
     <a ng:if="ctrl.imageCount() == 1"
-       href="{{ ctrl.firstImageUris.uris.downloadUri }}" download target="_blank">
+       href="{{ ctrl.firstImageUris.uris.downloadUri }}" download rel="noopener" target="_blank">
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
@@ -22,6 +22,7 @@
             ng:href="{{:: ctrl.firstImageUris.uris.lowResDownloadUri }}"
             class="drop-menu__items drop-menu__items--nopad"
             download
+            rel="noopener"
             target="_blank">
             <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
         </a>

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
@@ -14,7 +14,7 @@
                 <span class="date-added">{{::ctrl.formatTimestamp(usage.dateAdded)}}</span>
                 <ul class="reference-list">
                     <li ng-repeat="reference in usage.references">
-                        <a ng:if="reference.uri" href="{{reference.uri}}" title="Open in {{reference.type}}" target="_blank">
+                        <a ng:if="reference.uri" href="{{reference.uri}}" title="Open in {{reference.type}}" rel="noopener" target="_blank">
                             <gr-frontend-icon class="reference-list__icon" ng:if="reference.type === 'frontend'"></gr-frontend-icon>
                             <gr-composer-icon class="reference-list__icon" ng:if="reference.type === 'composer'"></gr-composer-icon>
                         </a>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -28,6 +28,7 @@
                 ng:if="ctrl.image.data.valid">
                 <li>
                     <a class="image-action image-action--first"
+                       rel="noopener"
                        target="_blank"
                        title="Pop out"
                        ng:href="/images/{{:: ctrl.image.data.id}}">

--- a/kahuna/public/js/errors/global.html
+++ b/kahuna/public/js/errors/global.html
@@ -6,7 +6,7 @@
 
         <p>
             If you can see this icon <img src="/assets/images/blocked-cookies.png" alt="blocked third party cookies" class="side-padded"/> in the address bar,
-            please follow <a href="{{ctrl.invalidSessionHelpLink}}" class="coloured-link" target="_blank">these instructions</a>.
+            please follow <a href="{{ctrl.invalidSessionHelpLink}}" class="coloured-link" rel="noopener" target="_blank">these instructions</a>.
         </p>
     </div>
 
@@ -29,7 +29,7 @@
 
         <p>
             If you can see this icon <img src="/assets/images/blocked-cookies.png" alt="blocked third party cookies" class="side-padded"/> in the address bar,
-            please follow <a href="{{ctrl.invalidSessionHelpLink}}" class="coloured-link" target="_blank">these instructions</a>.
+            please follow <a href="{{ctrl.invalidSessionHelpLink}}" class="coloured-link" rel="noopener" target="_blank">these instructions</a>.
         </p>
     </div>
 

--- a/kahuna/public/js/preview/image-large.html
+++ b/kahuna/public/js/preview/image-large.html
@@ -3,6 +3,7 @@
     <ul class="image-actions">
         <li>
             <a class="image-action image-action--first"
+               rel="noopener"
                target="_blank"
                title="Pop out"
                ng:href="/images/{{ctrl.image.data.id}}"

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -3,6 +3,7 @@
     <ul class="image-actions">
         <li>
             <a class="image-action image-action--first"
+               rel="noopener"
                target="_blank"
                title="Pop out"
                ng:href="/images/{{::ctrl.image.data.id}}"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -5,7 +5,7 @@
       ng:submit="usageRights.$valid && ctrl.save()">
 
     <div class="ure__description">
-        <a target="_blank" href="{{ctrl.usageRightsHelpLink}}">
+        <a rel="noopener" target="_blank" href="{{ctrl.usageRightsHelpLink}}">
             <gr-icon title="Rights Guide">
                 info_outline
             </gr-icon>


### PR DESCRIPTION
## What does this change?

This adds  rel="noopener" to all our  target="_blank"

Because the new htmllint does not allow this, and this should be a separate change.
## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
