### PR TITLE
check JAVA_HOME is set

### DIFF
--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -226,7 +226,19 @@ uploadApiKey() {
   echo "  uploaded"
 }
 
+checkForJavaHome() {
+  echo "Checking JAVA_HOME"
+  if [[ -z "$JAVA_HOME" ]]; then
+    echo "  JAVA_HOME not set, please set it before continuing"
+    echo "  This can be done by adding \"export JAVA_HOME=\$(/usr/libexec/java_home)\" to ~/.profile"
+    exit 1
+  else
+    echo "  JAVA_HOME is set to $JAVA_HOME"
+  fi
+}
+
 main() {
+  checkForJavaHome
   clean
   startDocker
   createCoreStack

--- a/dev/script/start.sh
+++ b/dev/script/start.sh
@@ -111,7 +111,19 @@ checkNodeVersion() {
   fi
 }
 
+checkForJavaHome() {
+  echo "Checking JAVA_HOME"
+  if [[ -z "$JAVA_HOME" ]]; then
+    echo "  JAVA_HOME not set, please set it before continuing"
+    echo "  This can be done by adding \"export JAVA_HOME=\$(/usr/libexec/java_home)\" to ~/.profile"
+    exit 1
+  else
+    echo "  JAVA_HOME is set to $JAVA_HOME"
+  fi
+}
+
 main() {
+  checkForJavaHome
   hasCredentials
   checkRequirements
   checkNodeVersion


### PR DESCRIPTION
## What does this change?
`JAVA_HOME` is needed for a few reasons, including [mkcert](https://github.com/FiloSottile/mkcert#supported-root-stores) (via dev-nginx). Having `JAVA_HOME` set will inform mkcert of which Java keystore it should add its CA to. Without `JAVA_HOME` set, the application logs will contain PKIX errors relating to Java being unable to verify a certificate being served by our localstack instance, which is [proxied behind `https://localstack.media.local.dev-gutools.co.uk`](https://github.com/guardian/grid/blob/master/dev/nginx-mappings.yml.template#L34).

Related:
- https://github.com/guardian/grid/pull/2927#issuecomment-620428246
- https://github.com/guardian/workflow-frontend/pull/185
- https://confluence.atlassian.com/kb/unable-to-connect-to-ssl-services-due-to-pkix-path-building-failed-error-779355358.html
- https://github.com/guardian/dev-nginx/blob/master/script/setup-cert#L22

## How can success be measured?
- scripts fail fast
- fewer errors in logs

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
