### PR TITLE
Sentry strat 1: Catch no-op HTTP errors before they make it to Sentry

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.js
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.js
@@ -7,6 +7,7 @@ import './gr-add-label.css';
 import template from './gr-add-label.html';
 
 import '../../directives/gr-auto-focus';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export var addLabel = angular.module('gr.addLabel', [
     'kahuna.services.label',
@@ -58,11 +59,11 @@ addLabel.controller('GrAddLabelCtrl', [
 
         ctrl.labelSearch = (q) => {
             if (! q) {
-                return $q.resolve([]);
+              return $q.resolve([]);
             } else {
-                return mediaApi.labelSearch({q}).then(resource => {
-                    return resource.data.map(d => d.key);
-                });
+              return mediaApi.labelSearch({q})
+                .then(resource => resource.data.map(d => d.key))
+                .catch(handlePossibleHttpError)
             }
         };
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -5,6 +5,7 @@ import template from './gr-image-metadata.html';
 import '../../image/service';
 import '../../edits/service';
 import '../gr-description-warning/gr-description-warning';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export const module = angular.module('gr.imageMetadata', [
     'gr.image.service',
@@ -62,9 +63,9 @@ module.controller('grImageMetadataCtrl', [
         ];
 
         ctrl.metadataSearch = (field, q) => {
-            return mediaApi.metadataSearch(field,  { q }).then(resource => {
-                return resource.data.map(d => d.key);
-            });
+            return mediaApi.metadataSearch(field,  { q })
+              .then(resource => resource.data.map(d => d.key))
+              .catch(handlePossibleHttpError)
         };
 
         ctrl.credits = function(searchText) {

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -13,6 +13,7 @@ import '../../forms/gr-xeditable/gr-xeditable';
 import '../../util/rx';
 import { editOptions, overwrite } from '../../util/constants/editOptions';
 import {radioList} from '../gr-radio-list/gr-radio-list';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export const grInfoPanel = angular.module('grInfoPanel', [
   'kahuna.services.image-accessor',
@@ -157,9 +158,9 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     };
 
     ctrl.metadataSearch = (field, q) => {
-      return mediaApi.metadataSearch(field,  { q }).then(resource => {
-        return resource.data.map(d => d.key);
-      });
+      return mediaApi.metadataSearch(field,  { q })
+        .then(resource => resource.data.map(d => d.key))
+        .catch(handlePossibleHttpError)
     };
 
     ctrl.descriptionOption = overwrite.key;

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
@@ -6,6 +6,7 @@ import template from './gr-photoshoot.html';
 import '../../image/service';
 import '../../services/photoshoot';
 import '../../services/image-accessor';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export const photoshoot = angular.module('gr.photoshoot', [
     'gr.image.service',
@@ -58,7 +59,8 @@ photoshoot.controller('GrPhotoshootCtrl', [
 
         ctrl.search = (q) => {
             return mediaApi.metadataSearch('photoshoot', { q })
-                .then(resource => resource.data.map(d => d.key));
+              .then(resource => resource.data.map(d => d.key))
+              .catch(handlePossibleHttpError)
         };
 
         ctrl.save = (title) => {

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
@@ -6,6 +6,7 @@ import template from './gr-preset-labels.html';
 import '../../directives/gr-auto-focus';
 import '../../services/preset-label';
 import {mediaApi} from '../../services/api/media-api';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export var presetLabels = angular.module('gr.presetLabels', [
     'gr.autoFocus',
@@ -38,7 +39,9 @@ presetLabels.controller('GrPresetLabelsCtrl', [
             ctrl.presetLabels = presetLabelService.getLabels();
         };
 
-        ctrl.suggestedLabelsSearch = q => mediaApi.labelsSuggest({q}).then(labels => labels.data);
+        ctrl.suggestedLabelsSearch = q => mediaApi.labelsSuggest({q})
+          .then(labels => labels.data)
+          .catch(handlePossibleHttpError)
 
         function save(labels) {
             ctrl.adding = true;

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -8,6 +8,7 @@ import {leases} from '../leases/leases';
 import {archiver} from '../components/gr-archiver-status/gr-archiver-status';
 import {collectionsApi} from '../services/api/collections-api';
 import {rememberScrollTop} from '../directives/gr-remember-scroll-top';
+import {handlePossibleHttpError} from "../sentry/sentry";
 
 
 export var imageEditor = angular.module('kahuna.edits.imageEditor', [

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -21,7 +21,7 @@ import {async}  from './util/async';
 import {digest} from './util/digest';
 
 import wfAnalyticsServiceMod  from './analytics/analytics';
-import {sentry} from './sentry/sentry';
+import {handlePossibleHttpError, sentry} from './sentry/sentry';
 
 import {userActions}        from './common/user-actions';
 
@@ -151,9 +151,9 @@ kahuna.run(['$log', '$rootScope', 'mediaApi', function($log, $rootScope, mediaAp
 kahuna.run(['$rootScope', 'mediaApi',
             ($rootScope, mediaApi) => {
 
-    mediaApi.getSession().then(session => {
-        $rootScope.$emit('events:user-loaded', session.user);
-    });
+    mediaApi.getSession()
+      .then(session => $rootScope.$emit('events:user-loaded', session.user))
+      .catch(handlePossibleHttpError)
 }]);
 
 
@@ -306,9 +306,9 @@ kahuna.controller('SessionCtrl',
                   ['$scope', '$state', '$stateParams', 'mediaApi',
                    function($scope, $state, $stateParams, mediaApi) {
 
-    mediaApi.getSession().then(session => {
-        $scope.user = session.user;
-    });
+    mediaApi.getSession()
+      .then(session => { $scope.user = session.user })
+      .catch(handlePossibleHttpError)
 }]);
 
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -10,6 +10,7 @@ import {guDateRange} from '../components/gu-date-range/gu-date-range';
 import template from './query.html';
 import {syntax} from './syntax/syntax';
 import {grStructuredQuery} from './structured-query/structured-query';
+import {handlePossibleHttpError} from "../sentry/sentry";
 
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
@@ -171,7 +172,7 @@ query.controller('SearchQueryCtrl', [
           ctrl.filter.nonFree = session.user.permissions.showPaid ?
             session.user.permissions.showPaid : undefined;
         }
-    });
+    }).catch(handlePossibleHttpError)
 
 
     function resetQuery() {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -17,6 +17,7 @@ import '../components/gr-downloader/gr-downloader';
 import '../components/gr-batch-export-original-images/gr-batch-export-original-images';
 import '../components/gr-panel-button/gr-panel-button';
 import '../components/gr-toggle-button/gr-toggle-button';
+import {handlePossibleHttpError} from "../sentry/sentry";
 
 export var results = angular.module('kahuna.search.results', [
     'kahuna.services.scroll-position',
@@ -167,7 +168,7 @@ results.controller('SearchResultsCtrl', [
             return images;
         }).catch(error => {
             ctrl.loadingError = error;
-            return $q.reject(error);
+            handlePossibleHttpError(error);
         }).finally(() => {
             ctrl.loading = false;
         });
@@ -203,7 +204,7 @@ results.controller('SearchResultsCtrl', [
 
                 // images should not contain any 'holes'
                 ctrl.images = compact(ctrl.imagesAll);
-            });
+            }).catch(handlePossibleHttpError)
         };
 
         // == Vertical position ==
@@ -238,7 +239,7 @@ results.controller('SearchResultsCtrl', [
                     if (! scopeGone) {
                         checkForNewImages();
                     }
-                });
+                }).catch(handlePossibleHttpError);
             }, pollingPeriod);
         }
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import {List, Map} from 'immutable';
 
 import {mediaApi} from '../../services/api/media-api';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export const querySuggestions = angular.module('querySuggestions', [
     mediaApi.name
@@ -130,22 +131,26 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
 
     function suggestCredit(prefix) {
         return mediaApi.metadataSearch('credit', {q: prefix}).
-            then(results => results.data.map(res => res.key));
+            then(results => results.data.map(res => res.key)).
+            catch(handlePossibleHttpError);
     }
 
     function suggestSource(prefix) {
         return mediaApi.metadataSearch('source', {q: prefix}).
-            then(results => results.data.map(res => res.key));
+            then(results => results.data.map(res => res.key)).
+            catch(handlePossibleHttpError);
     }
 
     function suggestLabels(prefix) {
         return mediaApi.labelsSuggest({q: prefix}).
-            then(labels => labels.data);
+            then(labels => labels.data).
+            catch(handlePossibleHttpError);
     }
 
     function suggestPhotoshoot(prefix) {
         return mediaApi.metadataSearch('photoshoot', {q: prefix}).
-        then(results => results.data.map(res => res.key));
+          then(results => results.data.map(res => res.key)).
+          catch(handlePossibleHttpError);
     }
 
     function getFilterSuggestions(field, value) {

--- a/kahuna/public/js/upload/recent/recent-uploads.js
+++ b/kahuna/public/js/upload/recent/recent-uploads.js
@@ -4,6 +4,7 @@ import '../../edits/image-editor';
 import '../../components/gr-delete-image/gr-delete-image';
 
 import template from './recent-uploads.html';
+import {handlePossibleHttpError} from "../../sentry/sentry";
 
 export let recentUploads = angular.module('kahuna.upload.recent', [
     'kahuna.edits.imageEditor',
@@ -45,7 +46,7 @@ recentUploads.controller('RecentUploadsCtrl', [
                     }
                 });
             });
-        });
+        }).catch(handlePossibleHttpError);
 
         ctrl.canBeDeleted = (image) => deletableImages.has(image.data.id);
 


### PR DESCRIPTION
## What does this change?

A way of preventing Sentry from seeing HTTP errors – adding a catch handler to each function that's missing one, with a utility function that filters out HTTP failures but allows other errors to propagate.

I've added handler code to `mediaApi` calls for now – if this approach is good, we can extend it to other hypermedia services.

## How can success be measured?

HTTP errors no longer make it to Sentry.

## Tested?
- [x] locally
- [ ] on TEST
