### PR TITLE
Handle bad email images better

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -169,15 +169,10 @@ class ImageLoaderController(auth: Authentication,
           }
         }
         .recover {
-        case _: IllegalArgumentException =>
-          Logger.warn("importImage request failed; invalid uri")
-          FailureResponse.invalidUri
-        case e: UserImageLoaderException =>
-          Logger.warn("importImage request failed; bad user input")
-          BadRequest(e.getMessage)
-        case NonFatal(_) =>
-          Logger.warn("importImage request failed")
-          FailureResponse.failedUriDownload
+          case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
+          case _: IllegalArgumentException => FailureResponse.invalidUri
+          case e: UserImageLoaderException => FailureResponse.badUserInput(e)
+          case NonFatal(_) => FailureResponse.failedUriDownload
       }
     }
   }

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -85,11 +85,11 @@ class ImageLoaderController(auth: Authentication,
       } recover {
         case e =>
           Logger.error("loadImage request ended with a failure", e)
-          e match {
-            case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes).as(ArgoMediaType)
-            case _: ImageProcessingException => FailureResponse.notAnImage(config.supportedMimeTypes).as(ArgoMediaType)
-            case e => println(e.getMessage); InternalServerError(Json.obj("error" -> e.getMessage)).as(ArgoMediaType)
-          }
+          (e match {
+            case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
+            case _: ImageProcessingException => FailureResponse.notAnImage(config.supportedMimeTypes)
+            case e => println(e.getMessage); InternalServerError(Json.obj("error" -> e.getMessage))
+          }).as(ArgoMediaType)
       }
     }
   }

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -2,12 +2,25 @@ package lib
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.model.{MimeType, UnsupportedMimeTypeException}
+import lib.imaging.UserImageLoaderException
 import play.api.Logger
 import play.api.mvc.Result
 
 object FailureResponse extends ArgoHelpers {
-  val invalidUri: Result = respondError(BadRequest, "invalid-uri", s"The provided 'uri' is not valid")
-  val failedUriDownload: Result = respondError(BadRequest, "failed-uri-download", s"The provided 'uri' could not be downloaded")
+  val invalidUri: Result = {
+    Logger.warn("importImage request failed; invalid uri")
+    respondError(BadRequest, "invalid-uri", s"The provided 'uri' is not valid")
+  }
+
+  def badUserInput(e: UserImageLoaderException): Result = {
+    Logger.warn("importImage request failed; bad user input")
+    BadRequest(e.getMessage)
+  }
+
+  val failedUriDownload: Result = {
+    Logger.warn("importImage request failed")
+    respondError(BadRequest, "failed-uri-download", s"The provided 'uri' could not be downloaded")
+  }
 
   def unsupportedMimeType(unsupported: UnsupportedMimeTypeException, supportedMimeTypes: List[MimeType]): Result = {
     Logger.info(s"Rejected request to load file: mime-type is not supported")


### PR DESCRIPTION
## What does this change?
Returns 400 rather than 500 when an email import has an 'image' which is not an image.
This is important because we currently return 500 - which sets off our alarm, but this form of error is out of our control and should not result in alarms.

## How can success be measured?
Responses for bad 'images' are 400, not 500 in the import endpoint.
See https://console.aws.amazon.com/s3/object/media-service-prod-s3watcherfailbucket-13rugy458tosk/email/2m.pdf?region=eu-west-1 for examples.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
