### PR TITLE
Update gr-collection-overlay.css

### DIFF
--- a/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.css
+++ b/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.css
@@ -23,7 +23,7 @@
 
 .collection-overlay__collections {
     background: rgba(68, 68, 68, 1);
-    height: calc(100vh);
+    height: calc(100vh - 60px);
     position: fixed;
     top: 30px;
     left: 50%;


### PR DESCRIPTION
## What does this change?
Updates the height of the collection picker modal overlay in recent uploads page to account for the element having a `top` offset.

`60px` because it is twice that of the `top` (30px) so it is still centred.

## How can success be measured?
All collections can be accessed on the uploads page.

## Screenshots (if applicable)
**Before**
![image](https://user-images.githubusercontent.com/836140/83013448-f2b59d00-a014-11ea-89b4-4fd5df241be8.png)

**After**
![image](https://user-images.githubusercontent.com/836140/83013435-ea5d6200-a014-11ea-9b87-48bf3b90bf80.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
