### PR TITLE
cache sbt dependencies in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
       with:
         path: ~/.ivy2/cache
         key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    - name: Cache SBT coursier cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.coursier/cache
+        key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
     - name: Cache SBT
       uses: actions/cache@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           npm install
           npm run riffraff-artefact
   ScalaBuild:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     services:
       elasticsearch:
         image: elasticsearch:7.5.2
@@ -72,11 +72,13 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+    - name: Setup JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
     - name: SBT
-      uses: ./.github/actions/sbt
       env:
         USE_DOCKER_FOR_TESTS: false
         ES6_TEST_URL: http://elasticsearch:9200
         LOCALSTACK_ENDPOINT: http://localstack:4566
-      with:
-        args: clean compile test
+      run: sbt clean compile test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+    container:
+      image: mozilla/sbt
+      volumes:
+        - /home/runner/.ivy2:/root/.ivy2
+        - /home/runner/.coursier:/root/.coursier
+        - /home/runner/.sbt:/root/.sbt
     steps:
     - uses: actions/checkout@v1
     - name: Cache SBT ivy cache
@@ -72,13 +78,10 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Setup JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
     - name: SBT
       env:
         USE_DOCKER_FOR_TESTS: false
         ES6_TEST_URL: http://elasticsearch:9200
         LOCALSTACK_ENDPOINT: http://localstack:4566
-      run: sbt clean compile test
+      run: |
+        sbt clean compile test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,16 @@ jobs:
           --health-retries 10
     steps:
     - uses: actions/checkout@v1
+    - name: Cache SBT ivy cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ivy2/cache
+        key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    - name: Cache SBT
+      uses: actions/cache@v1
+      with:
+        path: ~/.sbt
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: SBT
       uses: ./.github/actions/sbt
       env:


### PR DESCRIPTION
## What does this change?
Caching should improve build time.

See: https://github.com/actions/cache/blob/master/examples.md#scala---sbt

## How can success be measured?
Scala build time in GitHub Actions is faster.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
