### PR TITLE
Add more selectors for integration tests

### DIFF
--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -18,7 +18,8 @@
         class="job-info--editor__input"
         gr-search="ctrl.labelSearch(q)">
 
-        <input type="text"
+        <input data-cy="label-input"
+               type="text"
                class="text-input gr-add-label__form__input show-no-error"
                placeholder="label1, label2, label3…"
                gr-datalist-input
@@ -36,6 +37,7 @@
             <gr-icon-label gr-icon="close"><span ng-hide="ctrl.grSmall">Cancel</span></gr-icon-label>
         </button>
         <button
+            data-cy="save-new-label-button"
             class="gr-add-label__form__buttons__button-save button-save"
             type="submit"
             title="Save new label"

--- a/kahuna/public/js/components/gr-chips/gr-text-chip.html
+++ b/kahuna/public/js/components/gr-chips/gr-text-chip.html
@@ -1,4 +1,5 @@
-<input type="text"
+<input data-cy="image-search-input"
+       type="text"
        autocomplete="off"
        placeholder="Search for images... (type + for advanced search)"
        ng-trim="false"

--- a/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.html
+++ b/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.html
@@ -1,4 +1,5 @@
-<button class="collection-overlay__button"
+<button data-cy="add-image-to-collection-button"
+        class="collection-overlay__button"
         ng-click="ctrl.openCollectionTree()"
         gr-tooltip="Click to add image to a collection"
         gr-tooltip-position="left">

--- a/kahuna/public/js/components/gr-crop-image/gr-crop-image.html
+++ b/kahuna/public/js/components/gr-crop-image/gr-crop-image.html
@@ -1,5 +1,6 @@
 <span ng-if="ctrl.canBeCropped">
-    <a class="inner-clickable clickable side-padded"
+    <a  data-cy="crop-image-button"
+        class="inner-clickable clickable side-padded"
         ui-sref="crop({imageId: ctrl.image.data.id})"
         gr-track-click="Crop image button"
         gr-track-click-data="{'Location': ctrl.trackingLocation}"

--- a/kahuna/public/js/components/gr-delete-crops/gr-delete-crops.js
+++ b/kahuna/public/js/components/gr-delete-crops/gr-delete-crops.js
@@ -52,6 +52,7 @@ deleteCrops.directive('grDeleteCrops', [function () {
         },
         template: `
             <gr-confirm-delete
+                data-cy="delete-all-crops-button"
                 ng:if="ctrl.active"
                 gr:label="Delete ALL crops"
                 gr:on-confirm="ctrl.delete()">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -52,7 +52,7 @@
                     e:form="titleEditForm">{{ctrl.metadata.title}}</dd>
             </div>
 
-            <div class="image-info__wrap metadata-line__info" ng-if="ctrl.metadata.description || ctrl.userCanEdit">
+            <div data-cy="metadata-description" class="image-info__wrap metadata-line__info" ng-if="ctrl.metadata.description || ctrl.userCanEdit">
                 <button data-cy="it-edit-description-button"
                         class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
@@ -98,7 +98,7 @@
             <dd class="image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
 
             <dt class="image-info__byline image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">By</dt>
-            <dd class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
+            <dd data-cy="metadata-byline" class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="ctrl.metadata.byline || ctrl.userCanEdit">
                 <button data-cy="it-edit-byline-button"
                         class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
@@ -124,7 +124,7 @@
             </dd>
 
             <dt ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__credit image-info__wrap image-info__group--dl__key metadata-line__key">Credit</dt>
-            <dd ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
+            <dd data-cy="metadata-credit" ng-if="ctrl.metadata.credit || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
                 <button data-cy="it-edit-credit-button"
                         class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
@@ -168,7 +168,7 @@
 
 
             <dt ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__key metadata-line__key">Copyright</dt>
-            <dd ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
+            <dd data-cy="metadata-copyright" ng-if="ctrl.metadata.copyright || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
                 <button data-cy="it-edit-copyright-button"
                         class="image-info__edit"
                         ng-if="ctrl.userCanEdit"

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -11,6 +11,7 @@
             x:
             <form class="top-bar-item__form">
                 <input
+                    data-cy="crop-x-value-input"
                     type="number"
                     min="0"
                     max="{{ctrl.maxInputX()}}"
@@ -21,7 +22,8 @@
             y:
             <form class="top-bar-item__form">
                 <input
-                    type="number"
+                  data-cy="crop-y-value-input"
+                  type="number"
                     min="0"
                     max="{{ctrl.maxInputY()}}"
                     class="top-bar-item__form__input"
@@ -33,7 +35,8 @@
         <div class="top-bar-item side-padded">
             <form class="top-bar-item__form">
                 <input
-                    type="number"
+                  data-cy="crop-width-input"
+                  type="number"
                     min="1"
                     max="{{ctrl.originalWidth}}"
                     class="top-bar-item__form__input"
@@ -43,7 +46,8 @@
             &times;
             <form class="top-bar-item__form" ng-disabled="ctrl.freeRatio">
                 <input
-                    type="number"
+                  data-cy="crop-height-input"
+                  type="number"
                     min="1"
                     max="{{ctrl.originalHeight}}"
                     class="top-bar-item__form__input"

--- a/kahuna/public/js/upload/file-uploader.html
+++ b/kahuna/public/js/upload/file-uploader.html
@@ -6,7 +6,8 @@
            multiple
            gr-file-change="ctrl.uploadFiles($files)" />
 
-    <button class="file-uploader__select-files button"
+    <button data-cy="upload-button"
+            class="file-uploader__select-files button"
             gr-track-click="Upload action"
             gr-track-click-data="{ 'Action': 'Button click' }">
         <gr-icon-label gr-icon="file_upload">Upload</gr-icon-label>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -56,7 +56,9 @@
                 class="job-info--editor__input"
                 gr-search="ctrl.metadataSearch('credit', q)">
 
-                <input type="text"
+                <input
+                    data-cy="image-metadata-credit"
+                    type="text"
                     placeholder="eg The Guardian (source, agency or institution which owns the image)"
                     class="text-input job-info__credit"
                     required


### PR DESCRIPTION
## What does this change?

As the [Editorial Tools Integration Tests repository](https://github.com/guardian/editorial-tools-integration-tests) continues to be developed on, this PR adds more `data-cy` selectors to elements so that they can be more easily interacted with by Cypress. 

This should have no impact on production.


## How can success be measured?

The Grid continues to run as expected, and future integration tests can make use of these selectors.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
