### PR TITLE
Add selector for crop options

### DIFF
--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -57,7 +57,7 @@
         </div>
 
         <div class="inline-block side-padded">
-          <gr-radio-list gr-for="crop" gr-options="ctrl.cropOptions" gr-selected-option="ctrl.cropType"></gr-radio-list>
+          <gr-radio-list data-cy="crop-options" gr-for="crop" gr-options="ctrl.cropOptions" gr-selected-option="ctrl.cropType"></gr-radio-list>
         </div>
 
         <div class="top-bar-item" ng-switch="ctrl.image.data.cost">


### PR DESCRIPTION
## What does this change?

This adds a `data-cy` selector for crop options so that integration tests can select the freeform crop button more easily.

## How can success be measured?

Nothing breaks and integration tests work better!

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
