### PR TITLE
ignore usage updates from CAPI that cannot have originated from Grid

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -25,9 +25,13 @@ case class MediaUsage(
 ) {
 
   def isGridLikeId: Boolean = {
-    // remove events from CAPI that represent images previous to Grid existing
-    Logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
-    !mediaId.startsWith("gu-image-")
+    if (mediaId.startsWith("gu-image-")) {
+      // remove events from CAPI that represent images previous to Grid existing
+      Logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
+      false
+    } else {
+      true
+    }
   }
 
   def isRemoved: Boolean = (for {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -1,27 +1,35 @@
 package com.gu.mediaservice.model.usage
 
 import org.joda.time.DateTime
+import play.api.Logger
 
 case class UsageId(id: String) {
   override def toString = id
 }
 
 case class MediaUsage(
-                       usageId: UsageId,
-                       grouping: String,
-                       mediaId: String,
-                       usageType: UsageType,
-                       mediaType: String,
-                       status: UsageStatus,
-                       printUsageMetadata: Option[PrintUsageMetadata],
-                       digitalUsageMetadata: Option[DigitalUsageMetadata],
-                       syndicationUsageMetadata: Option[SyndicationUsageMetadata],
-                       frontUsageMetadata: Option[FrontUsageMetadata],
-                       downloadUsageMetadata: Option[DownloadUsageMetadata],
-                       lastModified: DateTime,
-                       dateAdded: Option[DateTime] = None,
-                       dateRemoved: Option[DateTime] = None
-                     ) {
+  usageId: UsageId,
+  grouping: String,
+  mediaId: String,
+  usageType: UsageType,
+  mediaType: String,
+  status: UsageStatus,
+  printUsageMetadata: Option[PrintUsageMetadata],
+  digitalUsageMetadata: Option[DigitalUsageMetadata],
+  syndicationUsageMetadata: Option[SyndicationUsageMetadata],
+  frontUsageMetadata: Option[FrontUsageMetadata],
+  downloadUsageMetadata: Option[DownloadUsageMetadata],
+  lastModified: DateTime,
+  dateAdded: Option[DateTime] = None,
+  dateRemoved: Option[DateTime] = None
+) {
+
+  def isGridLikeId: Boolean = {
+    // remove events from CAPI that represent images previous to Grid existing
+    Logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
+    !mediaId.startsWith("gu-image-")
+  }
+
   def isRemoved: Boolean = (for {
     added <- dateAdded
     removed <- dateRemoved

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -115,7 +115,10 @@ class UsageRecorder(usageMetrics: UsageMetrics, usageTable: UsageTable, usageStr
   private def getNotificationStream(dbUpdateStream: Observable[MatchedUsageUpdate]) = {
     dbUpdateStream.flatMap(matchedUsageUpdates => {
       def buildNotifications(usages: Set[MediaUsage]) = Observable.from(
-        usages.map(_.mediaId).toList.distinct.map(usageNotice.build))
+        usages
+          .filter(_.isGridLikeId)
+          .map(_.mediaId)
+          .toList.distinct.map(usageNotice.build))
 
       val usageGroup = matchedUsageUpdates.matchUsageGroup.usageGroup
       val dbUsageGroup = matchedUsageUpdates.matchUsageGroup.dbUsageGroup


### PR DESCRIPTION
## What does this change?
Grid image IDs don't follow the pattern `gu-image-`. These represent images that pre-date Grid. We can safely ignore these messages when we see them on the CAPI streams.

## How can success be measured?
Less noise in logs.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
