### PR TITLE
Improve visibility of batch image status changes in logs

### DIFF
--- a/admin-tools/lambda/src/main/resources/logback.xml
+++ b/admin-tools/lambda/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 
   <appender name="STDOUT" class="io.symphonia.lambda.logging.DefaultConsoleAppender">
-    <encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
       <pattern>%m%n</pattern>
     </encoder>
   </appender>

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -218,7 +218,7 @@ class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
     val scanSpec = new ScanSpec()
       .withFilterExpression(s"$StateField in (:finished, :not_found, :in_progress)")
       .withValueMap(new ValueMap()
-        .withNumber(":finished", Finished.stateId)
+        .withNumber(":finished", Enqueued.stateId)
         .withNumber(":not_found", NotFound.stateId)
         .withNumber(":in_progress", InProgress.stateId)
       )
@@ -247,83 +247,82 @@ class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
     */
 
   def updateStateToItemsFound(ids: List[String]): ProduceProgress = {
-    logger.info(s"updating items state to found")
-    updateItemsState(ids, Found)
+    updateItemsState(ids, Verified)
   }
 
   def updateStateToInconsistent(ids: List[String]): ProduceProgress = {
-    logger.info(s"updating items state to inconsistent")
     updateItemsState(ids, Inconsistent)
   }
 
   // used to synchronise situation of other lambda execution will start while previous one is still running
   def updateStateToItemsLocating(ids: List[String]): ProduceProgress = {
-    logger.info(s"updating items state to locating")
     updateItemsState(ids, Locating)
   }
 
   // used to synchronise situation of other lambda execution will start while previous one is still running
   def updateStateToItemsInProgress(ids: List[String]): ProduceProgress = {
-    logger.info(s"updating items state to in progress")
     updateItemsState(ids, InProgress)
   }
 
   // used to track images that were not projected successfully
-  def updateStateToNotFoundImage(notFoundId: String) =
-    updateItemState(notFoundId, NotFound.stateId)
+  def updateStateToNotFoundImage(notFoundId: String) = {
+    updateItemState(notFoundId, NotFound)
+  }
 
   def updateStateToFound(ids: List[String]): ProduceProgress = {
     logger.info(s"updating items state to found")
-    updateItemsState(ids, Found)
+    updateItemsState(ids, Verified)
   }
 
   def updateStateToFinished(ids: List[String]): ProduceProgress = {
-    logger.info(s"updating items state to finished")
-    updateItemsState(ids, Finished)
+    updateItemsState(ids, Enqueued)
   }
 
   // used in situation if something failed
   def resetItemsState(ids: List[String]): ProduceProgress = {
-    logger.info("resetting items state")
     updateItemsState(ids, Reset)
   }
 
   // used in situation if something failed
   def resetItemState(id: String): ProduceProgress = {
-    logger.info("resetting items state")
-    updateItemState(id, Reset.stateId)
+    updateItemState(id, Reset)
     Reset
   }
 
   // used in situation if something failed in a expected way and we want to ignore that file in next batch
    def setStateToKnownError(id: String): ProduceProgress = {
-    logger.info("setting item to KnownError state to ignore it next time")
-    updateItemState(id, KnownError.stateId)
+    updateItemState(id, KnownError)
     KnownError
   }
 
   def setStateToUnknownError(id: String): ProduceProgress = {
-    logger.info("setting item to UnknownError state to ignore it next time")
-    updateItemState(id, UnknownError.stateId)
+    updateItemState(id, UnknownError)
     UnknownError
   }
 
   def setStateToTooBig(id: String, size: Int): ProduceProgress = {
     logger.info(Markers.appendEntries(Map("tooBigSize" -> size).asJava),s"setting item $id to TooBig state (size $size) to ignore it next time")
-    updateItemState(id, TooBig.stateId)
+    updateItemState(id, TooBig)
     TooBig
   }
 
-  private def updateItemState(id: String, state: Int) = {
+  private def updateItemState(id: String, progress: ProduceProgress) = {
+    logger.info("Updating item state")(
+      Markers.appendEntries(Map(
+        "progressState" -> progress.stateId,
+        "progressName" -> progress.name,
+        "imageId" -> id
+      ).asJava
+    ))
     val us = new UpdateItemSpec().
       withPrimaryKey(PKField, id).
       withUpdateExpression(s"set $StateField = :sub")
-      .withValueMap(new ValueMap().withNumber(":sub", state))
+      .withValueMap(new ValueMap().withNumber(":sub", progress.stateId))
     table.updateItem(us)
   }
 
   private def updateItemsState(ids: List[String], progress: ProduceProgress, imageSize: Option[Int] = None): ProduceProgress = {
-    ids.foreach(id => updateItemState(id, progress.stateId))
+    ids.foreach(id => updateItemState(id, progress))
     progress
   }
 

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -307,13 +307,11 @@ class InputIdsStore(table: Table, batchSize: Int) extends LazyLogging {
   }
 
   private def updateItemState(id: String, progress: ProduceProgress) = {
-    logger.info("Updating item state")(
-      Markers.appendEntries(Map(
-        "progressState" -> progress.stateId,
-        "progressName" -> progress.name,
-        "imageId" -> id
-      ).asJava
-    ))
+    logger.info(Markers.appendEntries(Map(
+      "progressState" -> progress.stateId,
+      "progressName" -> progress.name,
+      "imageId" -> id
+    ).asJava), "Updating item state")
     val us = new UpdateItemSpec().
       withPrimaryKey(PKField, id).
       withUpdateExpression(s"set $StateField = :sub")

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/indexing/package.scala
@@ -8,12 +8,12 @@ package object indexing {
 
     val NotStarted = ProduceProgress("at rest", 0)
     val InProgress = ProduceProgress("in progress", 1)
-    val NotFound = ProduceProgress("not found", 2)
-    val Finished = ProduceProgress("finished", 3)
+    val NotFound = ProduceProgress("not found by image-loader", 2)
+    val Enqueued = ProduceProgress("enqueued", 3)
     val Reset = ProduceProgress("reset because of failure", 0)
     val KnownError = ProduceProgress("blacklisted because of known failure", 4)
-    val Locating = ProduceProgress("looking for image",5)
-    val Found = ProduceProgress("image found", 6)
+    val Locating = ProduceProgress("looking for image", 5)
+    val Verified = ProduceProgress("image verified in media-api", 6)
     val Inconsistent = ProduceProgress("re-ingested image not found in media-api", 7)
     val UnknownError = ProduceProgress("blacklisted because of unknown failure", 8)
     val TooBig = ProduceProgress("too big, putting back down", 9001)
@@ -22,11 +22,11 @@ package object indexing {
       NotStarted,
       InProgress,
       NotFound,
-      Finished,
+      Enqueued,
       Reset,
       KnownError,
       Locating,
-      Found,
+      Verified,
       Inconsistent,
       UnknownError,
       TooBig

--- a/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
+++ b/admin-tools/scripts/src/main/scala/com/gu/mediaservice/ImagesGroupByProgressState.scala
@@ -38,7 +38,7 @@ object ImagesGroupByProgressState extends App with LazyLogging {
     logger.info(s"starting to calculate stats at dynamoTable=$dynamoTable")
 
     val result = Map(
-      stateNameToCount(Finished),
+      stateNameToCount(Enqueued),
       stateNameToCount(NotFound),
       stateNameToCount(KnownError),
       stateNameToCount(NotStarted),


### PR DESCRIPTION
## What does this change?

This PR improves the visibility of batch image status changes in logs. Previously, we were struggling to answer questions like 'which images were changed to this status', or 'what changes did this image undergo during the reingestion process'.

Adding structured logs for the image id, progress state and name should let us do just that.

This PR also adds additional configuration to logback to ensure that log levels (previously missing) are added correctly.

## How can success be measured?

When images change status, a log line should be visible that includes structured information about the progress status number, its name, and the image id. That log should be marked as `level: info.`

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
