### PR TITLE
Add config value for whether downloads should be recorded as usages

### DIFF
--- a/dev/script/generate-dot-properties/service-config.js
+++ b/dev/script/generate-dot-properties/service-config.js
@@ -120,6 +120,7 @@ function getMediaApiConfig(config) {
         |quota.store.key=rcs-quota.json
         |security.cors.allowedOrigins=${getCorsAllowedOriginString(config)}
         |metrics.request.enabled=false
+        |image.record.download=false
         |`;
 }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -216,7 +216,9 @@ class MediaApi(
         val file = StreamConverters.fromInputStream(() => s3Object.getObjectContent)
         val entity = HttpEntity.Streamed(file, image.source.size, image.source.mimeType.map(_.name))
 
+        if(config.recordDownloadAsUsage) {
           postToUsages(config.usageUri + "/usages/download", auth.getOnBehalfOfPrincipal(request.user, request), id, Authentication.getIdentity(request.user))
+        }
 
           Future.successful(
             Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> s3Client.getContentDisposition(image, Source))
@@ -241,7 +243,9 @@ class MediaApi(
             case _ => Source
           }))
 
-        postToUsages(config.usageUri + "/usages/download", auth.getOnBehalfOfPrincipal(request.user, request), id, Authentication.getIdentity(request.user))
+        if(config.recordDownloadAsUsage) {
+          postToUsages(config.usageUri + "/usages/download", auth.getOnBehalfOfPrincipal(request.user, request), id, Authentication.getIdentity(request.user))
+        }
 
         Future.successful(
           Redirect(config.imgopsUri + List(sourceImageUri.getPath, sourceImageUri.getRawQuery).mkString("?") + s"&w=$width&h=$height&q=$quality")

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -28,6 +28,8 @@ class MediaApiConfig(override val configuration: Configuration) extends CommonCo
   // quota updates can only be turned off in DEV
   lazy val quotaUpdateEnabled: Boolean = if (isDev) properties.getOrElse("quota.update.enabled", "false").toBoolean else true
 
+  lazy val recordDownloadAsUsage: Boolean = boolean("image.record.download")
+
   lazy val imagesAlias: String = properties.getOrElse("es.index.aliases.read", configuration.get[String]("es.index.aliases.read"))
 
   lazy val elasticsearch6Url: String =  properties("es6.url")


### PR DESCRIPTION
## What does this change?
Following on from https://github.com/guardian/grid/pull/2977, this PR introduces a config value that can be used to determine whether downloads should be recorded as usages. By default, this value is set to `false` and the Grid will not record downloads as usages. 

## How can success be measured?
Running the Grid locally, upload an image. Click the 'Download' button, and observe that the Usages tab remains as in the image below:

![Screenshot 2020-07-23 at 12 43 14](https://user-images.githubusercontent.com/12645938/88282815-25f96d00-cce2-11ea-86be-d3e623c75d72.png)

## Tested?
- [x] locally
- [ ] on TEST
