### PR TITLE
Add selectors for rights

### DIFF
--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -103,7 +103,10 @@
                 <div class="result-editor__usage-rights-container">
                     <div ng-hide="ctrl.showUsageRights" class="result-editor__field-value">
                         <span>{{ctrl.usageRightsCategory || 'None'}}</span>
-                        <button class="image-info__edit" ng-click="ctrl.showUsageRights = !ctrl.showUsageRights">
+                        <button
+                          data-cy="edit-rights-button"
+                          class="image-info__edit"
+                          ng-click="ctrl.showUsageRights = !ctrl.showUsageRights">
                             <gr-icon>edit</gr-icon>
                         </button>
                         <button

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -185,7 +185,8 @@
             <gr-icon-label gr-icon="close">Cancel</gr-icon-label>
         </button>
 
-        <button class="ure__action button-ico button-save"
+        <button data-cy="save-usage-rights"
+            class="ure__action button-ico button-save"
             type="submit"
             title="save usage rights overrides"
             ng-disabled="ctrl.savingDisabled || !usageRights.$valid">


### PR DESCRIPTION
## What does this change?

Adding two more `data-cy` selectors for editing the rights. These were not pushed and should have been in the previous PR!

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
