### PR TITLE
Add TIFF to supported formats Upload msg

### DIFF
--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -108,7 +108,7 @@ jobs.controller('UploadJobsCtrl', [
             const reason = error.body && error.body.errorKey;
 
             const message = reason === 'unsupported-type' ?
-                'The Grid only supports JPG and PNG images.' +
+                'The Grid only supports JPG, PNG and TIFF images.' +
                 ' Please convert the image and try again.' :
                 error.body && error.body.errorMessage || 'unknown';
 


### PR DESCRIPTION
Updates the message upon uploading an unsupported file about our support for TIFFs. Hasn’t been widely advertised yet, because it would be great to fix at least some of the [outstanding issues with it](https://github.com/guardian/grid/issues/2395).

![image](https://user-images.githubusercontent.com/6032869/78195067-b5022100-7476-11ea-8a64-7f3b35704be1.png)


## Tested?
- [x] nah
