### PR TITLE
Guard against null image ids

### DIFF
--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -125,9 +125,13 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
             data = usages.map(wrapUsage)
           )
       }
-    }).recover { case error: Exception =>
-      Logger.error("UsageApi returned an error.", error)
-      respondError(InternalServerError, "image-usage-retrieve-failed", error.getMessage)
+    }).recover {
+      case error: BadInputException =>
+        Logger.error("UsageApi returned an error.", error)
+        respondError(BadRequest, "image-usage-retrieve-failed", error.getMessage)
+      case error: Exception =>
+        Logger.error("UsageApi returned an error.", error)
+        respondError(InternalServerError, "image-usage-retrieve-failed", error.getMessage)
     }
   }
 
@@ -188,6 +192,9 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
     usageTable.queryByImageId(mediaId).map(usages => {
       usages.foreach(usageTable.deleteRecord)
     }).recover{
+      case error: BadInputException =>
+        Logger.warn("UsageApi returned an error.", error)
+        respondError(BadRequest, "image-usage-delete-failed", error.getMessage)
       case error: Exception =>
         Logger.error("UsageApi returned an error.", error)
         respondError(InternalServerError, "image-usage-delete-failed", error.getMessage)

--- a/usage/app/lib/BadInputException.scala
+++ b/usage/app/lib/BadInputException.scala
@@ -1,0 +1,3 @@
+package lib
+
+class BadInputException(message: String) extends Exception

--- a/usage/app/model/UsageTable.scala
+++ b/usage/app/model/UsageTable.scala
@@ -35,6 +35,10 @@ class UsageTable(config: UsageConfig) extends DynamoDB(config, config.usageRecor
   }
 
   def queryByImageId(id: String): Future[Set[MediaUsage]] = Future {
+
+    if (id.isEmpty)
+      throw new Exception("Empty string received for image id")
+
     val imageIndex = table.getIndex(imageIndexName)
     val keyAttribute = new KeyAttribute(imageIndexName, id)
     val queryResult = imageIndex.query(keyAttribute)

--- a/usage/app/model/UsageTable.scala
+++ b/usage/app/model/UsageTable.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.dynamodbv2.model.ReturnValue
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.lib.usage.ItemToMediaUsage
 import com.gu.mediaservice.model.usage.{MediaUsage, PendingUsageStatus, PublishedUsageStatus, UsageTableFullKey}
-import lib.UsageConfig
+import lib.{BadInputException, UsageConfig}
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
@@ -37,7 +37,7 @@ class UsageTable(config: UsageConfig) extends DynamoDB(config, config.usageRecor
   def queryByImageId(id: String): Future[Set[MediaUsage]] = Future {
 
     if (id.isEmpty)
-      throw new Exception("Empty string received for image id")
+      throw new BadInputException("Empty string received for image id")
 
     val imageIndex = table.getIndex(imageIndexName)
     val keyAttribute = new KeyAttribute(imageIndexName, id)


### PR DESCRIPTION
## What does this change?
We have repeated errors in DynamoDB client where it appears the provided image id is null.  This is an attempt to report the problem more clearly to facilitate debugging.

## How can success be measured?
Unclear AWS Exception is replaced with clear custom exception.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
