### PR TITLE
Search for usage references

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -31,6 +31,7 @@ export const filterFields = [
     'usages@>added',
     'usages@platform',
     'usages@status',
+    'usages@reference',
     'has',
     'croppedBy',
     'filename',

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -94,7 +94,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
 
   def AllowedParentFieldName = rule { "usages" }
   def AllowedNestedFieldName = rule {
-    "status" | "platform" | "section" | "publication" | "orderedBy"
+    "status" | "platform" | "section" | "publication" | "orderedBy" | "reference"
   }
   def AllowedFieldName = rule {
     "illustrator" |
@@ -132,6 +132,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   }) match {
     case "publication" => MultipleField(List("publicationName", "publicationCode"))
     case "section" => MultipleField(List("sectionId","sectionCode"))
+    case "reference" => MultipleField(List("references.uri", "references.name").map(usagesField))
     case "in" => MultipleField(List("location", "city", "state", "country").map(getFieldPath))
     case field => SingleField(getFieldPath(field))
   }

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -46,7 +46,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   def IsFieldName = rule { "is" }
   def IsMatchValue = rule { String ~> IsValue }
 
-  def NestedMatch = rule { ParentField ~ "@" ~ NestedField ~ ':' ~ MatchValue }
+  def NestedMatch = rule { ParentField ~ "@" ~ NestedField ~ ':' ~ ExactMatchValue }
   def NestedDateMatch = rule { ParentField ~ "@" ~ DateConstraintMatch ~> (
     (parentField: Field, dateMatch: Match) => {
       Nested(parentField, dateMatch.field, dateMatch.value)

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -240,7 +240,7 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
           Nested(
             SingleField("usages"),
             SingleField("usages.status"),
-            Words("pending")
+            Phrase("pending")
           ))
         )
       }
@@ -253,7 +253,20 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               "usages.references.uri",
               "usages.references.name"
             )),
-            Words("foo")
+            Phrase("foo")
+          ))
+        )
+      }
+
+      it("should match nested usage reference query with url supplied") {
+        Parser.run("usages@reference:https://generic.cms/1234") should be (List(
+          Nested(
+            SingleField("usages"),
+            MultipleField(List(
+              "usages.references.uri",
+              "usages.references.name"
+            )),
+            Phrase("https://generic.cms/1234")
           ))
         )
       }

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -235,12 +235,25 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
     }
 
     describe("nested usage") {
-      it("should match nested usage query") {
+      it("should match nested usage status query") {
         Parser.run("usages@status:pending") should be (List(
           Nested(
             SingleField("usages"),
             SingleField("usages.status"),
             Words("pending")
+          ))
+        )
+      }
+
+      it("should match nested usage reference query") {
+        Parser.run("usages@reference:foo") should be (List(
+          Nested(
+            SingleField("usages"),
+            MultipleField(List(
+              "usages.references.uri",
+              "usages.references.name"
+            )),
+            Words("foo")
           ))
         )
       }


### PR DESCRIPTION
## What does this change?
Adds a new chip `usages@reference` to search for a [UsageReference](https://github.com/guardian/grid/blob/5ca61af6ecaecffc4acc142511bd596dd698b693/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageReference.scala).

We'll search against the usage reference `name` and `uri` properties. Not every usage reference has a `name` and not every usage reference has a `uri`.

A digital usage, recorded from the CMS (Composer) creates these references:
```json
"references": [
  {
    "type": "frontend",
    "uri": "https://www.theguardian.com/sport/live/2020/jul/30/england-v-ireland-first-cricket-odi-live",
    "name": "England v Ireland: first ODI – live!"
  },
  {
    "type": "composer",
    "uri": "https://composer.gutools.co.uk/content/5f2274f98f08f42f5d729f79"
  }
]
```

A print usage creates these references:
```json
"references": [
  {
    "type": "indesign",
    "name": "2020-07-30, Guardian, World (News), Page 29"
  }
]
```

Searching both fields means we can keep the UI simple; a search for a paper reference is the same as a search for a URL reference.

**Note**
This moves to using an `ExactMatchValue` instead of a `MatchValue`. Previously we were using a `MatchValue` which would result in the use of the englishSStemmerAnalyzer analyzer ([LOC link](https://github.com/guardian/grid/blob/5ca61af6ecaecffc4acc142511bd596dd698b693/media-api/app/lib/elasticsearch/QueryBuilder.scala#L22-L25)). This analyzer does a number of things, one of which is ignoring forward slashes ("/"). It's a fuzzy match.

When searching for a usage reference (against field `usages.references.uri` or `usages.references.name`), we'd want to be able to search by Composer URL for ease. The `MatchValue` doesn't work here.

`ExactMatchValue` is actually preferred in a nested query; you'd use a nested query when looking for a specific value, thus performing a fuzzy match is less performant than a term match.

See https://discuss.elastic.co/t/query-string-query-forward-slash-how-to-explained/16637.

**Alternative solutions**
We could search against the `composerUrl` in a [DigitalUsageMetadata](https://github.com/guardian/grid/blob/5ca61af6ecaecffc4acc142511bd596dd698b693/common-lib/src/main/scala/com/gu/mediaservice/model/usage/DigitalUsageMetadata.scala#L11), however that's very specific to the Guardian and to Composer. Using usage references keeps things a bit more generic and provides the benefit of searching for print usage references.

## How can success be measured?
We can search for images used in a particular bit of content, using either the Composer URL, article URL or the paper reference.

Other nested queries (all the usage chips) continue to work as expected.

## Screenshots (if applicable)
**Grid search and its corresponding Composer piece**
![image](https://user-images.githubusercontent.com/836140/88939966-14363d80-d27f-11ea-9d33-aa63b504b85f.png)

![image](https://user-images.githubusercontent.com/836140/88937747-72155600-d27c-11ea-8044-d2ef360e1eef.png)

**Searching for print reference**
![image](https://user-images.githubusercontent.com/836140/88937935-abe65c80-d27c-11ea-9046-d968d5f99d54.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms @blishen 

## Tested?
- [x] locally
- [x] on TEST
