### PR TITLE
Queue polls!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: [8.6.0]
+        node-version: [12.16.1]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/kahuna/.babelrc
+++ b/kahuna/.babelrc
@@ -1,5 +1,7 @@
 {
   "presets": [
-    "@babel/preset-env"
+    ["@babel/preset-env",{
+      "exclude":["@babel/plugin-transform-regenerator"]
+    }]
   ]
 }

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -46,7 +46,8 @@ addLabel.controller('GrAddLabelCtrl', [
 
         }
 
-        function saveFailed() {
+        function saveFailed(e) {
+          console.error(e);
             $window.alert('Something went wrong when saving, please try again!');
             ctrl.active = true;
         }

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -46,8 +46,7 @@ addLabel.controller('GrAddLabelCtrl', [
 
         }
 
-        function saveFailed(e) {
-          console.error(e);
+        function saveFailed() {
             $window.alert('Something went wrong when saving, please try again!');
             ctrl.active = true;
         }

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -83,16 +83,17 @@ async.service("queue", [
         return;
       }
       thingsDone++;
-      const { promise, func, retries } = queue.shift();
+      const { resolve, reject, func, retries } = queue.shift();
       console.log(`Shifted task off queue, queue now ${queue.length} long`);
       func()
         .then(resolved => {
-          promise.resolve(resolved);
+          resolve(resolved);
         })
         .catch(() => {
           console.log("poll failed");
+
           setTimeout(() => {
-            add({ promise, func, retries: retries + 1 });
+            add({ resolve, reject, func, retries: retries + 1 });
           }, getBackoffTimeFromRetries(retries));
         })
         .finally(() => {

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -113,7 +113,7 @@ async.service("queue", [
   }
 ]);
 
-async.factory("pollQ", [
+async.factory("apiPoll", [
   "$q",
   "queue",
   ($q, queue) => {
@@ -123,57 +123,6 @@ async.factory("pollQ", [
       console.log("adding in pollQ", func);
       queue.add({ promise: deferred, func });
       return deferred.promise;
-    };
-  }
-]);
-
-async.factory("poll", [
-  "$q",
-  "delay",
-  "race",
-  function($q, delay, race) {
-    function poll(func, pollEvery, maxWait) {
-      var timeout = delay(maxWait).then(() => $q.reject(new Error("timeout")));
-
-      // Returns the result of promise or a rejected timeout
-      // promise, whichever happens first
-      function withTimeout(promise) {
-        return race([promise, timeout]);
-      }
-
-      const JITTER = 100;
-      const BACKOFF = 2;
-      let i = 0;
-
-      const withBackoff = () => {
-        const jitter = Math.floor(Math.random() * JITTER);
-        const wait = pollEvery * BACKOFF ** i++ + jitter;
-        return wait;
-      };
-
-      function pollRecursive() {
-        return func().catch(() => {
-          return withTimeout(delay(withBackoff())).then(pollRecursive);
-        });
-      }
-
-      return withTimeout(pollRecursive());
-    }
-
-    return poll;
-  }
-]);
-
-// Polling with sensible defaults for API polling
-async.factory("apiPoll", [
-  "pollQ",
-  function(pollQ) {
-    // const pollFrequency = 500; // ms
-    // const pollTimeout   = 30 * 1000; // ms
-    return func => {
-      const p = pollQ(func);
-      console.log(p);
-      return p;
     };
   }
 ]);

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -1,109 +1,172 @@
-import angular from 'angular';
+import angular from "angular";
 
-export var async = angular.module('util.async', []);
+export var async = angular.module("util.async", []);
 
 /**
  * Return a lazy function that will yield before calling the input `func`.
  */
-async.factory('nextTick',
-  ['$timeout',
-    function($timeout) {
+async.factory("nextTick", [
+  "$timeout",
+  function($timeout) {
+    function nextTick(func) {
+      return () => $timeout(func, 0);
+    }
 
-      function nextTick(func) {
-        return () => $timeout(func, 0);
-      }
-
-      return nextTick;
-    }]);
-
+    return nextTick;
+  }
+]);
 
 /**
  * Return a Promise that is resolved with no value after `duration`.
  */
-async.factory('delay',
-  ['$q', '$timeout',
-    function($q, $timeout) {
+async.factory("delay", [
+  "$q",
+  "$timeout",
+  function($q, $timeout) {
+    function delay(duration) {
+      var defer = $q.defer();
+      $timeout(defer.resolve, duration);
+      return defer.promise;
+    }
 
-      function delay(duration) {
-        var defer = $q.defer();
-        $timeout(defer.resolve, duration);
-        return defer.promise;
+    return delay;
+  }
+]);
+
+async.factory("race", [
+  "$q",
+  function($q) {
+    function race(promises) {
+      var first = $q.defer();
+      promises.forEach(promise => {
+        promise.then(first.resolve, first.reject);
+      });
+      return first.promise;
+    }
+
+    return race;
+  }
+]);
+
+async.service("queue", [
+  "$q",
+  "delay",
+  ($q, delay) => {
+    let queue = [];
+    let running = false;
+    console.log("instantiating queue");
+    const add = ({ promise, func }) => {
+      console.log("adding to queue", func);
+      queue.push({ promise, func });
+      console.log(queue.length, JSON.stringify(queue));
+      if (!running) {
+        setTimeout(() => run(), 0);
       }
-
-      return delay;
-    }]);
-
-
-async.factory('race',
-  ['$q',
-    function($q) {
-
-      function race(promises) {
-        var first = $q.defer();
-        promises.forEach(promise => {
-          promise.then(first.resolve, first.reject);
-        });
-        return first.promise;
+    };
+    let thingsDone = 0;
+    const run = () => {
+      running = true;
+      if (queue.length === 0) {
+        console.log("We did ", thingsDone, "things");
+        thingsDone = 0;
+        running = false;
+        return;
       }
-
-      return race;
-    }]);
-
-
-async.factory('poll',
-  ['$q', 'delay', 'race',
-    function($q, delay, race) {
-
-      function poll(func, pollEvery, maxWait) {
-        var timeout = delay(maxWait).then(() => $q.reject(new Error('timeout')));
-
-        // Returns the result of promise or a rejected timeout
-        // promise, whichever happens first
-        function withTimeout(promise) {
-          return race([promise, timeout]);
-        }
-
-        const JITTER = 100;
-        const BACKOFF = 2;
-        let i = 0;
-
-        const withBackoff = () => {
-            const jitter = Math.floor(Math.random() * JITTER);
-            const wait = pollEvery * BACKOFF ** (i++) + jitter;
-            return wait;
-        };
-
-        function pollRecursive() {
-          return func().catch(() => {
-            return withTimeout(delay(withBackoff())).then(pollRecursive);
+      thingsDone++;
+      const { promise, func } = queue.shift();
+      console.log(`Shifted task off queue, queue now ${queue.length} long`);
+      func()
+        .then(resolved => promise.resolve(resolved))
+        .catch(() => {
+          console.log("poll failed");
+          add({ promise, func });
+        })
+        .finally(() => {
+          console.log("task complete");
+          delay(500).then(() => {
+            setTimeout(() => run(), 0);
           });
-        }
+        });
+    };
+    return { add };
+  }
+]);
 
-        return withTimeout(pollRecursive());
+async.factory("pollQ", [
+  "$q",
+  "queue",
+  ($q, queue) => {
+    console.log("instantiating pollQ with ", queue);
+    return func => {
+      let deferred = $q.defer();
+      console.log("adding in pollQ", func);
+      queue.add({ promise: deferred, func });
+      return deferred.promise;
+    };
+  }
+]);
+
+async.factory("poll", [
+  "$q",
+  "delay",
+  "race",
+  function($q, delay, race) {
+    function poll(func, pollEvery, maxWait) {
+      var timeout = delay(maxWait).then(() => $q.reject(new Error("timeout")));
+
+      // Returns the result of promise or a rejected timeout
+      // promise, whichever happens first
+      function withTimeout(promise) {
+        return race([promise, timeout]);
       }
 
-      return poll;
-    }]);
+      const JITTER = 100;
+      const BACKOFF = 2;
+      let i = 0;
 
+      const withBackoff = () => {
+        const jitter = Math.floor(Math.random() * JITTER);
+        const wait = pollEvery * BACKOFF ** i++ + jitter;
+        return wait;
+      };
+
+      function pollRecursive() {
+        return func().catch(() => {
+          return withTimeout(delay(withBackoff())).then(pollRecursive);
+        });
+      }
+
+      return withTimeout(pollRecursive());
+    }
+
+    return poll;
+  }
+]);
 
 // Polling with sensible defaults for API polling
-async.factory('apiPoll', ['poll', function(poll) {
-
-  const pollFrequency = 500; // ms
-  const pollTimeout   = 30 * 1000; // ms
-
-  return func => poll(func, pollFrequency, pollTimeout);
-}]);
-
+async.factory("apiPoll", [
+  "pollQ",
+  function(pollQ) {
+    // const pollFrequency = 500; // ms
+    // const pollTimeout   = 30 * 1000; // ms
+    return func => {
+      const p = pollQ(func);
+      console.log(p);
+      return p;
+    };
+  }
+]);
 
 // Return a promise resolved the next time the event is fired on the scope
-async.factory('onNextEvent', ['$q', function($q) {
+async.factory("onNextEvent", [
+  "$q",
+  function($q) {
+    function onNextEvent(scope, event) {
+      const defer = $q.defer();
+      const unregister = scope.$on(event, (_, arg) => defer.resolve(arg));
+      return defer.promise.finally(unregister);
+    }
 
-  function onNextEvent(scope, event) {
-    const defer = $q.defer();
-    const unregister = scope.$on(event, (_, arg) => defer.resolve(arg));
-    return defer.promise.finally(unregister);
+    return onNextEvent;
   }
-
-  return onNextEvent;
-}]);
+]);

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -49,8 +49,10 @@ async.factory("race", [
   }
 ]);
 
-async.service("queue", [() => {
-  return createQueue();
+async.service("queue", ['$timeout', ($timeout) => {
+  return createQueue({
+    timeout: $timeout
+  });
 }]);
 
 async.factory("apiPoll", [

--- a/kahuna/public/js/util/queue.js
+++ b/kahuna/public/js/util/queue.js
@@ -1,0 +1,68 @@
+export const queue = ({
+  JITTER = 100,
+  BACKOFF_BASE = 2,
+  INITIAL_BACKOFF_WAIT = 500,
+  MAX_WORKERS = 5,
+  MAX_RETRIES = 30 } = {}) => {
+
+
+  const getBackoffTimeFromRetries = noOfRetries => {
+    const jitter = Math.floor(Math.random() * JITTER);
+    const wait = INITIAL_BACKOFF_WAIT * BACKOFF_BASE ** noOfRetries + jitter;
+    return wait;
+  };
+
+  let queue = [];
+  let running = false;
+  console.log("instantiating queue");
+  const add = ({ resolve, reject, func, retries = 0 }) => {
+    console.log("adding to queue", func);
+    queue.push({ resolve, reject, func, retries });
+    console.log(queue.length, JSON.stringify(queue));
+    if (!running) {
+      run();
+    }
+  };
+
+  let thingsDone = 0;
+  const startWorker = () => {
+    running = true;
+    if (queue.length === 0) {
+      console.log("We did ", thingsDone, "things");
+      thingsDone = 0;
+      running = false;
+      return;
+    }
+    thingsDone++;
+    const { resolve, reject, func, retries } = queue.shift();
+    console.log(`Shifted task off queue, queue now ${queue.length} long`);
+    func()
+      .then(resolved => {
+        resolve(resolved);
+      })
+      .catch((e) => {
+        console.log("poll failed");
+        if (retries >= MAX_RETRIES) {
+          console.error("MAX RETRIES EXCEEDED");
+          reject(e);
+        }
+        setTimeout(() => {
+          add({ resolve, reject, func, retries: retries + 1 });
+        }, getBackoffTimeFromRetries(retries));
+      })
+      .finally(() => {
+        console.log("task complete");
+        // This adds the subsequent run call to the next tick,
+        // ensuring it is run in a new call stack.
+        setTimeout(() => startWorker(), 0);
+      });
+  };
+
+  const run = () => {
+    for (let i = 0; i < MAX_WORKERS; i++) {
+      setTimeout(startWorker(), 0);
+    }
+  };
+
+  return { add };
+};

--- a/kahuna/public/js/util/queue.js
+++ b/kahuna/public/js/util/queue.js
@@ -1,49 +1,38 @@
-export const queue = ({
-  JITTER = 100,
-  BACKOFF_BASE = 2,
-  INITIAL_BACKOFF_WAIT = 500,
-  MAX_WORKERS = 5,
-  MAX_RETRIES = 30 } = {}) => {
-
-
+export const createQueue = ({
+  jitterFactor = 100,
+  backoffBase = 2,
+  initialBackoffWait = 500,
+  maxWorkers = 5,
+  maxRetries = 30
+} = {}) => {
   const getBackoffTimeFromRetries = noOfRetries => {
-    const jitter = Math.floor(Math.random() * JITTER);
-    const wait = INITIAL_BACKOFF_WAIT * BACKOFF_BASE ** noOfRetries + jitter;
+    const jitter = Math.floor(Math.random() * jitterFactor);
+    const wait = initialBackoffWait * backoffBase ** noOfRetries + jitter;
     return wait;
   };
 
   let queue = [];
   let running = false;
-  console.log("instantiating queue");
   const add = ({ resolve, reject, func, retries = 0 }) => {
-    console.log("adding to queue", func);
     queue.push({ resolve, reject, func, retries });
-    console.log(queue.length, JSON.stringify(queue));
     if (!running) {
       run();
     }
   };
 
-  let thingsDone = 0;
   const startWorker = () => {
     running = true;
     if (queue.length === 0) {
-      console.log("We did ", thingsDone, "things");
-      thingsDone = 0;
       running = false;
       return;
     }
-    thingsDone++;
     const { resolve, reject, func, retries } = queue.shift();
-    console.log(`Shifted task off queue, queue now ${queue.length} long`);
     func()
       .then(resolved => {
         resolve(resolved);
       })
-      .catch((e) => {
-        console.log("poll failed");
-        if (retries >= MAX_RETRIES) {
-          console.error("MAX RETRIES EXCEEDED");
+      .catch(e => {
+        if (retries >= maxRetries) {
           reject(e);
         }
         setTimeout(() => {
@@ -51,7 +40,6 @@ export const queue = ({
         }, getBackoffTimeFromRetries(retries));
       })
       .finally(() => {
-        console.log("task complete");
         // This adds the subsequent run call to the next tick,
         // ensuring it is run in a new call stack.
         setTimeout(() => startWorker(), 0);
@@ -59,7 +47,7 @@ export const queue = ({
   };
 
   const run = () => {
-    for (let i = 0; i < MAX_WORKERS; i++) {
+    for (let i = 0; i < maxWorkers; i++) {
       setTimeout(startWorker(), 0);
     }
   };

--- a/kahuna/public/js/util/queue.js
+++ b/kahuna/public/js/util/queue.js
@@ -1,7 +1,6 @@
 /**
- * Creates a queue designed to limit the number of concurrent asynchronous operations,
- *
- * Calling `createQueue` returns an object that exposes an `add` function.
+ * Creates a queue designed to limit the number of concurrent asynchronous operations, and returns
+ * an object that exposes an `add` method to enqueue functions.
  *
  * Enqueued functions are called concurrently up to the worker limit, and retried with an
  * exponential backoff.

--- a/kahuna/public/js/util/queue.js
+++ b/kahuna/public/js/util/queue.js
@@ -3,7 +3,8 @@ export const createQueue = ({
   backoffBase = 2,
   initialBackoffWait = 500,
   maxWorkers = 5,
-  maxRetries = 30
+  maxRetries = 30,
+  timeout = setTimeout
 } = {}) => {
   const getBackoffTimeFromRetries = noOfRetries => {
     const jitter = Math.floor(Math.random() * jitterFactor);
@@ -35,20 +36,20 @@ export const createQueue = ({
         if (retries >= maxRetries) {
           reject(e);
         }
-        setTimeout(() => {
+        timeout(() => {
           add({ resolve, reject, func, retries: retries + 1 });
         }, getBackoffTimeFromRetries(retries));
       })
       .finally(() => {
         // This adds the subsequent run call to the next tick,
         // ensuring it is run in a new call stack.
-        setTimeout(() => startWorker(), 0);
+        timeout(() => startWorker(), 0);
       });
   };
 
   const run = () => {
     for (let i = 0; i < maxWorkers; i++) {
-      setTimeout(startWorker(), 0);
+      timeout(startWorker(), 0);
     }
   };
 

--- a/kahuna/public/js/util/queue.spec.js
+++ b/kahuna/public/js/util/queue.spec.js
@@ -4,6 +4,13 @@ const addToQueue = (q, func) => new Promise((resolve, reject) => {
   q.add({ resolve, reject, func });
 });
 
+const runner = (timeout, value, executionsBuffer) => () => new Promise((resolve) => {
+  setTimeout(() => {
+    executionsBuffer.push(value);
+    resolve(executionsBuffer);
+  }, timeout);
+});
+
 describe('queue', () => {
   it("should not retry too many times", async () => {
     const maxRetries = 5;
@@ -24,36 +31,38 @@ describe('queue', () => {
     const success = "YES";
     const q = createQueue();
     const fn = async () => success;
+
     await expect(addToQueue(q, fn)).resolves.toBe(success);
   });
 
   it("should run functions one after the other with one worker", async () => {
     const q = createQueue({ maxWorkers: 1 });
     let executions = [];
-    const runner = (timeout, value) => () => new Promise((resolve) => {
-      setTimeout(() => {
-        executions.push(value);
-        resolve(executions);
-      }, timeout);
-    });
-    const a = addToQueue(q, runner(1000, 1));
-    const b = addToQueue(q, runner(0, 2));
+    const a = addToQueue(q, runner(1000, 1, executions));
+    const b = addToQueue(q, runner(0, 2, executions));
     await Promise.all([a, b]);
+
     expect(executions).toEqual([1, 2]);
   });
 
   it("should run functions simultaneously with multiple workers", async () => {
     const q = createQueue({ maxWorkers: 2 });
     let executions = [];
-    const runner = (timeout, value)=>() => new Promise((resolve) => {
-      setTimeout(() => {
-        executions.push(value);
-        resolve(executions);
-      }, timeout);
-    });
-    const a = addToQueue(q, runner(1000, 1));
-    const b = addToQueue(q, runner(0, 2));
+    const a = addToQueue(q, runner(1000, 1, executions));
+    const b = addToQueue(q, runner(0, 2, executions));
     await Promise.all([a, b]);
+
     expect(executions).toEqual([2, 1]);
+  });
+
+  it("should begin additional functions as soon as pending functions are complete", async () => {
+    const q = createQueue({ maxWorkers: 2 });
+    let executions = [];
+    const a = addToQueue(q, runner(1000, 1, executions));
+    const b = addToQueue(q, runner(10, 2, executions));
+    const c = addToQueue(q, runner(10, 3, executions));
+    await Promise.all([a, b, c]);
+
+    expect(executions).toEqual([2, 3, 1]);
   });
 });

--- a/kahuna/public/js/util/queue.spec.js
+++ b/kahuna/public/js/util/queue.spec.js
@@ -30,7 +30,7 @@ describe('queue', () => {
   it("should run functions one after the other with one worker", async () => {
     const q = createQueue({ maxWorkers: 1 });
     let executions = [];
-    const runner = (timeout, value)=>() => new Promise((resolve) => {
+    const runner = (timeout, value) => () => new Promise((resolve) => {
       setTimeout(() => {
         executions.push(value);
         resolve(executions);

--- a/kahuna/public/js/util/queue.spec.js
+++ b/kahuna/public/js/util/queue.spec.js
@@ -1,0 +1,31 @@
+import { queue } from "./queue";
+
+const addToQueue = (q, func) => new Promise((resolve, reject) => {
+  console.log("EHHELLO");
+  q.add({ resolve, reject, func });
+});
+
+describe('queue', async () => {
+  it("should not retry too many times", async () => {
+    const MAX_RETRIES = 5;
+    const q = queue({
+      MAX_RETRIES,
+      INITIAL_BACKOFF_WAIT: 1
+    });
+    let attempts = 0;
+    const fn = async () => {
+      attempts++;
+      throw new Error("Never going to work.");
+    };
+    await expect(addToQueue(q, fn)).rejects.toStrictEqual(new Error("Never going to work."));
+    expect(attempts).toBe(MAX_RETRIES + 1);
+  });
+
+  it("should return a promise, which resolves", async () => {
+    const success = "YES";
+    const q = queue();
+    const fn = async () => success;
+    await expect(addToQueue(q, fn)).resolves.toBe(success);
+  });
+
+});

--- a/kahuna/public/js/util/queue.spec.js
+++ b/kahuna/public/js/util/queue.spec.js
@@ -1,16 +1,15 @@
-import { queue } from "./queue";
+import { createQueue } from "./queue";
 
 const addToQueue = (q, func) => new Promise((resolve, reject) => {
-  console.log("EHHELLO");
   q.add({ resolve, reject, func });
 });
 
-describe('queue', async () => {
+describe('queue', () => {
   it("should not retry too many times", async () => {
-    const MAX_RETRIES = 5;
-    const q = queue({
-      MAX_RETRIES,
-      INITIAL_BACKOFF_WAIT: 1
+    const maxRetries = 5;
+    const q = createQueue({
+      maxRetries,
+      initialBackoffWait: 1
     });
     let attempts = 0;
     const fn = async () => {
@@ -18,14 +17,43 @@ describe('queue', async () => {
       throw new Error("Never going to work.");
     };
     await expect(addToQueue(q, fn)).rejects.toStrictEqual(new Error("Never going to work."));
-    expect(attempts).toBe(MAX_RETRIES + 1);
+    expect(attempts).toBe(maxRetries + 1);
   });
 
   it("should return a promise, which resolves", async () => {
     const success = "YES";
-    const q = queue();
+    const q = createQueue();
     const fn = async () => success;
     await expect(addToQueue(q, fn)).resolves.toBe(success);
   });
 
+  it("should run functions one after the other with one worker", async () => {
+    const q = createQueue({ maxWorkers: 1 });
+    let executions = [];
+    const runner = (timeout, value)=>() => new Promise((resolve) => {
+      setTimeout(() => {
+        executions.push(value);
+        resolve(executions);
+      }, timeout);
+    });
+    const a = addToQueue(q, runner(1000, 1));
+    const b = addToQueue(q, runner(0, 2));
+    await Promise.all([a, b]);
+    expect(executions).toEqual([1, 2]);
+  });
+
+  it("should run functions simultaneously with multiple workers", async () => {
+    const q = createQueue({ maxWorkers: 2 });
+    let executions = [];
+    const runner = (timeout, value)=>() => new Promise((resolve) => {
+      setTimeout(() => {
+        executions.push(value);
+        resolve(executions);
+      }, timeout);
+    });
+    const a = addToQueue(q, runner(1000, 1));
+    const b = addToQueue(q, runner(0, 2));
+    await Promise.all([a, b]);
+    expect(executions).toEqual([2, 1]);
+  });
 });

--- a/kahuna/webpack.config.prod.js
+++ b/kahuna/webpack.config.prod.js
@@ -8,8 +8,7 @@ module.exports = merge(shared, {
       minimize: true,
       minimizer: [new TerserPlugin({
         sourceMap: true
-      })],
-
-    },
+      })]
+    }
   }
 );

--- a/kahuna/webpack.config.prod.js
+++ b/kahuna/webpack.config.prod.js
@@ -9,6 +9,7 @@ module.exports = merge(shared, {
       minimizer: [new TerserPlugin({
         sourceMap: true
       })]
+
     }
   }
 );


### PR DESCRIPTION
## What does this change?

This puts `apiPoll` behind a queue so we don't thundering herd every time a batch change is made. 

The queue is designed to limit the number of concurrent asynchronous operations.

Enqueued functions are called concurrently up to the worker limit, and retried with an exponential backoff.

## How can success be measured?

Batch editing large numbers of items is less unstable.

## Tested?
- [x] locally
- [x] on TEST
