### PR TITLE
Add “ via ” as byline and credit tokeniser

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -21,8 +21,8 @@ object BylineCreditReorganise extends MetadataCleaner {
   def removeBylineFromCredit(bylineField: Field, creditField: Field) =
     bylineField.map { byline =>
       val credit = creditField.getOrElse("")
-      val bylineParts = byline.split("/").filter(!_.isEmpty)
-      val creditParts = credit.split("/").filter(!_.isEmpty)
+      val bylineParts = byline.split(" via |/").filter(!_.isEmpty)
+      val creditParts = credit.split(" via |/").filter(!_.isEmpty)
 
       // It's very difficult to decide how to reorganise the byline or credits if they're both single tokens
       // since we'd need to know what's likely to be a name and what's likely to be an organisation.

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -25,7 +25,7 @@ object RedundantTokenRemover extends MetadataCleaner {
     byline = metadata.byline.map(removeHandoutTokens).filter(_.trim.nonEmpty).map(_.trim),
     credit = metadata.credit.map(removeHandoutTokens).flatMap { c =>
       if (c.isEmpty) {
-        metadata.credit.flatMap(c => c.split("/").lastOption)
+        metadata.credit.flatMap(c => c.split(" via |/").lastOption)
       } else {
         Some(c)
       }
@@ -33,7 +33,7 @@ object RedundantTokenRemover extends MetadataCleaner {
   )
 
   def removeHandoutTokens(text: String): String = {
-    text.split("/").filter { tok =>
+    text.split(" via |/").filter { tok =>
       val trimmedToken = tok.trim
       !toRemove.contains(trimmedToken)
     }.mkString("/")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -252,7 +252,7 @@ object ReutersParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     // Reuters and other misspellings
     // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("via Reuters") => image.copy(
+    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUETRS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("via Reuters") => image.copy(
       usageRights = Agency("Reuters"),
       metadata = image.metadata.copy(credit = Some("Reuters"))
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -59,7 +59,7 @@ object AapParser extends ImageProcessor {
 
 object ActionImagesParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Action Images") | Some("Action Images via Reuters") => image.copy(
+    case Some("Action Images") | Some("Action Images/Reuters") => image.copy(
       usageRights = Agency("Action Images")
     )
     case _ => image
@@ -252,7 +252,7 @@ object ReutersParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     // Reuters and other misspellings
     // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") => image.copy(
+    case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("via Reuters") => image.copy(
       usageRights = Agency("Reuters"),
       metadata = image.metadata.copy(credit = Some("Reuters"))
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -78,7 +78,7 @@ object UsageRightsConfig {
     "Rex Features",
     "Ronald Grant Archive",
     "Action Images",
-    "Action Images via Reuters"
+    "Action Images/Reuters"
   )
 
   val suppliersCollectionExcl = Map(

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -39,7 +39,7 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
     .whenCleaned("Andy Rowland", "UK Sports Pics Ltd")
   }
 
-  it ("should remove the byline from credit if matching") {
+  it ("should remove the byline from credit if matching, via case") {
     CreditByline("Andy Rowland", "Andy Rowland via UK Sports Pics Ltd")
       .whenCleaned("Andy Rowland", "UK Sports Pics Ltd")
   }
@@ -59,7 +59,7 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
       .whenCleaned("Philip Glass", "Barcroft Media")
   }
 
-  it ("should remove organisation from byline") {
+  it ("should remove organisation from byline, via case") {
     CreditByline("Philip Glass via Barcroft Media", "Barcroft Media")
       .whenCleaned("Philip Glass", "Barcroft Media")
   }
@@ -79,7 +79,7 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
       .whenCleaned("John Doe", "BPI/REX")
   }
 
-  it ("should handle empty credit when byline has organisation names") {
+  it ("should handle empty credit when byline has organisation names, via case") {
     CreditByline("John Doe via BPI/REX", "")
       .whenCleaned("John Doe", "BPI/REX")
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -19,6 +19,11 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
     .whenCleaned("Ella", "Ella Ling/BPI/REX")
   }
 
+  it ("should normalise via to slash") {
+    CreditByline("Philip Glass", "Anadolu Agency via Getty Images")
+      .whenCleaned("Philip Glass", "Anadolu Agency/Getty Images")
+  }
+
   it ("should remove matching byline from credit in triple slash") {
     CreditByline("Ella Ling/BPI/REX", "Ella Ling/BPI/REX")
     .whenCleaned("Ella Ling"        , "BPI/REX")
@@ -32,6 +37,11 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
   it ("should remove the byline from credit if matching") {
     CreditByline("Andy Rowland", "Andy Rowland/UK Sports Pics Ltd")
     .whenCleaned("Andy Rowland", "UK Sports Pics Ltd")
+  }
+
+  it ("should remove the byline from credit if matching") {
+    CreditByline("Andy Rowland", "Andy Rowland via UK Sports Pics Ltd")
+      .whenCleaned("Andy Rowland", "UK Sports Pics Ltd")
   }
 
   it ("should return the same if matching") {
@@ -49,6 +59,11 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
       .whenCleaned("Philip Glass", "Barcroft Media")
   }
 
+  it ("should remove organisation from byline") {
+    CreditByline("Philip Glass via Barcroft Media", "Barcroft Media")
+      .whenCleaned("Philip Glass", "Barcroft Media")
+  }
+
   it ("should handle empty byline") {
     CreditByline("", "Barcroft Media")
       .whenCleaned("", "Barcroft Media")
@@ -61,6 +76,11 @@ class BylineCreditReorganiseTest extends FunSpec with Matchers with MetadataHelp
 
   it ("should handle empty credit when byline has organisation names") {
     CreditByline("John Doe/BPI/REX", "")
+      .whenCleaned("John Doe", "BPI/REX")
+  }
+
+  it ("should handle empty credit when byline has organisation names") {
+    CreditByline("John Doe via BPI/REX", "")
       .whenCleaned("John Doe", "BPI/REX")
   }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemoverTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemoverTest.scala
@@ -3,8 +3,8 @@ package com.gu.mediaservice.lib.cleanup
 import org.scalatest.{FunSpec, Matchers}
 
 class RedundantTokenRemoverTest extends FunSpec with Matchers with MetadataHelper {
-  // We've seen both "/" and " / " in the wild so test with both
-  val separators = List("/", " / ")
+  // We've seen "/", " via " and " / " in the wild so test with both
+  val separators = List("/", " / ", " via ")
 
   separators.foreach { s =>
     it (s"Remove redundant byline, keep redundant credit - '$s' separator") {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -62,12 +62,12 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     }
   }
 
-  describe("Action Images via Reuters") {
-    it("should match 'Action Images via Reuters' credit") {
-      val image = createImageFromMetadata("credit" -> "Action Images via Reuters")
+  describe("Action Images/Reuters") {
+    it("should match 'Action Images/Reuters' credit") {
+      val image = createImageFromMetadata("credit" -> "Action Images/Reuters")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Action Images"))
-      processedImage.metadata.credit should be(Some("Action Images via Reuters"))
+      processedImage.metadata.credit should be(Some("Action Images/Reuters"))
     }
   }
 
@@ -169,7 +169,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     }
   }
 
-  
+
   describe("Corbis") {
     it("should match Corbis source") {
       val image = createImageFromMetadata("credit" -> "Demotix/Corbis", "source" -> "Corbis")
@@ -250,18 +250,18 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.credit should be(Some("Getty Images/Ikon Images"))
     }
 
-    it("should match 'Bloomberg via Getty Images' credit") {
-      val image = createImageFromMetadata("credit" -> "Bloomberg via Getty Images", "source" -> "Bloomberg")
+    it("should match 'Bloomberg/Getty Images' credit") {
+      val image = createImageFromMetadata("credit" -> "Bloomberg/Getty Images", "source" -> "Bloomberg")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Getty Images", Some("Bloomberg")))
-      processedImage.metadata.credit should be(Some("Bloomberg via Getty Images"))
+      processedImage.metadata.credit should be(Some("Bloomberg/Getty Images"))
     }
 
-    it("should match 'Some Long Provider via Getty Im' credit") {
-      val image = createImageFromMetadata("credit" -> "Some Long Provider via Getty Im", "source" -> "Some Long Provider")
+    it("should match 'Some Long Provider/Getty Im' credit") {
+      val image = createImageFromMetadata("credit" -> "Some Long Provider/Getty Im", "source" -> "Some Long Provider")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Getty Images", Some("Some Long Provider")))
-      processedImage.metadata.credit should be(Some("Some Long Provider via Getty Im"))
+      processedImage.metadata.credit should be(Some("Some Long Provider/Getty Im"))
     }
 
     it("should match 'Getty Images for Apple' credit") {
@@ -407,7 +407,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.usageRights should be(Agency("Ronald Grant Archive"))
       processedImage.metadata.credit should be(Some("Ronald Grant"))
     }
-    
+
     it("should match Ronald Grant Archive credit") {
       val image = createImageFromMetadata("credit" -> "Ronald Grant Archive")
       val processedImage = applyProcessors(image)


### PR DESCRIPTION
This adjusts our byline and credit fields cleaners to treat ` via ` exactly as they treat `/`. It provides more consistency in how we display information from different suppliers. It allows more of our cleaners to operate on wider set of bylines and credits. Some suppliers’ logic and its tests were adjusted too.

|Before:|After:|
|--|--|
|byline: `Agencja Gazeta`|byline: `Agencja Gazeta`|
|credit: `via Reuters`|credit: `Reuters`|
| | |
|byline: `Andrew Boyers`|byline: `Andrew Boyers`|
|credit: `Action Images via Reuters`|credit: `Action Images/Reuters`|
| | |
|byline: `Ed Garvey`|byline: `Ed Garvey`|
|credit: `Manchester City FC via EMPICS/PA Photos`|credit: `Manchester City FC/EMPICS/PA Photos`|
| | |
|byline: `Bloomberg`|byline: `Bloomberg`|
|credit: `Bloomberg via Getty Images`|credit: `Getty Images`|

One remaining issue is that this doesn’t deal with cleaners not being able to clean fields where those start with `via ` (`via Reuters` example at the top above is dealt with by supplierProcessor [change](https://github.com/guardian/grid/commit/86f0fb1e500b39c3710c87b9cb9db0432ef14d6e#diff-4b854d8f2e0bc0725c5b4804936b7875R255) separately*), so we can still have 

originalByline: `PIPPA FOWLES/10 DOWNING STREET`
original credit: `via REUTERS`
being cleaned to
byline: `Pippa Fowles`
credit: `10 DOWNING STREET/via REUTERS`

To sort this out, we would need to:
1. Adjust cleaners to remove tokenisers at the beginning of fields
2. Adjust supplierProcessor to work on last token in credit instead of the whole credit.

*two Reuters-related changes in this PR should be their own PR, but aren’t. Changes to business logic [shouldn’t require](https://github.com/guardian/grid/pull/2618) a PR anyway ;-)

@guardian/digital-cms & @itsibitzi (cos cleaners)

## Tested?
- [x] locally
- [x] on TEST
