### PR TITLE
Output test reports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val commonSettings = Seq(
   organization := "com.gu",
   version := "0.1",
   scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings"),
+  testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports")),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.5",
     "org.mockito" % "mockito-core" % "2.18.0"


### PR DESCRIPTION
## What does this change?
By outputting test reports, we can update CI to more easily identify which tests are failing; TC will display a list of executed tests in a separate location from the build log.

See https://github.com/guardian/janus/pull/1673

## How can success be measured?
CI output is easier to understand.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/836140/79219956-151b9e80-7e4b-11ea-9c56-90b166aead66.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [x] on TEST
