### PR TITLE
Provide documentation for making requests to Grid from the outside.

### DIFF
--- a/dev/script/generate-dot-properties/config.json5
+++ b/dev/script/generate-dot-properties/config.json5
@@ -27,7 +27,12 @@
 
   security: {
     frameAncestors: '',
-    corsAllowedOrigins: ''
+
+    // A list of trusted origins to allow requests from.
+    // These should be the subdomain to trust as the domain is added automatically..
+    // Grid will trust requests with a cookie and an `Origin` header set to this value.
+    // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin.
+    corsAllowedOrigins: [ ]
   },
 
   // Guardian specific properties for the Usage service

--- a/dev/script/generate-dot-properties/service-config.js
+++ b/dev/script/generate-dot-properties/service-config.js
@@ -3,13 +3,19 @@ function stripMargin(template, ...args) {
     return result.replace(/\r?(\n)\s*\|/g, '$1');
 }
 
+function getCorsAllowedOriginString(config) {
+  return config.security.corsAllowedOrigins
+    .map(origin => `${origin}.${config.DOMAIN}`)
+    .join(',');
+}
+
 function getAuthConfig(config) {
     return stripMargin`
         |domain.root=${config.DOMAIN}
         |s3.config.bucket=${config.coreStackProps.ConfigBucket}
         |auth.keystore.bucket=${config.coreStackProps.KeyBucket}
         |aws.region=${config.AWS_DEFAULT_REGION}
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
         |metrics.request.enabled=false
         |`;
@@ -25,7 +31,7 @@ function getCollectionsConfig(config) {
         |dynamo.table.imageCollections=ImageCollectionsTable
         |thrall.kinesis.stream.name=${config.coreStackProps.ThrallMessageStream}
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }
@@ -40,7 +46,7 @@ function getCropperConfig(config) {
         |thrall.kinesis.stream.name=${config.coreStackProps.ThrallMessageStream}
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
         |s3.config.bucket=${config.coreStackProps.ConfigBucket}
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }
@@ -54,7 +60,7 @@ function getImageLoaderConfig(config) {
         |auth.keystore.bucket=${config.coreStackProps.KeyBucket}
         |thrall.kinesis.stream.name=${config.coreStackProps.ThrallMessageStream}
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }
@@ -74,7 +80,7 @@ function getKahunaConfig(config) {
         |links.usageRightsHelp=${config.links.usageRightsHelp}
         |links.invalidSessionHelp=${config.links.invalidSessionHelp}
         |links.supportEmail=${config.links.supportEmail}
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |security.frameAncestors=https://*.${config.DOMAIN}
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
         |metrics.request.enabled=false
@@ -89,7 +95,7 @@ function getLeasesConfig(config) {
         |thrall.kinesis.stream.name=${config.coreStackProps.ThrallMessageStream}
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
         |dynamo.tablename.leasesTable=LeasesTable
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }
@@ -112,7 +118,7 @@ function getMediaApiConfig(config) {
         |es6.shards=${config.es6.shards}
         |es6.replicas=${config.es6.replicas}
         |quota.store.key=rcs-quota.json
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }
@@ -127,7 +133,7 @@ function getMetadataEditorConfig(config) {
         |aws.local.endpoint=https://localstack.media.${config.DOMAIN}
         |dynamo.table.edits=EditsTable
         |indexed.images.sqs.queue.url=${config.coreStackProps.IndexedImageMetadataQueue.replace("http://localhost:4576", `https://localstack.media.${config.DOMAIN}`)}
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }
@@ -180,7 +186,7 @@ function getUsageConfig(config) {
         |crier.preview.name=${config.guardian.crier.preview.streamName}
         |crier.live.name=${config.guardian.crier.live.streamName}
         |app.name=usage
-        |security.cors.allowedOrigins=${config.security.corsAllowedOrigins}
+        |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
         |`;
 }

--- a/docs/04-troubleshooting/03-authentication.md
+++ b/docs/04-troubleshooting/03-authentication.md
@@ -1,0 +1,14 @@
+# Authentication
+
+## 4XX response when calling Grid APIs from the outside
+If you're trying to make requests to Grid's API from the outside,
+you may find Grid returns with a `403` even though you're sending a valid cookie with the request.
+
+This is due to the [security filters](https://www.playframework.com/documentation/2.6.x/Filters) in use.
+We'll need to configure Grid to allow requests from the outside by setting `security.cors.allowedOrigins` in the config files located in `/etc/gu`.
+
+Once configured, Grid will trust requests which include the [`Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
+set to one of the domains specified, if they also include a valid cookie, of course!
+
+Note: the [generate-dot-properties](../../dev/script/generate-dot-properties) script can be used to create the config files in `/etc/gu`.
+Refer to [it's configuration](../../dev/script/generate-dot-properties/config.json5) to set `security.cors.allowedOrigins`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,10 @@
 ## [Troubleshooting](04-troubleshooting/)
 - [NGINX](04-troubleshooting/01-nginx.md)
 - [SBT](04-troubleshooting/02-sbt.md)
+- [Authentication](04-troubleshooting/03-authentication.md)
+
+## [Reingestion](05-reingestion/)
+- [Image reingestion](05-reingestion/01-how-to.md)
 
 ## [Archives](99-archives/)
 - [DEV Cloudformation Setup](99-archives/01-cloudformation.md)


### PR DESCRIPTION
## What does this change?
Document how to configure Grid to trust requests that originate from outside.

Grid only trusts requests from itself or from origins specified in config ([LOC reference link](https://github.com/guardian/grid/blob/b4342e99b5fa633f2b2bbc41834458068c65ae8b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala#L30-L32)) which include a valid cookie.

If you're making a request from outside Grid, for example from [`editions-card-builder`](https://github.com/guardian/editions-card-builder) or [`integration-tests`](https://github.com/guardian/editorial-tools-integration-tests), you will witness 403 responses if Grid doesn't trust the requesting origin.

In this PR I'm favouring documentation and an empty array in `config.json5` over listing some trusted domains as it's not possible to know all of the ones we'll use.

Note: this only impacts DEV config.

## How can success be measured?
It is easier to integrate with Grid.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@stephengeller 

## Tested?
- [x] locally
- [ ] on TEST
