### PR TITLE
Scroll when we zoom.

### DIFF
--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -14,7 +14,7 @@ import '../../util/seq';
 import {
     combine$,
     add$, sub$, mult$, div$, mod$,
-    floor$, ceil$, max$, min$
+    floor$, ceil$, max$, min$, round$
 } from './observable-utils';
 
 
@@ -64,8 +64,8 @@ lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
 
         const viewportBottom$ = add$(viewportTop$, viewportHeight$);
 
-        const currentRowTop$    = floor$(div$(viewportTop$,    cellHeight$));
-        const currentRowBottom$ = floor$(div$(viewportBottom$, cellHeight$));
+        const currentRowTop$    = round$(div$(viewportTop$,    cellHeight$));
+        const currentRowBottom$ = round$(div$(viewportBottom$, cellHeight$));
 
         const loadedRowTop$ = max$(sub$(currentRowTop$, preloadedRows$), 0).
             distinctUntilChanged();


### PR DESCRIPTION
## What does this change?
Zooming causes some weird floating point error which when it's floored
breaks scrolling. This uses round instead.

## How can success be measured?

Turns out zooming is not 
https://www.youtube.com/watch?v=8Cxry9cLFQI

## Screenshots (if applicable)

![scrooll](https://user-images.githubusercontent.com/2670496/78377802-01a94180-75c8-11ea-9a6c-ba9ba408ab96.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
