### PR TITLE
use latest version of localstack

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -3,7 +3,6 @@ package com.gu.mediaservice.lib.aws
 import java.nio.ByteBuffer
 import java.util.UUID
 
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.kinesis.model.PutRecordRequest
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
 import com.gu.mediaservice.lib.config.CommonConfig
@@ -17,15 +16,9 @@ class Kinesis(config: CommonConfig) {
 
   private val builder = AmazonKinesisClientBuilder.standard()
 
-  import config.{awsRegion, awsCredentials, thrallKinesisEndpoint, thrallKinesisStream}
+  import config.thrallKinesisStream
 
-  private def getKinesisClient: AmazonKinesis = {
-    Logger.info(s"creating kinesis publisher with endpoint=$thrallKinesisEndpoint , region=$awsRegion")
-   builder
-     .withEndpointConfiguration(new EndpointConfiguration(thrallKinesisEndpoint, awsRegion))
-     .withCredentials(awsCredentials)
-     .build()
-  }
+  private def getKinesisClient: AmazonKinesis = config.withLocalAWSCredentials(builder).build()
 
   private lazy val kinesisClient: AmazonKinesis = getKinesisClient
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class SqsMessageConsumer(queueUrl: String, awsEndpoint: String, config: CommonConfig, metric: Metric[Long]) extends ImageId {
+abstract class SqsMessageConsumer(queueUrl: String, config: CommonConfig, metric: Metric[Long]) extends ImageId {
   val actorSystem = ActorSystem("MessageConsumer")
 
   private implicit val ctx: ExecutionContext =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -17,9 +17,7 @@ trait CommonConfig {
   def configuration: Configuration
 
   lazy val properties: Map[String, String] = Properties.fromPath(s"/etc/gu/$appName.properties")
-
-  final val awsEndpoint = "ec2.eu-west-1.amazonaws.com"
-
+  
   final val elasticsearchStack = "media-service"
 
   final val elasticsearchApp = "elasticsearch"

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -119,8 +119,8 @@ checkNodeVersion() {
 }
 
 setupLocalKinesis() {
-  echo "Waiting localstack kinesis to launch on 4568..."
-  while ! curl -s http://localhost:4568 >/dev/null; do
+  echo "Waiting localstack kinesis to launch on 4566..."
+  while ! curl -s http://localhost:4566 >/dev/null; do
     sleep 1 # wait for 1 second before check again
   done
   echo "localstack kinesis launched"
@@ -135,10 +135,10 @@ setupLocalKinesis() {
   )
 
   for stream_name in "${streams[@]}"; do
-    stream_count=$(aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis list-streams | jq -r '.StreamNames[]' | grep -c "${stream_name}" || true)
+    stream_count=$(aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4566 kinesis list-streams | jq -r '.StreamNames[]' | grep -c "${stream_name}" || true)
     if [ "$stream_count" -eq 0 ]; then
       echo "creating local kinesis stream ${stream_name}"
-      aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4568 kinesis create-stream --shard-count 1 --stream-name "${stream_name}"
+      aws --profile media-service --region=eu-west-1 --endpoint-url=http://localhost:4566 kinesis create-stream --shard-count 1 --stream-name "${stream_name}"
     fi
   done
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,10 @@ services:
     ports:
       - "9090:9000"
   localstack:
-    image: localstack/localstack:0.10.8
+    image: localstack/localstack:latest
     ports:
-      - "4567-4584:4567-4584"
-      - "8081:8080"
+      - "4566:4566"
     environment:
-      - SERVICES=kinesis:4568,dynamodb:4569
+      - SERVICES=kinesis,dynamodb
       - DEFAULT_REGION=eu-west-1
       - KINESIS_ERROR_PROBABILITY=0.0
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "9090:9000"
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.11.0
     ports:
       - "4566:4566"
     environment:

--- a/docs/local-kinesis.md
+++ b/docs/local-kinesis.md
@@ -1,19 +1,19 @@
 
 ## Running app locally with local kinesis
 
-by running 
+by running
 
      ./dev-start.sh
 
-command you will run app with local mode, it will use local instance of kinesis provided by [localstack](https://github.com/localstack/localstack) on http://localhost:4568
+command you will run app with local mode, it will use local instance of kinesis provided by [localstack](https://github.com/localstack/localstack) on http://localhost:4566
 
 it is setup in `docker-compose.yml` file
 
-if you want to cleanup your local docker environment run 
+if you want to cleanup your local docker environment run
 
      docker-compose down -v --remove-orphans
 
 if you want to do a lookup what local kinesis contains run the following command:
 
     ./get-local-kinesis-records.sh
-    
+

--- a/get-local-kinesis-records.sh
+++ b/get-local-kinesis-records.sh
@@ -6,7 +6,7 @@ STREAM_NAME=${1:-media-service-DEV-thrall}
 LIMIT=${2:-100}
 
 ITERATOR=$(aws kinesis get-shard-iterator \
-  --endpoint-url=http://localhost:4568 \
+  --endpoint-url=http://localhost:4566 \
   --profile media-service \
   --region=eu-west-1 \
   --shard-id shardId-000000000000 \
@@ -16,7 +16,7 @@ ITERATOR=$(aws kinesis get-shard-iterator \
   --output text)
 
 DATA=$(aws kinesis get-records \
-  --endpoint-url=http://localhost:4568 \
+  --endpoint-url=http://localhost:4566 \
   --profile media-service \
   --region=eu-west-1 \
   --limit "$LIMIT" \

--- a/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala
+++ b/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class MetadataSqsMessageConsumer(config: EditsConfig, metadataEditorMetrics: MetadataEditorMetrics, store: EditsStore) extends SqsMessageConsumer(
-  config.queueUrl, config.awsEndpoint, config, metadataEditorMetrics.snsMessage) {
+  config.queueUrl, config, metadataEditorMetrics.snsMessage) {
 
   override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] =
     PartialFunction.condOpt(subject) {

--- a/scripts/generate-dot-properties/service-config.js
+++ b/scripts/generate-dot-properties/service-config.js
@@ -3,9 +3,7 @@ function stripMargin(template, ...args) {
     return result.replace(/\r?(\n)\s*\|/g, '$1');
 }
 
-const localKinesisURL='http://localhost:4568'
-
-const localDynamoURL='http://localhost:4569'
+const localstackURL ='http://localhost:4566'
 
 function getAuthConfig(config) {
     return stripMargin`
@@ -26,8 +24,7 @@ function getCollectionsConfig(config) {
         |dynamo.table.collections=${config.stackProps.CollectionsDynamoTable}
         |dynamo.table.imageCollections=${config.stackProps.ImageCollectionsDynamoTable}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
@@ -40,8 +37,7 @@ function getCropperConfig(config) {
         |publishing.image.bucket=${config.stackProps.ImageOriginBucket}
         |publishing.image.host=${config.stackProps.ImageOriginBucket}.s3.amazonaws.com
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
@@ -55,8 +51,7 @@ function getImageLoaderConfig(config) {
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
 }
@@ -87,8 +82,7 @@ function getLeasesConfig(config) {
         |aws.region=${config.aws.region}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |dynamo.tablename.leasesTable=${config.stackProps.LeasesDynamoTable}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
         |`;
@@ -102,8 +96,7 @@ function getMediaApiConfig(config) {
         |s3.thumb.bucket=${config.stackProps.ThumbBucket}
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |s3.config.bucket=${config.stackProps.ConfigBucket}
         |s3.usagemail.bucket=${config.stackProps.UsageMailBucket}
         |persistence.identifier=picdarUrn
@@ -124,8 +117,7 @@ function getMetadataEditorConfig(config) {
         |auth.keystore.bucket=${config.stackProps.KeyBucket}
         |s3.collections.bucket=${config.stackProps.CollectionsBucket}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |dynamo.table.edits=${config.stackProps.EditsDynamoTable}
         |indexed.images.sqs.queue.url=${config.stackProps.IndexedImageMetadataQueueUrl}
         |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
@@ -158,8 +150,7 @@ function getThrallConfig(config) {
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |`;
 }
 
@@ -173,8 +164,7 @@ function getUsageConfig(config) {
         |dynamo.tablename.usageRecordTable=${config.stackProps.UsageRecordTable}
         |composer.baseUrl=${config.composer.url}
         |thrall.kinesis.stream.name=${config.thrall.streamName}
-        |thrall.local.kinesis.url=${localKinesisURL}
-        |thrall.local.dynamodb.url=${localDynamoURL}
+        |aws.local.endpoint=${localstackURL}
         |crier.live.arn=${config.crier.live.roleArn}
         |crier.preview.arn=${config.crier.preview.roleArn}
         |crier.preview.name=${config.crier.preview.streamName}


### PR DESCRIPTION
## What does this change?
The latest version of localstack has a proxy running on 4566, this means we can talk to dynamo and kinesis on the same port which is a lot simpler.

## How can success be measured?
Keeping up to date.

Doing this in the hope that https://github.com/guardian/grid/pull/2896 can be merged back into master and CI succeeds.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
