### PR TITLE
Proposal: Add cover card crop for editions.

### DIFF
--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -8,7 +8,7 @@ const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
 const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
 const square = {key: 'square', ratio: 1, ratioString: '1:1'};
 const freeform = {key: 'freeform', ratio: null};
-const editionsCoverCard = {key: 'cover card', ratio: 10 / 18, ratioString: '10:18'};
+const editionsCoverCard = {key: 'cover card', ratio: 10 / 17, ratioString: '10:17'};
 
 const cropOptions = [landscape, portrait, video, square, freeform, editionsCoverCard];
 

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -8,8 +8,9 @@ const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
 const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
 const square = {key: 'square', ratio: 1, ratioString: '1:1'};
 const freeform = {key: 'freeform', ratio: null};
+const editionsCoverCard = {key: 'cover card', ratio: 10 / 18, ratioString: '10:18'};
 
-const cropOptions = [landscape, portrait, video, square, freeform];
+const cropOptions = [landscape, portrait, video, square, freeform, editionsCoverCard];
 
 export const cropUtil = angular.module('util.crop', ['util.storage']);
 
@@ -18,6 +19,7 @@ cropUtil.constant('portrait', portrait);
 cropUtil.constant('video', video);
 cropUtil.constant('square', square);
 cropUtil.constant('freeform', freeform);
+cropUtil.constant('editionsCoverCard', editionsCoverCard);
 cropUtil.constant('cropOptions', cropOptions);
 cropUtil.constant('defaultCrop', landscape);
 


### PR DESCRIPTION
## What does this change?
This adds a new crop size for use in the [editions card builder](https://editions-card-builder.gutools.co.uk/). Cover cards are a fixed size, so it doesn't make sense for the production team to be using a freeform crop.

The obvious downside to this is that this is adding a very guardian specific (and one team of the guardian at that) functionality to a general purpose image search tool. So maybe it could go behind a permission or client side feature flag or something...or maybe it doesn't belong in the grid.

## How can success be measured?
We ask the editions production team if it has saved them some time.

## Screenshots (if applicable)

![Screenshot 2020-08-19 at 17 36 24](https://user-images.githubusercontent.com/3606555/90665126-8927e200-e243-11ea-9cdf-53fc30ea2bb4.jpg)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
Discussed initially with @AWare , maybe @paperboyo might also have some thoughts? 

## Tested?
- [ ] locally
- [x] on TEST
