### PR TITLE
Prevent swimming images

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -78,6 +78,7 @@ body {
     margin: 0;
     padding: 0 0 0 0;
     font-synthesis: none;
+    overflow: hidden;
     overscroll-behavior: none;
 }
 


### PR DESCRIPTION
This tries to prevents further unnecessary scrolling possible:

![Moves](https://user-images.githubusercontent.com/6032869/81942159-b08e6380-95f1-11ea-9a07-1b2214e31514.gif)
 

Possibly related to my [earlier change](https://github.com/guardian/grid/pull/2950), but possibly not.


## Tested?
- [ ] locally
- [ ] on TEST
