### PR TITLE
bump node in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: [8.6.0]
+        node-version: [12.16.1]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## What does this change?
brings node version used in GitHub Actions in line with repo

follows https://github.com/guardian/grid/pull/2885

## How can success be measured?
Consistency?

## Screenshots (if applicable)
![img](https://media.giphy.com/media/ZC0BvDLNHJVytoMXgy/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
