### PR TITLE
add instructions for creating root collections

### DIFF
--- a/dev/.env
+++ b/dev/.env
@@ -9,3 +9,5 @@ AWS_DEFAULT_REGION=eu-west-1
 
 CORE_STACK_NAME=grid-dev-core
 AUTH_STACK_NAME=grid-dev-auth
+
+API_KEY=dev-

--- a/dev/script/create-root-collection.sh
+++ b/dev/script/create-root-collection.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=${DIR}/../..
+
+COLLECTION_NAME=${1:-TEST}
+
+# load values from .env into environment variables
+# see https://stackoverflow.com/a/30969768/3868241
+set -o allexport
+# shellcheck source=../.env
+source "$ROOT_DIR/dev/.env"
+set +o allexport
+
+echo "creating root collection $COLLECTION_NAME"
+
+curl -s -X POST -H "X-Gu-Media-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "data": "'"$COLLECTION_NAME"'" }' \
+  "https://media-collections.$DOMAIN/collections"

--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -210,6 +210,22 @@ generateDotProperties() {
   echo "  configuration files created in /etc/gu"
 }
 
+uploadApiKey() {
+  echo "uploading an api key"
+  keyBucket=$(getStackResource "$CORE_STACK_NAME" KeyBucket)
+
+  target="/tmp/$API_KEY"
+
+  echo "DEV Key" > "$target"
+
+  aws s3 cp "$target" \
+    "s3://$keyBucket/" \
+    --endpoint-url $LOCALSTACK_ENDPOINT
+
+  rm "$target"
+  echo "  uploaded"
+}
+
 main() {
   clean
   startDocker
@@ -223,6 +239,7 @@ main() {
 
   setupDevNginx
   generateDotProperties
+  uploadApiKey
   echo "Setup complete. You're now able to start Grid!"
 }
 

--- a/docs/03-apis/01-authentication.md
+++ b/docs/03-apis/01-authentication.md
@@ -14,6 +14,8 @@ This is typically used for server-server authentication.
 API keys are stored in the `KeyBucket` of the cloudformation stack; drop a key file here and it'll get picked by Grid
 within 10 minutes and you'll be able to make authenticated calls.
 
+Note `setup.sh` creates an initial API key `dev-`.
+
 ### Creating a Key
 Generate a key file with a random string as the filename. The contents of the file should be the application name.
 

--- a/docs/03-apis/02-collections.md
+++ b/docs/03-apis/02-collections.md
@@ -1,0 +1,23 @@
+# Collections
+
+Collections are a way of organising images in Grid. Collections have a hierarchy similar to:
+
+```
+ROOT COLLECTION 1
+  ⎿ Collection A
+    ⎿ Collection B
+       ⎿ ...
+ROOT COLLECTION 2
+  ⎿ Collection C
+    ⎿ Collection D
+       ⎿ ...
+```
+
+## Root collections
+Currently, root collections can only be created via the API. That is, Kahuna doesn't have a UI for it.
+
+We can use [create-root-collection.sh](../../dev/script/create-root-collection.sh) to create a root collection:
+
+```shell script
+./dev/script/create-root-collection.sh COLLECTION_NAME
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,9 @@
 - [Kahuna](02-running/02-kahuna.md)
 - [Accessing logs](02-running/03-logging.md)
 
-## [Api access](03-api-access/)
-- [Authentication](03-api-access/01-authentication.md)
+## [Apis](03-apis/)
+- [Authentication](03-apis/01-authentication.md)
+- [Collections](03-apis/02-collections.md)
 
 ## [Troubleshooting](04-troubleshooting/)
 - [NGINX](04-troubleshooting/01-nginx.md)


### PR DESCRIPTION
## What does this change?
Root collections do not have a UI at the moment and the only way to create them is via the API. Provide a script to simplify this process.

This PR also updates `setup.sh` to create an API key.

We should replace this with [grid-cli](https://github.com/guardian/grid-cli#grid-collectionadd-root-name), however `grid-cli` needs to be installed and configured first...

## How can success be measured?
Collections are friendlier.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
