### PR TITLE
add more detail to stopwatch

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/DateTimeUtils.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/DateTimeUtils.scala
@@ -1,9 +1,21 @@
 package com.gu.mediaservice.lib
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
 import org.joda.time.DateTime
 
 import scala.util.Try
 
 object DateTimeUtils {
+  private val EuropeLondonZone: ZoneId = ZoneId.of("Europe/London")
+
+  def now(): ZonedDateTime = ZonedDateTime.now(EuropeLondonZone)
+
+  def toString(zonedDateTime: ZonedDateTime): String = zonedDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+  def toString(instant: Instant): String = instant.atZone(EuropeLondonZone).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+  // TODO move this to a LocalDateTime
   def fromValueOrNow(value: Option[String]): DateTime = Try{new DateTime(value.get)}.getOrElse(DateTime.now)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/Stopwatch.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/Stopwatch.scala
@@ -1,17 +1,30 @@
 package com.gu.mediaservice.lib.logging
 
-import net.logstash.logback.marker.LogstashMarker
+import java.time.ZonedDateTime
+
+import com.gu.mediaservice.lib.DateTimeUtils
+
 import scala.concurrent.duration._
 
-case class DurationForLogging(duration: Duration) extends LogMarker {
+case class DurationForLogging(startTime: ZonedDateTime, duration: Duration) extends LogMarker {
   def toMillis: Long = duration.toMillis
-  def markerContents = Map("duration" -> toMillis)
+
+  override def markerContents = Map(
+    "start" -> DateTimeUtils.toString(startTime),
+    "end" -> DateTimeUtils.toString(DateTimeUtils.now()),
+    "duration" -> toMillis
+  )
 }
 
 class Stopwatch {
+  // This method can only be used to measure elapsed time and is not related to any other notion of system or wall-clock time.
+  // Therefore we additionally have `startTime` to track the time.
+  // see https://docs.oracle.com/javase/9/docs/api/java/lang/System.html#nanoTime--
   private val startedAt = System.nanoTime()
 
-  def elapsed: DurationForLogging = DurationForLogging((System.nanoTime() - startedAt).nanos)
+  private val startTime = DateTimeUtils.now()
+
+  def elapsed: DurationForLogging = DurationForLogging(startTime, (System.nanoTime() - startedAt).nanos)
 }
 
 object Stopwatch {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/logging/StopwatchTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/logging/StopwatchTest.scala
@@ -5,23 +5,15 @@ import org.scalatest.{FunSpec, Matchers}
 class StopwatchTest extends FunSpec with Matchers {
   it("should return the elapsed time") {
     val fiveSeconds: Long = 5 * 1000
-    val durationRegex = """\{duration=(\d*)\}""".r
 
-    def doWork = Thread.sleep(fiveSeconds)
+    def doWork: Unit = Thread.sleep(fiveSeconds)
     val stopwatch = Stopwatch.start
     doWork
 
-    val marker = stopwatch.elapsed.toLogMarker
-    val map = stopwatch.elapsed.markerContents
+    val markers = stopwatch.elapsed.markerContents
 
-
-    map("duration") should be >= fiveSeconds
-
-    (marker.toString match {
-      case durationRegex(duration) => {
-        duration.toLong
-      }
-      case _ => 0
-    }) should be >= fiveSeconds // >= as time is needed to call the function
+    markers.contains("start") shouldBe true
+    markers.contains("end") shouldBe true
+    markers("duration").toString.toLong should be >= fiveSeconds // >= as time is needed to call the function
   }
 }


### PR DESCRIPTION
## What does this change?
Adding a `start` and `end` marker to stop watch logs for more information.

This is taken from https://github.com/guardian/grid/pull/2896, alas the commits in that PR were not easy to cherry pick out 😢 .

## How can success be measured?
The more information we have, the better.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
