### PR TITLE
Ensure credentials for media-service exist and work before running Grid

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -24,6 +24,17 @@ isInstalled() {
   hash "$1" 2>/dev/null
 }
 
+hasCredentials() {
+  STATUS=$(aws sts get-caller-identity --profile media-service 2>&1 || true)
+  if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+    echo -e "${red}Credentials for the media-service profile are expired. Please fetch new credentials and run this again.${plain}"
+    exit 1
+  elif [[ ${STATUS} =~ ("could not be found") ]]; then
+    echo -e "${red}Credentials for the media-service profile are missing. Please ensure you have the right credentials.${plain}"
+    exit 1
+  fi
+}
+
 checkRequirement() {
     if ! isInstalled $1; then
         echo -e "${red}[MISSING DEPENDENCY] $1 not found. Please install $1${plain}"
@@ -133,6 +144,7 @@ setupLocalKinesis() {
 }
 
 main() {
+    hasCredentials
     checkRequirements
     checkNodeVersion
     setupImgops


### PR DESCRIPTION
## What does this change?

Previously, when running locally, developers could fully spin up the Grid without having the correct credentials for the media-service account, which is relied upon to gain access to resources. Only once trying to access the Grid through a browser (which may take a minute or two at least) do you find out that you are missing the credentials.

This adds a helper function to `dev-start.sh` to check for credentials before spinning up any local resources, improving the speed at which you get that feedback. 

[GetCallerIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html) requires no specific IAM permissions to run and is a useful tool to determine whether your session is valid or not. I've chosen to use this to validate the credentials, and have tested it to be working locally.

## How can success be measured?
Spinning up the Grid without credentials using `dev-start.sh` bails out early if credentials are missing or expired, but spins up fine if credentials are present and working.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/25747336/79204203-17bec980-7e34-11ea-95f1-38a43f5e7e00.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms 

## Tested?
- [X] locally
- [ ] on TEST
