### PR TITLE
Remove CSRF filter to allow integration tests to query subdomains

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -24,7 +24,7 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
   implicit val ec: ExecutionContext = executionContext
 
   final override def httpFilters: Seq[EssentialFilter] = {
-    Seq(corsFilter, csrfFilter, securityHeadersFilter, gzipFilter, new RequestLoggingFilter(materializer), new RequestMetricFilter(config, materializer))
+    Seq(corsFilter, securityHeadersFilter, gzipFilter, new RequestLoggingFilter(materializer), new RequestMetricFilter(config, materializer))
   }
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(


### PR DESCRIPTION
## What does this change?

 Grid subdomain HTTP requests (such as `api` and `media-collections`) return 403 (Forbidden) responses when calling from outside the domain. This is challenging because our Cypress integration tests make calls to the various APIs to set up and tear down test resources (such as collections and images), and we are currently unable to do so due to this. We still require authentication via the cookie or API key, so this could be an unnecessary blocker.

By removing the CSRF filter, Cypress is able to query the APIs using the cookie that's generated in the test, allowing us to set up and tear down the test environments as needed.

## How can success be measured?

Cypress can make requests to the Grid subdomains without being blocked by CSRF issues.


It would be good to get other people's thoughts on this, as there may be security implications to this change that we have not anticpated.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [ ] on TEST
