### PR TITLE
Show which service is being hit in the Pingler

### DIFF
--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,5 +1,6 @@
 <section ng-if="! ctrl.editInline">
-    <button class="image-info__edit"
+    <button id="it-photoshoot-edit-button"
+            class="image-info__edit"
             ng-click="photoshootEditForm.$show()"
             ng-hide="photoshootEditForm.$visible">
         ✎

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,6 +1,5 @@
 <section ng-if="! ctrl.editInline">
-    <button id="it-photoshoot-edit-button"
-            class="image-info__edit"
+    <button class="image-info__edit"
             ng-click="photoshootEditForm.$show()"
             ng-hide="photoshootEditForm.$visible">
         ✎

--- a/nginx-mappings.yml
+++ b/nginx-mappings.yml
@@ -25,3 +25,5 @@ mappings:
     port: 9200
   - prefix: admin-tools.media
     port: 9013
+  - prefix: thrall.media
+    port: 9002

--- a/the_pingler.sh
+++ b/the_pingler.sh
@@ -2,17 +2,17 @@
 
 set -o shwordsplit
 
-API="http://localhost:9001/management/healthcheck"
-THRALL="http://localhost:9002/management/healthcheck"
-IMAGE_LOADER="http://localhost:9003/management/healthcheck"
-KAHUNA="http://localhost:9005/management/healthcheck"
-CROPPER="http://localhost:9006/management/healthcheck"
-METADATA="http://localhost:9007/management/healthcheck"
-USAGE="http://localhost:9009/management/healthcheck"
-COLLECTIONS="http://localhost:9010/management/healthcheck"
-AUTH="http://localhost:9011/management/healthcheck"
-LEASES="http://localhost:9012/management/healthcheck"
-ADMIN_TOOLS="http://localhost:9013/management/healthcheck"
+API="https://api.media.local.dev-gutools.co.uk/management/healthcheck"
+THRALL="https://thrall.media.local.dev-gutools.co.uk/management/healthcheck"
+IMAGE_LOADER="https://loader.media.local.dev-gutools.co.uk/management/healthcheck"
+KAHUNA="https://media.local.dev-gutools.co.uk/management/healthcheck"
+CROPPER="https://cropper.media.local.dev-gutools.co.uk/management/healthcheck"
+METADATA="https://media-metadata.local.dev-gutools.co.uk/management/healthcheck"
+USAGE="https://media-usage.local.dev-gutools.co.uk/management/healthcheck"
+COLLECTIONS="https://media-collections.local.dev-gutools.co.uk/management/healthcheck"
+AUTH="https://media-auth.local.dev-gutools.co.uk/management/healthcheck"
+LEASES="https://media-leases.local.dev-gutools.co.uk/management/healthcheck"
+ADMIN_TOOLS="https://admin-tools.media.local.dev-gutools.co.uk/management/healthcheck"
 
 lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"
 


### PR DESCRIPTION
## What does this change?
Previously, it was hard to know which service the Pingler was hitting, and more importantly which one was breaking. This changes the endpoints to use the nginx-config endpoints (eg `api.media.local` rather than `localhost:9200` etc). This makes it easier to debug when things go wrong.

## How can success be measured?

Running the Pingler locally alongside a local Grid service successfully hits the microservices and returns green (if healthy!).


## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/25747336/78793700-ac47a880-79aa-11ea-9934-1277ce6f50a2.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms 


## Tested?
- [X] locally
- [ ] on TEST
