### PR TITLE
Feature/add people in image metadata

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -98,6 +98,7 @@ object Mappings {
     standardAnalysed("city").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("state").copyTo("metadata.englishAnalysedCatchAll"),
     standardAnalysed("country").copyTo("metadata.englishAnalysedCatchAll"),
+    nonAnalysedList("peopleInImage").copyTo("metadata.englishAnalysedCatchAll"),
     sStemmerAnalysed("englishAnalysedCatchAll")
   )
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -28,10 +28,12 @@ object ImageMetadataConverter {
     val xmpIptcPeople = fileMetadata.xmp.filterKeys(_ matches "Iptc4xmpExt:PersonInImage\\[\\d+\\]")
       .values
       .toList
+      .map(_.toString)
 
     val xmpGettyPeople = fileMetadata.xmp.filterKeys(_ matches "GettyImagesGIFT:Personality\\[\\d+\\]")
       .values
       .toList
+      .map(_.toString)
 
     (xmpIptcPeople ::: xmpGettyPeople).distinct
   }
@@ -89,8 +91,9 @@ object ImageMetadataConverter {
                             fileMetadata.iptc.get("Province/State"),
       country             = readXmpHeadStringProp("photoshop:Country") orElse
                             fileMetadata.iptc.get("Country/Primary Location Name"),
-      subjects            = extractSubjects(fileMetadata)),
+      subjects            = extractSubjects(fileMetadata),
       peopleInImage       = extractPeople(fileMetadata)
+    )
   }
 
   // IPTC doesn't appear to enforce the datetime format of the field, which means we have to

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -28,9 +28,12 @@ object ImageMetadataConverter {
     val xmpIptcPeople = fileMetadata.xmp.filterKeys(_ matches "Iptc4xmpExt:PersonInImage\\[\\d+\\]")
       .values
       .toList
-      .distinct
 
-    xmpIptcPeople // There may be other metadata that contains who is in the image we could use
+    val xmpGettyPeople = fileMetadata.xmp.filterKeys(_ matches "GettyImagesGIFT:Personality\\[\\d+\\]")
+      .values
+      .toList
+
+    (xmpIptcPeople ::: xmpGettyPeople).distinct
   }
 
   def fromFileMetadata(fileMetadata: FileMetadata): ImageMetadata = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -28,12 +28,18 @@ object ImageMetadataConverter {
     val xmpIptcPeople = fileMetadata.xmp.filterKeys(_ matches "Iptc4xmpExt:PersonInImage\\[\\d+\\]")
       .values
       .toList
-      .map(_.toString)
+      .flatMap{
+        case JsString(value) => Some(value)
+        case _ => None
+      }
 
     val xmpGettyPeople = fileMetadata.xmp.filterKeys(_ matches "GettyImagesGIFT:Personality\\[\\d+\\]")
       .values
       .toList
-      .map(_.toString)
+      .flatMap{
+        case JsString(value) => Some(value)
+        case _ => None
+      }
 
     (xmpIptcPeople ::: xmpGettyPeople).distinct
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -24,6 +24,15 @@ object ImageMetadataConverter {
       .distinct
   }
 
+  private def extractPeople(fileMetadata: FileMetadata): List[String] = {
+    val xmpIptcPeople = fileMetadata.xmp.filterKeys(_ matches "Iptc4xmpExt:PersonInImage\\[\\d+\\]")
+      .values
+      .toList
+      .distinct
+
+    xmpIptcPeople // There may be other metadata that contains who is in the image we could use
+  }
+
   def fromFileMetadata(fileMetadata: FileMetadata): ImageMetadata = {
     val xmp = fileMetadata.xmp
     val readXmpHeadStringProp: String => Option[String] = (name: String) => {
@@ -77,7 +86,8 @@ object ImageMetadataConverter {
                             fileMetadata.iptc.get("Province/State"),
       country             = readXmpHeadStringProp("photoshop:Country") orElse
                             fileMetadata.iptc.get("Country/Primary Location Name"),
-      subjects            = extractSubjects(fileMetadata))
+      subjects            = extractSubjects(fileMetadata)),
+      peopleInImage       = extractPeople(fileMetadata)
   }
 
   // IPTC doesn't appear to enforce the datetime format of the field, which means we have to

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -23,7 +23,8 @@ case class ImageMetadata(
   city:                Option[String]   = None,
   state:               Option[String]   = None,
   country:             Option[String]   = None,
-  subjects:            List[String]     = Nil
+  subjects:            List[String]     = Nil,
+  peopleInImage:       List[String]     = Nil
 )
 
 object ImageMetadata {
@@ -47,7 +48,8 @@ object ImageMetadata {
       (__ \ "city").readNullable[String] ~
       (__ \ "state").readNullable[String] ~
       (__ \ "country").readNullable[String] ~
-      (__ \ "subjects").readNullable[List[String]].map(_ getOrElse Nil)
+      (__ \ "subjects").readNullable[List[String]].map(_ getOrElse Nil) ~
+      (__ \ "peopleInImage").readNullable[List[String]].map(_ getOrElse Nil)
     )(ImageMetadata.apply _)
 
   implicit val IptcMetadataWrites: Writes[ImageMetadata] = (
@@ -68,7 +70,8 @@ object ImageMetadata {
       (__ \ "city").writeNullable[String] ~
       (__ \ "state").writeNullable[String] ~
       (__ \ "country").writeNullable[String] ~
-      (__ \ "subjects").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l))
+      (__ \ "subjects").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l)) ~
+      (__ \ "peopleInImage").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l))
     )(unlift(ImageMetadata.unapply))
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -24,7 +24,7 @@ case class ImageMetadata(
   state:               Option[String]   = None,
   country:             Option[String]   = None,
   subjects:            List[String]     = Nil,
-  peopleInImage:       List[String]     = Nil
+  peopleInImage:       Set[String]      = Set()
 )
 
 object ImageMetadata {
@@ -49,7 +49,7 @@ object ImageMetadata {
       (__ \ "state").readNullable[String] ~
       (__ \ "country").readNullable[String] ~
       (__ \ "subjects").readNullable[List[String]].map(_ getOrElse Nil) ~
-      (__ \ "peopleInImage").readNullable[List[String]].map(_ getOrElse Nil)
+      (__ \ "peopleInImage").readNullable[Set[String]].map(_ getOrElse Set())
     )(ImageMetadata.apply _)
 
   implicit val IptcMetadataWrites: Writes[ImageMetadata] = (
@@ -71,7 +71,7 @@ object ImageMetadata {
       (__ \ "state").writeNullable[String] ~
       (__ \ "country").writeNullable[String] ~
       (__ \ "subjects").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l)) ~
-      (__ \ "peopleInImage").writeNullable[List[String]].contramap((l: List[String]) => if (l.isEmpty) None else Some(l))
+      (__ \ "peopleInImage").writeNullable[Set[String]].contramap((l: Set[String]) => if (l.isEmpty) None else Some(l))
     )(unlift(ImageMetadata.unapply))
 
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -369,7 +369,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   // People in Image
 
   it("should populate peopleInImage field of ImageMetadata from corresponding xmp iptc ext fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1")))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage" -> JsArray(Seq(JsString("person 1")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (Set("person 1"))
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -375,31 +375,49 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   }
 
   it("should populate peopleInImage field of ImageMetadata from multiple corresponding people xmp fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
-      "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "Iptc4xmpExt:PersonInImage[3]" -> JsString("person 3"),
-      "GettyImagesGIFT:Personality[1]" -> JsString("person 4")))
+    val fileMetadata = FileMetadata(
+      Map(), Map(), Map(),
+      Map("Iptc4xmpExt:PersonInImage" ->
+        JsArray(
+          JsString("person 1"),
+          JsString("person 2"),
+          JsString("person 3")),
+      "GettyImagesGIFT:Personality" ->
+      JsArray(JsString("person 4"))
+      )
+    )
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (Set("person 1","person 2","person 3","person 4"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
-      "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "Iptc4xmpExt:PersonInImage[3]" -> JsString("person 2")))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(),
+      Map("Iptc4xmpExt:PersonInImage" ->
+        JsArray(
+          JsString("person 1"),
+          JsString("person 2"),
+          JsString("person 2")
+        )
+      ))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (Set("person 1","person 2"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp people fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
-      "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "GettyImagesGIFT:Personality[1]" -> JsString("person 2")))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(),
+      Map(
+        "Iptc4xmpExt:PersonInImage" -> JsArray(
+          JsString("person 1"),
+          JsString("person 2")
+        ),
+        "GettyImagesGIFT:Personality" -> JsArray(
+          JsString("person 2")
+        )
+      )
+    )
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (Set("person 1","person 2"))
   }
 
-  it("should ignore invalid peopleInImage field of ImageMetadata") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[-1]" -> JsString("person 1")))
-    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.peopleInImage should be ('empty)
-  }
 
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -374,16 +374,24 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     imageMetadata.peopleInImage should be (List("person 1"))
   }
 
-  it("should populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
+  it("should populate peopleInImage field of ImageMetadata from multiple corresponding people xmp fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
-      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 3"))
+      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 3",
+      "GettyImagesGIFT:Personality[1]" -> "person 4"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.peopleInImage should be (List("person 1","person 2","person 3"))
+    imageMetadata.peopleInImage should be (List("person 1","person 2","person 3","person 4"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
       "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 2"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.peopleInImage should be (List("person 1","person 2"))
+  }
+
+  it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp people fields") {
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
+      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "GettyImagesGIFT:Personality[1]" -> "person 2"))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (List("person 1","person 2"))
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -378,12 +378,12 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     val fileMetadata = FileMetadata(
       Map(), Map(), Map(),
       Map("Iptc4xmpExt:PersonInImage" ->
-        JsArray(
+        JsArray(Seq(
           JsString("person 1"),
           JsString("person 2"),
-          JsString("person 3")),
+          JsString("person 3"))),
       "GettyImagesGIFT:Personality" ->
-      JsArray(JsString("person 4"))
+      JsArray(Seq(JsString("person 4")))
       )
     )
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
@@ -393,11 +393,11 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(),
       Map("Iptc4xmpExt:PersonInImage" ->
-        JsArray(
+        JsArray(Seq(
           JsString("person 1"),
           JsString("person 2"),
           JsString("person 2")
-        )
+        ))
       ))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (Set("person 1","person 2"))
@@ -406,13 +406,13 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp people fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(),
       Map(
-        "Iptc4xmpExt:PersonInImage" -> JsArray(
+        "Iptc4xmpExt:PersonInImage" -> JsArray(Seq(
           JsString("person 1"),
           JsString("person 2")
-        ),
-        "GettyImagesGIFT:Personality" -> JsArray(
+        )),
+        "GettyImagesGIFT:Personality" -> JsArray(Seq(
           JsString("person 2")
-        )
+        ))
       )
     )
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -369,35 +369,35 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   // People in Image
 
   it("should populate peopleInImage field of ImageMetadata from corresponding xmp iptc ext fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1"))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (List("person 1"))
   }
 
   it("should populate peopleInImage field of ImageMetadata from multiple corresponding people xmp fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
-      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 3",
-      "GettyImagesGIFT:Personality[1]" -> "person 4"))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
+      "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "Iptc4xmpExt:PersonInImage[3]" -> JsString("person 3"),
+      "GettyImagesGIFT:Personality[1]" -> JsString("person 4")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (List("person 1","person 2","person 3","person 4"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
-      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 2"))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
+      "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "Iptc4xmpExt:PersonInImage[3]" -> JsString("person 2")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (List("person 1","person 2"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp people fields") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
-      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "GettyImagesGIFT:Personality[1]" -> "person 2"))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
+      "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "GettyImagesGIFT:Personality[1]" -> JsString("person 2")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be (List("person 1","person 2"))
   }
 
   it("should ignore invalid peopleInImage field of ImageMetadata") {
-    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[-1]" -> "person 1"))
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[-1]" -> JsString("person 1")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.peopleInImage should be ('empty)
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -371,7 +371,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should populate peopleInImage field of ImageMetadata from corresponding xmp iptc ext fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.peopleInImage should be (List("person 1"))
+    imageMetadata.peopleInImage should be (Set("person 1"))
   }
 
   it("should populate peopleInImage field of ImageMetadata from multiple corresponding people xmp fields") {
@@ -379,21 +379,21 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
       "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "Iptc4xmpExt:PersonInImage[3]" -> JsString("person 3"),
       "GettyImagesGIFT:Personality[1]" -> JsString("person 4")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.peopleInImage should be (List("person 1","person 2","person 3","person 4"))
+    imageMetadata.peopleInImage should be (Set("person 1","person 2","person 3","person 4"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
       "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "Iptc4xmpExt:PersonInImage[3]" -> JsString("person 2")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.peopleInImage should be (List("person 1","person 2"))
+    imageMetadata.peopleInImage should be (Set("person 1","person 2"))
   }
 
   it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp people fields") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> JsString("person 1"),
       "Iptc4xmpExt:PersonInImage[2]" -> JsString("person 2"), "GettyImagesGIFT:Personality[1]" -> JsString("person 2")))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.peopleInImage should be (List("person 1","person 2"))
+    imageMetadata.peopleInImage should be (Set("person 1","person 2"))
   }
 
   it("should ignore invalid peopleInImage field of ImageMetadata") {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -10,22 +10,23 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
   it("should return an empty ImageMetadata for empty FileMetadata") {
     val fileMetadata = FileMetadata(Map(), Map(), Map(), Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.dateTaken should be('empty)
-    imageMetadata.description should be('empty)
-    imageMetadata.credit should be('empty)
-    imageMetadata.byline should be('empty)
-    imageMetadata.bylineTitle should be('empty)
-    imageMetadata.title should be('empty)
-    imageMetadata.copyrightNotice should be('empty)
-    imageMetadata.copyright should be('empty)
-    imageMetadata.suppliersReference should be('empty)
-    imageMetadata.source should be('empty)
-    imageMetadata.specialInstructions should be('empty)
-    imageMetadata.keywords should be('empty)
-    imageMetadata.subLocation should be('empty)
-    imageMetadata.city should be('empty)
-    imageMetadata.state should be('empty)
-    imageMetadata.country should be('empty)
+    imageMetadata.dateTaken should be ('empty)
+    imageMetadata.description should be ('empty)
+    imageMetadata.credit should be ('empty)
+    imageMetadata.byline should be ('empty)
+    imageMetadata.bylineTitle should be ('empty)
+    imageMetadata.title should be ('empty)
+    imageMetadata.copyrightNotice should be ('empty)
+    imageMetadata.copyright should be ('empty)
+    imageMetadata.suppliersReference should be ('empty)
+    imageMetadata.source should be ('empty)
+    imageMetadata.specialInstructions should be ('empty)
+    imageMetadata.keywords should be ('empty)
+    imageMetadata.subLocation should be ('empty)
+    imageMetadata.city should be ('empty)
+    imageMetadata.state should be ('empty)
+    imageMetadata.country should be ('empty)
+    imageMetadata.peopleInImage should be ('empty)
   }
 
   it("should populate string fields of ImageMetadata from default FileMetadata fields") {
@@ -364,5 +365,33 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03 BST 2014") shouldBe "2014-12-16T00:02:03.000Z"
   }
 
+
+  // People in Image
+
+  it("should populate peopleInImage field of ImageMetadata from corresponding xmp iptc ext fields") {
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.peopleInImage should be (List("person 1"))
+  }
+
+  it("should populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
+      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 3"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.peopleInImage should be (List("person 1","person 2","person 3"))
+  }
+
+  it("should distinctly populate peopleInImage field of ImageMetadata from multiple corresponding xmp iptc ext fields") {
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[1]" -> "person 1",
+      "Iptc4xmpExt:PersonInImage[2]" -> "person 2", "Iptc4xmpExt:PersonInImage[3]" -> "person 2"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.peopleInImage should be (List("person 1","person 2"))
+  }
+
+  it("should ignore invalid peopleInImage field of ImageMetadata") {
+    val fileMetadata = FileMetadata(Map(), Map(), Map(), Map("Iptc4xmpExt:PersonInImage[-1]" -> "person 1"))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.peopleInImage should be ('empty)
+  }
 
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,10 @@
 __TL;DR__ When you update the mapping, use [Reindex](#Reindex),
 when you add a mapping, use [UpdateMapping](#UpdateMapping)
 
+If using SSH tunnel, and you wish to execute commands via https, you will need to add something like:
+```127.0.0.1      es.eu-west-1.es.amazonaws.com``` to your `/private/etc/hosts` file to match the certificate path. Then when issuing the command do
+```scripts/run <command> https://es.eu-west-1.es.amazonaws.com:<tunneled_port>```
+
 ### Reindex
 On occasion you will need to update the our [Elasticsearch mappings](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala).
 Unfortunately, you need to change the mapping and then reindex the data to apply said change.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,10 +5,6 @@
 __TL;DR__ When you update the mapping, use [Reindex](#Reindex),
 when you add a mapping, use [UpdateMapping](#UpdateMapping)
 
-If using SSH tunnel, and you wish to execute commands via https, you will need to add something like:
-```127.0.0.1      es.eu-west-1.es.amazonaws.com``` to your `/private/etc/hosts` file to match the certificate path. Then when issuing the command do
-```scripts/run <command> https://es.eu-west-1.es.amazonaws.com:<tunneled_port>```
-
 ### Reindex
 On occasion you will need to update the our [Elasticsearch mappings](https://github.com/guardian/grid/blob/master/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala).
 Unfortunately, you need to change the mapping and then reindex the data to apply said change.


### PR DESCRIPTION
this pr is https://github.com/guardian/grid/pull/2667 but rebased

# Original PR Desc
~Note: This PR requires https://github.com/guardian/grid/pull/2664 to be merged first.~
**As this adds a new mapping into ES the `UpdateMapping` command will need to be run against the ES index first.** (this is just adding a new field and not editing existing ones, so relatively safe/easy)

## What does this change?

This adds a new field `peopleInImage` to the metadata of the image. It extracts from the XMP fields: `Iptc4xmpExt:PersonInImage` and `GettyImagesGIFT:Personality` - more can easily be added if/when found. 

The following is an example of the metadata section in the api response after uploading an image which includes the person in image metadata:
```
  "metadata": {
    "dateTaken": "2019-10-24T15:09:53.460Z",
    "description": "TOKYO, JAPAN - OCTOBER 24: Kieran Read, Scott Barrett, Aaron Smith, Codie Taylor and Shannon Frizell of the All Blacks stretch during a New Zealand All Blacks training session at Tatsuminomori Seaside Park on October 24, 2019 in Tokyo, Japan. (Photo by Hannah Peters/Getty Images)",
    "credit": "Getty Images",
    "byline": "Hannah Peters",
    "bylineTitle": "Staff",
    "title": "New Zealand Media Access",
    "copyrightNotice": "2019 Getty Images",
    "copyright": "2019 Getty Images",
    "suppliersReference": "775424562",
    "source": "Getty Images AsiaPac",
    "specialInstructions": "All use in books (including autobiographies) or magazines, which are entirely dedicated to any and/or all RWCL competitions and/or Matches requires separate written approval from Rugby World Cup Limited.",
    "keywords": [
      "sport",
      "rugby",
      "rugby union",
      "rugby union world cup",
      "rugby union world cup 2019",
      "all blacks - rugby team",
      "bestof",
      "topix"
    ],
    "city": "Tokyo",
    "country": "Japan",
    "subjects": [
      "sport"
    ],
    "peopleInImage": [
      "Codie Taylor",
      "Aaron Smith",
      "Shannon Frizell",
      "Kieran Read",
      "Scott Barrett"
    ]
  }
```

This will be the first PR in a series of PRs to add functionality to search for people who are in an image, and to display who is in an image in the metadata section of the UI.
