### PR TITLE
Add more selectors for collection tests

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -1,5 +1,6 @@
 <div ng-init="node = ctrl.node" class="hover-parent">
-    <div class="node__info flex-container"
+    <div data-cy="{{node.data.data.description + '-collection'}}"
+         class="node__info flex-container"
          ng-class="{'node__info--selected' : ctrl.isSelected}"
          gr-drop-into-collection="node.data.fullPath">
 
@@ -25,7 +26,8 @@
             {{:: node.data.data.description}}
         </button>
 
-        <a ng-if="! ctrl.hasCustomSelect"
+        <a data-cy="collection-child-link"
+           ng-if="! ctrl.hasCustomSelect"
            class="node__name flex-spacer"
            ui-sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId)})">
             {{:: node.data.data.description}}
@@ -37,7 +39,8 @@
                            gr-on-confirm="ctrl.remove()">
         </gr-confirm-delete>
 
-        <button class="node__action clickable"
+        <button data-cy="create-new-folder-button"
+                class="node__action clickable"
                 type="button"
                 title="Add a new sub-collection"
                 ng-if="grCollectionTreeCtrl.editing"
@@ -66,7 +69,8 @@
     </div>
 
     <form class="node__add-child" ng-if="active" ng-submit="ctrl.addChild(childName);">
-        <input  gr-auto-focus
+        <input  data-cy="collection-child-input"
+                gr-auto-focus
                 class="text-input node__add-child-input"
                 type="text"
                 required
@@ -76,7 +80,7 @@
         <div class="error error--small" ng-if="formError">{{formError}}</div>
 
         <div class="node__add-child-buttons">
-            <button type="submit" class="button-save" title="Save">
+            <button data-cy="save-child-button" type="submit" class="button-save" title="Save">
                 <gr-icon-label gr-icon="check"></gr-icon-label>
             </button>
             <button type="button" class="button-cancel" ng-click="clearForm()" title="Cancel">

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -10,7 +10,8 @@
     <div class="flex-container collections-panel-heading text-small" ng-if="! ctrl.error">
         <div class="flex-spacer">Collections</div>
 
-        <button ng-class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
+        <button data-cy="edit-collections-button"
+                ng-class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
                 ng-click="$parent.editing = !$parent.editing">
             <gr-icon-label ng-if="! $parent.editing"
                            gr-icon="edit">Edit</gr-icon-label>
@@ -19,6 +20,7 @@
         </button>
     </div>
     <gr-collection-tree gr-nodes="ctrl.collections"
+              data-cy="collection-tree"
               gr-editing="editing"
               gr-selected-images="ctrl.selectedImages$"
               gr-selected-collections="ctrl.selectedCollections">

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -28,6 +28,7 @@
 
     <a ng-if="! ctrl.selectionMode" class="preview__link"
        ui-sref="image({imageId: ctrl.image.data.id})"
+       data-cy="image-preview-link"
        ui-drag-data="ctrl.image | asImageDragData"
        title="{{::ctrl.imageDescription}}">
        <div class="preview__fade"></div>

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -11,6 +11,7 @@
     <div ng-if="! ctrl.loadingError">
         <div class="results-toolbar">
             <gr-panel-button-small
+                data-cy="show-collections-panel"
                 class="results-toolbar-item results-toolbar-item--left results-toolbar-item--no-hover"
                 gr-panel="ctrl.collectionsPanel"
                 gr-position="left"


### PR DESCRIPTION
## What does this change?

This adds some more selectors for integration tests, namely for collection selection and editing.

## How can success be measured?

Integration tests can leverage the selectors to interact with collections, and nothing breaks.


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [X] on TEST
