### PR TITLE
Sentry strat 2: Examine errors to prevent Sentry from seeing failed HTTP requests

### DIFF
--- a/kahuna/public/js/sentry/sentry.js
+++ b/kahuna/public/js/sentry/sentry.js
@@ -27,8 +27,8 @@ function parseUnhandledRejectionMessage(errorMsg) {
   }
   const maybeMessageJson = errorMsg.substr(messageIndex + unhandledRejectionMessage.length);
   try {
-    return JSON.parse(maybeMessageJson)
-  } catch(e) {
+    return JSON.parse(maybeMessageJson);
+  } catch (e) {
     return;
   }
 }
@@ -47,7 +47,7 @@ function isHttpError(obj) {
   });
 
   return httpErrorProps.every(key => objKeys.indexOf(key) !== -1) ||
-    anyHttpErrorProps.every(key => objKeys.indexOf(key) !== -1)
+    anyHttpErrorProps.every(key => objKeys.indexOf(key) !== -1);
 }
 
 sentry.factory('sentryEnabled', ['sentryDsn', function(sentryDsn) {

--- a/kahuna/public/js/sentry/sentry.js
+++ b/kahuna/public/js/sentry/sentry.js
@@ -3,10 +3,51 @@ import raven from 'raven-js';
 
 export var sentry = angular.module('sentry', []);
 
+// Standard AngularJS HTTP request with $http
 const httpErrorProps = ['config', 'data', 'headers', 'status', 'statusText'];
+// HTTP request made with [AnyHttp](https://github.com/argo-rest/any-http-angular), used by Theseus (see theseus-angular.js)
+const anyHttpErrorProps = ['uri', 'body', 'status', 'headers'];
+
+const unhandledRejectionMessage = "Possibly unhandled rejection: ";
+
+/**
+ * Parses the JSON contained in an unhandled promise rejection, if it exists.
+ * Otherwise, returns undefined.
+ *
+ * @param {string} errorMsg
+ * @return {obj|undefined}
+ */
+function parseUnhandledRejectionMessage(errorMsg) {
+  if (typeof errorMsg !== "string") {
+    return;
+  }
+  const messageIndex = errorMsg.indexOf(unhandledRejectionMessage);
+  if (messageIndex === -1) {
+    return;
+  }
+  const maybeMessageJson = errorMsg.substr(messageIndex + unhandledRejectionMessage.length);
+  try {
+    return JSON.parse(maybeMessageJson)
+  } catch(e) {
+    return;
+  }
+}
+
+
+/**
+ * Does this object represent a failed HTTP request?
+ *
+ * @param {object} obj
+ * @returns {boolean}
+ */
 function isHttpError(obj) {
-    const objKeys = Object.keys(obj);
-    return httpErrorProps.every(key => objKeys.indexOf(key) !== -1);
+  const objKeys = Object.keys({
+    ...obj,
+    ...(parseUnhandledRejectionMessage(obj) || {})
+  });
+
+  return httpErrorProps.every(key => objKeys.indexOf(key) !== -1) ||
+    anyHttpErrorProps.every(key => objKeys.indexOf(key) !== -1)
 }
 
 sentry.factory('sentryEnabled', ['sentryDsn', function(sentryDsn) {
@@ -21,7 +62,7 @@ sentry.config(['$provide', function ($provide) {
 
             // Don't send failed HTTP requests as that's mostly just
             // noise we already get in other logs
-            if (! isHttpError(exception)) {
+            if (!isHttpError(exception)) {
                 raven.captureException(exception, cause);
             }
         };


### PR DESCRIPTION
## What does this change?

One way of preventing Sentry from seeing HTTP errors. The way it does this is ... well. You decide!

## How can success be measured?

HTTP errors no longer make it to Sentry.

## Tested?
- [x] locally
- [ ] on TEST
