### PR TITLE
Download to usages

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -244,6 +244,10 @@ object Mappings {
     keywordField("front")
   )
 
+  def downloadUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).fields(
+    keywordField("downloadedBy")
+  )
+
   def usagesMapping(name: String): NestedField = nestedField(name).
     fields(
     keywordField("id"),
@@ -258,7 +262,8 @@ object Mappings {
     printUsageMetadata("printUsageMetadata"),
     digitalUsageMetadata("digitalUsageMetadata"),
     syndicationUsageMetadata("syndicationUsageMetadata"),
-    frontUsageMetadata("frontUsageMetadata")
+    frontUsageMetadata("frontUsageMetadata"),
+    downloadUsageMetadata("downloadUsageMetadata")
   )
 
   def leaseMapping(name: String): ObjectField = nonDynamicObjectField(name).fields(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -28,7 +28,7 @@ abstract class GridComponents(context: Context) extends BuiltInComponentsFromCon
   }
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
-    allowedOrigins = Origins.Matching(Set(config.services.kahunaBaseUri) ++ config.services.corsAllowedDomains)
+    allowedOrigins = Origins.Matching(Set(config.services.kahunaBaseUri, config.services.apiBaseUri) ++ config.services.corsAllowedDomains)
   )
 
   lazy val management = new Management(controllerComponents, buildInfo)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
@@ -28,6 +28,8 @@ object ItemToMediaUsage {
         .map(_.asScala.toMap).flatMap(buildSyndication),
       Option(item.getMap[Any]("front_metadata"))
         .map(_.asScala.toMap).flatMap(buildFront),
+      Option(item.getMap[Any]("download_metadata"))
+        .map(_.asScala.toMap).flatMap(buildDownload),
       new DateTime(item.getLong("last_modified")),
       Try {
         item.getLong("date_added")
@@ -90,4 +92,11 @@ object ItemToMediaUsage {
     }.toOption
   }
 
+  private def buildDownload(metadataMap: Map[String, Any]): Option[DownloadUsageMetadata] = {
+    Try {
+      DownloadUsageMetadata(
+        metadataMap("downloadedBy").asInstanceOf[String]
+      )
+    }.toOption
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -17,7 +17,8 @@ object UsageBuilder {
     usage.printUsageMetadata,
     usage.digitalUsageMetadata,
     usage.syndicationUsageMetadata,
-    usage.frontUsageMetadata
+    usage.frontUsageMetadata,
+    usage.downloadUsageMetadata
   )
 
   private def buildStatusString(usage: MediaUsage): UsageStatus = if (usage.isRemoved) RemovedUsageStatus else usage.status
@@ -31,6 +32,7 @@ object UsageBuilder {
       case DigitalUsage => buildDigitalUsageReference(usage)
       case PrintUsage => buildPrintUsageReference(usage)
       case SyndicationUsage => buildSyndicationUsageReference(usage)
+      case DownloadUsage => buildDownloadUsageReference(usage)
     }
   }
 
@@ -63,6 +65,16 @@ object UsageBuilder {
     List(
       UsageReference(
         SyndicationUsageReference, None, Some(metadata.partnerName)
+      )
+    )
+  }).getOrElse(
+    List[UsageReference]()
+  )
+
+  private def buildDownloadUsageReference(usage: MediaUsage): List[UsageReference] = usage.downloadUsageMetadata.map (metadata => {
+    List(
+      UsageReference(
+        DownloadUsageReference, None, Some(metadata.downloadedBy)
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DownloadUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DownloadUsageMetadata.scala
@@ -1,0 +1,16 @@
+package com.gu.mediaservice.model.usage
+
+import play.api.libs.json.{Json, Reads, Writes}
+
+case class DownloadUsageMetadata(
+  downloadedBy: String
+) extends UsageMetadata {
+  override def toMap: Map[String, Any] = Map(
+    "downloadedBy" -> downloadedBy
+  )
+}
+
+object DownloadUsageMetadata {
+  implicit val reader: Reads[DownloadUsageMetadata] = Json.reads[DownloadUsageMetadata]
+  implicit val writer: Writes[DownloadUsageMetadata] = Json.writes[DownloadUsageMetadata]
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -17,6 +17,7 @@ case class MediaUsage(
                        digitalUsageMetadata: Option[DigitalUsageMetadata],
                        syndicationUsageMetadata: Option[SyndicationUsageMetadata],
                        frontUsageMetadata: Option[FrontUsageMetadata],
+                       downloadUsageMetadata: Option[DownloadUsageMetadata],
                        lastModified: DateTime,
                        dateAdded: Option[DateTime] = None,
                        dateRemoved: Option[DateTime] = None

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
@@ -18,7 +18,8 @@ case class Usage(
   printUsageMetadata: Option[PrintUsageMetadata] = None,
   digitalUsageMetadata: Option[DigitalUsageMetadata] = None,
   syndicationUsageMetadata: Option[SyndicationUsageMetadata] = None,
-  frontUsageMetadata: Option[FrontUsageMetadata] = None
+  frontUsageMetadata: Option[FrontUsageMetadata] = None,
+  downloadUsageMetadata: Option[DownloadUsageMetadata] = None
 )
 object Usage {
   import JodaWrites._

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReferenceType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReferenceType.scala
@@ -9,6 +9,7 @@ trait UsageReferenceType {
     case ComposerUsageReference => "composer"
     case SyndicationUsageReference => "syndication"
     case FrontUsageReference => "front"
+    case DownloadUsageReference => "download"
   }
 }
 
@@ -22,6 +23,7 @@ object UsageReferenceType {
     case "composer" => ComposerUsageReference
     case "syndication" => SyndicationUsageReference
     case "front" => FrontUsageReference
+    case "download" => DownloadUsageReference
   }
 }
 
@@ -30,3 +32,4 @@ object FrontendUsageReference extends UsageReferenceType
 object ComposerUsageReference extends UsageReferenceType
 object SyndicationUsageReference extends UsageReferenceType
 object FrontUsageReference extends UsageReferenceType
+object DownloadUsageReference extends UsageReferenceType

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
@@ -8,6 +8,7 @@ sealed trait UsageStatus {
     case PublishedUsageStatus => "published"
     case RemovedUsageStatus => "removed"
     case SyndicatedUsageStatus => "syndicated"
+    case DownloadedUsageStatus => "downloaded"
     case UnknownUsageStatus => "unknown"
   }
 }
@@ -18,6 +19,7 @@ object UsageStatus {
     case "published" => PublishedUsageStatus
     case "removed" => RemovedUsageStatus
     case "syndicated" => SyndicatedUsageStatus
+    case "downloaded" => DownloadedUsageStatus
     case "unknown" => UnknownUsageStatus
   }
 
@@ -32,6 +34,7 @@ object PendingUsageStatus extends UsageStatus
 object PublishedUsageStatus extends UsageStatus
 object RemovedUsageStatus extends UsageStatus
 object SyndicatedUsageStatus extends UsageStatus
+object DownloadedUsageStatus extends UsageStatus
 
 // For Fronts usages as we don't know if a front is in draft or is live
 // TODO remove this once we do!

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageType.scala
@@ -7,6 +7,7 @@ trait UsageType {
     case PrintUsage => "print"
     case DigitalUsage => "digital"
     case SyndicationUsage => "syndication"
+    case DownloadUsage => "download"
   }
 }
 
@@ -18,9 +19,11 @@ object UsageType {
     case "print" => PrintUsage
     case "digital" => DigitalUsage
     case "syndication" => SyndicationUsage
+    case "download" => DownloadUsage
   }
 }
 
 object PrintUsage extends UsageType
 object DigitalUsage extends UsageType
 object SyndicationUsage extends UsageType
+object DownloadUsage extends UsageType

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
@@ -40,6 +40,8 @@ module.controller('grImageUsageCtrl', [
           return 'Pending publication';
         case 'published':
           return 'Published';
+        case 'downloaded':
+          return 'Downloads';
         case 'unknown':
           return 'Front'; // currently only fronts have an `unknown` type, see TODO above
         default:

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -31,9 +31,16 @@ imageUsagesService.factory('imageUsagesService', [function() {
         return `${metadata.get('front')}, ${metadata.get('addedBy')}`;
       }
 
+      function downloadUsageTitle(usage) {
+        const metadata = usage.get('downloadUsageMetadata');
+        return `${metadata.get('downloadedBy')}`;
+      }
+
       function usageTitle(usage) {
         if (usage.has('frontUsageMetadata')) {
           return frontsUsageTitle(usage);
+        } else if (usage.has('downloadUsageMetadata')) {
+          return downloadUsageTitle(usage);
         }
         const referenceType =
           usage.get('platform') === 'print' ? 'indesign' : 'frontend';

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -38,7 +38,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context) {
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics)
+  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, wsClient)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -3,9 +3,10 @@ package controllers
 import java.net.URI
 
 import akka.stream.scaladsl.StreamConverters
+import com.google.common.net.HttpHeaders
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model.{Action, _}
-import com.gu.mediaservice.lib.auth.Authentication.{ApiKeyAccessor, PandaUser, Principal}
+import com.gu.mediaservice.lib.auth.Authentication._
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.aws.{ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting.printDateTime
@@ -13,11 +14,13 @@ import com.gu.mediaservice.lib.logging.GridLogger
 import com.gu.mediaservice.model._
 import com.gu.permissions.PermissionDefinition
 import lib._
-import lib.elasticsearch.{ElasticSearch, _}
+import lib.elasticsearch._
+import org.apache.http.entity.ContentType
 import org.http4s.UriTemplate
 import org.joda.time.DateTime
 import play.api.http.HttpEntity
 import play.api.libs.json._
+import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
@@ -31,7 +34,8 @@ class MediaApi(
                 override val config: MediaApiConfig,
                 override val controllerComponents: ControllerComponents,
                 s3Client: S3Client,
-                mediaApiMetrics: MediaApiMetrics
+                mediaApiMetrics: MediaApiMetrics,
+                ws: WSClient
 )(implicit val ec: ExecutionContext) extends BaseController with ArgoHelpers with PermissionsHandler {
 
   private val searchParamList = List("q", "ids", "offset", "length", "orderBy",
@@ -212,9 +216,11 @@ class MediaApi(
         val file = StreamConverters.fromInputStream(() => s3Object.getObjectContent)
         val entity = HttpEntity.Streamed(file, image.source.size, image.source.mimeType.map(_.name))
 
-        Future.successful(
-          Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> s3Client.getContentDisposition(image, Source))
-        )
+          postToUsages(config.usageUri + "/usages/download", auth.getOnBehalfOfPrincipal(request.user, request), id, Authentication.getIdentity(request.user))
+
+          Future.successful(
+            Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> s3Client.getContentDisposition(image, Source))
+          )
       }
       case _ => Future.successful(ImageNotFound(id))
     }
@@ -235,6 +241,8 @@ class MediaApi(
             case _ => Source
           }))
 
+        postToUsages(config.usageUri + "/usages/download", auth.getOnBehalfOfPrincipal(request.user, request), id, Authentication.getIdentity(request.user))
+
         Future.successful(
           Redirect(config.imgopsUri + List(sourceImageUri.getPath, sourceImageUri.getRawQuery).mkString("?") + s"&w=$width&h=$height&q=$quality")
         )
@@ -243,6 +251,27 @@ class MediaApi(
     }
   }
 
+  def postToUsages(uri: String, onBehalfOfPrincipal: Authentication.OnBehalfOfPrincipal, mediaId: String, user: String) = {
+    val baseRequest = ws.url(uri)
+      .withHttpHeaders(Authentication.originalServiceHeaderName -> config.appName,
+        HttpHeaders.ORIGIN -> config.rootUri,
+        HttpHeaders.CONTENT_TYPE -> ContentType.APPLICATION_JSON.getMimeType)
+
+    val request = onBehalfOfPrincipal match {
+      case OnBehalfOfApiKey(service) =>
+        print(service.accessor.identity)
+        baseRequest.addHttpHeaders(Authentication.apiKeyHeaderName -> service.accessor.identity)
+      case OnBehalfOfUser(_, cookie) =>
+        baseRequest.addCookies(cookie)
+    }
+
+    val usagesMetadata = Map("mediaId" -> mediaId,
+      "dateAdded" -> printDateTime(DateTime.now()),
+      "downloadedBy" -> user)
+
+    GridLogger.info(s"Making usages download request")
+    request.post(Json.toJson(Map("data" -> usagesMetadata))) //fire and forget
+  }
   def imageSearch() = auth.async { request =>
     implicit val r = request
 

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -192,9 +192,9 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
         errorKey = "download-usage-parse-failed",
         errorMessage = JsError.toJson(e).toString
       ),
-      fur => {
-        GridLogger.info("recording download usage", req.user.accessor, fur.mediaId)
-        val group = usageGroup.build(fur)
+      usageRequest => {
+        GridLogger.info("recording download usage", req.user.accessor, usageRequest.mediaId)
+        val group = usageGroup.build(usageRequest)
         usageRecorder.usageSubject.onNext(group)
         Accepted
       }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -184,6 +184,23 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
     )
   }}
 
+  def setDownloadUsages() = auth(parse.json) { req => {
+    val request = (req.body \ "data").validate[DownloadUsageRequest]
+    request.fold(
+      e => respondError(
+        BadRequest,
+        errorKey = "download-usage-parse-failed",
+        errorMessage = JsError.toJson(e).toString
+      ),
+      fur => {
+        GridLogger.info("recording download usage", req.user.accessor, fur.mediaId)
+        val group = usageGroup.build(fur)
+        usageRecorder.usageSubject.onNext(group)
+        Accepted
+      }
+    )
+  }}
+
   def deleteUsages(mediaId: String) = auth.async {
     usageTable.queryByImageId(mediaId).map(usages => {
       usages.foreach(usageTable.deleteRecord)

--- a/usage/app/lib/MediaUsageBuilder.scala
+++ b/usage/app/lib/MediaUsageBuilder.scala
@@ -17,6 +17,7 @@ object MediaUsageBuilder {
     None,
     None,
     None,
+    None,
     printUsage.dateAdded
   )
 
@@ -32,6 +33,7 @@ object MediaUsageBuilder {
       status = mediaWrapper.contentStatus,
       printUsageMetadata = None,
       digitalUsageMetadata = Some(mediaWrapper.usageMetadata),
+      None,
       None,
       None,
       lastModified = mediaWrapper.lastModified
@@ -51,6 +53,7 @@ object MediaUsageBuilder {
       digitalUsageMetadata = None,
       syndicationUsageMetadata = Some(syndicationUsageRequest.metadata),
       None,
+      None,
       lastModified = syndicationUsageRequest.dateAdded
     )
   }
@@ -69,8 +72,27 @@ object MediaUsageBuilder {
       digitalUsageMetadata = None,
       syndicationUsageMetadata = None,
       frontUsageMetadata = Some(frontUsageRequest.metadata),
+      None,
       lastModified = frontUsageRequest.dateAdded
     )
   }
 
+  def build(downloadUsageRequest: DownloadUsageRequest, groupId: String): MediaUsage = {
+    val usageId = UsageIdBuilder.build(downloadUsageRequest)
+
+    MediaUsage (
+      usageId,
+      groupId,
+      downloadUsageRequest.mediaId,
+      DownloadUsage,
+      mediaType = "image",
+      downloadUsageRequest.status,
+      printUsageMetadata = None,
+      digitalUsageMetadata = None,
+      syndicationUsageMetadata = None,
+      frontUsageMetadata = None,
+      downloadUsageMetadata = Some(downloadUsageRequest.metadata),
+      lastModified = downloadUsageRequest.dateAdded
+    )
+  }
 }

--- a/usage/app/lib/UsageMetadataBuilder.scala
+++ b/usage/app/lib/UsageMetadataBuilder.scala
@@ -15,6 +15,14 @@ class UsageMetadataBuilder(config: UsageConfig) {
       Try(URI.create(s"${config.composerContentBaseUrl}/$composerId")).toOption
     })
 
+  def buildDownload(metadataMap: Map[String, Any]): Option[DownloadUsageMetadata] = {
+    Try {
+      DownloadUsageMetadata(
+        metadataMap("downloadedBy").asInstanceOf[String]
+      )
+    }.toOption
+  }
+
   def build(content: Content): DigitalUsageMetadata = {
     DigitalUsageMetadata(
       URI.create(content.webUrl),

--- a/usage/app/model/DownloadUsageRequest.scala
+++ b/usage/app/model/DownloadUsageRequest.scala
@@ -1,0 +1,22 @@
+package model
+
+import com.gu.mediaservice.model.usage.{DownloadUsageMetadata, UnknownUsageStatus, UsageStatus}
+import org.joda.time.DateTime
+import play.api.libs.json.{JodaReads, JodaWrites, Json, Reads, Writes}
+
+case class DownloadUsageRequest (
+  dateAdded: DateTime,
+  downloadedBy: String,
+  mediaId: String
+) {
+  val metadata: DownloadUsageMetadata = DownloadUsageMetadata(downloadedBy)
+  val status: UsageStatus = UnknownUsageStatus
+}
+object DownloadUsageRequest {
+  import JodaWrites._
+  import JodaReads._
+
+  implicit val reads: Reads[DownloadUsageRequest] = Json.reads[DownloadUsageRequest]
+  implicit val writes: Writes[DownloadUsageRequest] = Json.writes[DownloadUsageRequest]
+}
+

--- a/usage/app/model/DownloadUsageRequest.scala
+++ b/usage/app/model/DownloadUsageRequest.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.mediaservice.model.usage.{DownloadUsageMetadata, UnknownUsageStatus, UsageStatus}
+import com.gu.mediaservice.model.usage.{DownloadUsageMetadata, DownloadedUsageStatus, UsageStatus}
 import org.joda.time.DateTime
 import play.api.libs.json.{JodaReads, JodaWrites, Json, Reads, Writes}
 
@@ -10,7 +10,7 @@ case class DownloadUsageRequest (
   mediaId: String
 ) {
   val metadata: DownloadUsageMetadata = DownloadUsageMetadata(downloadedBy)
-  val status: UsageStatus = UnknownUsageStatus
+  val status: UsageStatus = DownloadedUsageStatus
 }
 object DownloadUsageRequest {
   import JodaWrites._

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -40,6 +40,13 @@ class UsageGroupOps(config: UsageConfig, liveContentApi: LiveContentApi, mediaWr
     ).mkString("_"))
   }"
 
+  def buildId(downloadUsageRequest: DownloadUsageRequest): String = s"download/${
+    MD5.hash(List(
+      downloadUsageRequest.mediaId,
+      downloadUsageRequest.metadata.downloadedBy
+    ).mkString("_"))
+  }"
+
   def build(content: Content, status: UsageStatus, lastModified: DateTime, isReindex: Boolean) =
     ContentWrapper.build(content, status, lastModified).map(contentWrapper => {
       val usages = createUsages(contentWrapper, isReindex)
@@ -76,6 +83,16 @@ class UsageGroupOps(config: UsageConfig, liveContentApi: LiveContentApi, mediaWr
       usageGroupId,
       frontUsageRequest.status,
       frontUsageRequest.dateAdded
+    )
+  }
+
+  def build(downloadUsageRequest: DownloadUsageRequest): UsageGroup = {
+    val usageGroupId = buildId(downloadUsageRequest)
+    UsageGroup(
+      Set(MediaUsageBuilder.build(downloadUsageRequest, usageGroupId)),
+      usageGroupId,
+      downloadUsageRequest.status,
+      downloadUsageRequest.dateAdded
     )
   }
 

--- a/usage/app/model/UsageIdBuilder.scala
+++ b/usage/app/model/UsageIdBuilder.scala
@@ -32,4 +32,10 @@ object UsageIdBuilder {
     Some(frontUsageRequest.metadata.front),
     Some(frontUsageRequest.status)
   ))
+
+  def build(downloadUsageRequest: DownloadUsageRequest) = buildId(List(
+    Some(downloadUsageRequest.mediaId),
+    Some(downloadUsageRequest.metadata.downloadedBy),
+    Some(downloadUsageRequest.status)
+  ))
 }

--- a/usage/app/model/UsageRecord.scala
+++ b/usage/app/model/UsageRecord.scala
@@ -20,6 +20,7 @@ case class UsageRecord(
   digitalUsageMetadata: Option[DigitalUsageMetadata] = None,
   syndicationUsageMetadata: Option[SyndicationUsageMetadata] = None,
   frontUsageMetadata: Option[FrontUsageMetadata] = None,
+  downloadUsageMetadata: Option[DownloadUsageMetadata] = None,
   dateAdded: Option[DateTime] = None,
   // Either is used here to represent 3 possible states:
   // remove-date, add-date and no-date
@@ -37,6 +38,7 @@ case class UsageRecord(
         digitalUsageMetadata.map(_.toMap).map(map => M("digital_metadata").set(map.asJava)),
         syndicationUsageMetadata.map(_.toMap).map(map => M("syndication_metadata").set(map.asJava)),
         frontUsageMetadata.map(_.toMap).map(map => M("front_metadata").set(map.asJava)),
+        downloadUsageMetadata.map(_.toMap).map(map => M("download_metadata").set(map.asJava)),
         dateAdded.map(dateAdd => N("date_added").set(dateAdd.getMillis)),
         dateRemoved.fold(
           _ => Some(N("date_removed").remove),
@@ -65,7 +67,8 @@ object UsageRecord {
     mediaUsage.printUsageMetadata,
     mediaUsage.digitalUsageMetadata,
     mediaUsage.syndicationUsageMetadata,
-    mediaUsage.frontUsageMetadata
+    mediaUsage.frontUsageMetadata,
+    mediaUsage.downloadUsageMetadata
   )
 
   def buildCreateRecord(mediaUsage: MediaUsage) = UsageRecord(
@@ -80,6 +83,7 @@ object UsageRecord {
     mediaUsage.digitalUsageMetadata,
     mediaUsage.syndicationUsageMetadata,
     mediaUsage.frontUsageMetadata,
+    mediaUsage.downloadUsageMetadata,
     Some(mediaUsage.lastModified),
     Left("clear")
   )

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -6,6 +6,7 @@ DELETE  /usages/media/:mediaId                          controllers.UsageApi.del
 POST    /usages/print                                   controllers.UsageApi.setPrintUsages
 POST    /usages/syndication                             controllers.UsageApi.setSyndicationUsages
 POST    /usages/front                                   controllers.UsageApi.setFrontUsages
+POST    /usages/download                                controllers.UsageApi.setDownloadUsages
 
 GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
 


### PR DESCRIPTION
## What does this change?
This is https://github.com/guardian/grid/pull/2670 rebased with `master` to bring it back into a mergeable state. I can't work out how to push to that particular branch, presumably because ownership resides in the fork.

From the original PR:

> Usages has a new 'downloads' type which records who has downloaded what and when. This is in a similar way to how the other usages are set up, and takes an API call to mark an image as downloaded (along with who downloaded it and a time stamp).
Media API has been updated so when downloads occur it will send a async request over to usages to mark it as download. This is a best effort call and no error handling is in place, as I don't think we should be too bothered if this call fails or not.

Sequence of events is:
1. User clicks download, issuing a `GET` to `/download` in `media-api`
1. Server fetches image from S3 and issues a `POST` to `usages`
1. On receipt of the `POST` request, `usages` persists information in dynamodb (pre-existing behaviour)
1. `usages` places a message on kinesis for `thrall` to consume (pre-existing behaviour)
1. `thrall` consumes message and indexes it into elasticsearch (pre-existing behaviour)

I not sure this is the correct way to achieve this as it breaks the implicit rule in Grid that two services don't talk directly to each other, enqueuing a message to be processed asynchronously is preferred:

1. User clicks download, issuing a `GET` to `/download` in `media-api`
1. Server fetches image from S3 and enqueues message for `usages` to consume
1. `usages` consumes message and persists information in dynamodb (pre-existing behaviour)
1. `usages` places a message on kinesis for `thrall` to consume (pre-existing behaviour)
1. `thrall` consumes message and indexes it into elasticsearch (pre-existing behaviour)

I'd suggest we do not do this in this PR however to keep the diff small and as close to the original PR as possible.

Note: Images with usages are kept indefinitely. Therefore images that are downloaded from Grid will begin to be persisted with this change. This might not be the behaviour we want. I'd recommend we talk with the picture desk about this and address it in a separate PR if necessary. We're currently keeping the vast majority of images already, so it might not be an issue.

## How can success be measured?
Image downloads are recorded as a usage both in the usage-api (dynamodb) and media-api (elasticsearch).

## Screenshots (if applicable)
**Kahuna**
![image](https://user-images.githubusercontent.com/836140/87212336-e449e900-c315-11ea-980d-7bfd0b427ad2.png)

**Usage API**
![image](https://user-images.githubusercontent.com/836140/87212375-12c7c400-c316-11ea-9764-64b1198e0010.png)

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

## Tested?
- [x] locally
- [x] on TEST

## Deploy sequence
This requires an update of the elasticsearch mapping. This is a manual step so care is needed when deploying.

1. Disable continuous deployment
1. Merge
1. Update mappings
1. Deploy
1. Enable continuous deployment