### PR TITLE
Fix label suggester

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -139,8 +139,8 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
     }
 
     function suggestLabels(prefix) {
-        return mediaApi.labelsSuggest({q: prefix}).
-            then(labels => labels.data);
+        return mediaApi.labelSearch({q: prefix}).
+        then(results => results.data.map(res => res.key));
     }
 
     function suggestPhotoshoot(prefix) {


### PR DESCRIPTION
## What does this change?
For a long time, our labels suggester was broken (fixes https://github.com/guardian/grid/issues/1799). It was using defunct `labelsSuggest` which performs ppl-who-bough-also-bought kind of suggesting, which may be useful one day somewhere, but never when autocompleting existing labels! This switches it to use `labelSearch` instead.

## How can success be measured?
Sane autocompletion for labels.

## Screenshots (if applicable)
<img width="266" alt="image" src="https://user-images.githubusercontent.com/6032869/79336968-f2f64f00-7f24-11ea-86e7-cc6690d382c1.png">
Hello?!


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
