### PR TITLE
Use non-deprecated Angular HTML attributes

### DIFF
--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -14,7 +14,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title ui:title ui:title-suffix="the grid">the grid</title>
+    <title ui-title ui-title-suffix="the grid">the grid</title>
     <!-- htmllint line-ending-style="false" -->
 
 
@@ -47,9 +47,9 @@
 
   </head>
   <body>
-    <p class="loader" ng:hide="true">Loading the grid…</p>
+    <p class="loader" ng-hide="true">Loading the grid…</p>
 
-    <div ui:view></div>
+    <div ui-view></div>
 
     <ui-global-errors></ui-global-errors>
 

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -1,10 +1,10 @@
 <nav class="user-actions drop-menu">
     <button class="drop-menu__button"
             type="button"
-            ng:click="showUserActions = !showUserActions">
+            ng-click="showUserActions = !showUserActions">
         <gr-icon>more_vert</gr-icon>
     </button>
-    <ul class="drop-menu__items drop-menu__items--right" ng:if="showUserActions">
+    <ul class="drop-menu__items drop-menu__items--right" ng-if="showUserActions">
         <li><a href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
         <li><a href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
         <li><a href="/logout" target="_self">Logout</a></li>

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -1,46 +1,46 @@
-<button ng:class="{'small': ctrl.grSmall}"
-        ng:click="ctrl.active = true"
-        ng:disabled="ctrl.adding"
-        ng:if="!ctrl.active"
-        gr:tooltip="Add label"
-        gr:tooltip-position="left">
+<button ng-class="{'small': ctrl.grSmall}"
+        ng-click="ctrl.active = true"
+        ng-disabled="ctrl.adding"
+        ng-if="!ctrl.active"
+        gr-tooltip="Add label"
+        gr-tooltip-position="left">
 
-    <gr-icon ng:class="{'spin': ctrl.adding}">add_box</gr-icon>
+    <gr-icon ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span>
-       <span ng:show="ctrl.adding">Adding...</span>
+       <span ng-show="ctrl.adding">Adding...</span>
     </span>
 </button>
 <form class="gr-add-label__form"
-        ng:if="ctrl.active"
-        ng:submit="ctrl.save()">
+        ng-if="ctrl.active"
+        ng-submit="ctrl.save()">
     <gr-datalist
         class="job-info--editor__input"
-        gr:search="ctrl.labelSearch(q)">
+        gr-search="ctrl.labelSearch(q)">
 
         <input type="text"
                class="text-input gr-add-label__form__input show-no-error"
                placeholder="label1, label2, label3…"
-               gr:datalist-input
-               gr:datalist-input-on-cancel="ctrl.cancel()"
-               gr:datalist-input-selector="ctrl.selectLastLabel($value)"
-               gr:datalist-input-updater="ctrl.labelAppend($currentValue, $selectedValue)"
-               gr:auto-focus
+               gr-datalist-input
+               gr-datalist-input-on-cancel="ctrl.cancel()"
+               gr-datalist-input-selector="ctrl.selectLastLabel($value)"
+               gr-datalist-input-updater="ctrl.labelAppend($currentValue, $selectedValue)"
+               gr-auto-focus
                required
-               ng:model="ctrl.newLabel"
-               ng:disabled="ctrl.adding" />
+               ng-model="ctrl.newLabel"
+               ng-disabled="ctrl.adding" />
     </gr-datalist>
 
     <span class="gr-add-label__form__buttons">
-        <button class="gr-add-label__form__buttons__button-cancel button-cancel" type="button" ng:click="ctrl.cancel()" title="Close">
-            <gr-icon-label gr-icon="close"><span ng:hide="ctrl.grSmall">Cancel</span></gr-icon-label>
+        <button class="gr-add-label__form__buttons__button-cancel button-cancel" type="button" ng-click="ctrl.cancel()" title="Close">
+            <gr-icon-label gr-icon="close"><span ng-hide="ctrl.grSmall">Cancel</span></gr-icon-label>
         </button>
         <button
             class="gr-add-label__form__buttons__button-save button-save"
             type="submit"
             title="Save new label"
-            ng:disabled="ctrl.adding">
+            ng-disabled="ctrl.adding">
             <gr-icon-label gr-icon="check">
-                <span ng:hide="ctrl.grSmall">Save</span>
+                <span ng-hide="ctrl.grSmall">Save</span>
             </gr-icon-label>
         </button>
     </span>

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
@@ -1,39 +1,39 @@
-<span ng:if="! ctrl.readonly"
-      ng:switch="ctrl.archivedState"
+<span ng-if="! ctrl.readonly"
+      ng-switch="ctrl.archivedState"
       class="gr-archiver-status"
-      ng:class="{'gr-archiver-status--interactive': ctrl.archivedState !== 'kept',
+      ng-class="{'gr-archiver-status--interactive': ctrl.archivedState !== 'kept',
                  'gr-archiver-status--archived':    ctrl.archivedState !== 'unarchived',
                  'gr-archiver-status--unarchived':  ctrl.archivedState === 'unarchived'}">
-    <span ng:switch-when="kept"
+    <span ng-switch-when="kept"
           title="Kept in Library because the image has been {{ctrl.archivedExplanation}}.">
         <gr-library-locked-icon class="gr-archiver-status__icon"></gr-library-locked-icon>
     </span>
-    <button ng:switch-when="archived"
+    <button ng-switch-when="archived"
             type="button"
             class="gr-archiver-status__button inner-clickable"
             title="Remove from Library"
-            ng:click="ctrl.unarchive()"
-            ng:disabled="ctrl.archiving">
+            ng-click="ctrl.unarchive()"
+            ng-disabled="ctrl.archiving">
         <gr-library-added-icon class="gr-archiver-status__icon"></gr-library-added-icon>
         <gr-library-remove-icon class="gr-archiver-status__icon"></gr-library-remove-icon>
     </button>
-    <button ng:switch-when="unarchived"
+    <button ng-switch-when="unarchived"
             type="button"
             class="gr-archiver-status__button inner-clickable"
             title="Add to Library"
-            ng:click="ctrl.archive()"
-            ng:disabled="ctrl.archiving">
+            ng-click="ctrl.archive()"
+            ng-disabled="ctrl.archiving">
         <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
     </button>
 </span>
 
-<span ng:if="ctrl.readonly"
-      ng:switch="ctrl.archivedState"
+<span ng-if="ctrl.readonly"
+      ng-switch="ctrl.archivedState"
       class="gr-archiver-status gr-archiver-status--archived">
-    <span ng:switch-when="kept">
+    <span ng-switch-when="kept">
         <gr-library-locked-icon class="gr-archiver-status__icon"></gr-library-locked-icon>
     </span>
-    <span ng:switch-when="archived">
+    <span ng-switch-when="archived">
         <gr-library-added-icon class="gr-archiver-status__icon"></gr-library-added-icon>
     </span>
 </span>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -1,30 +1,30 @@
 <div class="batch-archive"
-     ng:switch="ctrl.archivedState">
-    <span ng:switch-when="kept"
+     ng-switch="ctrl.archivedState">
+    <span ng-switch-when="kept"
           class="side-padded batch-archive__button batch-archive__button--disabled"
-          gr:tooltip="{{ctrl.archivedExplanation}}"
-          gr:tooltip-updates>
+          gr-tooltip="{{ctrl.archivedExplanation}}"
+          gr-tooltip-updates>
         <gr-library-locked-icon class="batch-archive__icon"></gr-library-locked-icon>
         <span class="icon-label">Kept in Library</span>
     </span>
 
-    <button ng:switch-when="archived"
+    <button ng-switch-when="archived"
             type="button"
             class="clickable side-padded batch-archive__button"
-            ng:click="ctrl.unarchive()"
-            ng:disabled="ctrl.archiving">
+            ng-click="ctrl.unarchive()"
+            ng-disabled="ctrl.archiving">
         <gr-library-remove-icon class="batch-archive__icon"></gr-library-remove-icon>
-        <span ng:if="!ctrl.archiving">Remove from Library</span>
-        <span ng:if="ctrl.archiving">Removing from Library…</span>
+        <span ng-if="!ctrl.archiving">Remove from Library</span>
+        <span ng-if="ctrl.archiving">Removing from Library…</span>
     </button>
 
-    <button ng:switch-when="unarchived"
+    <button ng-switch-when="unarchived"
             type="button"
             class="clickable side-padded batch-archive__button"
-            ng:click="ctrl.archive()"
-            ng:disabled="ctrl.archiving">
+            ng-click="ctrl.archive()"
+            ng-disabled="ctrl.archiving">
         <gr-library-add-icon class="batch-archive__icon"></gr-library-add-icon>
-        <span ng:if="!ctrl.archiving">Add to Library</span>
-        <span ng:if="ctrl.archiving">Adding to Library…</span>
+        <span ng-if="!ctrl.archiving">Add to Library</span>
+        <span ng-if="ctrl.archiving">Adding to Library…</span>
     </button>
 </div>

--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.html
@@ -1,15 +1,15 @@
-<div ng:click="ctrl.callBatchCrop(); $event.stopPropagation();"
-     gr:track-click="Full frame button"
+<div ng-click="ctrl.callBatchCrop(); $event.stopPropagation();"
+     gr-track-click="Full frame button"
      confirmed="false"
      needsConfirmation="false"
      ng-if="!ctrl.allHaveFullCrops"
      class="inner-clickable clickable">
-        <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}" ng:hide="ctrl.needsConfirmation">Crop<span ng:if="ctrl.cropping">ping</span> full frame<span ng:if="ctrl.cropping">…</span></gr-icon-label>
-        <gr-icon-label gr-icon="check_circle" ng:show="ctrl.needsConfirmation">Confirm full frame</gr-icon-label>
+        <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}" ng-hide="ctrl.needsConfirmation">Crop<span ng-if="ctrl.cropping">ping</span> full frame<span ng-if="ctrl.cropping">…</span></gr-icon-label>
+        <gr-icon-label gr-icon="check_circle" ng-show="ctrl.needsConfirmation">Confirm full frame</gr-icon-label>
 </div>
 <div
-     gr:tooltip="Selected images have full frames"
-     gr:tooltip-position="bottom"
+     gr-tooltip="Selected images have full frames"
+     gr-tooltip-position="bottom"
      ng-if="ctrl.allHaveFullCrops"
      class="inner-clickable inner-clickable--disabled">
         <gr-icon-label gr-icon="crop">Crop full frame</gr-icon-label>

--- a/kahuna/public/js/components/gr-chips/gr-chips.html
+++ b/kahuna/public/js/components/gr-chips/gr-chips.html
@@ -1,16 +1,16 @@
 <div class="gr-chips__wrapper"
-     ng:click="$grChipsCtrl.wrapperClicked($event)">
-    <span ng:repeat="$chip in $grChipsCtrl.items"
-          ng:switch="$chip.type"
+     ng-click="$grChipsCtrl.wrapperClicked($event)">
+    <span ng-repeat="$chip in $grChipsCtrl.items"
+          ng-switch="$chip.type"
           class="gr-chips__chip-wrapper"
-          ng:class="$chip.type === 'text' ? 'text-chip' : 'filter-chip'">
-       <gr-text-chip ng:switch-when="text"
+          ng-class="$chip.type === 'text' ? 'text-chip' : 'filter-chip'">
+       <gr-text-chip ng-switch-when="text"
                      gr-chip="$chip"></gr-text-chip>
-       <gr-filter-chip ng:switch-when="filter"
+       <gr-filter-chip ng-switch-when="filter"
                        gr-chip="$chip"></gr-filter-chip>
-       <gr-static-filter-chip ng:switch-when="static-filter"
+       <gr-static-filter-chip ng-switch-when="static-filter"
                               gr-chip="$chip"></gr-static-filter-chip>
-       <gr-filter-chooser-chip ng:switch-when="filter-chooser"
+       <gr-filter-chooser-chip ng-switch-when="filter-chooser"
                                gr-chip="$chip"></gr-filter-chooser-chip>
     </span>
 </div>

--- a/kahuna/public/js/components/gr-chips/gr-filter-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chip.html
@@ -2,7 +2,7 @@
              gr-on-select="$grFilterChipCtrl.apply($value)">
     <button type="button"
             class="gr-filter-chip__type"
-            ng:click="$grFilterChipCtrl.toggleFilterType()"
+            ng-click="$grFilterChipCtrl.toggleFilterType()"
     >{{$chip.filterType === 'inclusion' ? '+' : '−' }}</button
     ><span class="gr-filter-chip__key">{{$chip.key}}:</span
     ><input type="text"
@@ -10,13 +10,13 @@
             class="gr-filter-chip__value"
             gr-datalist-input
             gr-auto-width
-            ng:trim="false"
+            ng-trim="false"
             gr-chip-input
             gr-chip-input-on-enter="$grFilterChipCtrl.apply($chip.value)"
             gr-chip-input-backspace-at-start="$grFilterChipCtrl.removeSelf()"
-            ng:model="$chip.value"
+            ng-model="$chip.value"
     /><button type="button"
               class="gr-filter-chip__remove"
-              ng:click="$grChipsCtrl.removeChip($chip)"
+              ng-click="$grChipsCtrl.removeChip($chip)"
     >✕</button>
 </gr-datalist>

--- a/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-filter-chooser-chip.html
@@ -7,10 +7,10 @@
             class="gr-filter-chooser-chip__value"
             gr-datalist-input
             gr-auto-width
-            ng:trim="false"
+            ng-trim="false"
             gr-chip-input
             gr-chip-input-on-enter="$grFilterChooserChipCtrl.apply($chip.value)"
             gr-chip-input-backspace-at-start="$grFilterChooserChipCtrl.removeSelf()"
-            ng:model="$chip.value"
+            ng-model="$chip.value"
     />
 </gr-datalist>

--- a/kahuna/public/js/components/gr-chips/gr-static-filter-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-static-filter-chip.html
@@ -1,10 +1,10 @@
 <button type="button"
         class="gr-static-filter-chip__type"
-        ng:click="$grStaticFilterChipCtrl.toggleFilterType()"
+        ng-click="$grStaticFilterChipCtrl.toggleFilterType()"
 >{{$chip.filterType === 'inclusion' ? '+' : '−' }}</button
 ><span class="gr-static-filter-chip__key">{{$chip.key}}:</span
 ><span class="gr-static-filter-chip__value">{{$chip.value}}</span
 ><button type="button"
          class="gr-static-filter-chip__remove"
-         ng:click="$grChipsCtrl.removeChip($chip)"
+         ng-click="$grChipsCtrl.removeChip($chip)"
 >✕</button>

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -1,9 +1,9 @@
 <input type="text"
        autocomplete="off"
        placeholder="Search for images... (type + for advanced search)"
-       ng:trim="false"
+       ng-trim="false"
        gr-chip-input
        gr-chip-input-backspace-at-start="$grTextChipCtrl.removePrevious()"
-       ng:model="$grChipCtrl.chip.value"
-       ng:keypress="$grTextChipCtrl.handleKey($event)"
+       ng-model="$grChipCtrl.chip.value"
+       ng-keypress="$grTextChipCtrl.handleKey($event)"
 />

--- a/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.html
+++ b/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.html
@@ -1,37 +1,37 @@
 <button class="collection-overlay__button"
-        ng:click="ctrl.openCollectionTree()"
+        ng-click="ctrl.openCollectionTree()"
         gr-tooltip="Click to add image to a collection"
         gr-tooltip-position="left">
     <gr-icon>add_box</gr-icon>
 </button>
-<div ng:if="ctrl.addCollection" class="collection-overlay"
-         ng:init="editing = false">
+<div ng-if="ctrl.addCollection" class="collection-overlay"
+         ng-init="editing = false">
     <button class="collection-overlay__cancel"
-            ng:click="ctrl.addCollection = false">
+            ng-click="ctrl.addCollection = false">
         <gr-icon>close</gr-icon>
     </button>
     <div class="collection-overlay__collections"
-         gr:remember-scroll-top="true">
-        <div class="error" ng:if="ctrl.collectionError">
+         gr-remember-scroll-top="true">
+        <div class="error" ng-if="ctrl.collectionError">
             There was an error loading the collections.
             Please try again later.
         </div>
           <div class="collection-overlay__collections__heading">
             <p class="collection-overlay__collections__heading-text">Select a collection to add image to</p>
-            <button ng:class="{'button-edit': ! editing, 'button-save': editing}"
-              ng:click="editing = !editing;">
-              <gr-icon-label ng:if="! editing"
-                              gr:icon="edit">Edit</gr-icon-label>
-              <gr-icon-label ng:if="editing"
-                              gr:icon="check">Finished</gr-icon-label>
+            <button ng-class="{'button-edit': ! editing, 'button-save': editing}"
+              ng-click="editing = !editing;">
+              <gr-icon-label ng-if="! editing"
+                              gr-icon="edit">Edit</gr-icon-label>
+              <gr-icon-label ng-if="editing"
+                              gr-icon="check">Finished</gr-icon-label>
             </button>
           </div>
 
         <gr-collection-tree
-            gr:nodes="ctrl.collections"
-            gr:selection-mode="true"
-            gr:on-select="ctrl.addToCollection($collection)"
-            gr:editing="editing"
+            gr-nodes="ctrl.collections"
+            gr-selection-mode="true"
+            gr-on-select="ctrl.addToCollection($collection)"
+            gr-editing="editing"
         ></gr-collection-tree>
     </div>
 </div>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -1,85 +1,85 @@
-<div ng:init="node = ctrl.node" class="hover-parent">
+<div ng-init="node = ctrl.node" class="hover-parent">
     <div class="node__info flex-container"
-         ng:class="{'node__info--selected' : ctrl.isSelected}"
-         gr:drop-into-collection="node.data.fullPath">
+         ng-class="{'node__info--selected' : ctrl.isSelected}"
+         gr-drop-into-collection="node.data.fullPath">
 
         <div class="node__marker"
              style="background: {{:: node.data.cssColour}}"></div>
 
-        <div class="node__spacer" ng:if="node.data.children.length === 0">
+        <div class="node__spacer" ng-if="node.data.children.length === 0">
             <gr-icon></gr-icon>
         </div>
 
         <button type="button"
                 class="node__toggler clickable"
-                ng:click="ctrl.showChildren = !ctrl.showChildren"
-                ng:if="node.data.children.length > 0">
+                ng-click="ctrl.showChildren = !ctrl.showChildren"
+                ng-if="node.data.children.length > 0">
 
-            <gr-icon ng:show="ctrl.showChildren">expand_more</gr-icon>
-            <gr-icon ng:hide="ctrl.showChildren">chevron_right</gr-icon>
+            <gr-icon ng-show="ctrl.showChildren">expand_more</gr-icon>
+            <gr-icon ng-hide="ctrl.showChildren">chevron_right</gr-icon>
         </button>
 
         <button class="node__name flex-spacer"
-                ng:if="ctrl.hasCustomSelect"
-                ng:click="ctrl.select()">
+                ng-if="ctrl.hasCustomSelect"
+                ng-click="ctrl.select()">
             {{:: node.data.data.description}}
         </button>
 
-        <a ng:if="! ctrl.hasCustomSelect"
+        <a ng-if="! ctrl.hasCustomSelect"
            class="node__name flex-spacer"
-           ui:sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId)})">
+           ui-sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId)})">
             {{:: node.data.data.description}}
         </a>
 
         <gr-confirm-delete class="node__action clickable"
                            title="Delete this collection"
-                           ng:if="ctrl.deletable && grCollectionTreeCtrl.editing"
+                           ng-if="ctrl.deletable && grCollectionTreeCtrl.editing"
                            gr-on-confirm="ctrl.remove()">
         </gr-confirm-delete>
 
         <button class="node__action clickable"
                 type="button"
                 title="Add a new sub-collection"
-                ng:if="grCollectionTreeCtrl.editing"
-                ng:click="$parent.active = !$parent.active">
+                ng-if="grCollectionTreeCtrl.editing"
+                ng-click="$parent.active = !$parent.active">
             <gr-icon>create_new_folder</gr-icon>
         </button>
 
         <div class="text-small flex-container flex-center"
-             ng:if="ctrl.saving || dropIntoCollectionSaving">Adding…</div>
+             ng-if="ctrl.saving || dropIntoCollectionSaving">Adding…</div>
 
         <div class="text-small flex-container flex-center"
-             ng:if="ctrl.removing">Removing…</div>
+             ng-if="ctrl.removing">Removing…</div>
 
         <button class="node__action clickable hover-child"
                 title="Remove selected images from this collection"
-                ng:if="!grCollectionTreeCtrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
-                ng:click="ctrl.removeImagesFromCollection()">
+                ng-if="!grCollectionTreeCtrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
+                ng-click="ctrl.removeImagesFromCollection()">
             <gr-icon>indeterminate_check_box</gr-icon>
         </button>
         <button class="node__action clickable hover-child"
                 title="Add selected images to this collection"
-                ng:if="!grCollectionTreeCtrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
-                ng:click="ctrl.addImagesToCollection()">
+                ng-if="!grCollectionTreeCtrl.editing && ctrl.hasImagesSelected && !ctrl.saving && !ctrl.removing"
+                ng-click="ctrl.addImagesToCollection()">
             <gr-icon>add_to_photos</gr-icon>
         </button>
     </div>
 
-    <form class="node__add-child" ng:if="active" ng:submit="ctrl.addChild(childName);">
-        <input  gr:auto-focus
+    <form class="node__add-child" ng-if="active" ng-submit="ctrl.addChild(childName);">
+        <input  gr-auto-focus
                 class="text-input node__add-child-input"
                 type="text"
                 required
-                ng:model="childName"
+                ng-model="childName"
                 placeholder="e.g. summer2015…" />
 
-        <div class="error error--small" ng:if="formError">{{formError}}</div>
+        <div class="error error--small" ng-if="formError">{{formError}}</div>
 
         <div class="node__add-child-buttons">
             <button type="submit" class="button-save" title="Save">
                 <gr-icon-label gr-icon="check"></gr-icon-label>
             </button>
-            <button type="button" class="button-cancel" ng:click="clearForm()" title="Cancel">
+            <button type="button" class="button-cancel" ng-click="clearForm()" title="Cancel">
                 <gr-icon-label gr-icon="close"></gr-icon-label>
             </button>
         </div>

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -1,26 +1,26 @@
-<div ng:init="editing = false">
-    <div class="error" ng:if="ctrl.error">
+<div ng-init="editing = false">
+    <div class="error" ng-if="ctrl.error">
         There was an error loading the collections.
         Please try again later.
     </div>
 
     <!-- TODO: we'll probably move this out to another template once we have something more
     final -->
-    <!-- We use $parent.editing here as ng:if creates it's own child scope -->
-    <div class="flex-container collections-panel-heading text-small" ng:if="! ctrl.error">
+    <!-- We use $parent.editing here as ng-if creates it's own child scope -->
+    <div class="flex-container collections-panel-heading text-small" ng-if="! ctrl.error">
         <div class="flex-spacer">Collections</div>
 
-        <button ng:class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
-                ng:click="$parent.editing = !$parent.editing">
-            <gr-icon-label ng:if="! $parent.editing"
-                           gr:icon="edit">Edit</gr-icon-label>
-            <gr-icon-label ng:if="$parent.editing"
-                           gr:icon="check">Finished</gr-icon-label>
+        <button ng-class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
+                ng-click="$parent.editing = !$parent.editing">
+            <gr-icon-label ng-if="! $parent.editing"
+                           gr-icon="edit">Edit</gr-icon-label>
+            <gr-icon-label ng-if="$parent.editing"
+                           gr-icon="check">Finished</gr-icon-label>
         </button>
     </div>
-    <gr-collection-tree gr:nodes="ctrl.collections"
-              gr:editing="editing"
-              gr:selected-images="ctrl.selectedImages$"
-              gr:selected-collections="ctrl.selectedCollections">
+    <gr-collection-tree gr-nodes="ctrl.collections"
+              gr-editing="editing"
+              gr-selected-images="ctrl.selectedImages$"
+              gr-selected-collections="ctrl.selectedCollections">
     </gr-collection-tree>
 </div>

--- a/kahuna/public/js/components/gr-crop-image/gr-crop-image.html
+++ b/kahuna/public/js/components/gr-crop-image/gr-crop-image.html
@@ -1,18 +1,18 @@
-<span ng:if="ctrl.canBeCropped">
+<span ng-if="ctrl.canBeCropped">
     <a class="inner-clickable clickable side-padded"
-        ui:sref="crop({imageId: ctrl.image.data.id})"
-        gr:track-click="Crop image button"
-        gr:track-click-data="{'Location': ctrl.trackingLocation}"
+        ui-sref="crop({imageId: ctrl.image.data.id})"
+        gr-track-click="Crop image button"
+        gr-track-click-data="{'Location': ctrl.trackingLocation}"
         gr-tooltip="Crop image [C]">
         <gr-icon-label gr-icon="crop">Crop image</gr-icon-label>
     </a>
-    <a ng:if="!ctrl.hasFullCrop" class="drop-menu clickable inner-clickable side-padded button-right-side" ng:click="showUserActions = !showUserActions">
+    <a ng-if="!ctrl.hasFullCrop" class="drop-menu clickable inner-clickable side-padded button-right-side" ng-click="showUserActions = !showUserActions">
         <span>▾</span>
-        <gr-export-original-image ng:if="showUserActions" class="drop-menu__items drop-menu__items--nopad" image="ctrl.image" cropping="ctrl.cropping" ng:class="{ 'drop-menu__items--action' : ctrl.cropping }"></gr-export-original-image>
+        <gr-export-original-image ng-if="showUserActions" class="drop-menu__items drop-menu__items--nopad" image="ctrl.image" cropping="ctrl.cropping" ng-class="{ 'drop-menu__items--action' : ctrl.cropping }"></gr-export-original-image>
     </a>
 </span>
 
-<span ng:if="! ctrl.canBeCropped"
+<span ng-if="! ctrl.canBeCropped"
 	class="crop-item side-padded">
 	<gr-icon-label gr-icon="crop">Cannot crop</gr-icon-label>
 </span>

--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.html
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.html
@@ -1,5 +1,5 @@
 <gr-confirm-delete
-  ng:if="ctrl.userHasPermission"
-  gr:label="Delete ALL usages"
-  gr:on-confirm="ctrl.delete()">
+  ng-if="ctrl.userHasPermission"
+  gr-label="Delete ALL usages"
+  gr-on-confirm="ctrl.delete()">
 </gr-confirm-delete>

--- a/kahuna/public/js/components/gr-description-warning/gr-description-warning.html
+++ b/kahuna/public/js/components/gr-description-warning/gr-description-warning.html
@@ -1,4 +1,4 @@
-<div class="flex-right text-small" ng:show="showWarning">
+<div class="flex-right text-small" ng-show="showWarning">
     <span class="message">
         Your description is too short! Ideally, please state who, what where, when and why.
     </span>

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -1,10 +1,10 @@
 <div class="image-info">
-    <dl class="image-info__group image-info__wrap" ng:if="ctrl.crops.length > 0">
+    <dl class="image-info__group image-info__wrap" ng-if="ctrl.crops.length > 0">
         <div class="gr-display-crops">
             <button class="gr-display-crops"
-                    ng:click="ctrl.showCrops = !ctrl.showCrops">
-                <span ng:hide="ctrl.showCrops">▸ Show</span>
-                <span ng:show="ctrl.showCrops">▾ Hide</span>
+                    ng-click="ctrl.showCrops = !ctrl.showCrops">
+                <span ng-hide="ctrl.showCrops">▸ Show</span>
+                <span ng-show="ctrl.showCrops">▾ Hide</span>
                 crops
             </button>
         </div>
@@ -12,13 +12,13 @@
         <dd ng-show="ctrl.showCrops">
             <ul>
                 <li class="image-info__group--dl gr-display-crops__crop"
-                    ng:repeat="crop in ctrl.crops">
+                    ng-repeat="crop in ctrl.crops">
                     <div class="gr-display-crops__crop__list image-info__group--dl__key image-info__heading">
                         <div>{{crop.specification.aspectRatio | asCropType}}</div>
                         <div>{{crop.master.dimensions.width}} x {{crop.master.dimensions.height}}</div>
                     </div>
                     <ul>
-                        <li ng:repeat="asset in crop.assets">
+                        <li ng-repeat="asset in crop.assets">
                             <a href="{{asset.file}}">{{asset.dimensions.width}} x {{asset.dimensions.height}}</a>
                         </li>
                     </ul>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -1,25 +1,25 @@
 <span class="download">
     <button type="button"
             title="Download images"
-            ng:disabled="ctrl.downloading"
-            ng:if="ctrl.imageCount() > 1"
-            ng:click="ctrl.download('downloadUri')">
+            ng-disabled="ctrl.downloading"
+            ng-if="ctrl.imageCount() > 1"
+            ng-click="ctrl.download('downloadUri')">
         <gr-icon-label gr-icon="file_download">
-            Download<span ng:show="ctrl.downloading">ing</span>
+            Download<span ng-show="ctrl.downloading">ing</span>
         </gr-icon-label>
     </button>
 
-    <a ng:if="ctrl.imageCount() == 1"
+    <a ng-if="ctrl.imageCount() == 1"
        href="{{ ctrl.firstImageUris.uris.downloadUri }}" download rel="noopener" target="_blank">
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
-    <button ng:if="ctrl.imageCount() == 1"
+    <button ng-if="ctrl.imageCount() == 1"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
-            ng:click="showExpandedDownload = !showExpandedDownload">
+            ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
-        <a ng:if="showExpandedDownload"
-            ng:href="{{:: ctrl.firstImageUris.uris.lowResDownloadUri }}"
+        <a ng-if="showExpandedDownload"
+            ng-href="{{:: ctrl.firstImageUris.uris.lowResDownloadUri }}"
             class="drop-menu__items drop-menu__items--nopad"
             download
             rel="noopener"
@@ -28,12 +28,12 @@
         </a>
     </button>
 
-    <button ng:if="ctrl.imageCount() > 1"
+    <button ng-if="ctrl.imageCount() > 1"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
-            ng:click="showExpandedDownload = !showExpandedDownload">
+            ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
-        <a ng:if="showExpandedDownload"
-            ng:click="ctrl.download('lowResDownloadUri')"
+        <a ng-if="showExpandedDownload"
+            ng-click="ctrl.download('lowResDownloadUri')"
             class="drop-menu__items drop-menu__items--nopad">
             <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
         </a>

--- a/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.html
+++ b/kahuna/public/js/components/gr-export-original-image/gr-export-original-image.html
@@ -1,4 +1,4 @@
-<div ng:click="ctrl.callCrop(); $event.stopPropagation();"
-     gr:track-click="Full frame button">
-        <gr-icon-label gr-icon="crop"></gr-icon-label> Crop<span ng:if="ctrl.cropping">ping</span> full frame<span ng:if="ctrl.cropping">…</span>
+<div ng-click="ctrl.callCrop(); $event.stopPropagation();"
+     gr-track-click="Full frame button">
+        <gr-icon-label gr-icon="crop"></gr-icon-label> Crop<span ng-if="ctrl.cropping">ping</span> full frame<span ng-if="ctrl.cropping">…</span>
 </div>

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
@@ -1,18 +1,18 @@
-<div ng:switch="messageState">
-    <div ng:switch-when="no_rights"
+<div ng-switch="messageState">
+    <div ng-switch-when="no_rights"
         class="image-notice image-info__group status cost cost--pay">
         No rights to use this image
     </div>
-    <div ng:switch-when="overquota"
+    <div ng-switch-when="overquota"
         class="image-notice image-info__group status cost cost--pay">
         Quota exceeded for this supplier
     </div>
-    <div ng:switch-when="pay"
+    <div ng-switch-when="pay"
          class="image-notice image-info__group status cost cost--pay">
         Pay to use
     </div>
 
-    <div ng:switch-when="conditional"
+    <div ng-switch-when="conditional"
          class="image-notice image-info__group cost cost--conditional"
          title="This image can be used but only within certain restrictions">
         <b>Restricted use:</b> {{image.data.usageRights.restrictions}}

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -4,46 +4,46 @@
             <dt class="metadata-line__key">Rights & restrictions</dt>
 
             <gr-usage-rights-editor
-                ng:if="ctrl.showUsageRights"
-                gr:usage-rights="[ctrl.usageRights]"
-                gr:on-save="ctrl.showUsageRights = false"
-                gr:on-cancel="ctrl.showUsageRights = false">
+                ng-if="ctrl.showUsageRights"
+                gr-usage-rights="[ctrl.usageRights]"
+                gr-on-save="ctrl.showUsageRights = false"
+                gr-on-cancel="ctrl.showUsageRights = false">
             </gr-usage-rights-editor>
 
-            <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
+            <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
                 {{ctrl.usageCategory || 'None'}}
             </dd>
 
             <button
-                ng:click="ctrl.showUsageRights = true"
-                ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
+                ng-click="ctrl.showUsageRights = true"
+                ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights"
                 class="image-info__edit">✎</button>
         </dl>
     </div>
     <div class="image-info">
-    <dl class="image-info__group image-info__wrap" ng:if="ctrl.displayLeases()">
+    <dl class="image-info__group image-info__wrap" ng-if="ctrl.displayLeases()">
         <dt class="image-info__heading image-info__heading--first flex-container image-info__heading--lease">
             <span class="metadata-line__key flex-spacer">Leases</span>
         </dt>
 
         <gr-leases
-            gr:images="[ctrl.image]"
-            gr:user-can-edit="ctrl.userCanEdit">
+            gr-images="[ctrl.image]"
+            gr-user-can-edit="ctrl.userCanEdit">
         </gr-leases>
     </dl>
 </div>
 
     <div class="image-info__group">
         <dl>
-            <div class="image-info__wrap" ng:if="ctrl.metadata.title">
+            <div class="image-info__wrap" ng-if="ctrl.metadata.title">
                 <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="titleEditForm.$show()"
-                        ng:hide="titleEditForm.$visible">✎</button>
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="titleEditForm.$show()"
+                        ng-hide="titleEditForm.$visible">✎</button>
                 <dt class="metadata-line metadata-line__key">Title</dt>
                 <dd class="image-info__title metadata-line__info"
                     editable-text="ctrl.metadata.title"
-                    ng:hide="titleEditForm.$visible"
+                    ng-hide="titleEditForm.$visible"
                     onbeforesave="ctrl.updateMetadataField('title', $data)"
                     e:ng-class="{'image-info__editor--error': $error,
                                  'image-info__editor--saving': titleEditForm.$waiting,
@@ -51,15 +51,15 @@
                     e:form="titleEditForm">{{ctrl.metadata.title}}</dd>
             </div>
 
-            <div class="image-info__wrap metadata-line__info" ng:if="ctrl.metadata.description || ctrl.userCanEdit">
+            <div class="image-info__wrap metadata-line__info" ng-if="ctrl.metadata.description || ctrl.userCanEdit">
                 <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="descriptionEditForm.$show()"
-                        ng:hide="descriptionEditForm.$visible">✎</button>
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="descriptionEditForm.$show()"
+                        ng-hide="descriptionEditForm.$visible">✎</button>
                 <dt class="metadata-line metadata-line__key">Description</dt>
                 <dd class="image-info__description"
                     editable-textarea="ctrl.metadata.description"
-                    ng:hide="descriptionEditForm.$visible"
+                    ng-hide="descriptionEditForm.$visible"
                     onbeforesave="ctrl.updateMetadataField('description', $data)"
                     e:msd-elastic
                     e:ng-class="{'image-info__editor--error': $error,
@@ -71,16 +71,16 @@
         </dl>
     </div>
 
-    <div class="image-info__group" ng:if="ctrl.metadata.specialInstructions">
+    <div class="image-info__group" ng-if="ctrl.metadata.specialInstructions">
         <dl class="image-info__wrap">
             <button class="image-info__edit"
-                    ng:if="ctrl.userCanEdit"
-                    ng:click="specialInstructionsEditForm.$show()"
-                    ng:hide="specialInstructionsEditForm.$visible">✎</button>
+                    ng-if="ctrl.userCanEdit"
+                    ng-click="specialInstructionsEditForm.$show()"
+                    ng-hide="specialInstructionsEditForm.$visible">✎</button>
             <dt class="metadata-line metadata-line__key">Special instructions</dt>
             <dd class="image-info__special-instructions"
                 editable-textarea="ctrl.metadata.specialInstructions"
-                ng:hide="specialInstructionsEditForm.$visible"
+                ng-hide="specialInstructionsEditForm.$visible"
                 onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
                 e:msd-elastic
                 e:ng-class="{'image-info__editor--error': $error,
@@ -92,45 +92,45 @@
 
     <div class="image-info__group">
         <dl class="image-info__group--dl metadata-line">
-            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap" ng:if="ctrl.metadata.dateTaken">Taken on</dt>
-            <dd class="image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
+            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap" ng-if="ctrl.metadata.dateTaken">Taken on</dt>
+            <dd class="image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
 
-            <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng:if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
-            <dd class="image-info__wrap image-info__group--dl__value metadata-line__info" ng:if="ctrl.metadata.byline || ctrl.userCanEdit">
+            <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
+            <dd class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
                 <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="bylineEditForm.$show()"
-                        ng:hide="bylineEditForm.$visible"
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="bylineEditForm.$show()"
+                        ng-hide="bylineEditForm.$visible"
                     >✎</button>
                         <span class="image-info__byline"
                               editable-text="ctrl.metadata.byline"
-                              ng:hide="bylineEditForm.$visible"
+                              ng-hide="bylineEditForm.$visible"
                               onbeforesave="ctrl.updateMetadataField('byline', $data)"
                               e:ng-class="{'image-info__editor--error': $error,
                                            'image-info__editor--saving': bylineEditForm.$waiting,
                                            'text-input': true}"
                               e:form="bylineEditForm">
 
-                            <span ng:if="ctrl.metadata.byline">
-                                <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                            <span ng-if="ctrl.metadata.byline">
+                                <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
                             </span>
-                            <span ng:if="! ctrl.metadata.byline">
+                            <span ng-if="! ctrl.metadata.byline">
                                 Unknown (click ✎ to add)
                             </span>
                         </span>
             </dd>
 
-            <dt ng:if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
-            <dd ng:if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
+            <dt ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
+            <dd ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
                 <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="creditEditForm.$show()"
-                        ng:hide="creditEditForm.$visible"
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="creditEditForm.$show()"
+                        ng-hide="creditEditForm.$visible"
                     >✎</button>
 
                         <span class="metadata-line__info"
                               editable-text="ctrl.metadata.credit"
-                              ng:hide="creditEditForm.$visible"
+                              ng-hide="creditEditForm.$visible"
                               e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
                               onbeforesave="ctrl.updateMetadataField('credit', $data)"
                               e:ng-class="{'image-info__editor--error': $error,
@@ -138,51 +138,51 @@
                                            'text-input': true}"
                               e:form="creditEditForm">
 
-                            <span ng:if="ctrl.metadata.credit">
-                                <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                            <span ng-if="ctrl.metadata.credit">
+                                <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
                             </span>
-                            <span ng:if="! ctrl.metadata.credit">
+                            <span ng-if="! ctrl.metadata.credit">
                                 Unknown (click ✎ to add)
                             </span>
                         </span>
             </dd>
 
 
-            <dt ng:if="ctrl.hasLocationInformation" class="image-info__group--dl__key metadata-line__key image-info__wrap">Location</dt>
-            <dd ng:if="ctrl.hasLocationInformation" class="image-info__group--dl__value metadata-line__info">
-                <span ng:repeat="prop in ['subLocation', 'city', 'state', 'country']" ng:if="ctrl.metadata[prop]">
+            <dt ng-if="ctrl.hasLocationInformation" class="image-info__group--dl__key metadata-line__key image-info__wrap">Location</dt>
+            <dd ng-if="ctrl.hasLocationInformation" class="image-info__group--dl__value metadata-line__info">
+                <span ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
                     <span class="metadata-line__info">
-                        <a ui:sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">
+                        <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">
                             {{ctrl.metadata[prop]}}
                         </a>
                     </span>
-                    <span ng:if="! $last">
+                    <span ng-if="! $last">
                         ,
                     </span>
                 </span>
             </dd>
 
 
-            <dt ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
-            <dd ng:if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
+            <dt ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
+            <dd ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
                 <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="copyrightEditForm.$show()"
-                        ng:hide="copyrightEditForm.$visible"
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="copyrightEditForm.$show()"
+                        ng-hide="copyrightEditForm.$visible"
                     >✎</button>
                         <span class="image-info__copyright"
                               editable-text="ctrl.metadata.copyright"
-                              ng:hide="copyrightEditForm.$visible"
+                              ng-hide="copyrightEditForm.$visible"
                               onbeforesave="ctrl.updateMetadataField('copyright', $data)"
                               e:ng-class="{'image-info__editor--error': $error,
                                            'image-info__editor--saving': copyrightEditForm.$waiting,
                                            'text-input': true}"
                               e:form="copyrightEditForm">
 
-                            <span ng:if="ctrl.metadata.copyright">
-                                <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
+                            <span ng-if="ctrl.metadata.copyright">
+                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
                             </span>
-                            <span ng:if="! ctrl.metadata.copyright">
+                            <span ng-if="! ctrl.metadata.copyright">
                                 Unknown (click ✎ to add)
                             </span>
                         </span>
@@ -199,15 +199,15 @@
             <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">Uploader</dt>
             <dd class="image-info__group--dl__value metadata-line__info">
                         <span class="metadata-line__info">
-                            <a ui:sref="search.results({query: (ctrl.image.data.uploadedBy | queryFilter:'uploader')})">{{ctrl.image.data.uploadedBy | stripEmailDomain}}</a>
+                            <a ui-sref="search.results({query: (ctrl.image.data.uploadedBy | queryFilter:'uploader')})">{{ctrl.image.data.uploadedBy | stripEmailDomain}}</a>
                         </span>
             </dd>
 
-            <dt ng:if="ctrl.image.data.uploadInfo.filename"
+            <dt ng-if="ctrl.image.data.uploadInfo.filename"
                 class="image-info__group--dl__key metadata-line__key image-info__wrap">
                 Filename
             </dt>
-            <dd ng:if="ctrl.image.data.uploadInfo.filename"
+            <dd ng-if="ctrl.image.data.uploadInfo.filename"
                 class="image-info__group--dl__value metadata-line__info"
                 title="{{ctrl.image.data.uploadInfo.filename}}">
                         <span class="metadata-line__info select-all-wrap">
@@ -215,15 +215,15 @@
                         </span>
             </dd>
 
-            <dt ng:if="ctrl.metadata.subjects.length > 0"
+            <dt ng-if="ctrl.metadata.subjects.length > 0"
                 class="image-info__group--dl__key metadata-line__key image-info__wrap">
                 Subjects
             </dt>
-            <dd ng:if="ctrl.metadata.subjects.length > 0"
+            <dd ng-if="ctrl.metadata.subjects.length > 0"
                 class="image-info__group--dl__value metadata-line__info">
                 <span class="metadata-line__info">
-                    <span ng:repeat="subject in ctrl.metadata.subjects">
-                        <a ui:sref="search.results({query: (subject | queryFilter:'subject')})">
+                    <span ng-repeat="subject in ctrl.metadata.subjects">
+                        <a ui-sref="search.results({query: (subject | queryFilter:'subject')})">
                             {{subject}}
                         </a>
                     </span>
@@ -234,18 +234,18 @@
     <!-- FIXME: iff has useful metadata -->
     <div class="image-info__group image-info__group--full-metadata">
         <button class="metadata-reveal"
-                ng:click="metadataExpanded = !metadataExpanded">
-            <span ng:hide="metadataExpanded">▸ Show</span>
-            <span ng:show="metadataExpanded">▾ Hide</span>
+                ng-click="metadataExpanded = !metadataExpanded">
+            <span ng-hide="metadataExpanded">▸ Show</span>
+            <span ng-show="metadataExpanded">▾ Hide</span>
             full metadata
         </button>
 
-        <div ng:if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
-            <dl ng:repeat="(key, value) in ctrl.metadata" ng:if="ctrl.isUsefulMetadata(key)" class="metadata__body image-info__group--dl">
+        <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
+            <dl ng-repeat="(key, value) in ctrl.metadata" ng-if="ctrl.isUsefulMetadata(key)" class="metadata__body image-info__group--dl">
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
             </dl>
-            <dl ng:repeat="(key, value) in ctrl.identifiers" class="metadata__body image-info__group--dl">
+            <dl ng-repeat="(key, value) in ctrl.identifiers" class="metadata__body image-info__group--dl">
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
             </dl>
@@ -261,16 +261,16 @@
         </dt>
         <dd class="metadata-line__info flex-container"
             ng-repeat="collection in ctrl.image.data.collections">
-            <a ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})">
+            <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})">
                 {{collection.data.path.join(' ▸ ')}}
             </a>
             <span class="flex-spacer"></span>
-            <span ng:if="ctrl.removingCollection === collection">Removing…</span>
+            <span ng-if="ctrl.removingCollection === collection">Removing…</span>
             <button class="clickable" type="button"
-                    ng:click="ctrl.removeImageFromCollection(collection)"
-                    ng:hide="ctrl.removingCollection === collection"
-                    gr:tooltip="Remove image from this collection"
-                    gr:tooltip-position="top-left">
+                    ng-click="ctrl.removeImageFromCollection(collection)"
+                    ng-hide="ctrl.removingCollection === collection"
+                    gr-tooltip="Remove image from this collection"
+                    gr-tooltip-position="top-left">
                 <gr-icon-label gr-icon="clear"></gr-icon-label>
             </button>
         </dd>
@@ -281,7 +281,7 @@
     <dl class="image-info__group image-info__wrap">
         <dt class="image-info__heading image-info__heading--first flex-container">
             <span class="flex-spacer">Labels</span>
-            <gr-add-label gr-small="true" images="[ctrl.image]" ng:blur="ctrl.cancel"></gr-add-label>
+            <gr-add-label gr-small="true" images="[ctrl.image]" ng-blur="ctrl.cancel"></gr-add-label>
         </dt>
         <dd class="image-info__group--fixed-panel image-info__wrap">
             <ui-labeller image="ctrl.image"></ui-labeller>
@@ -312,13 +312,13 @@
 </div>
 
 <div class="image-info">
-    <dl class="image-info__group image-info__wrap" ng:if="ctrl.metadata.keywords.length > 0">
+    <dl class="image-info__group image-info__wrap" ng-if="ctrl.metadata.keywords.length > 0">
         <dt class="image-info__heading image-info__wrap">Keywords</dt>
         <dd class="image-info__keywords">
             <ul>
                 <li class="image-info__keyword"
-                    ng:repeat="keyword in ctrl.metadata.keywords track by $index">
-                    <a ui:sref="search.results({query: (keyword | queryFilter:'keyword')})">
+                    ng-repeat="keyword in ctrl.metadata.keywords track by $index">
+                    <a ui-sref="search.results({query: (keyword | queryFilter:'keyword')})">
                         {{keyword}}
                     </a>
                 </li>

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
@@ -5,8 +5,8 @@
 
     <ul>
         <li class="gr-image-usage__record" ng-repeat="usage in ctrl.usages">
-            <gr-icon ng:if="usage.platform === 'print'" class="usage-list__icon" ng-class="{'icon-warning': ctrl.isRecent(usage.dateAdded)}">local_library</gr-icon>
-            <gr-icon ng:if="usage.platform === 'digital'" class="usage-list__icon" ng-class="{'icon-warning': ctrl.isRecent(usage.dateAdded)}">phonelink</gr-icon>
+            <gr-icon ng-if="usage.platform === 'print'" class="usage-list__icon" ng-class="{'icon-warning': ctrl.isRecent(usage.dateAdded)}">local_library</gr-icon>
+            <gr-icon ng-if="usage.platform === 'digital'" class="usage-list__icon" ng-class="{'icon-warning': ctrl.isRecent(usage.dateAdded)}">phonelink</gr-icon>
 
             {{usage.title}}
 
@@ -14,9 +14,9 @@
                 <span class="date-added">{{::ctrl.formatTimestamp(usage.dateAdded)}}</span>
                 <ul class="reference-list">
                     <li ng-repeat="reference in usage.references">
-                        <a ng:if="reference.uri" href="{{reference.uri}}" title="Open in {{reference.type}}" rel="noopener" target="_blank">
-                            <gr-frontend-icon class="reference-list__icon" ng:if="reference.type === 'frontend'"></gr-frontend-icon>
-                            <gr-composer-icon class="reference-list__icon" ng:if="reference.type === 'composer'"></gr-composer-icon>
+                        <a ng-if="reference.uri" href="{{reference.uri}}" title="Open in {{reference.type}}" rel="noopener" target="_blank">
+                            <gr-frontend-icon class="reference-list__icon" ng-if="reference.type === 'frontend'"></gr-frontend-icon>
+                            <gr-composer-icon class="reference-list__icon" ng-if="reference.type === 'composer'"></gr-composer-icon>
                         </a>
                     </li>
                 </ul>

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
@@ -3,7 +3,7 @@
 </div>
 
 <gr-delete-usages
-  ng:if="ctrl.usagesCount > 0"
-  gr:image="ctrl.image"
-  gr:on-delete="ctrl.onUsagesDeleted()">
+  ng-if="ctrl.usagesCount > 0"
+  gr-image="ctrl.image"
+  gr-on-delete="ctrl.onUsagesDeleted()">
 </gr-delete-usages>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -1,36 +1,36 @@
 <div class="image-details">
 
     <div class="panel__top"
-        ng:if="ctrl.selectedImages.size === 0">
+        ng-if="ctrl.selectedImages.size === 0">
         No images selected
     </div>
 
-    <div ng:if="ctrl.selectedImages.size > 0"
+    <div ng-if="ctrl.selectedImages.size > 0"
          class="panel__top">
         <ul class="costs">
-            <li ng:repeat="cost in ctrl.selectedCosts | orderBy:'data'">
-                <div ng:switch="cost.data">
-                    <div ng:switch-when="free"
+            <li ng-repeat="cost in ctrl.selectedCosts | orderBy:'data'">
+                <div ng-switch="cost.data">
+                    <div ng-switch-when="free"
                          class="image-notice image-info__group status cost cost--free">
                         {{cost.count}} free
                     </div>
 
-                    <div ng:switch-when="no_rights"
+                    <div ng-switch-when="no_rights"
                          class="image-notice image-info__group status cost cost--pay">
                         {{cost.count}} no rights
                     </div>
 
-                    <div ng:switch-when="pay"
+                    <div ng-switch-when="pay"
                          class="image-notice image-info__group status cost cost--pay">
                         {{cost.count}} paid
                     </div>
 
-                    <div ng:switch-when="overquota"
+                    <div ng-switch-when="overquota"
                          class="image-notice image-info__group status cost cost--pay">
                         {{cost.count}} over quota
                     </div>
 
-                    <div ng:switch-when="conditional"
+                    <div ng-switch-when="conditional"
                          class="image-notice image-info__group cost cost--conditional">
                         {{cost.count}} restricted
                     </div>
@@ -39,23 +39,23 @@
         </ul>
     </div>
 
-    <div ng:if="ctrl.selectedImages.size > 0">
+    <div ng-if="ctrl.selectedImages.size > 0">
         <div class="image-info__group">
             <dl class="image-info__wrap metadata-line image-info__usage-rights">
                 <dt class="metadata-line__key">Rights & restrictions</dt>
                 <gr-usage-rights-editor
-                    ng:if="ctrl.showUsageRights"
-                    gr:usage-rights="ctrl.usageRights"
-                    gr:on-save="ctrl.showUsageRights = false"
-                    gr:on-cancel="ctrl.showUsageRights = false">
+                    ng-if="ctrl.showUsageRights"
+                    gr-usage-rights="ctrl.usageRights"
+                    gr-on-save="ctrl.showUsageRights = false"
+                    gr-on-cancel="ctrl.showUsageRights = false">
                 </gr-usage-rights-editor>
-                <dd class="image-info__title" ng:if="! ctrl.showUsageRights">
+                <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
                     {{ctrl.usageCategory || 'None'}}
                 </dd>
 
                 <button
-                    ng:click="ctrl.showUsageRights = true"
-                    ng:hide="!ctrl.userCanEdit || ctrl.showUsageRights"
+                    ng-click="ctrl.showUsageRights = true"
+                    ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights"
                     class="image-info__edit">✎</button>
             </dl>
         </div>
@@ -66,47 +66,47 @@
                     <span>Leases</span>
                 </div>
                 <gr-leases
-                    gr:images="ctrl.selectedImages"
-                    gr:on-save="ctrl.showLeases = false"
-                    gr:user-can-edit="ctrl.userCanEdit"
-                    gr:on-cancel="ctrl.showLeases = false">
+                    gr-images="ctrl.selectedImages"
+                    gr-on-save="ctrl.showLeases = false"
+                    gr-user-can-edit="ctrl.userCanEdit"
+                    gr-on-cancel="ctrl.showLeases = false">
                 </gr-leases>
             </dl>
         </div>
 
         <div class="image-info__group">
             <dl>
-                <div class="image-info__wrap" ng:if="ctrl.rawMetadata.title">
+                <div class="image-info__wrap" ng-if="ctrl.rawMetadata.title">
                     <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="titleEditForm.$show()"
-                            ng:hide="titleEditForm.$visible">✎</button>
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="titleEditForm.$show()"
+                            ng-hide="titleEditForm.$visible">✎</button>
                     <dt class="metadata-line metadata-line__key">Title</dt>
-                    <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
+                    <div class="metadata-line__info" ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.title)}"
                          editable-text="ctrl.metadata.title"
-                         ng:hide="titleEditForm.$visible"
+                         ng-hide="titleEditForm.$visible"
                          onbeforesave="ctrl.updateMetadataField('title', $data)"
                          e:form="titleEditForm"
                          e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': titleEditForm.$waiting,
                                       'text-input': true}">
 
-                        <div ng:if="ctrl.userCanEdit">
-                            <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                        <div ng-if="ctrl.userCanEdit">
+                            <dd class="image-info__title" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
                                 Multiple titles (click ✎ to edit <strong>all</strong>)
                             </dd>
 
-                            <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                            <dd class="image-info__title" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
                                 {{ctrl.metadata.title || "unknown (click ✎ to add the title)"}}
                             </dd>
                         </div>
 
-                        <div ng:if="!ctrl.userCanEdit">
-                            <dd class="image-info__title" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                        <div ng-if="!ctrl.userCanEdit">
+                            <dd class="image-info__title" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
                                 Multiple titles
                             </dd>
 
-                            <dd class="image-info__title" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
+                            <dd class="image-info__title" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
                                 {{ctrl.metadata.title || "unknown"}}
                             </dd>
                         </div>
@@ -114,43 +114,43 @@
                 </div>
                 <div class="image-info__wrap">
                     <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="descriptionEditForm.$show()"
-                            ng:hide="descriptionEditForm.$visible">✎</button>
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="descriptionEditForm.$show()"
+                            ng-hide="descriptionEditForm.$visible">✎</button>
                     <dt class="metadata-line metadata-line__key">Description</dt>
                     <form editable-form name="descriptionEditForm" onaftersave="ctrl.updateDescriptionField('description', $data)">
                       <div ng-hide="descriptionEditForm.$visible">
-                        <div ng:if="ctrl.userCanEdit">
+                        <div ng-if="ctrl.userCanEdit">
                             <dd class="image-info__description"
-                                ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
-                                ng:click="descriptionEditForm.$show()"
+                                ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                ng-click="descriptionEditForm.$show()"
                                 >Multiple descriptions (click ✎ to edit <strong>all</strong>)
                             </dd>
 
                             <dd class="image-info__description"
-                                ng:click="descriptionEditForm.$show()"
-                                ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                ng-click="descriptionEditForm.$show()"
+                                ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
                                 >{{ctrl.metadata.description || "Unknown (click ✎ to add the description)"}}
                             </dd>
                         </div>
 
-                        <div ng:if="!ctrl.userCanEdit">
+                        <div ng-if="!ctrl.userCanEdit">
                             <dd class="image-info__description"
-                                ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
                                 >Multiple descriptions
                             </dd>
 
                             <dd class="image-info__description"
-                                ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
+                                ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.description)"
                                 >{{ctrl.metadata.description || "unknown"}}
                             </dd>
                         </div>
                     </div>
                     <div
                         class="metadata-line__info"
-                        ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
+                        ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
                          editable-textarea="ctrl.metadata.description"
-                         ng:hide="descriptionEditForm.$visible"
+                         ng-hide="descriptionEditForm.$visible"
                          e:msd-elastic
                          e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': descriptionEditForm.$waiting,
@@ -181,18 +181,18 @@
             </div>
         </dl>
         </div>
-        <div class="image-info__group" ng:if="ctrl.rawMetadata.specialInstructions">
+        <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions">
             <dl class="image-info__wrap">
                 <button class="image-info__edit"
-                        ng:if="ctrl.userCanEdit"
-                        ng:click="specialInstructionsEditForm.$show()"
-                        ng:hide="specialInstructionsEditForm.$visible">✎</button>
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="specialInstructionsEditForm.$show()"
+                        ng-hide="specialInstructionsEditForm.$visible">✎</button>
                 <dt class="metadata-line metadata-line__key">Special instructions</dt>
 
 
-                <div class="metadata-line__info" ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
+                <div class="metadata-line__info" ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
                      editable-textarea="ctrl.metadata.specialInstructions"
-                     ng:hide="specialInstructionsEditForm.$visible"
+                     ng-hide="specialInstructionsEditForm.$visible"
                      onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
                      e:msd-elastic
                      e:form="specialInstructionsEditForm"
@@ -200,25 +200,25 @@
                                   'image-info__editor--saving': specialInstructionsEditForm.$waiting,
                                   'text-input': true}">
 
-                    <div ng:if="ctrl.userCanEdit">
-                        <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                    <div ng-if="ctrl.userCanEdit">
+                        <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
                             class="image-info__special-instructions"
                             >Multiple special instructions (click ✎ to edit <strong>all</strong>)
                         </dd>
 
-                        <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                        <dd ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
                             class="image-info__special-instructions"
                             >{{ctrl.metadata.specialInstructions}}
                         </dd>
                     </div>
 
-                    <div ng:if="!ctrl.userCanEdit">
-                        <dd ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                    <div ng-if="!ctrl.userCanEdit">
+                        <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
                             class="image-info__special-instructions"
                             >Multiple special instructions
                         </dd>
 
-                        <dd ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
+                        <dd ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
                             class="image-info__special-instructions"
                             >{{ctrl.metadata.specialInstructions}}
                         </dd>
@@ -229,36 +229,36 @@
 
         <div class="image-info__group">
             <dl class="image-info__group--dl metadata-line">
-                <dt ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
-                <dd ng:if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
+                <dt ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
+                <dd ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
                     <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="bylineEditForm.$show()"
-                            ng:hide="bylineEditForm.$visible"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="bylineEditForm.$show()"
+                            ng-hide="bylineEditForm.$visible"
                             >✎</button>
-                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
                           editable-text="ctrl.metadata.byline"
-                          ng:hide="bylineEditForm.$visible"
+                          ng-hide="bylineEditForm.$visible"
                           onbeforesave="ctrl.updateMetadataField('byline', $data)"
                           e:form="bylineEditForm"
                           e:ng-class="{'image-info__editor--error': $error,
                                        'image-info__editor--saving': bylineEditForm.$waiting,
                                        'text-input': true}">
 
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
                             Multiple bylines (click ✎ to edit <strong>all</strong>)
                         </span>
 
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
                             Multiple bylines
                         </span>
 
-                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
-                            <span ng:if="ctrl.metadata.byline">
-                                <a ui:sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
+                            <span ng-if="ctrl.metadata.byline">
+                                <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
                             </span>
 
-                            <span ng:if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
+                            <span ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add the byline)</span>
                         </span>
                     </span>
                 </dd>
@@ -266,14 +266,14 @@
                 <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
                 <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
                     <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="creditEditForm.$show()"
-                            ng:hide="creditEditForm.$visible"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="creditEditForm.$show()"
+                            ng-hide="creditEditForm.$visible"
                             >✎</button>
 
-                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
                           editable-text="ctrl.metadata.credit"
-                          ng:hide="creditEditForm.$visible"
+                          ng-hide="creditEditForm.$visible"
                           e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
                           onbeforesave="ctrl.updateMetadataField('credit', $data)"
                           e:form="creditEditForm"
@@ -281,62 +281,62 @@
                                        'image-info__editor--saving': creditEditForm.$waiting,
                                        'text-input': true}">
 
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
                             Multiple credits (click ✎ to edit <strong>all</strong>)
                         </span>
 
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
                             Multiple credits
                         </span>
 
-                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
-                            <span ng:if="ctrl.metadata.credit">
-                                <a ui:sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
+                            <span ng-if="ctrl.metadata.credit">
+                                <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
                             </span>
 
-                            <span ng:if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
+                            <span ng-if="!ctrl.metadata.credit && ctrl.userCanEdit">unknown (click ✎ to add the credit)</span>
                         </span>
                     </span>
                 </dd>
 
-                <dt ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
-                <dd ng:if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                <dt ng-if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
+                <dd ng-if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                     <button class="image-info__edit"
-                            ng:if="ctrl.userCanEdit"
-                            ng:click="copyrightEditForm.$show()"
-                            ng:hide="copyrightEditForm.$visible"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="copyrightEditForm.$show()"
+                            ng-hide="copyrightEditForm.$visible"
                             >✎</button>
-                    <span ng:class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
                           editable-text="ctrl.metadata.copyright"
-                          ng:hide="copyrightEditForm.$visible"
+                          ng-hide="copyrightEditForm.$visible"
                           onbeforesave="ctrl.updateMetadataField('copyright', $data)"
                           e:form="copyrightEditForm"
                           e:ng-class="{'image-info__editor--error': $error,
                                        'image-info__editor--saving': copyrightEditForm.$waiting,
                                        'text-input': true}">
 
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
                             Multiple copyrights (click ✎ to edit <strong>all</strong>)
                         </span>
 
-                        <span class="metadata-line__info" ng:if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
                             Multiple copyrights
                         </span>
 
-                        <span class="metadata-line__info" ng:if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
-                            <span ng:if="ctrl.metadata.copyright">
-                                <a ui:sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
+                            <span ng-if="ctrl.metadata.copyright">
+                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
                             </span>
 
-                            <span ng:if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
+                            <span ng-if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>
                         </span>
                     </span>
                 </dd>
 
-                <dt ng:if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Filename</dt>
-                <dd ng:if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                    <span ng:if="ctrl.hasMultipleValues(ctrl.extraInfo.filename)">Multiple filenames</span>
-                    <span ng:if="!ctrl.hasMultipleValues(ctrl.extraInfo.filename)">{{ctrl.extraInfo.filename}}</span>
+                <dt ng-if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Filename</dt>
+                <dd ng-if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                    <span ng-if="ctrl.hasMultipleValues(ctrl.extraInfo.filename)">Multiple filenames</span>
+                    <span ng-if="!ctrl.hasMultipleValues(ctrl.extraInfo.filename)">{{ctrl.extraInfo.filename}}</span>
                 </dd>
             </dl>
         </div>
@@ -344,25 +344,25 @@
         <div class="image-info__group">
             <div class="image-info__heading">
                 <span>Labels</span>
-                <gr-add-label ng:blur="ctrl.cancel"
+                <gr-add-label ng-blur="ctrl.cancel"
                               gr-small="true"
                               images="ctrl.selectedImages">
                 </gr-add-label>
             </div>
             <ul class="labels">
                 <li class="label"
-                    ng:repeat="label in ctrl.selectedLabels | orderBy:'data'"
-                    ng:class="{'label--partial': label.count < ctrl.selectedImages.size}">
-                    <button ng:if="label.count < ctrl.selectedImages.size"
+                    ng-repeat="label in ctrl.selectedLabels | orderBy:'data'"
+                    ng-class="{'label--partial': label.count < ctrl.selectedImages.size}">
+                    <button ng-if="label.count < ctrl.selectedImages.size"
                             class="label__add"
                             title="Apply label to all"
-                            ng:click="ctrl.addLabel(label.data)">
+                            ng-click="ctrl.addLabel(label.data)">
                         <gr-icon>library_add</gr-icon>
                     </button>
                     <span class="label__value">{{label.data}}</span>
                     <button class="label__remove"
                             title="Remove label from all"
-                            ng:click="ctrl.removeLabel(label.data)">
+                            ng-click="ctrl.removeLabel(label.data)">
                         <gr-icon>close</gr-icon>
                     </button>
                 </li>

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,8 +1,8 @@
-<div ng:if="ctrl.showInvalidReasons" class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
+<div ng-if="ctrl.showInvalidReasons" class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
     <strong ng-if="!ctrl.isOverridden">Unusable Image <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon></strong>
     <strong ng-if="ctrl.isOverridden"><strike>Unusable Image</strike> <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon></strong>
     <ul>
-        <li ng:repeat="(key, reason) in ctrl.invalidReasons">
+        <li ng-repeat="(key, reason) in ctrl.invalidReasons">
             {{reason}}
         </li>
     </ul>

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -1,44 +1,44 @@
 <div class="fill-height flex-container"
-     ng:class="{ 'flex-container--rtl': ctrl.position == 'right' }">
+     ng-class="{ 'flex-container--rtl': ctrl.position == 'right' }">
     <button class="button-ico-square clickable"
             type="button"
-            ng:if="!ctrl.state.hidden"
-            ng:click="ctrl.hidePanel()"
-            ng:class="{'bg-light': !ctrl.state.hidden}"
-            gr:tooltip="Hide {{:: ctrl.name}} panel"
-            gr:tooltip-position="{{:: ctrl.toolTipPosition()}}"
-            gr:track-click="{{:: ctrl.trackingName}}"
-            gr:track-click-data="ctrl.trackingData('Hide panel')">
+            ng-if="!ctrl.state.hidden"
+            ng-click="ctrl.hidePanel()"
+            ng-class="{'bg-light': !ctrl.state.hidden}"
+            gr-tooltip="Hide {{:: ctrl.name}} panel"
+            gr-tooltip-position="{{:: ctrl.toolTipPosition()}}"
+            gr-track-click="{{:: ctrl.trackingName}}"
+            gr-track-click-data="ctrl.trackingData('Hide panel')">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
 
     <button class="button-ico-square clickable"
             type="button"
-            ng:if="ctrl.state.hidden"
-            ng:click="ctrl.showPanel()"
-            gr:tooltip="Show {{:: ctrl.name}} panel"
-            gr:tooltip-position="{{:: ctrl.toolTipPosition()}}"
-            gr:track-click="{{:: ctrl.trackingName}}"
-            gr:track-click-data="ctrl.trackingData('Show panel')">
+            ng-if="ctrl.state.hidden"
+            ng-click="ctrl.showPanel()"
+            gr-tooltip="Show {{:: ctrl.name}} panel"
+            gr-tooltip-position="{{:: ctrl.toolTipPosition()}}"
+            gr-track-click="{{:: ctrl.trackingName}}"
+            gr-track-click-data="ctrl.trackingData('Show panel')">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
 
-    <div ng:if="!ctrl.state.hidden">
+    <div ng-if="!ctrl.state.hidden">
         <button class="button-ico-square clickable"
                 type="button"
-                ng:if="!ctrl.state.locked"
-                ng:click="ctrl.lockPanel()"
-                gr:track-click="{{:: ctrl.trackingName}}"
-                gr:track-click-data="ctrl.trackingData('Lock panel')">
+                ng-if="!ctrl.state.locked"
+                ng-click="ctrl.lockPanel()"
+                gr-track-click="{{:: ctrl.trackingName}}"
+                gr-track-click-data="ctrl.trackingData('Lock panel')">
             <gr-icon>lock_open</gr-icon>
         </button>
         <button class="button-ico-square clickable"
                 type="button"
-                ng:if="ctrl.state.locked"
-                ng:click="ctrl.unlockPanel()"
-                ng:class="{'bg-light': ctrl.state.locked}"
-                gr:track-click="{{:: ctrl.trackingName}}"
-                gr:track-click-data="ctrl.trackingData('Unlock panel')">
+                ng-if="ctrl.state.locked"
+                ng-click="ctrl.unlockPanel()"
+                ng-class="{'bg-light': ctrl.state.locked}"
+                gr-track-click="{{:: ctrl.trackingName}}"
+                gr-track-click-data="ctrl.trackingData('Unlock panel')">
             <gr-icon>lock</gr-icon>
         </button>
     </div>

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button.html
@@ -1,38 +1,38 @@
-<div class="fill-height flex-container" ng:class="{ 'flex-container--rtl': ctrl.position == 'right' }">
+<div class="fill-height flex-container" ng-class="{ 'flex-container--rtl': ctrl.position == 'right' }">
     <button class="inner-clickable clickable" type="button"
-            ng:if="!ctrl.state.hidden" ng:click="ctrl.hidePanel()"
-            ng:class="{'bg-light': !ctrl.state.hidden}"
-            gr:track-click="{{ctrl.trackingName}}"
-            gr:track-click-data="ctrl.trackingData('Hide panel')">
+            ng-if="!ctrl.state.hidden" ng-click="ctrl.hidePanel()"
+            ng-class="{'bg-light': !ctrl.state.hidden}"
+            gr-track-click="{{ctrl.trackingName}}"
+            gr-track-click-data="ctrl.trackingData('Hide panel')">
         <gr-icon-label gr-icon="chrome_reader_mode">Hide {{ctrl.name}} panel</gr-icon-label>
     </button>
 
     <button class="inner-clickable clickable" type="button"
-            ng:if="ctrl.state.hidden"
-            ng:click="ctrl.showPanel()"
-            gr:track-click="{{ctrl.trackingName}}"
-            gr:track-click-data="ctrl.trackingData('Show panel')">
+            ng-if="ctrl.state.hidden"
+            ng-click="ctrl.showPanel()"
+            gr-track-click="{{ctrl.trackingName}}"
+            gr-track-click-data="ctrl.trackingData('Show panel')">
         <gr-icon-label gr-icon="chrome_reader_mode">Show {{ctrl.name}} panel</gr-icon-label>
     </button>
 
-    <div ng:if="!ctrl.state.hidden"
-         ng:class="{
+    <div ng-if="!ctrl.state.hidden"
+         ng-class="{
             'separator-left': ctrl.position  === 'left',
             'separator-right': ctrl.position === 'right'
          }">
         <button class="button-ico-square clickable" type="button"
-                ng:if="!ctrl.state.locked"
-                ng:click="ctrl.lockPanel()"
-                gr:track-click="{{ctrl.trackingName}}"
-                gr:track-click-data="ctrl.trackingData('Lock panel')">
+                ng-if="!ctrl.state.locked"
+                ng-click="ctrl.lockPanel()"
+                gr-track-click="{{ctrl.trackingName}}"
+                gr-track-click-data="ctrl.trackingData('Lock panel')">
             <gr-icon>lock_open</gr-icon>
         </button>
         <button class="button-ico-square clickable" type="button"
-                ng:if="ctrl.state.locked"
-                ng:click="ctrl.unlockPanel()"
-                ng:class="{'bg-light': ctrl.state.locked}"
-                gr:track-click="{{ctrl.trackingName}}"
-                gr:track-click-data="ctrl.trackingData('Unlock panel')">
+                ng-if="ctrl.state.locked"
+                ng-click="ctrl.unlockPanel()"
+                ng-class="{'bg-light': ctrl.state.locked}"
+                gr-track-click="{{ctrl.trackingName}}"
+                gr-track-click-data="ctrl.trackingData('Unlock panel')">
             <gr-icon>lock</gr-icon>
         </button>
     </div>

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,12 +1,12 @@
-<section ng:if="! ctrl.editInline">
+<section ng-if="! ctrl.editInline">
     <button class="image-info__edit"
-            ng:click="photoshootEditForm.$show()"
-            ng:hide="photoshootEditForm.$visible">
+            ng-click="photoshootEditForm.$show()"
+            ng-hide="photoshootEditForm.$visible">
         ✎
     </button>
 
     <span editable-text="ctrl.photoshootData.title"
-          ng:hide="photoshootEditForm.$visible"
+          ng-hide="photoshootEditForm.$visible"
           e:form="photoshootEditForm"
           e:uib-:typeahead="photoshoot for photoshoot in ctrl.search($viewValue) | limitTo:8"
           e:ng-class="{'image-info__editor--error': $error,
@@ -14,43 +14,43 @@
                        'text-input': true}"
           e:placeholder="describing a set of related images, e.g. for syndication purposes"
           onbeforesave="ctrl.save($data)">
-        <span ng:if="! ctrl.hasPhotoshootData">
+        <span ng-if="! ctrl.hasPhotoshootData">
             Unknown (click ✎ to add)
         </span>
 
-        <span ng:if="ctrl.hasPhotoshootData">
-            <span ng:if="ctrl.hasSinglePhotoshoot">
-                <a ui:sref="search.results({query: (ctrl.photoshootData.title | queryFilter:'photoshoot')})">
+        <span ng-if="ctrl.hasPhotoshootData">
+            <span ng-if="ctrl.hasSinglePhotoshoot">
+                <a ui-sref="search.results({query: (ctrl.photoshootData.title | queryFilter:'photoshoot')})">
                     {{ctrl.photoshootData.title}}
                 </a>
             </span>
 
-            <span ng:if="!ctrl.hasSinglePhotoshoot">
+            <span ng-if="!ctrl.hasSinglePhotoshoot">
                 Multiple photoshoots (click ✎ to edit <strong>all</strong>)
             </span>
         </span>
     </span>
 </section>
 
-<section ng:if="ctrl.editInline" class="edit-inline flex-container">
+<section ng-if="ctrl.editInline" class="edit-inline flex-container">
     <gr-datalist class="job-info--editor__input"
-                 gr:search="ctrl.search(q)"
+                 gr-search="ctrl.search(q)"
                  gr-tooltip="Naming a set of images for syndication etc, e.g. SL-07/18-heatwave (initials-MM/YY-title)."
                  gr-tooltip-position="bottom">
         <input type="text"
                name="photoshoot"
                class="text-input job-info--credit full-width"
                placeholder="Naming a set of images for syndication etc, e.g. SL-07/18-heatwave (initials-MM/YY-title)."
-               gr:datalist-input
-               ng:model="ctrl.photoshootData.title"
-               ng:change="ctrl.save(ctrl.photoshootData.title)"
-               ng:model-options="{ updateOn: 'gr:datalist:update blur' }" />
+               gr-datalist-input
+               ng-model="ctrl.photoshootData.title"
+               ng-change="ctrl.save(ctrl.photoshootData.title)"
+               ng-model-options="{ updateOn: 'gr-datalist:update blur' }" />
     </gr-datalist>
 
     <button type="button"
             class="job-editor__apply-to-all"
             title="Apply this photoshoot to all your current uploads"
-            ng:if="ctrl.withBatch"
-            ng:click="ctrl.batchApply(ctrl.photoshootData.title)"
+            ng-if="ctrl.withBatch"
+            ng-click="ctrl.batchApply(ctrl.photoshootData.title)"
     >⇔</button>
 </section>

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
@@ -1,14 +1,14 @@
 <div class="preset-labeller">
     <ul class="preset-labels"
-        ng:if="ctrl.presetLabels.length > 0">
+        ng-if="ctrl.presetLabels.length > 0">
         <li class="preset-label"
-            ng:repeat="label in ctrl.presetLabels">
-            <a ui:sref="search.results({query: (label | queryLabelFilter)})"
+            ng-repeat="label in ctrl.presetLabels">
+            <a ui-sref="search.results({query: (label | queryLabelFilter)})"
                class="preset-label__value preset-label__link">{{label}}</a>
 
             <button class="preset-label__remove"
                     title="Remove label"
-                    ng:click="ctrl.removePresetLabel(label)">
+                    ng-click="ctrl.removePresetLabel(label)">
                 <gr-icon>close</gr-icon>
             </button>
         </li>
@@ -16,43 +16,43 @@
 </div>
 
 <div class="add-preset-label">
-    <button ng:click="ctrl.active = true"
-            ng:disabled="ctrl.adding"
-            ng:if="!ctrl.active"
+    <button ng-click="ctrl.active = true"
+            ng-disabled="ctrl.adding"
+            ng-if="!ctrl.active"
             title="Add a new label">
 
-        <gr-icon ng:class="{'spin': ctrl.adding}">add_box</gr-icon>
-        <span ng:show="ctrl.adding">Adding...</span>
+        <gr-icon ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
+        <span ng-show="ctrl.adding">Adding...</span>
     </button>
     <form class="flex-container"
-          ng:if="ctrl.active"
-          ng:submit="ctrl.save()">
+          ng-if="ctrl.active"
+          ng-submit="ctrl.save()">
 
         <gr-datalist class="related-labels__datalist"
-                     gr:search="ctrl.suggestedLabelsSearch(q)">
+                     gr-search="ctrl.suggestedLabelsSearch(q)">
           <input type="text"
                class="text-input show-no-error"
                placeholder="e.g. observer"
                required
-               gr:auto-focus
-               gr:datalist-input
-               ng:model-options="{ updateOn: 'gr:datalist:update' }"
-               ng:change="ctrl.save()"
-               ng:model="ctrl.newLabel"
-               ng:disabled="ctrl.adding" />
+               gr-auto-focus
+               gr-datalist-input
+               ng-model-options="{ updateOn: 'gr-datalist:update' }"
+               ng-change="ctrl.save()"
+               ng-model="ctrl.newLabel"
+               ng-disabled="ctrl.adding" />
         </gr-datalist>
 
         <span class="flex-container">
-            <button class="add-preset-label__button button-cancel" type="button" ng:click="ctrl.cancel()" title="Close">
-                <gr-icon-label gr-icon="close"><span ng:hide="ctrl.grSmall">Cancel</span></gr-icon-label>
+            <button class="add-preset-label__button button-cancel" type="button" ng-click="ctrl.cancel()" title="Close">
+                <gr-icon-label gr-icon="close"><span ng-hide="ctrl.grSmall">Cancel</span></gr-icon-label>
             </button>
             <button
                 class="add-preset-label__button button-save"
                 type="submit"
                 title="Save new label"
-                ng:disabled="ctrl.adding">
+                ng-disabled="ctrl.adding">
                 <gr-icon-label gr-icon="check">
-                    <span ng:hide="ctrl.grSmall">Save</span>
+                    <span ng-hide="ctrl.grSmall">Save</span>
                 </gr-icon-label>
             </button>
         </span>

--- a/kahuna/public/js/components/gr-syndication-rights/gr-syndication-rights.html
+++ b/kahuna/public/js/components/gr-syndication-rights/gr-syndication-rights.html
@@ -1,9 +1,9 @@
 <section>
-    <span ng:if="!ctrl.hasInformationFromRCS">
+    <span ng-if="!ctrl.hasInformationFromRCS">
         No information available.
     </span>
 
-    <span ng:if="ctrl.hasInformationFromRCS">
-        Syndication rights have <strong ng:if="!ctrl.hasRightsAcquired">not</strong> been acquired for this image.
+    <span ng-if="ctrl.hasInformationFromRCS">
+        Syndication rights have <strong ng-if="!ctrl.hasRightsAcquired">not</strong> been acquired for this image.
     </span>
 </section>

--- a/kahuna/public/js/components/gr-toggle-button/gr-toggle-button.html
+++ b/kahuna/public/js/components/gr-toggle-button/gr-toggle-button.html
@@ -1,6 +1,6 @@
 <div class="fill-height flex-container flex-container--rtl">
     <button class="inner-clickable clickable" type="button"
-            ng:click="toggle()">
+            ng-click="toggle()">
         <gr-icon-label gr-icon="{{ icon }}">{{ showHide }} {{ name }}</gr-icon-label>
     </button>
 </div>

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -1,38 +1,38 @@
-<div class="gu-date-range" ng:init="ctrl.showOverlay = false">
+<div class="gu-date-range" ng-init="ctrl.showOverlay = false">
     <button type="button"
             class="gu-date-range__display"
-            ng:click="ctrl.showOverlay = !ctrl.showOverlay"
-            gr:track-click="{{ctrl.trackingName}}"
-            gr:track-click-data="{ 'Action': 'Show Hide' }">
+            ng-click="ctrl.showOverlay = !ctrl.showOverlay"
+            gr-track-click="{{ctrl.trackingName}}"
+            gr-track-click-data="{ 'Action': 'Show Hide' }">
         <gr-icon>event</gr-icon>
         <div class="gu-date-range__display--value">
             {{ctrl.guSelectedField}}
-            <span ng:if="ctrl.guDisplayStartDate !== ctrl.guAnyTimeText && !ctrl.guDisplayEndDate">from </span>
+            <span ng-if="ctrl.guDisplayStartDate !== ctrl.guAnyTimeText && !ctrl.guDisplayEndDate">from </span>
             {{ctrl.guDisplayStartDate}}
-            <span ng:if="ctrl.guDisplayEndDate">to {{ctrl.guDisplayEndDate}}</span>
+            <span ng-if="ctrl.guDisplayEndDate">to {{ctrl.guDisplayEndDate}}</span>
         </div>
 
         <div class="gu-date-range__display__icon gu-date-range__display__icon__toggle">
-            <span ng:hide="ctrl.showOverlay">▸</span>
-            <span ng:show="ctrl.showOverlay">▾</span>
+            <span ng-hide="ctrl.showOverlay">▸</span>
+            <span ng-show="ctrl.showOverlay">▾</span>
         </div>
     </button>
 
-    <div class="gu-date-range__overlay search__overlay" ng:show="ctrl.showOverlay">
-        <div ng:show="ctrl.guShowExtras">
+    <div class="gu-date-range__overlay search__overlay" ng-show="ctrl.showOverlay">
+        <div ng-show="ctrl.guShowExtras">
             <h2 class="gu-date-range__overlay__title search__overlay__title">Field</h2>
             <div class="gu-date-range__overlay__fieldset">
                 <div class="radio-list">
-                    <div ng:repeat="field in ctrl.guFields track by field.name"
+                    <div ng-repeat="field in ctrl.guFields track by field.name"
                          class="radio-list__item">
                         <input type="radio"
                                id="gu-date-range__field__{{:: field.name}}"
                                class="radio-list__circle"
                                name="field-uploaded"
-                               ng:value=":: field.value"
-                               ng:model="ctrl.guDisplayField">
+                               ng-value=":: field.value"
+                               ng-model="ctrl.guDisplayField">
                         <label for="gu-date-range__field__{{:: field.name}}" class="radio-list__label"
-                               ng:class="{'radio-list--selected': ctrl.guDisplayField === field.value}">
+                               ng-class="{'radio-list--selected': ctrl.guDisplayField === field.value}">
                             <div class="radio-list__selection-state"></div>
                             <div class="radio-list__label-value">{{:: field.label}}</div>
                         </label>
@@ -44,10 +44,10 @@
             <div class="gu-date-range__overlay__fieldset">
                 <button type="button"
                         class="gu-date-range__overlay__preset__button button"
-                        ng:repeat="presetDate in ctrl.guPresetDates"
-                        ng:click="setPresetDate(presetDate.value)"
-                        gr:track-click="{{ctrl.trackingName}}"
-                        gr:track-click-data="{ 'Action': 'Preset Date', 'Preset Date': presetDate.label }">
+                        ng-repeat="presetDate in ctrl.guPresetDates"
+                        ng-click="setPresetDate(presetDate.value)"
+                        gr-track-click="{{ctrl.trackingName}}"
+                        gr-track-click-data="{ 'Action': 'Preset Date', 'Preset Date': presetDate.label }">
                     {{presetDate.label}}
                 </button>
             </div>
@@ -59,7 +59,7 @@
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--start"/>
                 <button type="button"
                         class="gu-date-range__overlay__pikaday__clear button-shy"
-                        ng:click="clearStart()">
+                        ng-click="clearStart()">
                     Clear
                 </button>
             </span>
@@ -69,7 +69,7 @@
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--end"/>
                 <button type="button"
                         class="gu-date-range__overlay__pikaday__clear button-shy"
-                        ng:click="clearEnd()">
+                        ng-click="clearEnd()">
                     Clear
                 </button>
             </span>
@@ -78,19 +78,19 @@
         <div class="gu-date-range__overlay__buttons">
             <button type="button"
                     class="gu-date-range__overlay__button__cancel button-shy"
-                    ng:click="cancel()">
+                    ng-click="cancel()">
                 Cancel
             </button>
             <button type="button"
                     class="gu-date-range__overlay__button__ok button"
-                    ng:click="save()"
-                    gr:track-click="{{ctrl.trackingName}}"
-                    gr:track-click-data="{ 'Action': 'Set Filter' }">
+                    ng-click="save()"
+                    gr-track-click="{{ctrl.trackingName}}"
+                    gr-track-click-data="{ 'Action': 'Set Filter' }">
                 Filter
             </button>
         </div>
     </div>
 
-    <input hidden type="text" class="gu-date-range__input__start--hidden" ng:model="pikaStartValue">
-    <input hidden type="text" class="gu-date-range__input__end--hidden" ng:model="pikaEndValue">
+    <input hidden type="text" class="gu-date-range__input__start--hidden" ng-model="pikaStartValue">
+    <input hidden type="text" class="gu-date-range__input__end--hidden" ng-model="pikaEndValue">
 </div>

--- a/kahuna/public/js/components/gu-date/gu-date.html
+++ b/kahuna/public/js/components/gu-date/gu-date.html
@@ -1,22 +1,22 @@
-<div class="gu-date" ng:init="showingOverlay = false">
+<div class="gu-date" ng-init="showingOverlay = false">
     <span class="flex-container">
-        <button type="button" ng:click="showingOverlay = !showingOverlay">
+        <button type="button" ng-click="showingOverlay = !showingOverlay">
             <gr-icon-label gr-icon="event">{{label}}</gr-icon-label>
             {{displayValue}}
-            <gr-icon ng:show="showingOverlay">expand_less</gr-icon>
-            <gr-icon ng:show="!showingOverlay">expand_more</gr-icon>
+            <gr-icon ng-show="showingOverlay">expand_less</gr-icon>
+            <gr-icon ng-show="!showingOverlay">expand_more</gr-icon>
         </button>
         <span class="flex-spacer"></span>
         <button type="button"
-                ng:click="clear()"
-                gr:tooltip="clear {{label}}"
-                gr:tooltip-position="left">
+                ng-click="clear()"
+                gr-tooltip="clear {{label}}"
+                gr-tooltip-position="left">
             <gr-icon>close</gr-icon>
         </button>
     </span>
 
-    <div ng:show="showingOverlay" class="gu-date__container"></div>
+    <div ng-show="showingOverlay" class="gu-date__container"></div>
 
-    <input hidden type="text" class="gu-date__value--hidden" ng:model="pikaValue">
+    <input hidden type="text" class="gu-date__value--hidden" ng-model="pikaValue">
 </div>
 

--- a/kahuna/public/js/components/gu-lazy-preview/gu-lazy-preview.html
+++ b/kahuna/public/js/components/gu-lazy-preview/gu-lazy-preview.html
@@ -3,24 +3,24 @@
     <div class="preview-view-item" ng-if="previewCtrl.item">
 
         <div class="preview-view-item__select preview-view-item__select--selected"
-             ng:if="ctrl.imageHasBeenSelected(previewCtrl.item)">
+             ng-if="ctrl.imageHasBeenSelected(previewCtrl.item)">
             <input type="checkbox"
                    class="preview-view-item__select__checkbox"
                    id="id-{{::previewCtrl.item.data.id}}-preview-view-item__select__checkbox--select"
                    checked="true"
-                   ng:click="ctrl.deselect(previewCtrl.item)"/>
+                   ng-click="ctrl.deselect(previewCtrl.item)"/>
             <label for="id-{{::previewCtrl.item.data.id}}-preview-view-item__select__checkbox--select"
                    class="preview-view-item__select__checkbox__label">
                 <gr-icon>check_box</gr-icon>
             </label>
         </div>
         <div class="preview-view-item__select"
-             ng:if="!ctrl.imageHasBeenSelected(previewCtrl.item)"
-             ng:class="{ 'preview-view-item__select--no-pointer-events': ctrl.inSelectionMode}">
+             ng-if="!ctrl.imageHasBeenSelected(previewCtrl.item)"
+             ng-class="{ 'preview-view-item__select--no-pointer-events': ctrl.inSelectionMode}">
             <input type="checkbox"
                    class="preview-view-item__select__checkbox"
                    id="id-{{::previewCtrl.item.data.id}}-preview-view-item__select__checkbox--deselect"
-                   ng:click="ctrl.select(previewCtrl.item)" />
+                   ng-click="ctrl.select(previewCtrl.item)" />
             <label for="id-{{::previewCtrl.item.data.id}}-preview-view-item__select__checkbox--deselect"
                    class="preview-view-item__select__checkbox__label">
                 <gr-icon>check_box</gr-icon>
@@ -28,7 +28,7 @@
         </div>
 
         <ui-preview-image-large class="preview-view-item__preview"
-                                ng:class="{ 'preview-view-item__preview--selected': ctrl.imageHasBeenSelected(previewCtrl.item)}"
+                                ng-class="{ 'preview-view-item__preview--selected': ctrl.imageHasBeenSelected(previewCtrl.item)}"
                                 image="previewCtrl.item"
                                 selection-mode="inSelectionMode">
             <button class="mark-as-seen image-action"
@@ -42,13 +42,13 @@
     <div class="preview-view__controls">
 
         <button class="preview-view__control preview-view__control--left"
-                ng:click="previewCtrl.prevItem()"
+                ng-click="previewCtrl.prevItem()"
                 title="Previous">
             <gr-icon>navigate_before</gr-icon>
         </button>
 
         <button class="preview-view__control preview-view__control--right"
-                ng:click="previewCtrl.nextItem()"
+                ng-click="previewCtrl.nextItem()"
                 title="Next">
             <gr-icon>navigate_next</gr-icon>
         </button>

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -1,7 +1,7 @@
 <gr-top-bar>
     <gr-top-bar-nav>
         <a class="top-bar-item clickable side-padded"
-           ui:sref="image({ imageId: ctrl.image.data.id })"
+           ui-sref="image({ imageId: ctrl.image.data.id })"
            gr-tooltip="cancel [esc]">
             <gr-icon-label gr-icon="cancel">Cancel</gr-icon-label></a>
     </gr-top-bar-nav>
@@ -15,8 +15,8 @@
                     min="0"
                     max="{{ctrl.maxInputX()}}"
                     class="top-bar-item__form__input"
-                    ng:model="ctrl.inputX"
-                    ng:change="ctrl.broadcastXChange()"/>
+                    ng-model="ctrl.inputX"
+                    ng-change="ctrl.broadcastXChange()"/>
             </form>
             y:
             <form class="top-bar-item__form">
@@ -25,8 +25,8 @@
                     min="0"
                     max="{{ctrl.maxInputY()}}"
                     class="top-bar-item__form__input"
-                    ng:model="ctrl.inputY"
-                    ng:change="ctrl.broadcastYChange()"/>
+                    ng-model="ctrl.inputY"
+                    ng-change="ctrl.broadcastYChange()"/>
             </form>
         </div>
 
@@ -37,18 +37,18 @@
                     min="1"
                     max="{{ctrl.originalWidth}}"
                     class="top-bar-item__form__input"
-                    ng:model="ctrl.inputWidth"
-                    ng:change="ctrl.broadcastWidthChange()"/>
+                    ng-model="ctrl.inputWidth"
+                    ng-change="ctrl.broadcastWidthChange()"/>
             </form>
             &times;
-            <form class="top-bar-item__form" ng:disabled="ctrl.freeRatio">
+            <form class="top-bar-item__form" ng-disabled="ctrl.freeRatio">
                 <input
                     type="number"
                     min="1"
                     max="{{ctrl.originalHeight}}"
                     class="top-bar-item__form__input"
-                    ng:model="ctrl.inputHeight"
-                    ng:change="ctrl.broadcastHeightChange()"/>
+                    ng-model="ctrl.inputHeight"
+                    ng-change="ctrl.broadcastHeightChange()"/>
             </form>
         </div>
 
@@ -56,18 +56,18 @@
           <gr-radio-list gr-for="crop" gr-options="ctrl.cropOptions" gr-selected-option="ctrl.cropType"></gr-radio-list>
         </div>
 
-        <div class="top-bar-item" ng:switch="ctrl.image.data.cost">
-            <div ng:switch-when="pay"
+        <div class="top-bar-item" ng-switch="ctrl.image.data.cost">
+            <div ng-switch-when="pay"
                  class="cost cost--pay">
                 Pay to use
             </div>
 
-            <div ng:switch-when="overquota"
+            <div ng-switch-when="overquota"
                  class="cost cost--pay">
                 Quota exceeded for this supplier
             </div>
 
-            <div ng:switch-when="conditional"
+            <div ng-switch-when="conditional"
                  class="cost cost--conditional"
                  title="restricted use: {{ctrl.image.data.usageRights.restrictions}}">
                 <!-- As `conditional` can only be set with usageRights, let's
@@ -81,16 +81,16 @@
         <div class="top-bar-item side-padded">
             <button class="button crop__action"
                     type="button"
-                    ng:click="ctrl.callCrop()"
-                    ng:disabled="ctrl.cropping"
+                    ng-click="ctrl.callCrop()"
+                    ng-disabled="ctrl.cropping"
                     gr-tooltip="Crop [enter]">
-                <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}">Crop<span ng:show="ctrl.cropping">ping…</span></gr-icon-label>
+                <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}">Crop<span ng-show="ctrl.cropping">ping…</span></gr-icon-label>
             </button>
         </div>
     </gr-top-bar-actions>
 </gr-top-bar>
 
-<div class="warning" ng:if="ctrl.cropSizeWarning()">
+<div class="warning" ng-if="ctrl.cropSizeWarning()">
     This crop is very small and will result in a low-quality image.
     Please try to use a larger crop.
 </div>
@@ -100,11 +100,11 @@
         <div class="easel__image-container">
             <img class="easel__image easel__image--cropper"
                  alt="original image to crop"
-                 ng:src="{{ctrl.optimisedImageUri}}"
-                 ui:crop-box="ctrl.coords"
-                 ui:crop-box-original-width="ctrl.originalWidth"
-                 ui:crop-box-original-height="ctrl.originalHeight"
-                 ui:crop-box-crop-type="ctrl.cropType"
+                 ng-src="{{ctrl.optimisedImageUri}}"
+                 ui-crop-box="ctrl.coords"
+                 ui-crop-box-original-width="ctrl.originalWidth"
+                 ui-crop-box-original-height="ctrl.originalHeight"
+                 ui-crop-box-crop-type="ctrl.cropType"
 
                  grid:track-image="ctrl.image"
                  grid:track-image-location="original-cropping"

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -4,34 +4,34 @@
     <div class="result-editor__result">
 
         <!-- only give the image link if the image is valid -->
-        <div ng:switch="ctrl.status === 'ready'" class="image-actions-container">
+        <div ng-switch="ctrl.status === 'ready'" class="image-actions-container">
             <a class="result-editor__img-link"
-               ng:switch-when="true"
-               ui:sref="image({imageId: ctrl.image.data.id})"
-               ui:drag-data="ctrl.image | asImageDragData">
+               ng-switch-when="true"
+               ui-sref="image({imageId: ctrl.image.data.id})"
+               ui-drag-data="ctrl.image | asImageDragData">
 
                 <img class="result-editor__img"
                      alt="original image thumbnail"
-                     ng:src="{{:: ctrl.image.data.thumbnail | assetFile}}"
-                     gr:image-fade-on-load
+                     ng-src="{{:: ctrl.image.data.thumbnail | assetFile}}"
+                     gr-image-fade-on-load
                  />
             </a>
 
             <img class="result-editor__img"
                  alt="original image thumbnail"
-                 ng:switch-default
-                 ng:src="{{:: ctrl.image.data.thumbnail | assetFile}}"
-                 gr:image-fade-on-load
+                 ng-switch-default
+                 ng-src="{{:: ctrl.image.data.thumbnail | assetFile}}"
+                 gr-image-fade-on-load
              />
 
             <ul class="image-actions"
-                ng:if="ctrl.image.data.valid">
+                ng-if="ctrl.image.data.valid">
                 <li>
                     <a class="image-action image-action--first"
                        rel="noopener"
                        target="_blank"
                        title="Pop out"
-                       ng:href="/images/{{:: ctrl.image.data.id}}">
+                       ng-href="/images/{{:: ctrl.image.data.id}}">
                         <gr-icon>open_in_new</gr-icon>
                     </a>
                 </li>
@@ -39,7 +39,7 @@
                 <li>
                     <a class="image-action"
                        title="crop"
-                       ui:sref="crop({ imageId: ctrl.image.data.id })">
+                       ui-sref="crop({ imageId: ctrl.image.data.id })">
                         <gr-icon>crop</gr-icon>
                     </a>
                 </li>
@@ -48,29 +48,29 @@
 
         <div class="result-editor__info">
             <div class="result-editor__info-item result-editor__info-item--first"
-                 ng:switch="ctrl.image.data.cost">
+                 ng-switch="ctrl.image.data.cost">
                 <span class="result-editor__status status status--invalid"
-                      ng:switch-when="pay">Pay to use</span>
+                      ng-switch-when="pay">Pay to use</span>
 
                 <span class="result-editor__status status status--invalid"
-                      ng:switch-when="overquota">Quota exceeded for this supplier</span>
+                      ng-switch-when="overquota">Quota exceeded for this supplier</span>
 
                 <span class="result-editor__status status status--valid"
-                      ng:switch-when="free">Free to use</span>
+                      ng-switch-when="free">Free to use</span>
 
                 <span class="result-editor__status status"
-                      ng:switch-when="conditional">Restricted use</span>
+                      ng-switch-when="conditional">Restricted use</span>
             </div>
 
             <div class="result-editor__info-item"
-                 ng:switch="ctrl.status">
+                 ng-switch="ctrl.status">
                 <a class="result-editor__status status status--valid"
-                   ng:switch-when="ready"
-                   ui:sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
+                   ng-switch-when="ready"
+                   ui-sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
 
                 <a class="result-editor__status status status--invalid"
-                   ng:switch-when="invalid"
-                   ui:sref="image({imageId: ctrl.image.data.id})">
+                   ng-switch-when="invalid"
+                   ui-sref="image({imageId: ctrl.image.data.id})">
                         Unusable
                    <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
                 </a>
@@ -82,13 +82,13 @@
         </div>
         <span class="result-editor__save-status-container">
             <span class="result-editor__save-status"
-                  ng:show="ctrl.saving">Saving… <span class="saving">⧖</span>
+                  ng-show="ctrl.saving">Saving… <span class="saving">⧖</span>
             </span>
             <span class="result-editor__save-status"
-                  ng:show="ctrl.saved">Saved</span>
+                  ng-show="ctrl.saved">Saved</span>
 
             <span class="result-editor__save-status result-editor__save-status--error"
-                  ng:show="ctrl.error">Something went wrong… try again?</span>
+                  ng-show="ctrl.error">Something went wrong… try again?</span>
         </span>
     </div>
 
@@ -101,26 +101,26 @@
                 </span>
 
                 <div class="result-editor__usage-rights-container">
-                    <div ng:hide="ctrl.showUsageRights" class="result-editor__field-value">
+                    <div ng-hide="ctrl.showUsageRights" class="result-editor__field-value">
                         <span>{{ctrl.usageRightsCategory || 'None'}}</span>
-                        <button class="image-info__edit" ng:click="ctrl.showUsageRights = !ctrl.showUsageRights">
+                        <button class="image-info__edit" ng-click="ctrl.showUsageRights = !ctrl.showUsageRights">
                             <gr-icon>edit</gr-icon>
                         </button>
                         <button
                             class="job-editor__apply-to-all"
                             title="Apply these rights &amp; restrictions to all your current uploads"
                             type="button"
-                            ng:if="ctrl.withBatch"
-                            ng:click="ctrl.batchApplyUsageRights()"
+                            ng-if="ctrl.withBatch"
+                            ng-click="ctrl.batchApplyUsageRights()"
                             >⇔</button>
                     </div>
 
                     <gr-usage-rights-editor
-                        ng:if="ctrl.showUsageRights"
+                        ng-if="ctrl.showUsageRights"
                         class="result-editor__usage-rights"
-                        gr:usage-rights="[ctrl.usageRights]"
-                        gr:on-save="ctrl.showUsageRights = false"
-                        gr:on-cancel="ctrl.showUsageRights = false">
+                        gr-usage-rights="[ctrl.usageRights]"
+                        gr-on-save="ctrl.showUsageRights = false"
+                        gr-on-cancel="ctrl.showUsageRights = false">
                     </gr-usage-rights-editor>
                 </div>
             </div>
@@ -130,10 +130,10 @@
                     Leases
                 </span>
                 <div class="result-editor__field-container__leases flex-spacer">
-                    <gr-leases gr:images="[ctrl.image]"
+                    <gr-leases gr-images="[ctrl.image]"
                         with-batch="ctrl.withBatch"
                         class="leases-flex"
-                        gr:user-can-edit="true">
+                        gr-user-can-edit="true">
                     </gr-leases>
                 </div>
             </div>
@@ -158,34 +158,34 @@
                     Collections
                 </span>
                <gr-collection-overlay image="ctrl.image"></gr-collection-overlay>
-               <span class="preview__collections__collection__apply-all" ng:if="ctrl.withBatch">
-                    <button ng:if="! ctrl.confirmDelete"
+               <span class="preview__collections__collection__apply-all" ng-if="ctrl.withBatch">
+                    <button ng-if="! ctrl.confirmDelete"
                             title="Apply these collections to all your current uploads"
-                            ng:click="ctrl.batchApplyCollections()"
+                            ng-click="ctrl.batchApplyCollections()"
                     >⇔</button>
                     <button title="Remove ALL collections"
                             class="button button--confirm-delete"
-                            ng:if="ctrl.confirmDelete"
-                            ng:click="ctrl.batchRemoveCollections()">
+                            ng-if="ctrl.confirmDelete"
+                            ng-click="ctrl.batchRemoveCollections()">
                         <gr-icon>warning</gr-icon>Remove ALL collections in job?
                     </button>
                 </span>
                 <div class="result-editor__field-container__collections">
                     <ul class="preview__collections">
                         <li class="preview__collections__collection"
-                            ng:repeat="collection in ctrl.image.data.collections track by collection.data.pathId">
+                            ng-repeat="collection in ctrl.image.data.collections track by collection.data.pathId">
                             <a gr-tooltip="Click to open collection: {{::collection.data.path.join(' ▸ ')}}"
                                gr-tooltip-position="top"
-                               ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
-                               ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
+                               ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                               ng-attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                                class="preview__collections__collection__value">
                                 {{::collection.data.description}}
                             </a>
                             <button gr-tooltip="Click to remove image from this collection"
                                     gr-tooltip-position="top"
                                     class="preview__collections__collection__remove"
-                                    ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
-                                    ng:click="ctrl.removeImageFromCollection(collection)">
+                                    ng-attr-style="{{::ctrl.getCollectionStyle(collection)}}"
+                                    ng-click="ctrl.removeImageFromCollection(collection)">
                                 <gr-icon>close</gr-icon>
                             </button>
                         </li>
@@ -197,7 +197,7 @@
                 <span class="result-editor__field-label  flex-no-shrink text-small">
                     Labels
                 </span>
-                <div class="result-editor__field-container__labels" ng:class="{'result-editor__field-container__labels--hidden' : ctrl.inputtingLabel}">
+                <div class="result-editor__field-container__labels" ng-class="{'result-editor__field-container__labels--hidden' : ctrl.inputtingLabel}">
                     <gr-add-label
                         images="[ctrl.image]"
                         active="ctrl.inputtingLabel"
@@ -224,7 +224,7 @@
 
         <section>
             <h1>File information</h1>
-            <div class="result-editor__field-container" ng:if=":: ctrl.image.data.uploadInfo.filename">
+            <div class="result-editor__field-container" ng-if=":: ctrl.image.data.uploadInfo.filename">
                 <div class="result-editor__field-label text-small">File name</div>
                 <div class="result-editor__field-value">{{:: ctrl.image.data.uploadInfo.filename}}</div>
             </div>

--- a/kahuna/public/js/edits/labeller-compact.html
+++ b/kahuna/public/js/edits/labeller-compact.html
@@ -1,14 +1,14 @@
 <div class="labeller">
     <ul class="labels"
-        ng:if="ctrl.labels.data.length > 0">
+        ng-if="ctrl.labels.data.length > 0">
         <li class="label"
-            ng:repeat="label in ctrl.labels.data">
+            ng-repeat="label in ctrl.labels.data">
 
-            <span ng:if="ctrl.disabled" class="label__value label__value--compact">{{label.data}}</span>
+            <span ng-if="ctrl.disabled" class="label__value label__value--compact">{{label.data}}</span>
 
             <a class="label__value label__value--compact label__link"
-               ng:if="!ctrl.disabled"
-               ui:sref="search.results({query: (label.data | queryLabelFilter)})">
+               ng-if="!ctrl.disabled"
+               ui-sref="search.results({query: (label.data | queryLabelFilter)})">
                 {{label.data}}
             </a>
         </li>

--- a/kahuna/public/js/edits/labeller.html
+++ b/kahuna/public/js/edits/labeller.html
@@ -1,30 +1,30 @@
 <div class="labeller">
-    <span ng:if="ctrl.withBatch" class="labeller__apply-all">
+    <span ng-if="ctrl.withBatch" class="labeller__apply-all">
         <button
             title="Apply these labels to all your current uploads"
-            ng:if="!ctrl.confirmDelete"
-            ng:click="ctrl.batchApplyLabels()"
+            ng-if="!ctrl.confirmDelete"
+            ng-click="ctrl.batchApplyLabels()"
         >⇔</button>
 
         <button title="Remove ALL labels"
                 class="button button--confirm-delete"
-                ng:if="ctrl.confirmDelete"
-                ng:click="ctrl.batchRemoveLabels()">
+                ng-if="ctrl.confirmDelete"
+                ng-click="ctrl.batchRemoveLabels()">
             <gr-icon>warning</gr-icon>Remove ALL labels in job?
         </button>
     </span>
 
     <ul class="labels"
-        ng:if="ctrl.labels.data.length > 0">
+        ng-if="ctrl.labels.data.length > 0">
         <li class="label"
-            ng:repeat="label in ctrl.labels.data"
-            ng:class="{'label--removing': ctrl.labelsBeingRemoved.has(label)}">
-            <a ui:sref="search.results({query: (label.data | queryLabelFilter)})"
+            ng-repeat="label in ctrl.labels.data"
+            ng-class="{'label--removing': ctrl.labelsBeingRemoved.has(label)}">
+            <a ui-sref="search.results({query: (label.data | queryLabelFilter)})"
                class="label__value label__link">{{label.data}}</a>
 
             <button class="label__remove"
                     title="Remove label"
-                    ng:click="ctrl.removeLabel(label.data)">
+                    ng-click="ctrl.removeLabel(label.data)">
                 <gr-icon>close</gr-icon>
             </button>
         </li>

--- a/kahuna/public/js/errors/global.html
+++ b/kahuna/public/js/errors/global.html
@@ -1,6 +1,6 @@
-<ng:messages for="ctrl.errors" class="global-errors">
+<ng-messages for="ctrl.errors" class="global-errors">
     <div class="global-error error"
-         ng:message="unauthorised">
+         ng-message="unauthorised">
         😱 Your session has become invalid.
         Please <a href="{{ctrl.getCurrentLocation()}}" target="_self" class="coloured-link">login again</a> to reauthenticate.
 
@@ -11,7 +11,7 @@
     </div>
 
     <div class="global-error error"
-         ng:message="authFailed">
+         ng-message="authFailed">
         <div>😱 We couldn't log you back in.</div>
 
         <div>
@@ -33,17 +33,17 @@
         </p>
     </div>
 
-    <div class="global-error warning" ng:message="unknown">
+    <div class="global-error warning" ng-message="unknown">
         An unknown error has occurred.
         If the problem persists please <a href="{{ctrl.supportEmailLink}}" class="coloured-link">email the Grid team</a>.
 
         <gr-icon class="global-error__close"
                  title="Close"
-                 ng:click="ctrl.dismiss('unknown')">close</gr-icon>
+                 ng-click="ctrl.dismiss('unknown')">close</gr-icon>
     </div>
 
-    <div class="global-error error" ng:message="server">
+    <div class="global-error error" ng-message="server">
         A server error has occurred; the Grid may not be fully functional at this time.
         If the problem persists please <a href="{{ctrl.supportEmailLink}}" class="coloured-link">email the Grid team</a>.
     </div>
-</ng:messages>
+</ng-messages>

--- a/kahuna/public/js/forms/datalist.html
+++ b/kahuna/public/js/forms/datalist.html
@@ -1,11 +1,11 @@
 <div class="datalist">
-    <ng:transclude></ng:transclude>
-    <div class="datalist__options" ng:if="ctrl.active && ctrl.results.length > 0">
+    <ng-transclude></ng-transclude>
+    <div class="datalist__options" ng-if="ctrl.active && ctrl.results.length > 0">
         <div class="datalist__option"
-             ng:repeat="(key, result) in ctrl.results"
-             ng:click="ctrl.setValueTo(result)"
-             ng:mouseover="ctrl.setIndex(key)"
-             ng:class="{ 'datalist__option--selected': ctrl.isSelected(key) }">
+             ng-repeat="(key, result) in ctrl.results"
+             ng-click="ctrl.setValueTo(result)"
+             ng-mouseover="ctrl.setIndex(key)"
+             ng-class="{ 'datalist__option--selected': ctrl.isSelected(key) }">
              {{result}}
         </div>
     </div>

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -1,13 +1,13 @@
 <img class="image-crop__image"
-     ng:class="{'image-crop__image--disabled': !ctrl.allowCropSelection(crop) }"
+     ng-class="{'image-crop__image--disabled': !ctrl.allowCropSelection(crop) }"
      alt="cropped image thumbnail"
-     ng:src="{{:: extremeAssets.smallest | assetFile}}" />
+     ng-src="{{:: extremeAssets.smallest | assetFile}}" />
 <div class="image-crop__info"
-     ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
+     ng-class="{'image-crop__info--selected': crop == ctrl.crop}">
   <div class="flex-container">
     {{:: crop.specification.aspectRatio | asCropType}}
     <span class="flex-spacer"></span>
-    <span ng:if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
+    <span ng-if="crop.specification.aspectRatio">({{:: crop.specification.aspectRatio}})</span>
   </div>
 
   <div class="flex-container image-crop__more-info">

--- a/kahuna/public/js/image/image-error.html
+++ b/kahuna/public/js/image/image-error.html
@@ -1,6 +1,6 @@
 <gr-top-bar>
     <gr-top-bar-nav>
-        <a class="top-bar-item side-padded clickable" ui:sref="search" title="Back to search">
+        <a class="top-bar-item side-padded clickable" ui-sref="search" title="Back to search">
             <gr-icon-label gr-icon="search">Search</gr-icon-label>
         </a>
     </gr-top-bar-nav>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -1,13 +1,13 @@
 <gr-top-bar>
     <gr-top-bar-nav>
-        <a class="top-bar-item side-padded clickable" ui:sref="search" title="Back to search">
+        <a class="top-bar-item side-padded clickable" ui-sref="search" title="Back to search">
             <gr-icon-label gr-icon="youtube_searched_for">Back to search</gr-icon-label>
         </a>
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
         <gr-delete-image class="top-bar-item clickable"
-                         ng:if="ctrl.canBeDeleted"
+                         ng-if="ctrl.canBeDeleted"
                          images="[ctrl.image]">
         </gr-delete-image>
 
@@ -16,7 +16,7 @@
         </gr-downloader>
 
         <gr-archiver class="top-bar-item"
-                     gr:image="ctrl.image">
+                     gr-image="ctrl.image">
         </gr-archiver>
 
         <gr-crop-image class="top-bar-item" image="ctrl.image" has-full-crop="ctrl.hasFullCrop" tracking-location="Top bar">
@@ -32,15 +32,15 @@
                 <dt class="image-info__heading">Original <span class="image-info__file-size"> {{:: ctrl.image.data.source.size | asFileSize}}</span></dt>
                     <dd class="image-info__heading--crops">
                         <div class="image-crop"
-                             ng:class="{'image-crop--selected': !ctrl.crop}">
+                             ng-class="{'image-crop--selected': !ctrl.crop}">
                             <a draggable="true"
-                                ui:sref="{ crop: null }"
-                                ui:drag-data="ctrl.image | asImageDragData">
+                                ui-sref="{ crop: null }"
+                                ui-drag-data="ctrl.image | asImageDragData">
                                 <img class="image-crop__image"
                                      alt="original image thumbnail"
-                                     ng:src="{{:: ctrl.image.data.thumbnail | assetFile }}" />
+                                     ng-src="{{:: ctrl.image.data.thumbnail | assetFile }}" />
                                 <div class="image-crop__aspect-ratio"
-                                    ng:class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
+                                    ng-class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
                                     {{::ctrl.image.data.source.dimensions.width}} &times; {{::ctrl.image.data.source.dimensions.height}}
                                 </div>
                             </a>
@@ -49,27 +49,27 @@
                 </dt>
             </dl>
         </div>
-        <div ng:if="ctrl.hasFullCrop" class="image-info__group">
+        <div ng-if="ctrl.hasFullCrop" class="image-info__group">
             <dt class="image-info__heading">Full frame</dt>
             <dd>
                 <div class="image-crop"
-                     ng:init="crop = ctrl.fullCrop"
-                     ng:class="{'image-crop--selected': crop == ctrl.crop}"
+                     ng-init="crop = ctrl.fullCrop"
+                     ng-class="{'image-crop--selected': crop == ctrl.crop}"
                      ng-switch="ctrl.allowCropSelection(crop)">
-                    <a ng:switch-when="true"
+                    <a ng-switch-when="true"
                        draggable="true"
-                       ng:init="extremeAssets = (crop | getExtremeAssets)"
-                       ng:click="ctrl.cropSelected(crop)"
-                       ui:sref="{ crop: crop.id }"
-                       ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
-                       ui:drag-image="extremeAssets.smallest | assetFile">
+                       ng-init="extremeAssets = (crop | getExtremeAssets)"
+                       ng-click="ctrl.cropSelected(crop)"
+                       ui-sref="{ crop: crop.id }"
+                       ui-drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                       ui-drag-image="extremeAssets.smallest | assetFile">
                         <img class="image-crop__image"
                              alt="full frame image thumbnail"
-                             ng:src="{{:: extremeAssets.smallest | assetFile }}"
-                             ng:class="{'image-crop__image--disabled': !ctrl.allowCropSelection(crop) }"/>
+                             ng-src="{{:: extremeAssets.smallest | assetFile }}"
+                             ng-class="{'image-crop__image--disabled': !ctrl.allowCropSelection(crop) }"/>
 
                         <div class="flex-container image-crop__info image-crop__more-info"
-                             ng:class="{'image-crop__info--selected': crop == ctrl.crop}">
+                             ng-class="{'image-crop__info--selected': crop == ctrl.crop}">
                             {{:: crop.specification.bounds.width}} &times; {{:: crop.specification.bounds.height}}
                             <span class="flex-spacer"></span>
                             <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
@@ -78,7 +78,7 @@
                     <div ng-switch-when="false"
                          draggable="false"
                          class="image-crop--disabled"
-                         ng:init="extremeAssets = (crop | getExtremeAssets)"
+                         ng-init="extremeAssets = (crop | getExtremeAssets)"
                          gr-tooltip="{{:: ctrl.capitalisedCropType}} crops only"
                          gr-tooltip-position="top">
                       <ng-include src="'/assets/js/image/crop.html'"></ng-include>
@@ -86,29 +86,29 @@
                 </div>
             </dd>
         </div>
-        <div class="image-info__group" ng:if="ctrl.hasCrops">
+        <div class="image-info__group" ng-if="ctrl.hasCrops">
             <dl class="image-info__group--dl">
                 <dt class="image-info__heading">Crops</dt>
                 <dd class="image-info__heading--crops">
                     <ul class="image-crops">
                         <li class="image-crop"
-                            ng:repeat="crop in ctrl.crops"
+                            ng-repeat="crop in ctrl.crops"
                             ng-switch="ctrl.allowCropSelection(crop)"
-                            ng:class="{'image-crop--selected': crop == ctrl.crop}">
+                            ng-class="{'image-crop--selected': crop == ctrl.crop}">
                             <a draggable="true"
-                               ng:init="extremeAssets = (crop | getExtremeAssets)"
+                               ng-init="extremeAssets = (crop | getExtremeAssets)"
                                ng-switch-when="true"
-                               ng:click="ctrl.cropSelected(crop)"
-                               ui:sref="{crop: crop.id}"
-                               ui:drag-data="ctrl.image | asImageAndCropsDragData:crop"
-                               ui:drag-image="extremeAssets.smallest | assetFile">
+                               ng-click="ctrl.cropSelected(crop)"
+                               ui-sref="{crop: crop.id}"
+                               ui-drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                               ui-drag-image="extremeAssets.smallest | assetFile">
 
                               <ng-include src="'/assets/js/image/crop.html'"></ng-include>
                             </a>
                             <div
                                 class="image-crop--disabled"
                                 draggable="false"
-                                ng:init="extremeAssets = (crop | getExtremeAssets)"
+                                ng-init="extremeAssets = (crop | getExtremeAssets)"
                                 ng-switch-when="false"
                                 gr-tooltip="{{:: ctrl.capitalisedCropType}} crops only"
                                 gr-tooltip-position="top"
@@ -124,8 +124,8 @@
 
     <gr-delete-crops
             class="image-details__delete-crops"
-            gr:image="ctrl.image"
-            gr:on-delete="ctrl.onCropsDeleted()"></gr-delete-crops>
+            gr-image="ctrl.image"
+            gr-on-delete="ctrl.onCropsDeleted()"></gr-delete-crops>
 </div>
 
 <div class="image-details image-details--full-image">
@@ -134,38 +134,38 @@
   <gr-radio-list gr-for="tabs" gr-options="ctrl.tabs" gr-selected-option="ctrl.selectedTab"></gr-radio-list>
 
   <div class="image-details image-details--scroll">
-    <gr-image-metadata gr-image="ctrl.image" ng:if="ctrl.selectedTab === 'metadata'"></gr-image-metadata>
-    <gr-image-usage gr-image="ctrl.image" ng:if="ctrl.selectedTab === 'usages'"></gr-image-usage>
+    <gr-image-metadata gr-image="ctrl.image" ng-if="ctrl.selectedTab === 'metadata'"></gr-image-metadata>
+    <gr-image-usage gr-image="ctrl.image" ng-if="ctrl.selectedTab === 'usages'"></gr-image-usage>
   </div>
 </div>
 
 <div class="image-holder">
     <div class="easel">
         <div class="easel__canvas"
-             ng:if="!ctrl.crop"
+             ng-if="!ctrl.crop"
              draggable="true"
-             ui:drag-data="ctrl.image | asImageDragData">
+             ui-drag-data="ctrl.image | asImageDragData">
           <img class="easel__image easel__image--checkered__background"
                alt="preview of original image"
-               ng:src="{{:: ctrl.optimisedImageUri}}"
+               ng-src="{{:: ctrl.optimisedImageUri}}"
                grid:track-image="ctrl.image"
                grid:track-image-location="original"
                grid:track-image-loadtime
-               gr:image-fade-on-load/>
+               gr-image-fade-on-load/>
         </div>
 
         <!-- TODO: As this loads async, add a loader -->
-        <div class="easel__canvas" ng:if="ctrl.crop"
+        <div class="easel__canvas" ng-if="ctrl.crop"
              draggable="true"
-             ui:drag-data="ctrl.image | asImageAndCropsDragData:ctrl.crop"
-             ui:drag-image="extremeAssets.smallest | assetFile">
+             ui-drag-data="ctrl.image | asImageAndCropsDragData:ctrl.crop"
+             ui-drag-image="extremeAssets.smallest | assetFile">
             <a class="easel__image-container"
-               ng:init="extremeAssets = (ctrl.crop | getExtremeAssets)"
-               ui:sref="{crop: ctrl.cropKey}">
+               ng-init="extremeAssets = (ctrl.crop | getExtremeAssets)"
+               ui-sref="{crop: ctrl.cropKey}">
                 <!-- TODO: Add tracking to crop -->
                 <img class="easel__image easel__image--checkered__background"
                      alt="cropped image"
-                     ng:src="{{:: extremeAssets.largest | assetFile}}"
+                     ng-src="{{:: extremeAssets.largest | assetFile}}"
                 />
             </a>
         </div>

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -1,35 +1,35 @@
-<button ng:class="{'small': ctrl.grSmall}"
-        ng:click="ctrl.editing = true"
-        ng:if="ctrl.userCanEdit"
-        gr:tooltip="Add lease"
-        gr:tooltip-position="bottom">
+<button ng-class="{'small': ctrl.grSmall}"
+        ng-click="ctrl.editing = true"
+        ng-if="ctrl.userCanEdit"
+        gr-tooltip="Add lease"
+        gr-tooltip-position="bottom">
 
-    <gr-icon ng-show="!ctrl.editing" ng:class="{'spin': ctrl.adding}">add_box</gr-icon>
+    <gr-icon ng-show="!ctrl.editing" ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span>
-       <span ng:show="ctrl.adding">Updating...</span>
+       <span ng-show="ctrl.adding">Updating...</span>
     </span>
 </button>
-<span ng:if="ctrl.withBatch" class="leases__apply-all">
+<span ng-if="ctrl.withBatch" class="leases__apply-all">
     <button
         title="Apply these leases to all your current uploads"
-        ng:if="!ctrl.confirmDelete"
-        ng:click="ctrl.batchApplyLeases()"
+        ng-if="!ctrl.confirmDelete"
+        ng-click="ctrl.batchApplyLeases()"
     >⇔</button>
 
     <button title="Remove ALL leases"
             class="button button--confirm-delete"
-            ng:if="ctrl.confirmDelete"
-            ng:click="ctrl.batchRemoveLeases()">
+            ng-if="ctrl.confirmDelete"
+            ng-click="ctrl.batchRemoveLeases()">
         <gr-icon>warning</gr-icon>Remove ALL leases in job?
     </button>
 </span>
 
 
 <form class="lease__form full-width"
-      ng:show="!ctrl.adding && ctrl.editing"
-      ng:submit="ctrl.save()">
+      ng-show="!ctrl.adding && ctrl.editing"
+      ng-submit="ctrl.save()">
 
-  <select id="access-select" ng:model="ctrl.access" ng-required="required">
+  <select id="access-select" ng-model="ctrl.access" ng-required="required">
       <option ng-selected="true" value="">Please select access</option>
       <optgroup label="Cropping">
           <option value="allow-use">Allow cropping</option>
@@ -45,11 +45,11 @@
     <div ng-switch-when="deny-syndication">
         <div class="flex-container">
             <label class="full-width">
-                <input type="checkbox" ng:model="showCal" />
+                <input type="checkbox" ng-model="showCal" />
                 Expire
             </label>
         </div>
-        <gu-date ng:if="showCal"
+        <gu-date ng-if="showCal"
                  class="full-width"
                  date="ctrl.newLease.endDate"
                  min-date="ctrl.midnightTomorrow"
@@ -59,11 +59,11 @@
     <div ng-switch-when="allow-syndication">
         <div class="flex-container">
             <label class="full-width">
-                <input type="checkbox" ng:model="showCal" />
+                <input type="checkbox" ng-model="showCal" />
                 Delay
             </label>
         </div>
-        <gu-date ng:if="showCal"
+        <gu-date ng-if="showCal"
                  class="full-width"
                  date="ctrl.newLease.startDate"
                  min-date="ctrl.midnightTomorrow"
@@ -72,17 +72,17 @@
 
         <div class="flex-container">
             <label class="full-width">
-                <input type="checkbox" ng:model="ctrl.noteCallAgencyClause" />
+                <input type="checkbox" ng-model="ctrl.noteCallAgencyClause" />
                 Call Agency
             </label>
             <label class="full-width">
-                <input type="checkbox" ng:model="ctrl.notePremiumClause" />
+                <input type="checkbox" ng-model="ctrl.notePremiumClause" />
                 Premium
             </label>
         </div>
     </div>
     <div ng-switch-default>
-        <gu-date-range-x ng:if="ctrl.access"
+        <gu-date-range-x ng-if="ctrl.access"
                         start="ctrl.newLease.startDate"
                         end="ctrl.newLease.endDate">
         </gu-date-range-x>
@@ -90,21 +90,21 @@
   </div>
 
   <input type="text"
-         ng:if="ctrl.access"
-         ng:model="ctrl.newLease.notes"
+         ng-if="ctrl.access"
+         ng-model="ctrl.newLease.notes"
          placeholder="Notes..."/>
 
   <div class="lease__form__buttons">
-    <button class="lease__form__buttons__button-cancel button-cancel" type="button" ng:click="ctrl.cancel()" title="Close">
-        <gr-icon-label gr-icon="close"><span ng:hide="ctrl.grSmall">Cancel</span></gr-icon-label>
+    <button class="lease__form__buttons__button-cancel button-cancel" type="button" ng-click="ctrl.cancel()" title="Close">
+        <gr-icon-label gr-icon="close"><span ng-hide="ctrl.grSmall">Cancel</span></gr-icon-label>
     </button>
     <button
         class="lease__form__buttons__button-save button-save"
         type="submit"
         title="Save new label"
-        ng:disabled="ctrl.adding">
+        ng-disabled="ctrl.adding">
         <gr-icon-label gr-icon="check">
-            <span ng:hide="ctrl.grSmall">Save</span>
+            <span ng-hide="ctrl.grSmall">Save</span>
         </gr-icon-label>
     </button>
   </div>
@@ -113,21 +113,21 @@
 
 
 <div class="leases__wrapper image-info__wrap">
-  <div class="image-info__lease" ng:if="ctrl.totalImages > 1">
+  <div class="image-info__lease" ng-if="ctrl.totalImages > 1">
     {{ctrl.activeLeases(ctrl.leases)}} current leases + {{ctrl.inactiveLeases(ctrl.leases)}} inactive leases
   </div>
 
-  <ul ng:if="ctrl.totalImages === 1">
+  <ul ng-if="ctrl.totalImages === 1">
     <li ng-repeat="lease in ctrl.leases.leases"
-        gr:tooltip="{{ctrl.toolTip(lease)}}"
+        gr-tooltip="{{ctrl.toolTip(lease)}}"
         class="lease__item"
-        gr:tooltip-position="bottom">
+        gr-tooltip-position="bottom">
 
-        <div class="lease__current" ng:class="ctrl.leaseStatus(lease).current" ng:if="ctrl.leaseStatus(lease).current"></div>
+        <div class="lease__current" ng-class="ctrl.leaseStatus(lease).current" ng-if="ctrl.leaseStatus(lease).current"></div>
 
-        <div class="lease__access" ng:class="ctrl.leaseStatus(lease).access"></div>
+        <div class="lease__access" ng-class="ctrl.leaseStatus(lease).access"></div>
 
-        <div class="lease__wrapper" ng:class="ctrl.leaseStatus(lease).current">
+        <div class="lease__wrapper" ng-class="ctrl.leaseStatus(lease).current">
           <div class="lease">
             <div class="lease__text">
               <div>{{ctrl.leaseName(lease)}}</div>

--- a/kahuna/public/js/preview/image-large.html
+++ b/kahuna/public/js/preview/image-large.html
@@ -6,64 +6,64 @@
                rel="noopener"
                target="_blank"
                title="Pop out"
-               ng:href="/images/{{ctrl.image.data.id}}"
-               gr:stop-propagation="click"
-               gr:track-click="Popout button">
+               ng-href="/images/{{ctrl.image.data.id}}"
+               gr-stop-propagation="click"
+               gr-track-click="Popout button">
                 <gr-icon>open_in_new</gr-icon>
             </a>
         </li>
 
-        <li ng:if="! ctrl.selectionMode">
+        <li ng-if="! ctrl.selectionMode">
             <a class="image-action"
                title="crop"
-               ng:if="ctrl.states.isValid"
-               ui:sref="crop({ imageId: ctrl.image.data.id })">
+               ng-if="ctrl.states.isValid"
+               ui-sref="crop({ imageId: ctrl.image.data.id })">
                 <gr-icon>crop</gr-icon>
             </a>
         </li>
-        <li ng:if="! ctrl.selectionMode">
-            <ng:transclude></ng:transclude>
+        <li ng-if="! ctrl.selectionMode">
+            <ng-transclude></ng-transclude>
         </li>
     </ul>
 
-    <a ng:if="! ctrl.selectionMode" class="preview__link preview__link--large"
-       ui:sref="image({imageId: ctrl.image.data.id})"
-       ui:drag-data="ctrl.image | asImageDragData">
+    <a ng-if="! ctrl.selectionMode" class="preview__link preview__link--large"
+       ui-sref="image({imageId: ctrl.image.data.id})"
+       ui-drag-data="ctrl.image | asImageDragData">
        <div class="preview__fade"></div>
        <div class="preview__loading">
            <gr-icon class="preview__loading__icon">autorenew</gr-icon>
        </div>
        <img class="preview__image"
             alt="{{ctrl.image.data.metadata.description}}"
-            ng:src="{{ctrl.optimisedImage }}"
+            ng-src="{{ctrl.optimisedImage }}"
             ng-if="!ctrl.loading"
-            gr:image-fade-on-load />
+            gr-image-fade-on-load />
     </a>
 
-    <span ng:if="ctrl.selectionMode" class="preview__no-link preview__no-link--large">
+    <span ng-if="ctrl.selectionMode" class="preview__no-link preview__no-link--large">
         <div class="preview__fade"></div>
         <div class="preview__loading">
             <gr-icon class="preview__loading__icon">autorenew</gr-icon>
         </div>
         <img class="preview__image"
              alt="{{ctrl.image.data.metadata.description}}"
-             ng:src="{{ctrl.optimisedImage }}"
-             ui:drag-data="ctrl.image | asImageDragData"
+             ng-src="{{ctrl.optimisedImage }}"
+             ui-drag-data="ctrl.image | asImageDragData"
              ng-if="!ctrl.loading"
-             gr:image-preloader />
+             gr-image-preloader />
     </span>
 
     <div class="preview__info-container">
 
-        <div class="preview__info preview__info--large" ng:if="! ctrl.hideInfo">
+        <div class="preview__info preview__info--large" ng-if="! ctrl.hideInfo">
             <div class="flex-container">
                 <ul class="bottom-bar__meta-item preview__collections">
                     <li class="preview__collections__collection"
-                        ng:repeat="collection in ctrl.image.data.collections"
+                        ng-repeat="collection in ctrl.image.data.collections"
                         gr-tooltip="Click to open collection: {{collection.data.path.join(' ▸ ')}}"
                         gr-tooltip-position="top">
-                        <a ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
-                           ng:attr-style="{{ctrl.getCollectionStyle(collection)}}"
+                        <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                           ng-attr-style="{{ctrl.getCollectionStyle(collection)}}"
                            class="preview__collections__collection__value">
                             {{collection.data.description}}
                         </a>
@@ -73,15 +73,15 @@
                 <ui-labeller-compact class="preview__labeller"
                                      image="ctrl.image"
                                      disabled="ctrl.selectionMode"
-                                     ng:if="!ctrl.inputtingLabel">
+                                     ng-if="!ctrl.inputtingLabel">
                 </ui-labeller-compact>
                 <span class="flex-spacer"></span>
                 <gr-add-label class="gr-add-label"
-                              ng:if="!ctrl.selectionMode"
+                              ng-if="!ctrl.selectionMode"
                               images="[ctrl.image]"
                               gr-small="true"
                               active="ctrl.inputtingLabel"
-                              ng:class="{'gr-add-label--inactive': !ctrl.inputtingLabel}">
+                              ng-class="{'gr-add-label--inactive': !ctrl.inputtingLabel}">
                 </gr-add-label>
             </div>
 
@@ -101,21 +101,21 @@
 
                 <span class="bottom-bar__meta-item preview__has-crops"
                       title="this image has crops"
-                      ng:if="ctrl.states.hasCrops">
+                      ng-if="ctrl.states.hasCrops">
 
                     <gr-icon gr-small>crop</gr-icon>
                 </span>
 
                 <span class="bottom-bar__meta-item preview__has-print-usages"
                       title="This image has been used {{ctrl.usageListRecent.length >0 ? 'RECENTLY': '' }} in Print Content"
-                      ng:if="ctrl.hasPrintUsages">
+                      ng-if="ctrl.hasPrintUsages">
 
                     <gr-icon gr-small ng-class="{'icon-warning': ctrl.usageListRecent.length >0}">local_library</gr-icon>
                 </span>
 
                 <span class="bottom-bar__meta-item preview__has-web-usages"
                       title="This image has been used {{ctrl.usageListRecent.length >0 ? 'RECENTLY': '' }} in Digital Content"
-                      ng:if="ctrl.hasDigitalUsages">
+                      ng-if="ctrl.hasDigitalUsages">
 
                     <gr-icon gr-small ng-class="{'icon-warning': ctrl.usageListRecent.length >0}">phonelink</gr-icon>
                 </span>
@@ -127,27 +127,27 @@
                 </gr-archiver-status>
 
                 <div class="bottom-bar__action bottom-bar__action--cost preview__cost"
-                     ng:if="ctrl.states.costState !== 'free'"
-                     ng:switch="ctrl.states.costState">
-                    <div ng:switch-when="pay"
+                     ng-if="ctrl.states.costState !== 'free'"
+                     ng-switch="ctrl.states.costState">
+                    <div ng-switch-when="pay"
                          class="cost cost--pay">
                         <!-- material icons doesn't have a £ icon -->
                         <span title="pay to use">£</span>
                     </div>
 
-                    <div ng:switch-when="no_rights"
+                    <div ng-switch-when="no_rights"
                         class="cost cost--no_rights">
 
                         <!-- material icons doesn't have a £ icon -->
                         <gr-icon>warning</gr-icon>
                     </div>
 
-                    <div ng:switch-when="overquota"
+                    <div ng-switch-when="overquota"
                          class="cost cost--pay">
                         <gr-icon>trending_up</gr-icon>
                     </div>
 
-                    <div ng:switch-when="conditional"
+                    <div ng-switch-when="conditional"
                          class="cost cost--conditional"
                          title="{{ctrl.image.data.usageRights.restrictions}}">
                          <!-- As `conditional` can only be set with usageRights, let's

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -6,57 +6,57 @@
                rel="noopener"
                target="_blank"
                title="Pop out"
-               ng:href="/images/{{::ctrl.image.data.id}}"
-               gr:stop-propagation="click"
-               gr:track-click="Popout button">
+               ng-href="/images/{{::ctrl.image.data.id}}"
+               gr-stop-propagation="click"
+               gr-track-click="Popout button">
                 <gr-icon>open_in_new</gr-icon>
             </a>
         </li>
 
-        <li ng:if="! ctrl.selectionMode">
+        <li ng-if="! ctrl.selectionMode">
             <a class="image-action"
                title="crop"
-               ng:if="ctrl.states.isValid"
-               ui:sref="crop({ imageId: ctrl.image.data.id })">
+               ng-if="ctrl.states.isValid"
+               ui-sref="crop({ imageId: ctrl.image.data.id })">
                 <gr-icon>crop</gr-icon>
             </a>
         </li>
-        <li ng:if="! ctrl.selectionMode">
-            <ng:transclude></ng:transclude>
+        <li ng-if="! ctrl.selectionMode">
+            <ng-transclude></ng-transclude>
         </li>
     </ul>
 
-    <a ng:if="! ctrl.selectionMode" class="preview__link"
-       ui:sref="image({imageId: ctrl.image.data.id})"
-       ui:drag-data="ctrl.image | asImageDragData"
+    <a ng-if="! ctrl.selectionMode" class="preview__link"
+       ui-sref="image({imageId: ctrl.image.data.id})"
+       ui-drag-data="ctrl.image | asImageDragData"
        title="{{::ctrl.imageDescription}}">
        <div class="preview__fade"></div>
        <img class="preview__image"
             ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
             alt="{{::ctrl.imageDescription}}"
-            ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
-            gr:image-fade-on-load />
+            ng-src="{{::ctrl.image.data.thumbnail | assetFile}}"
+            gr-image-fade-on-load />
     </a>
 
-    <span ng:if="ctrl.selectionMode" class="preview__no-link">
+    <span ng-if="ctrl.selectionMode" class="preview__no-link">
         <div class="preview__fade"></div>
         <img class="preview__image"
              ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
              alt="{{::ctrl.image.data.metadata.description}}"
-             ng:src="{{::ctrl.image.data.thumbnail | assetFile}}"
-             ui:drag-data="ctrl.image | asImageDragData"
-             gr:image-fade-on-load />
+             ng-src="{{::ctrl.image.data.thumbnail | assetFile}}"
+             ui-drag-data="ctrl.image | asImageDragData"
+             gr-image-fade-on-load />
     </span>
 
-    <div class="preview__info" ng:if="! ctrl.hideInfo">
+    <div class="preview__info" ng-if="! ctrl.hideInfo">
         <div class="flex-container">
             <ul class="bottom-bar__meta-item preview__collections">
                 <li class="preview__collections__collection"
-                    ng:repeat="collection in ctrl.image.data.collections"
+                    ng-repeat="collection in ctrl.image.data.collections"
                     gr-tooltip="Click to open collection: {{::collection.data.path.join(' ▸ ')}}"
                     gr-tooltip-position="top">
-                    <a ui:sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
-                       ng:attr-style="{{::ctrl.getCollectionStyle(collection)}}"
+                    <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                       ng-attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                        class="preview__collections__collection__value">
                         {{::collection.data.description}}
                     </a>
@@ -66,15 +66,15 @@
             <ui-labeller-compact class="preview__labeller"
                                  image="ctrl.image"
                                  disabled="ctrl.selectionMode"
-                                 ng:if="!ctrl.inputtingLabel">
+                                 ng-if="!ctrl.inputtingLabel">
             </ui-labeller-compact>
             <span class="flex-spacer"></span>
             <gr-add-label class="gr-add-label"
-                          ng:if="!ctrl.selectionMode"
+                          ng-if="!ctrl.selectionMode"
                           images="[ctrl.image]"
                           gr-small="true"
                           active="ctrl.inputtingLabel"
-                          ng:class="{'gr-add-label--inactive': !ctrl.inputtingLabel}">
+                          ng-class="{'gr-add-label--inactive': !ctrl.inputtingLabel}">
             </gr-add-label>
         </div>
 
@@ -94,20 +94,20 @@
 
             <span class="bottom-bar__meta-item preview__has-crops"
                   title="this image has crops"
-                  ng:if="ctrl.states.hasCrops">
+                  ng-if="ctrl.states.hasCrops">
 
                 <gr-icon gr-small>crop</gr-icon>
             </span>
 
             <span class="bottom-bar__meta-item preview__has-print-usages"
                   title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
-                  ng:if="ctrl.hasPrintUsages">
+                  ng-if="ctrl.hasPrintUsages">
                 <gr-icon gr-small ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
             </span>
 
             <span class="bottom-bar__meta-item preview__has-web-usages"
                   title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
-                  ng:if="ctrl.hasDigitalUsages">
+                  ng-if="ctrl.hasDigitalUsages">
 
                 <gr-icon gr-small ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
             </span>
@@ -123,9 +123,9 @@
             </div>
 
             <div class="bottom-bar__action bottom-bar__action--cost preview__cost"
-                 ng:if="ctrl.flagState !== 'free'"
-                 ng:switch="ctrl.flagState">
-                <div ng:switch-when="no_rights"
+                 ng-if="ctrl.flagState !== 'free'"
+                 ng-switch="ctrl.flagState">
+                <div ng-switch-when="no_rights"
                      class="cost cost--no_rights"
                      title="No current rights to use this image!">
 
@@ -133,7 +133,7 @@
                     <gr-icon>warning</gr-icon>
                 </div>
 
-                <div ng:switch-when="overquota"
+                <div ng-switch-when="overquota"
                      class="cost cost--overquota"
                      title="Quota for images from this supplier has been exceeded!">
 
@@ -141,7 +141,7 @@
                     <gr-icon>trending_up</gr-icon>
                 </div>
 
-                <div ng:switch-when="pay"
+                <div ng-switch-when="pay"
                      class="cost cost--pay"
                      title="Pay to use">
 
@@ -150,7 +150,7 @@
                 </div>
 
 
-                <div ng:switch-when="conditional"
+                <div ng-switch-when="conditional"
                      class="cost cost--conditional"
                      title="{{ctrl.image.data.usageRights.restrictions}}">
                      <!-- As `conditional` can only be set with usageRights, let's

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -2,20 +2,20 @@
     <span class="search-query">
         <gr-icon class="search-query__magnifier search-query__icon">search</gr-icon>
         <gr-structured-query class="search-query__query"
-                             ng:model="searchQuery.filter.query">
+                             ng-model="searchQuery.filter.query">
         </gr-structured-query>
         <button class="search-query__icon search-query__clear clear-button"
                 type="button"
                 title="Clear query"
-                ng:show="searchQuery.filter.query"
-                ng:click="searchQuery.resetQuery()">
+                ng-show="searchQuery.filter.query"
+                ng-click="searchQuery.resetQuery()">
             <gr-icon>cancel</gr-icon>
         </button>
     </span>
 
     <button class="search__advanced-toggle"
             type="button"
-            ng:click="searchInfo = !searchInfo"
+            ng-click="searchInfo = !searchInfo"
             gr-tooltip="Display advanced search information">
         <gr-icon>info_outline</gr-icon>
     </button>
@@ -23,26 +23,26 @@
     <div class="search__modifier-container">
         <button class="search__modifier-toggle"
                 type="button"
-                ng:click="filtersShown = !filtersShown ">
+                ng-click="filtersShown = !filtersShown ">
             <gr-icon class="search__modifier-toggle__icon">filter_list</gr-icon>
             <span class="search__modifier-toggle__text">Search filters</span>
         </button>
 
-        <ul class="search__modifier search__filter" ng:class="filtersShown ? 'search__filter--show' : 'search__filter--hide'">
+        <ul class="search__modifier search__filter" ng-class="filtersShown ? 'search__filter--show' : 'search__filter--hide'">
             <li class="search__modifier-item">
             <label>
                <!-- minor mindfuck logic as we want an optional flag
                             when the option is off -->
                 <input type="checkbox"
-                    ng:model="searchQuery.filter.nonFree"
-                    ng:true-value="undefined"
-                    ng:false-value="'true'" />
+                    ng-model="searchQuery.filter.nonFree"
+                    ng-true-value="undefined"
+                    ng-false-value="'true'" />
                 Free to use only
 
                 <!-- TODO: Decide on correct cost filter model -->
                 <!--
-                <select ng:init="searchQuery.filter.payType = searchQuery.filter.payType || 'free'"
-                        ng:model="searchQuery.filter.payType"
+                <select ng-init="searchQuery.filter.payType = searchQuery.filter.payType || 'free'"
+                        ng-model="searchQuery.filter.payType"
                         ng-options="item.value as item.label for item in searchQuery.payTypeOptions">
 
                 </select>
@@ -54,7 +54,7 @@
             <li class="search__modifier-item">
             <label>
                 <input type="checkbox"
-                    ng:model="searchQuery.filter.uploadedByMe" />
+                    ng-model="searchQuery.filter.uploadedByMe" />
                 My uploads
             </label>
             </li>
@@ -76,50 +76,50 @@
     <div class="search__modifier-container">
         <button class="search__modifier-toggle"
                 type="button"
-                ng:click="orderShown = !orderShown">
+                ng-click="orderShown = !orderShown">
             <gr-icon class="search__modifier-toggle__icon">sort</gr-icon>
             <span class="search__modifier-toggle__text">Sort order</span>
         </button>
 
         <ul class="search__modifier order__option"
-            ng:class="orderShown ? 'order__option--show' : 'order__option--hide'">
+            ng-class="orderShown ? 'order__option--show' : 'order__option--hide'">
             <li class="search__modifier-item radio-list">
                 <div class="radio-list__item">
                     <input type="radio"
                            id="sort-direction__desc"
                            class="radio-list__circle"
                            name="sort-direction"
-                           ng:value="undefined"
-                           ng:model="searchQuery.ordering.orderBy">
+                           ng-value="undefined"
+                           ng-model="searchQuery.ordering.orderBy">
                     <label for="sort-direction__desc" class="radio-list__label"
-                           ng:class="{'radio-list--selected': searchQuery.ordering.orderBy === undefined}">
+                           ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === undefined}">
                         <div class="radio-list__selection-state"></div>
                         <div class="radio-list__label-value">Newest first</div>
                     </label>
                 </div>
-                <div ng:if="!searchQuery.collectionSearch"
+                <div ng-if="!searchQuery.collectionSearch"
                      class="radio-list__item">
                     <input type="radio"
                            id="sort-direction__asc"
                            class="radio-list__circle"
                            name="sort-direction"
-                           ng:value="'oldest'"
-                           ng:model="searchQuery.ordering.orderBy">
+                           ng-value="'oldest'"
+                           ng-model="searchQuery.ordering.orderBy">
                     <label for="sort-direction__asc" class="radio-list__label"
-                           ng:class="{'radio-list--selected': searchQuery.ordering.orderBy === 'oldest'}">
+                           ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === 'oldest'}">
                         <div class="radio-list__selection-state"></div>
                         <div class="radio-list__label-value">Oldest first</div>
                     </label>
                 </div>
-                <div ng:if="searchQuery.collectionSearch" class="radio-list__item">
+                <div ng-if="searchQuery.collectionSearch" class="radio-list__item">
                     <input type="radio"
                            id="sort-direction__added-to-collection"
                            class="radio-list__circle"
                            name="sort-direction"
-                           ng:value="'dateAddedToCollection'"
-                           ng:model="searchQuery.ordering.orderBy">
+                           ng-value="'dateAddedToCollection'"
+                           ng-model="searchQuery.ordering.orderBy">
                     <label for="sort-direction__added-to-collection" class="radio-list__label"
-                           ng:class="{'radio-list--selected': searchQuery.ordering.orderBy === 'dateAddedToCollection'}">
+                           ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === 'dateAddedToCollection'}">
                         <div class="radio-list__selection-state"></div>
                         <div class="radio-list__label-value">Recently Added First</div>
                     </label>
@@ -130,4 +130,4 @@
     </div>
 </form>
 
-<gr-syntax ng:if="searchInfo"></gr-syntax>
+<gr-syntax ng-if="searchInfo"></gr-syntax>

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -1,28 +1,28 @@
 <!-- TODO: show only after a delay -->
-<div ng:if="ctrl.loading"
+<div ng-if="ctrl.loading"
      class="image-loading-results">
     Fetching images…
 </div>
 
-<div ng:if="! ctrl.loading">
-    <div ng:if="ctrl.loadingError">
+<div ng-if="! ctrl.loading">
+    <div ng-if="ctrl.loadingError">
         Error loading results: {{ctrl.loadingError}}
     </div>
-    <div ng:if="! ctrl.loadingError">
+    <div ng-if="! ctrl.loadingError">
         <div class="results-toolbar">
             <gr-panel-button-small
                 class="results-toolbar-item results-toolbar-item--left results-toolbar-item--no-hover"
-                gr:panel="ctrl.collectionsPanel"
-                gr:position="left"
-                gr:name="collections"
-                gr:icon="collections">
+                gr-panel="ctrl.collectionsPanel"
+                gr-position="left"
+                gr-name="collections"
+                gr-icon="collections">
             </gr-panel-button-small>
 
             <div class="results-toolbar-item results-toolbar-item--static
                         image-results-count">
                 {{ctrl.totalResults | toLocaleString}} matches
-                <button ng:if="ctrl.newImagesCount > 0"
-                        ng:click="ctrl.revealNewImages()"
+                <button ng-if="ctrl.newImagesCount > 0"
+                        ng-click="ctrl.revealNewImages()"
                         class="image-results-count__new"
                         gr-tooltip="{{ctrl.newImagesCount}} new images as of {{ctrl.lastestTimeMoment}}"
                         gr-tooltip-position="right"
@@ -33,12 +33,12 @@
 
             <div class="results-toolbar__right flex-container">
                 <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static"
-                     ng:if="ctrl.selectionCount > 0">
+                     ng-if="ctrl.selectionCount > 0">
                     {{ctrl.selectionCount}} selected
                 </div>
 
                 <div class="results-toolbar-item results-toolbar-item--right results-toolbar-item--static results-toolbar-item__progress"
-                    ng-style="ctrl.buildBatchProgressGradient()" ng:if="ctrl.batchOperations.length > 0">
+                    ng-style="ctrl.buildBatchProgressGradient()" ng-if="ctrl.batchOperations.length > 0">
 
                     <span ng-repeat="entry in ctrl.batchOperations">
                         Updating {{entry.key}}: {{entry.completed}}/{{entry.total}}
@@ -46,47 +46,47 @@
                 </div>
 
                 <a class="results-toolbar-item results-toolbar-item--right"
-                   ng:click="ctrl.clearSelection()"
-                   ng:if="ctrl.selectionCount > 0">
+                   ng-click="ctrl.clearSelection()"
+                   ng-if="ctrl.selectionCount > 0">
                     <gr-icon-label gr-icon="clear">Clear selection</gr-icon-label>
                 </a>
 
                 <gr-batch-export-original-images class="results-toolbar-item results-toolbar-item--right"
                   images="ctrl.selectedImages"
-                  ng:if="ctrl.selectionCount > 0"></gr-batch-export-original-images>
+                  ng-if="ctrl.selectionCount > 0"></gr-batch-export-original-images>
 
                 <gr-downloader class="results-toolbar-item results-toolbar-item--right"
                     images="ctrl.selectedImages"
-                    ng:if="ctrl.selectionCount > 0"></gr-downloader>
+                    ng-if="ctrl.selectionCount > 0"></gr-downloader>
 
                 <gr-delete-image class="results-toolbar-item results-toolbar-item--right"
                                  images="ctrl.selectedImages"
-                                 ng:if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0">
+                                 ng-if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0">
                 </gr-delete-image>
 
                 <gr-archiver class="results-toolbar-item results-toolbar-item--right"
-                             gr:images="ctrl.selectedImages"
-                             ng:if="ctrl.selectionCount > 0">
+                             gr-images="ctrl.selectedImages"
+                             ng-if="ctrl.selectionCount > 0">
                 </gr-archiver>
 
                 <gr-toggle-button class="results-toolbar-item results-toolbar-item--no-hover results-toolbar-item--right"
-                                  gr:toggle="ctrl.previewView"
-                                  gr:icon="find_in_page"
-                                  gr:name="Preview">
+                                  gr-toggle="ctrl.previewView"
+                                  gr-icon="find_in_page"
+                                  gr-name="Preview">
                 </gr-toggle-button>
 
                 <gr-panel-button
                     class="results-toolbar-item results-toolbar-item--no-hover results-toolbar-item--right"
-                    gr:panel="ctrl.metadataPanel"
-                    gr:position="right"
-                    gr:name="info"
-                    gr:icon="info">
+                    gr-panel="ctrl.metadataPanel"
+                    gr-position="right"
+                    gr-name="info"
+                    gr-icon="info">
                 </gr-panel-button>
             </div>
         </div>
 
         <ul class="results"
-            ng:if="!ctrl.previewView"
+            ng-if="!ctrl.previewView"
             gu:lazy-table="ctrl.imagesAll"
             gu:lazy-table-cell-min-width="280"
             gu:lazy-table-cell-height="292"
@@ -94,35 +94,35 @@
             gu:lazy-table-load-range="ctrl.loadRange($start, $end)"
             gu-lazy-table-shortcuts>
 
-            <li ng:repeat="image in ctrl.images track by image.data.id"
+            <li ng-repeat="image in ctrl.images track by image.data.id"
                 gu:lazy-table-cell="image">
 
                 <div class="result"
-                     ng:class="{ 'result--seen': ctrl.imageHasBeenSeen(image),
+                     ng-class="{ 'result--seen': ctrl.imageHasBeenSeen(image),
                                  'result--selected': ctrl.imageHasBeenSelected(image)}">
 
                     <!-- <HACK> -->
                     <!-- We don't want to add a property on `image` to determine the state of the checkbox, so render two individual inputs. -->
                     <!-- </HACK> -->
                     <div class="result__select result__select--selected"
-                         ng:if="ctrl.imageHasBeenSelected(image)">
+                         ng-if="ctrl.imageHasBeenSelected(image)">
                         <input type="checkbox"
                                class="result__select__checkbox"
                                id="id-{{::image.data.id}}-result__select__checkbox--select"
                                checked="true"
-                               ng:click="ctrl.deselect(image)"/>
+                               ng-click="ctrl.deselect(image)"/>
                         <label for="id-{{::image.data.id}}-result__select__checkbox--select"
                                class="result__select__checkbox__label">
                             <gr-icon>check_box</gr-icon>
                         </label>
                     </div>
                     <div class="result__select"
-                         ng:if="!ctrl.imageHasBeenSelected(image)"
-                         ng:class="{ 'result__select--no-pointer-events': ctrl.inSelectionMode}">
+                         ng-if="!ctrl.imageHasBeenSelected(image)"
+                         ng-class="{ 'result__select--no-pointer-events': ctrl.inSelectionMode}">
                         <input type="checkbox"
                                class="result__select__checkbox"
                                id="id-{{::image.data.id}}-result__select__checkbox--deselect"
-                               ng:click="ctrl.select(image)" />
+                               ng-click="ctrl.select(image)" />
                         <label for="id-{{::image.data.id}}-result__select__checkbox--deselect"
                                class="result__select__checkbox__label">
                             <gr-icon>check_box</gr-icon>
@@ -131,12 +131,12 @@
 
                     <ui-preview-image image="image"
                                       selection-mode="ctrl.inSelectionMode"
-                                      ng:class="{'preview__quick-select': ctrl.inSelectionMode}"
-                                      ng:click="ctrl.onImageClick(image, $event)">
+                                      ng-class="{'preview__quick-select': ctrl.inSelectionMode}"
+                                      ng-click="ctrl.onImageClick(image, $event)">
                         <button class="mark-as-seen image-action"
                                 title="Mark all images until this point as seen"
-                                ui:localstore="search.seenFrom"
-                                ui:localstore-val="ctrl.getLastSeenVal(image)">
+                                ui-localstore="search.seenFrom"
+                                ui-localstore-val="ctrl.getLastSeenVal(image)">
                             <gr-icon>remove_red_eye</gr-icon>
                         </button>
                     </ui-preview-image>
@@ -145,7 +145,7 @@
         </ul>
 
         <gu:lazy-preview
-            ng:if="ctrl.previewView"
+            ng-if="ctrl.previewView"
             gu:lazy-preview-items="ctrl.images"
             gu:lazy-preview-items-total="ctrl.imagesAll"
             gu:lazy-preview-preloaded-items="20"
@@ -153,13 +153,13 @@
             gu:lazy-preview-selection-mode="ctrl.inSelectionMode">
         </gu:lazy-preview>
 
-        <div ng:if="ctrl.totalResults > ctrl.maxResults && !ctrl.previewView"
+        <div ng-if="ctrl.totalResults > ctrl.maxResults && !ctrl.previewView"
              class="image-results-more">
             <div class="image-results-more__heading">Too many results to display</div>
             <div class="image-results-more__instructions">Please refine your search to limit the number of results</div>
         </div>
 
-        <div ng:if="ctrl.totalResults == 0"
+        <div ng-if="ctrl.totalResults == 0"
              class="image-no-results">
             No matches, sorry! Try altering your search.
         </div>

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -51,7 +51,7 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
         require: ['grStructuredQuery', 'ngModel'],
         template: `
 <gr-chips autofocus="autofocus"
-          ng:model="ctrl.structuredQuery"
+          ng-model="ctrl.structuredQuery"
           gr:valid-keys="ctrl.filterFields"
           gr:on-change="ctrl.structuredQueryChanged($chips)"
           gr:autocomplete="ctrl.getSuggestions($chip)">

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -1,6 +1,6 @@
 <div class="advanced-search-help">
     <button class="advanced-search-help__cancel"
-            ng:click="$parent.searchInfo = false">
+            ng-click="$parent.searchInfo = false">
         <gr-icon>close</gr-icon>
     </button>
     <div class="advanced-search-help__section">
@@ -14,12 +14,12 @@
         <h3 class="advanced-search-help__section__sub-heading">All filtering fields</h3>
         <dl class="advanced-search-example flex-container">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="by" gr:example-search="Cookie Monster"></gr-chip-example>
+                <gr-chip-example gr-filter-field="by" gr-example-search="Cookie Monster"></gr-chip-example>
             </dt>
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="category" gr:example-search="screengrab"></gr-chip-example>
+                <gr-chip-example gr-filter-field="category" gr-example-search="screengrab"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Has a suggestion list.
@@ -27,22 +27,22 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="city" gr:example-search="Austin"></gr-chip-example>
+                <gr-chip-example gr-filter-field="city" gr-example-search="Austin"></gr-chip-example>
             </dt>
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="copyright" gr:example-search="2016 Getty Images"></gr-chip-example>
+                <gr-chip-example gr-filter-field="copyright" gr-example-search="2016 Getty Images"></gr-chip-example>
             </dt>
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="country" gr:example-search="India"></gr-chip-example>
+                <gr-chip-example gr-filter-field="country" gr-example-search="India"></gr-chip-example>
             </dt>
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="credit" gr:example-search="REUTERS"></gr-chip-example>
+                <gr-chip-example gr-filter-field="credit" gr-example-search="REUTERS"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Currently case-sensitive. Has a suggestion list.
@@ -50,12 +50,12 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="description" gr:example-search="Beaches"></gr-chip-example>
+                <gr-chip-example gr-filter-field="description" gr-example-search="Beaches"></gr-chip-example>
             </dt>
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="illustrator" gr:example-search="Steve Bell"></gr-chip-example>
+                <gr-chip-example gr-filter-field="illustrator" gr-example-search="Steve Bell"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Has a suggestion list.
@@ -63,7 +63,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="in" gr:example-search="Xanadu"></gr-chip-example>
+                <gr-chip-example gr-filter-field="in" gr-example-search="Xanadu"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Searches the <em>city</em> and <em>country</em> fields.
@@ -71,7 +71,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="keyword" gr:example-search="Film Still"></gr-chip-example>
+                <gr-chip-example gr-filter-field="keyword" gr-example-search="Film Still"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Currently case-sensitive.
@@ -79,7 +79,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="label" gr:example-search="pp"></gr-chip-example>
+                <gr-chip-example gr-filter-field="label" gr-example-search="pp"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Typing <span class="advanced-search-example__input">#</span> automatically creates a label filter.
@@ -87,7 +87,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="source" gr:example-search="WireImage"></gr-chip-example>
+                <gr-chip-example gr-filter-field="source" gr-example-search="WireImage"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Currently case-sensitive. Has a suggestion list.
@@ -95,7 +95,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="supplier" gr:example-search="AAP"></gr-chip-example>
+                <gr-chip-example gr-filter-field="supplier" gr-example-search="AAP"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Has a suggestion list.
@@ -103,7 +103,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="state" gr:example-search="Jammu and Kashmir"></gr-chip-example>
+                <gr-chip-example gr-filter-field="state" gr-example-search="Jammu and Kashmir"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 This refers to a location.
@@ -111,7 +111,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="subject" gr:example-search="politics"></gr-chip-example>
+                <gr-chip-example gr-filter-field="subject" gr-example-search="politics"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Has a suggestion list.
@@ -119,7 +119,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="uploader" gr:example-search="Getty"></gr-chip-example>
+                <gr-chip-example gr-filter-field="uploader" gr-example-search="Getty"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Search by person (email) or agency (folder).
@@ -127,7 +127,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="usages@&gt;added" gr:example-search="2016-01-10"></gr-chip-example>
+                <gr-chip-example gr-filter-field="usages@&gt;added" gr-example-search="2016-01-10"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Images used <em>after</em> a given date YYYY-MM-DD.
@@ -135,7 +135,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="usages@&lt;added" gr:example-search="2012-07-29"></gr-chip-example>
+                <gr-chip-example gr-filter-field="usages@&lt;added" gr-example-search="2012-07-29"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Images used <em>before</em> a given date YYYY-MM-DD.
@@ -143,7 +143,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="usages@status" gr:example-search="published"></gr-chip-example>
+                <gr-chip-example gr-filter-field="usages@status" gr-example-search="published"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Has a suggestion list.
@@ -151,7 +151,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="usages@platform" gr:example-search="print"></gr-chip-example>
+                <gr-chip-example gr-filter-field="usages@platform" gr-example-search="print"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Has a suggestion list: filter by print or digital usage.
@@ -159,7 +159,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr:filter-field="has" gr:example-search="crops"></gr-chip-example>
+                <gr-chip-example gr-filter-field="has" gr-example-search="crops"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Checks for the existence of a field, eg. usageRights, crops, location.
@@ -167,7 +167,7 @@
         </dl>
         <dl class="advanced-search-example">
           <dt class="advanced-search-example__field">
-            <gr-chip-example gr:filter-field="is" gr:example-search="under-quota"></gr-chip-example>
+            <gr-chip-example gr-filter-field="is" gr-example-search="under-quota"></gr-chip-example>
           </dt>
           <dd class="advanced-search-example__explanation">
             Returns images from suppliers with free usage quota.

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -5,9 +5,9 @@
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
-        <a ui:sref="upload"
-           gr:track-click="Your recent uploads button"
-           gr:track-click-data="{'Location': 'Search navigation'}"
+        <a ui-sref="upload"
+           gr-track-click="Your recent uploads button"
+           gr-track-click-data="{'Location': 'Search navigation'}"
            class="top-bar-item clickable side-padded"
            title="my recent uploads">
             <gr-icon-label gr-icon="photo_library">My recent uploads</gr-icon-label>
@@ -17,8 +17,8 @@
 </gr-top-bar>
 
 <gr-panels class="search-panels">
-    <gr-panel gr:left="true" gr:panel="ctrl.collectionsPanel" gr:icon="collections"
-              gr:remember-scroll="true">
+    <gr-panel gr-left="true" gr-panel="ctrl.collectionsPanel" gr-icon="collections"
+              gr-remember-scroll="true">
         <ui-view name="collectionPanel"></ui-view>
     </gr-panel>
 
@@ -26,7 +26,7 @@
         <ui-view name="results"></ui-view>
     </gr-panel-content>
 
-    <gr-panel gr:right="true" gr:panel="ctrl.metadataPanel" gr:icon="collections">
+    <gr-panel gr-right="true" gr-panel="ctrl.metadataPanel" gr-icon="collections">
         <ui-view name="infoPanel"></ui-view>
     </gr-panel>
 </gr-panels>

--- a/kahuna/public/js/upload/dnd-uploader.html
+++ b/kahuna/public/js/upload/dnd-uploader.html
@@ -1,11 +1,11 @@
-<div class="dnd-uploader" ng:if="dndUploader.activated">
+<div class="dnd-uploader" ng-if="dndUploader.activated">
     <div class="dnd-uploader__info">
         <div class="dnd-uploader__heading">Dropzone!</div>
         <div class="dnd-uploader__explainer">Drop files or GuardianWitness URLs here to upload them instantly to the Grid</div>
     </div>
 </div>
 
-<div class="dnd-uploader" ng:if="dndUploader.importing">
+<div class="dnd-uploader" ng-if="dndUploader.importing">
     <div class="dnd-uploader__info">
         <div class="dnd-uploader__heading">Importing…</div>
     </div>

--- a/kahuna/public/js/upload/file-uploader.html
+++ b/kahuna/public/js/upload/file-uploader.html
@@ -1,14 +1,14 @@
 <form class="file-uploader">
-    <!-- you cannot bind ng:model="files" nor use ng:change:
+    <!-- you cannot bind ng-model="files" nor use ng-change:
     https://github.com/angular/angular.js/issues/1375 -->
     <input class="file-uploader__file"
            name="files" type="file"
            multiple
-           gr:file-change="ctrl.uploadFiles($files)" />
+           gr-file-change="ctrl.uploadFiles($files)" />
 
     <button class="file-uploader__select-files button"
-            gr:track-click="Upload action"
-            gr:track-click-data="{ 'Action': 'Button click' }">
+            gr-track-click="Upload action"
+            gr-track-click-data="{ 'Action': 'Button click' }">
         <gr-icon-label gr-icon="file_upload">Upload</gr-icon-label>
     </button>
 </form>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -1,4 +1,4 @@
-<form class="job-editor" name="jobEditor" ng:submit="ctrl.save()" novalidate>
+<form class="job-editor" name="jobEditor" ng-submit="ctrl.save()" novalidate>
     <div class="job-editor__inputs">
         <label class="job-info--editor__field flex-center">
             <div class="job-info--editor__label job-info--editor__label flex-center text-small">Description</div>
@@ -8,19 +8,19 @@
                 required
                 class="text-input job-info--editor__input job-info--editor__input--description"
                 msd-elastic
-                ng:model="ctrl.metadata.description"
-                ng:controller="DescriptionPlaceholderCtrl"
-                ng:change="ctrl.save()"
-                ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-model="ctrl.metadata.description"
+                ng-controller="DescriptionPlaceholderCtrl"
+                ng-change="ctrl.save()"
+                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
             ></textarea>
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this description to all your current uploads"
                 type="button"
-                ng:if="ctrl.withBatch"
-                ng:click="ctrl.batchApplyMetadata('description')"
+                ng-if="ctrl.withBatch"
+                ng-click="ctrl.batchApplyMetadata('description')"
             >⇔</button>
         </label>
 
@@ -34,18 +34,18 @@
                 name="byline"
                 placeholder="eg Tom Jenkins (author’s name ONLY, leave empty if unknown)"
                 class="text-input job-info--editor__input job-info--editor__input--byline"
-                ng:model="ctrl.metadata.byline"
-                ng:change="ctrl.save()"
-                ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-model="ctrl.metadata.byline"
+                ng-change="ctrl.save()"
+                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
             />
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this byline to all your current uploads"
                 type="button"
-                ng:if="ctrl.withBatch"
-                ng:click="ctrl.batchApplyMetadata('byline')"
+                ng-if="ctrl.withBatch"
+                ng-click="ctrl.batchApplyMetadata('byline')"
             >⇔</button>
 
         </label>
@@ -54,44 +54,44 @@
 
             <gr-datalist
                 class="job-info--editor__input"
-                gr:search="ctrl.metadataSearch('credit', q)">
+                gr-search="ctrl.metadataSearch('credit', q)">
 
                 <input type="text"
                     placeholder="eg The Guardian (source, agency or institution which owns the image)"
                     class="text-input job-info__credit"
                     required
-                    gr:datalist-input
-                    ng:model="ctrl.metadata.credit"
-                    ng:change="ctrl.save()"
-                    ng:model-options="{ updateOn: 'gr:datalist:update blur' }" />
+                    gr-datalist-input
+                    ng-model="ctrl.metadata.credit"
+                    ng-change="ctrl.save()"
+                    ng-model-options="{ updateOn: 'gr-datalist:update blur' }" />
             </gr-datalist>
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this credit to all"
                 type="button"
-                ng:if="ctrl.withBatch"
-                ng:click="ctrl.batchApplyMetadata('credit')"
+                ng-if="ctrl.withBatch"
+                ng-click="ctrl.batchApplyMetadata('credit')"
             >⇔</button>
         </div>
-        <label ng:if="ctrl.copyrightWasInitiallyThere" class="job-info--editor__field flex-center">
+        <label ng-if="ctrl.copyrightWasInitiallyThere" class="job-info--editor__field flex-center">
             <div class="job-info--editor__label text-small">Copyright</div>
             <input
                 type="text"
                 name="copyright"
                 class="text-input job-info--editor__input job-info--editor__input--copyright"
-                ng:model="ctrl.metadata.copyright"
-                ng:change="ctrl.save()"
-                ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-model="ctrl.metadata.copyright"
+                ng-change="ctrl.save()"
+                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
             />
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this copyright to all your current uploads"
                 type="button"
-                ng:if="ctrl.withBatch"
-                ng:click="ctrl.batchApplyMetadata('copyright')"
+                ng-if="ctrl.withBatch"
+                ng-click="ctrl.batchApplyMetadata('copyright')"
             >⇔</button>
         </label>
 
@@ -101,18 +101,18 @@
                 type="text"
                 name="special-instructions"
                 class="text-input job-info--editor__input"
-                ng:model="ctrl.metadata.specialInstructions"
-                ng:change="ctrl.save()"
-                ng:model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng:class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-model="ctrl.metadata.specialInstructions"
+                ng-change="ctrl.save()"
+                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
             />
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply these instructions to all your current uploads"
                 type="button"
-                ng:if="ctrl.withBatch"
-                ng:click="ctrl.batchApplyMetadata('specialInstructions')"
+                ng-if="ctrl.withBatch"
+                ng-click="ctrl.batchApplyMetadata('specialInstructions')"
             >⇔</button>
         </label>
     </div>

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -1,45 +1,45 @@
 <ul>
-    <li ng:repeat="job in ctrl.jobs | orderBy: 'name'"  class="upload-result">
+    <li ng-repeat="job in ctrl.jobs | orderBy: 'name'"  class="upload-result">
 
-        <div ng:if="!job.image"
+        <div ng-if="!job.image"
              class="job-uploading">
 
             <div class="result-editor__result">
                 <div>
-                    <img ng:src="{{job.dataUrl}}" class="preview__image" />
+                    <img ng-src="{{job.dataUrl}}" class="preview__image" />
 
                     <div class="preview__bottom-bar bottom-bar">
                         <div class="bottom-bar__meta">
-                            {{job.name}}<span ng:if="job.size">, {{job.size | asFileSize}}</span>
+                            {{job.name}}<span ng-if="job.size">, {{job.size | asFileSize}}</span>
                         </div>
 
                         <div class="bottom-bar__actions"></div>
                     </div>
                 </div>
                 <div class="job-status status"
-                     ng:class="{
+                     ng-class="{
                          'status--invalid': job.status === 'upload error',
                          'status--valid':   job.status === 'uploaded'
                      }">
 
                      {{job.status}}
-                     <span ng:if="job.status === 'upload error'">({{job.error}})</span>
+                     <span ng-if="job.status === 'upload error'">({{job.error}})</span>
                 </div>
             </div>
 
             <gr-confirm-delete class="flex-right"
-                               ng:if="job.status === 'upload error'"
-                               gr:on-confirm="ctrl.removeJob(job)">
+                               ng-if="job.status === 'upload error'"
+                               gr-on-confirm="ctrl.removeJob(job)">
             </gr-confirm-delete>
         </div>
 
-        <ui-image-editor ng:if="job.image"
+        <ui-image-editor ng-if="job.image"
                          image="job.image"
                          with-batch="ctrl.jobs.length > 1">
         </ui-image-editor>
 
         <gr-delete-image class="flex-right"
-                         ng:if="job.canBeDeleted"
+                         ng-if="job.canBeDeleted"
                          images="[job.image]">
         </gr-delete-image>
     </li>

--- a/kahuna/public/js/upload/prompt/prompt.html
+++ b/kahuna/public/js/upload/prompt/prompt.html
@@ -4,7 +4,7 @@
 
 <div class="preset-labels">
     <p class="preset-labels__heading">Apply
-        <span ng:if="ctrl.presetLabels.length === 0 && !ctrl.active">label e.g. Observer </span>
+        <span ng-if="ctrl.presetLabels.length === 0 && !ctrl.active">label e.g. Observer </span>
     </p>
     <gr-preset-labels></gr-preset-labels>
     <p class="preset-labels__heading">to all uploads</p>

--- a/kahuna/public/js/upload/recent/recent-uploads.html
+++ b/kahuna/public/js/upload/recent/recent-uploads.html
@@ -1,14 +1,14 @@
-<p ng:if="! ctrl.myUploads">
+<p ng-if="! ctrl.myUploads">
     Loading…
 </p>
-<p ng:if="ctrl.myUploads.data.length == 0">
+<p ng-if="ctrl.myUploads.data.length == 0">
     You haven’t uploaded anything yet.
 </p>
-<ul ng:if="ctrl.myUploads.data.length > 0">
-    <li ng:repeat="result in ctrl.myUploads.data track by result.data.id" class="upload-result">
+<ul ng-if="ctrl.myUploads.data.length > 0">
+    <li ng-repeat="result in ctrl.myUploads.data track by result.data.id" class="upload-result">
         <ui-image-editor image="result"></ui-image-editor>
         <gr-delete-image class="flex-right"
-                         ng:if="ctrl.canBeDeleted(result)"
+                         ng-if="ctrl.canBeDeleted(result)"
                          images="[result]"></gr-delete-image>
     </li>
 </ul>

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -1,7 +1,7 @@
 <gr-top-bar>
     <gr-top-bar-nav>
         <a class="top-bar-item side-padded"
-           ui:sref="search"><gr-icon>search</gr-icon>
+           ui-sref="search"><gr-icon>search</gr-icon>
            <span class="top-bar-item__label">Search</span></a>
     </gr-top-bar-nav>
     <gr-top-bar-actions></gr-top-bar-actions>
@@ -11,11 +11,11 @@
     <file-prompt class="section"></file-prompt>
 
     <section class="section"
-             ng:if="ctrl.latestJob && ctrl.latestJob.length > 0">
+             ng-if="ctrl.latestJob && ctrl.latestJob.length > 0">
 
         <div class="flex-container section-heading current-uploads">
             <h2 class="flex-spacer">Your current uploads</h2>
-            <a ng:controller="SessionCtrl" class="coloured-link" ui:sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
+            <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
         </div>
 
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
@@ -24,7 +24,7 @@
     <section class="section">
         <div class="flex-container section-heading">
             <h2 class="flex-spacer">Your past 50 uploads</h2>
-            <a ng:controller="SessionCtrl" class="coloured-link" ui:sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
+            <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
         </div>
 
         <recent-uploads></recent-uploads>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -1,8 +1,8 @@
 <form class="usage-rights-editor ure"
       novalidate
       name="usageRights"
-      ng:class="{'ure__category-invalid': ctrl.categoryInvalid}"
-      ng:submit="usageRights.$valid && ctrl.save()">
+      ng-class="{'ure__category-invalid': ctrl.categoryInvalid}"
+      ng-submit="usageRights.$valid && ctrl.save()">
 
     <div class="ure__description">
         <a rel="noopener" target="_blank" href="{{ctrl.usageRightsHelpLink}}">
@@ -17,14 +17,14 @@
         model, even though they don't exist in the form -->
         <select
             class="full-width"
-            ng:model="ctrl.category"
-            ng:disabled="ctrl.saving"
-            ng:options="category as category.name for category in ctrl.categories track by category.value"
-            ng:change="ctrl.reset()">
+            ng-model="ctrl.category"
+            ng-disabled="ctrl.saving"
+            ng-options="category as category.name for category in ctrl.categories track by category.value"
+            ng-change="ctrl.reset()">
         </select>
     </label>
 
-    <div class="ure__caution warning warning--small" ng:if="ctrl.category.caution">
+    <div class="ure__caution warning warning--small" ng-if="ctrl.category.caution">
         {{ctrl.category.caution}}
     </div>
 
@@ -32,9 +32,9 @@
         {{ctrl.category.description}}
     </div>
 
-    <div class="ure__properties" ng:if="ctrl.category">
+    <div class="ure__properties" ng-if="ctrl.category">
         <div class="ure__multiple-rights-warning"
-            ng:if="ctrl.usageRights.length > 1">
+            ng-if="ctrl.usageRights.length > 1">
             Multiple rights & restrictions
             <gr-icon
                 title="Some specific information about the usage rights of these images might be missing below and will be overridden.">
@@ -44,78 +44,78 @@
 
         <div
             class="form-property"
-            ng:repeat="property in ctrl.category.properties"
-            ng:class="{ 'form-property--last': $last }">
+            ng-repeat="property in ctrl.category.properties"
+            ng-class="{ 'form-property--last': $last }">
 
             <!-- TODO: potentially pull restrictions out from the
             server request and add it to all properties -->
-            <div ng:if="property.name === 'restrictions'">
+            <div ng-if="property.name === 'restrictions'">
                 <label>
                     <input type="checkbox"
-                           ng:model="ctrl.showRestrictions"
-                           ng:disabled="ctrl.forceRestrictions" />
+                           ng-model="ctrl.showRestrictions"
+                           ng-disabled="ctrl.forceRestrictions" />
                     Restricted
                 </label>
 
-                <div ng:if="ctrl.showRestrictions"
-                     ng:switch="ctrl.category.defaultRestrictions === undefined">
+                <div ng-if="ctrl.showRestrictions"
+                     ng-switch="ctrl.category.defaultRestrictions === undefined">
                     <!-- We don't allow you to set the restrictions if there are defaults.
                     This might not be the behaviour we want in the future, but works for now. -->
                     <textarea
                         class="text-input form-input-text"
                         name="{{ property.name }}"
                         placeholder="What restrictions apply to this image? e.g. 'Use in relation to the Windsor Triathlon only'"
-                        ng:switch-when="true"
-                        ng:model="ctrl.model[property.name]"
-                        ng:required="ctrl.showRestrictions"></textarea>
+                        ng-switch-when="true"
+                        ng-model="ctrl.model[property.name]"
+                        ng-required="ctrl.showRestrictions"></textarea>
 
                     <textarea
                         class="text-input form-input-text"
                         disabled="disabled"
-                        ng:switch-default>{{ctrl.category.defaultRestrictions}}</textarea>
+                        ng-switch-default>{{ctrl.category.defaultRestrictions}}</textarea>
 
                 </div>
             </div>
 
-            <div ng:if="property.name !== 'restrictions'"
-                 ng:init="fieldUniqueId = $id">
+            <div ng-if="property.name !== 'restrictions'"
+                 ng-init="fieldUniqueId = $id">
                 <label class="form-label" for="ure-field-{{::fieldUniqueId}}">
                     <div class="form-label__text">{{ property.label }}</div>
                     <!-- TODO: Show errors here -->
                     <!--<div class="form-label__error">Error</div>-->
                 </label>
 
-                <div ng:switch="property.type">
-                    <div ng:switch-when="string">
+                <div ng-switch="property.type">
+                    <div ng-switch-when="string">
                         <input
                             id="ure-field-{{::fieldUniqueId}}"
                             class="text-input form-input-text"
                             type="text"
                             name="{{ property.name }}"
                             placeholder="e.g. {{ property.examples }}"
-                            ng:if="!property.options && !property.optionsMap"
-                            ng:model="ctrl.model[property.name]"
-                            ng:required="property.required" />
+                            ng-if="!property.options && !property.optionsMap"
+                            ng-model="ctrl.model[property.name]"
+                            ng-required="property.required" />
 
-                        <div ng:if="property.options"
-                             ng:switch="property.options.length > 3"
-                             ng:init="options = ctrl.getOptionsFor(property)">
-                                <div class="radio-list" ng:switch-when="false">
+                        <div ng-if="property.options"
+                             ng-switch="property.options.length > 3"
+                             ng-init="options = ctrl.getOptionsFor(property)">
+                                <div class="radio-list" ng-switch-when="false">
                                     <div class="radio-list__item"
-                                         ng:repeat="o in options">
+                                         ng-repeat="o in options">
 
                                         <input type="radio"
                                             id="id-{{::$id}}-{{o.key}}-{{property.name}}-radio-list__item"
                                             class="radio-list__circle"
                                             name="{{property.name}}-radio-list"
                                             placeholder="e.g. {{ property.examples }}"
-                                            ng:value="o.value"
-                                            ng:required="property.required"
-                                            ng:model="ctrl.model[property.name]" />
+                                            ng-value="o.value"
+                                            ng-required="property.required"
+                                            ng-model="ctrl.model[property.name]" />
                                         <label
                                             for="id-{{::$id}}-{{o.key}}-{{property.name}}-radio-list__item"
                                             class="radio-list__label"
-                                            ng:class="{'radio-list--selected': ctrl.model[property.name] === o.value || (!ctrl.model[property.name] && o.value === null)}">
+                                            ng-class="{'radio-list--selected': ctrl.model[property.name] === o.value || (!ctrl.model[property.name] && o.value === null)}">
                                             <div class="radio-list__selection-state"></div>
                                             <div class="radio-list__label-value">{{ o.key }}</div>
                                         </label>
@@ -127,25 +127,25 @@
                                     class="full-width"
                                     id="ure-field-{{::fieldUniqueId}}"
                                     name="{{ property.name }}"
-                                    ng:switch-when="true"
-                                    ng:model="ctrl.model[property.name]"
-                                    ng:required="property.required"
-                                    ng:options="o.value as o.key for o in options">
+                                    ng-switch-when="true"
+                                    ng-model="ctrl.model[property.name]"
+                                    ng-required="property.required"
+                                    ng-options="o.value as o.key for o in options">
                                 </select>
                         </div>
 
                         <div class="flex-container"
-                             ng:if="property.optionsMap"
-                             ng:init="otherValue = ctrl.isOtherValue(property)">
+                             ng-if="property.optionsMap"
+                             ng-init="otherValue = ctrl.isOtherValue(property)">
 
                             <select
                                 class="full-width"
                                 id="ure-field-{{::fieldUniqueId}}"
                                 name="{{ property.name }}"
-                                ng:model="ctrl.model[property.name]"
-                                ng:required="property.required"
-                                ng:options="o for o in ctrl.getOptionsMapFor(property)"
-                                ng:if="!otherValue">
+                                ng-model="ctrl.model[property.name]"
+                                ng-required="property.required"
+                                ng-options="o for o in ctrl.getOptionsMapFor(property)"
+                                ng-if="!otherValue">
                                 <option value="">None</option>
                             </select>
 
@@ -153,12 +153,12 @@
                                 class="text-input full-width"
                                 id="ure-field-{{::fieldUniqueId}}"
                                 placeholder="e.g. {{ property.examples }}"
-                                ng:model="ctrl.model[property.name]"
-                                ng:required="property.required"
-                                ng:if="otherValue" />
+                                ng-model="ctrl.model[property.name]"
+                                ng-required="property.required"
+                                ng-if="otherValue" />
 
                             <label class="flex-no-shrink">
-                                <input type="checkbox" ng:model="otherValue" />
+                                <input type="checkbox" ng-model="otherValue" />
                                 Other
                             </label>
                         </div>
@@ -169,16 +169,16 @@
                         id="ure-field-{{::fieldUniqueId}}"
                         name="{{ property.name }}"
                         placeholder="e.g. {{ property.examples }}"
-                        ng:model="ctrl.model[property.name]"
-                        ng:switch-when="text"
-                        ng:required="property.required">
+                        ng-model="ctrl.model[property.name]"
+                        ng-switch-when="text"
+                        ng-required="property.required">
                     </textarea>
                 </div>
             </div>
         </div>
     </div>
     <div class="ure__bar">
-        <button class="ure__action button-ico button-cancel" type="button" ng:click="ctrl.cancel()"
+        <button class="ure__action button-ico button-cancel" type="button" ng-click="ctrl.cancel()"
                 title="close usage rights overrides">
             <gr-icon-label gr-icon="close">Cancel</gr-icon-label>
         </button>
@@ -186,9 +186,9 @@
         <button class="ure__action button-ico button-save"
             type="submit"
             title="save usage rights overrides"
-            ng:disabled="ctrl.savingDisabled || !usageRights.$valid">
-            <gr-icon-label ng:if="!ctrl.saving" gr-icon="check">Save</gr-icon-label>
-            <gr-icon ng:if="ctrl.saving">timelapse</gr-icon>
+            ng-disabled="ctrl.savingDisabled || !usageRights.$valid">
+            <gr-icon-label ng-if="!ctrl.saving" gr-icon="check">Save</gr-icon-label>
+            <gr-icon ng-if="ctrl.saving">timelapse</gr-icon>
         </button>
     </div>
 </form>


### PR DESCRIPTION
## What does this change?

This updates the Angular HTML codebase to use `ng-` instead of `ng:`, as well as similar attributes (`ui`, `gr`), as these are deprecated.

## How can success be measured?

The Kahuna frontend still works as usual with this change.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
