### PR TITLE
Remove overscroll behaviour

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -78,6 +78,7 @@ body {
     margin: 0;
     padding: 0 0 0 0;
     font-synthesis: none;
+    overscroll-behavior: none;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## What does this change?
It serves death to bounce.

## How can success be measured?
No unnecessary movement; we are fine with not having it at the very bottom of the search results. Because one day, there isn’t going to be the bottom.

## Dżif:
![Bounce](https://user-images.githubusercontent.com/6032869/81748757-4adf9180-94a2-11ea-8a6e-12d1c4f99989.gif)


## Who should look at this?
@guardian/digital-cms & @itsibitzi


## Tested?
- [x] locally
- [ ] on TEST
