### PR TITLE
More performant selections!

### DIFF
--- a/kahuna/public/js/lib/data-structure/ordered-set-factory.js
+++ b/kahuna/public/js/lib/data-structure/ordered-set-factory.js
@@ -29,6 +29,10 @@ orderedSetFactory.value('orderedSetFactory', function() {
         return (set) => set.add(item);
     }
 
+    function union(items) {
+        return (set) => set.union(items);
+    }
+
     function remove(item) {
         return (set) => set.delete(item);
     }
@@ -49,6 +53,7 @@ orderedSetFactory.value('orderedSetFactory', function() {
 
         // Operations
         add(item)    { queueOperation(add(item));    },
+        union(items) { queueOperation(union(items)); },
         remove(item) { queueOperation(remove(item)); },
         toggle(item) { queueOperation(toggle(item)); },
         clear()      { queueOperation(clear());      }

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -392,15 +392,15 @@ results.controller('SearchResultsCtrl', [
                         return;
                     }
 
-                    var start = imageIndex > lastSelectedIndex ?
-                        lastSelectedIndex : imageIndex;
+                    var start = Math.min(imageIndex, lastSelectedIndex);
 
-                    var end = imageIndex > lastSelectedIndex ?
-                        imageIndex : lastSelectedIndex;
+                    var end = Math.max(imageIndex, lastSelectedIndex) + 1;
 
-                    for (let i of range(start, end)) {
-                        ctrl.select(ctrl.images[i]);
-                    }
+                    const imageURIs = ctrl.images.slice(start,end).map(image => image.uri);
+                    console.log(selection);
+                    selection.union(imageURIs);
+                    console.log(selection);
+                    $window.getSelection().removeAllRanges();
                 }
                 else {
                     $window.getSelection().removeAllRanges();

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -68,7 +68,6 @@ results.controller('SearchResultsCtrl', [
     'selectedImages$',
     'results',
     'panels',
-    'range',
     'isReloadingPreviousSearch',
 
     function($rootScope,
@@ -88,7 +87,6 @@ results.controller('SearchResultsCtrl', [
              selectedImages$,
              results,
              panels,
-             range,
              isReloadingPreviousSearch) {
 
         const ctrl = this;
@@ -396,10 +394,11 @@ results.controller('SearchResultsCtrl', [
 
                     var end = Math.max(imageIndex, lastSelectedIndex) + 1;
 
-                    const imageURIs = ctrl.images.slice(start,end).map(image => image.uri);
-                    console.log(selection);
+                    const imageURIs = ctrl.images
+                      .slice(start, end)
+                      .map(image => image.uri);
                     selection.union(imageURIs);
-                    console.log(selection);
+
                     $window.getSelection().removeAllRanges();
                 }
                 else {


### PR DESCRIPTION
## What does this change?
Previously, we were handling multiple selects, by calling `image.select()`
![big screenshot](https://user-images.githubusercontent.com/2670496/78266775-23d68d00-74fe-11ea-8476-60d85249145c.png)

This was adding to the set (reactively) and then `$window.getSelection().removeAllRanges()` which 🤷‍♂ can't be necessary. 

So this PR makes this add all the images to the Set in one hit instead. 

![image](https://user-images.githubusercontent.com/2670496/78268260-da873d00-74ff-11ea-9e5d-cdb9eafb1b8a.png)


`ordered-set-factory` is a dependency of `result` because of https://github.com/guardian/grid/blob/6130e85e83d80470e1729897b94ead8535c620e6/kahuna/public/js/search/index.js#L164


## How can success be measured?
⏱ 
## Screenshots (if applicable)
![fastselectsmall](https://user-images.githubusercontent.com/2670496/78265758-cb52c000-74fc-11ea-8281-a20d09c61411.gif)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
