### PR TITLE
include extra config with `file` directive

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -20,4 +20,4 @@ es {
 }
 
 # PROD only stuff (play secret etc)
-include "/etc/gu/grid-prod.properties"
+include file("/etc/gu/grid-prod.properties")


### PR DESCRIPTION
## What does this change?
In #2927 we're enabling running Grid locally in localstack. It's quite a big PR which makes it hard to properly reason about. This change can be shipped independently. Small and often over big bang.

Include extra config with `file` directive. Not entirely sure how this is working in TEST and PROD 🤔 

Before merging:
- [x] Update TEST config
- [x] Update PROD config

## How can success be measured?
no-op in TEST and PROD, but it allows us to use `/etc/gu/grid-prod.properties` for extra panda properties in DEV ([related commit](https://github.com/guardian/grid/pull/2927/commits/2b740eb3800579929435f573ac804973eb416b12) from from #2927).

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [x] on TEST
