### PR TITLE
Highlight search terms in the preview

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -82,7 +82,15 @@
         <p class="preview__description"
            title="{{ctrl.image.data.metadata.description || ctrl.image.data.metadata.title}}">
             <!-- Ensure contents in P to maintain height -->
-            {{ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;'}}
+            <span ng-repeat="word in ctrl.descriptionHighlighted">
+              <span ng-if="word.highlight">
+                <mark>{{word.term}}</mark>
+              </span>
+              <span ng-if="!word.highlight">
+                {{word.term}}
+              </span>
+
+            </span>
         </p>
     </div>
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -89,7 +89,6 @@
               <span ng-if="!word.highlight">
                 {{word.term}}
               </span>
-
             </span>
         </p>
     </div>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -51,7 +51,7 @@ image.controller('uiPreviewImageCtrl', [
         `Staff Image: ${ctrl.image.data.metadata.description}` :
         ctrl.image.data.metadata.description;
 
-    const queryTerms = (ctrl.query || "").split(" ");
+    const queryTerms = `${ctrl.query}`.split(" ");
     const description = ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;';
     ctrl.descriptionHighlighted = description.split(" ").map(term => queryTerms.includes(term) ? { term, highlight: true } : { term });
 

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -50,10 +50,16 @@ image.controller('uiPreviewImageCtrl', [
     ctrl.imageDescription = ctrl.states.isStaffPhotographer ?
         `Staff Image: ${ctrl.image.data.metadata.description}` :
         ctrl.image.data.metadata.description;
-
-    const queryTerms = `${ctrl.query}`.split(" ");
-    const description = ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;';
-    ctrl.descriptionHighlighted = description.split(" ").map(term => queryTerms.includes(term) ? { term, highlight: true } : { term });
+      const queryTerms = `${ctrl.query()}`.split(" ").filter(_=>_.length > 2);
+      const description = ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;';
+      ctrl.descriptionHighlighted = description.split(" ").map(term => {
+        const normalisedTerm = term.replace(/[^a-zA-Z0-9]/g, '');
+        if (queryTerms.some(queryTerm => (normalisedTerm.localeCompare(queryTerm, undefined, { sensitivity: 'base' }) == 0)))
+        {
+          return { term, highlight: true };
+        }
+        return { term };
+      });
 
     ctrl.flagState = ctrl.states.costState;
 

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -38,7 +38,6 @@ image.controller('uiPreviewImageCtrl', [
         imageService,
         imageUsagesService) {
     var ctrl = this;
-
     const freeUpdateListener = $rootScope.$on('image-updated', (e, updatedImage) => {
         if (ctrl.image.data.id === updatedImage.data.id) {
             ctrl.states = imageService(updatedImage).states;
@@ -51,6 +50,10 @@ image.controller('uiPreviewImageCtrl', [
     ctrl.imageDescription = ctrl.states.isStaffPhotographer ?
         `Staff Image: ${ctrl.image.data.metadata.description}` :
         ctrl.image.data.metadata.description;
+
+    const queryTerms = (ctrl.query || "").split(" ");
+    const description = ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;';
+    ctrl.descriptionHighlighted = description.split(" ").map(term => queryTerms.includes(term) ? { term, highlight: true } : { term });
 
     ctrl.flagState = ctrl.states.costState;
 
@@ -81,7 +84,8 @@ image.directive('uiPreviewImage', function() {
         scope: {
             image: '=',
             hideInfo: '=',
-            selectionMode: '='
+            selectionMode: '=',
+            query: '&'
         },
         // extra actions can be transcluded in
         transclude: true,
@@ -99,7 +103,9 @@ image.directive('uiPreviewImageLarge', ['observe$', 'inject$', 'imgops',
             scope: {
                 image: '=',
                 hideInfo: '=',
-                selectionMode: '='
+                selectionMode: '=',
+                query: '&'
+
             },
             // extra actions can be transcluded in
             transclude: true,
@@ -108,6 +114,7 @@ image.directive('uiPreviewImageLarge', ['observe$', 'inject$', 'imgops',
             controllerAs: 'ctrl',
             bindToController: true,
             link: function(scope, element, attrs, ctrl) {
+
                 ctrl.loading = false;
                 const image$ = new Rx.Subject();
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -3,7 +3,6 @@
      class="image-loading-results">
     Fetching images…
 </div>
-
 <div ng-if="! ctrl.loading">
     <div ng-if="ctrl.loadingError">
         Error loading results: {{ctrl.loadingError}}
@@ -133,7 +132,9 @@
                     <ui-preview-image image="image"
                                       selection-mode="ctrl.inSelectionMode"
                                       ng-class="{'preview__quick-select': ctrl.inSelectionMode}"
-                                      ng-click="ctrl.onImageClick(image, $event)">
+                                      ng-click="ctrl.onImageClick(image, $event)"
+                                      query="ctrl.query"
+                                      >
                         <button class="mark-as-seen image-action"
                                 title="Mark all images until this point as seen"
                                 ui-localstore="search.seenFrom"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -97,6 +97,7 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.images = [];
         ctrl.newImagesCount = 0;
+        ctrl.query = $stateParams.query || "";
 
         // Preview control
         ctrl.previewView = false;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -133,6 +133,10 @@ textarea {
     resize: vertical;
 }
 
+mark {
+  padding: 2px;
+}
+
 /* annoyingly we have to have these seperate as the moz-placeholder breaks the
 Chrome selector */
 input[disabled],


### PR DESCRIPTION
## What does this change?

This highlights the search term in the mini image preview.

An image may be a search hit if the search term appears late in the description, if it does, the chance of it being the correct image is diminished. 

This may be better to match the entire term, instead of by word in the query. This is just a proof of concept. (TODO: make it work/capitalisation)

## How can success be measured?

Does it help avoid accidental wrong images and is it liked by end users.

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/2670496/88830483-e9d47980-d1c5-11ea-977c-1d98c0fd9354.png)
![image](https://user-images.githubusercontent.com/2670496/88830500-f35de180-d1c5-11ea-8108-e410f21ac671.png)


## Who should look at this?
@guardian/digital-cms 


## Tested?
- [X] locally
- [ ] on TEST
