### PR TITLE
produce a thrall message with the correct subject for usage deletions

### DIFF
--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -193,7 +193,7 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
         respondError(InternalServerError, "image-usage-delete-failed", error.getMessage)
     }
 
-    val updateMessage = UpdateMessage(subject = " delete-usages", id = Some(mediaId))
+    val updateMessage = UpdateMessage(subject = "delete-usages", id = Some(mediaId))
     notifications.publish(updateMessage)
     Future.successful(Ok)
   }


### PR DESCRIPTION
## What does this change?
Pairing with @paperboyo, this corrects the subject of the message written to the kinesis stream for thrall when usages are deleted.

Thrall is looking for [`delete-usages`](https://github.com/guardian/grid/blob/ea3fe602b307e81c24273683ba03426e78fe054f/thrall/app/lib/kinesis/MessageProcessor.scala#L39) however we were producing ` delete-usages` 😅 and so thrall was dropping the message.

More reason to create the [sum type](https://github.com/guardian/grid/pull/2759)!

## How can success be measured?
Usage deletions work again!

## Screenshots (if applicable)
![img](https://media.giphy.com/media/CuKEZdZ3V01gI/giphy.gif)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
