### PR TITLE
further restrict image deletions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -35,7 +35,11 @@ case class Image(
 
   def hasUsages = usages.nonEmpty
 
-  def canBeDeleted = !hasExports && !hasUsages
+  def hasLeases = leases.leases.nonEmpty
+
+  def hasCollections = collections.nonEmpty
+
+  def canBeDeleted = !hasExports && !hasUsages && !hasLeases && !hasCollections
 
   def rcsPublishDate: Option[DateTime] = syndicationRights.flatMap(_.published)
 


### PR DESCRIPTION
## What does this change?
Stricter conditions for image deletion. Essentially, you can only delete an image when there is nothing in the various dynamodb tables.

In processing a `delete-image` message, it sends a further message to [metadata editor](https://github.com/guardian/grid/blob/186741448e3bb1f7bc9eb01850792a481f7817e7/thrall/app/lib/kinesis/MessageProcessor.scala#L166) for it to [remove entries from dynamodb](https://github.com/guardian/grid/blob/2cc135c8fc8e3e2d92e5c092d90cf1b46beaa554/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala#L18). As we're not doing the same for leases or collections, we can have a scenario where there are phantom records in these dynamodb tables.

By restricting the conditions under which an image is eligible for deletion, we can ensure these tables are empty before the image gets deleted. That is, if you want to delete an image, first remove its leases, collections, usages and crops.

The alternative to this is for lease and collections to get notified by thrall, similar to metadata-editor.

## How can success be measured?
Cleaner dynamodb tables.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
