### PR TITLE
Add identifiers for integration tests

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -1,4 +1,5 @@
-<button ng-class="{'small': ctrl.grSmall}"
+<button data-cy="it-add-label-button"
+        ng-class="{'small': ctrl.grSmall}"
         ng-click="ctrl.active = true"
         ng-disabled="ctrl.adding"
         ng-if="!ctrl.active"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -15,6 +15,7 @@
             </dd>
 
             <button
+                data-cy="it-edit-usage-rights-button"
                 ng-click="ctrl.showUsageRights = true"
                 ng-hide="!ctrl.userCanEdit || ctrl.showUsageRights"
                 class="image-info__edit">✎</button>
@@ -52,7 +53,8 @@
             </div>
 
             <div class="image-info__wrap metadata-line__info" ng-if="ctrl.metadata.description || ctrl.userCanEdit">
-                <button class="image-info__edit"
+                <button data-cy="it-edit-description-button"
+                        class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
                         ng-click="descriptionEditForm.$show()"
                         ng-hide="descriptionEditForm.$visible">✎</button>
@@ -97,7 +99,8 @@
 
             <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
             <dd class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
-                <button class="image-info__edit"
+                <button data-cy="it-edit-byline-button"
+                        class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
                         ng-click="bylineEditForm.$show()"
                         ng-hide="bylineEditForm.$visible"
@@ -122,7 +125,8 @@
 
             <dt ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
             <dd ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
-                <button class="image-info__edit"
+                <button data-cy="it-edit-credit-button"
+                        class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
                         ng-click="creditEditForm.$show()"
                         ng-hide="creditEditForm.$visible"
@@ -165,7 +169,8 @@
 
             <dt ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
             <dd ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
-                <button class="image-info__edit"
+                <button data-cy="it-edit-copyright-button"
+                        class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
                         ng-click="copyrightEditForm.$show()"
                         ng-hide="copyrightEditForm.$visible"

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,5 +1,6 @@
 <section ng-if="! ctrl.editInline">
-    <button class="image-info__edit"
+    <button data-cy="it-photoshoot-edit-button"
+            class="image-info__edit"
             ng-click="photoshootEditForm.$show()"
             ng-hide="photoshootEditForm.$visible">
         ✎

--- a/kahuna/public/js/edits/labeller.html
+++ b/kahuna/public/js/edits/labeller.html
@@ -22,7 +22,8 @@
             <a ui-sref="search.results({query: (label.data | queryLabelFilter)})"
                class="label__value label__link">{{label.data}}</a>
 
-            <button class="label__remove"
+            <button data-cy="it-remove-label-button"
+                    class="label__remove"
                     title="Remove label"
                     ng-click="ctrl.removeLabel(label.data)">
                 <gr-icon>close</gr-icon>

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -4,7 +4,7 @@
         gr-tooltip="Add lease"
         gr-tooltip-position="bottom">
 
-    <gr-icon ng-show="!ctrl.editing" ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
+    <gr-icon data-cy="it-add-lease-icon" ng-show="!ctrl.editing" ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span>
        <span ng-show="ctrl.adding">Updating...</span>
     </span>
@@ -103,7 +103,7 @@
         type="submit"
         title="Save new label"
         ng-disabled="ctrl.adding">
-        <gr-icon-label gr-icon="check">
+        <gr-icon-label data-cy="it-save-lease" gr-icon="check">
             <span ng-hide="ctrl.grSmall">Save</span>
         </gr-icon-label>
     </button>
@@ -135,7 +135,7 @@
               <p>{{::ctrl.formatEndTimestamp(lease.endDate)}}</p>
               <div>{{lease.notes}}</div>
             </div>
-            <gr-confirm-delete class="gr-delete-lease flex-right"
+            <gr-confirm-delete data-cy="it-confirm-delete-lease" class="gr-delete-lease flex-right"
               gr-on-confirm="ctrl.delete(lease)">
             </gr-confirm-delete>
 

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -16,6 +16,7 @@
         <!-- We reset the model here else properties remain attached to the\
         model, even though they don't exist in the form -->
         <select
+            data-cy="it-rights-select"
             class="full-width"
             ng-model="ctrl.category"
             ng-disabled="ctrl.saving"
@@ -89,6 +90,7 @@
                     <div ng-switch-when="string">
                         <input
                             id="ure-field-{{::fieldUniqueId}}"
+                            data-cy="it-edit-usage-input"
                             class="text-input form-input-text"
                             type="text"
                             name="{{ property.name }}"


### PR DESCRIPTION
## What does this change?

This PR adds IDs to various elements in the Grid UI, so they can be used by integration tests for the Grid. As the integration tests grow, more IDs or other identifiers are likely to be added, but these are the necessary IDs to get the tests currently implemented [here](https://github.com/guardian/editorial-tools-integration-tests).

Following a discussion [here](https://github.com/guardian/grid/pull/2935), `data-cy=` has been used to add identifiers, abiding by [Cypress best practices](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).

## How can success be measured?

Elements with IDs added still work as intended and the integration tests pass.


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [X] on TEST
