### PR TITLE
Move to ubuntu LTS for imaging

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -91,7 +91,7 @@ deployments:
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-imaging-eoan
+          Recipe: grid-imaging
         ImgOpsAmiId:
           BuiltBy: amigo
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?

~This is blocked on ansible properly supporting ubuntu 20.04. 
https://github.com/ansible/ansible/pull/69161~

We are using the normal ubuntu package and not the ppa.


This changes the imaging ami to `grid-imaging` from `grid-imaging-eoan`
Eoan wasn't LTS, so will run out of support soon. Now there's a new LTS version we can use that. 

Supercedes https://github.com/guardian/grid/pull/2847

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
