### PR TITLE
PR and Handout to be Restricted by default

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -215,11 +215,14 @@ final case class PrImage(restrictions: Option[String] = None) extends UsageRight
 }
 object PrImage extends UsageRightsSpec {
   val category = "PR Image"
-  val defaultCost = Some(Free)
+  val defaultCost = Some(Conditional)
   val name = "PR Image"
   val description =
     "Images supplied for publicity purposes such as press launches, charity events, travel, " +
       "promotional images, etc."
+
+  override val caution =
+    Some("For use only within the context originally provided for (please state it below).")
 
   implicit val formats: Format[PrImage] =
     UsageRights.subtypeFormat(PrImage.category)(Json.format[PrImage])
@@ -231,11 +234,14 @@ final case class Handout(restrictions: Option[String] = None) extends UsageRight
 }
 object Handout extends UsageRightsSpec {
   val category = "handout"
-  val defaultCost = Some(Free)
+  val defaultCost = Some(Conditional)
   val name = "Handout"
   val description =
     "Images supplied on general release to all media e.g. images provided by police for new " +
       "stories, family shots in biographical pieces, etc."
+
+  override val caution =
+    Some("For use only within the context originally provided for (please state it below).")
 
   implicit val formats: Format[Handout] =
     UsageRights.subtypeFormat(Handout.category)(Json.format[Handout])

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -1,4 +1,4 @@
-package lib.usagerights
+CommissionedAgencypackage lib.usagerights
 
 import com.gu.mediaservice.model._
 import lib.UsageQuota
@@ -22,14 +22,14 @@ class CostCalculatorTest extends FunSpec with Matchers with MockitoSugar {
     }
 
     it("should be free with a free category") {
-      val usageRights = Handout()
+      val usageRights = CommissionedAgency()
       val cost = Costing.getCost(usageRights)
 
       cost should be (Free)
     }
 
     it("should be conditional with a free category and restrictions") {
-      val usageRights = Handout(
+      val usageRights = CommissionedAgency(
         restrictions = Some("Restrictions")
       )
       val cost = Costing.getCost(usageRights)

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -22,14 +22,14 @@ class CostCalculatorTest extends FunSpec with Matchers with MockitoSugar {
     }
 
     it("should be free with a free category") {
-      val usageRights = CommissionedAgency()
+      val usageRights = Obituary()
       val cost = Costing.getCost(usageRights)
 
       cost should be (Free)
     }
 
     it("should be conditional with a free category and restrictions") {
-      val usageRights = CommissionedAgency(
+      val usageRights = Obituary(
         restrictions = Some("Restrictions")
       )
       val cost = Costing.getCost(usageRights)

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -1,4 +1,4 @@
-CommissionedAgencypackage lib.usagerights
+package lib.usagerights
 
 import com.gu.mediaservice.model._
 import lib.UsageQuota


### PR DESCRIPTION
This is a Picture Desk request. These two categories of Usage Rights seem to often be (mis)used as a _I’m-not-sure-what-this-is-let-me-choose-first-one_ option. This will prevent that.


## Tested?
- [ ] locally
- [x] on TEST
