### PR TITLE
Add ‘removed’ to usages@status: suggestion

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -152,7 +152,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
 
     function getFilterSuggestions(field, value) {
         switch (field) {
-        case 'usages@status': return ['published', 'pending'];
+        case 'usages@status': return ['published', 'pending', 'removed'];
         case 'usages@platform': return ['print', 'digital'];
         case 'subject':  return prefixFilter(value)(subjects);
         case 'label':    return suggestLabels(value);


### PR DESCRIPTION
Currently, it’s not easy to see Taken down pictures, without hacking URL. This provides suggestions.

## Screenshots (if applicable)

<img width="257" alt="image" src="https://user-images.githubusercontent.com/6032869/89037602-b402d280-d336-11ea-9619-0869588ab559.png">

## Tested?
- [ ] locally
- [x] on TEST
