### PR TITLE
Comment out Jonny Weeks from Staff list

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -48,7 +48,7 @@ object MetadataConfig {
     "Graham Turner"   -> "The Guardian",
     "Helen Davidson"  -> "The Guardian",
     "Jill Mead"       -> "The Guardian",
-    "Jonny Weeks"     -> "The Guardian",
+    //"Jonny Weeks"     -> "The Guardian", (Commented out as Jonny's photo's aren't always as Staff.)
     "Joshua Robertson" -> "The Guardian",
     "Rachel Vere"     -> "The Guardian",
     "Roger Tooth"     -> "The Guardian",


### PR DESCRIPTION
Jonny's work comes to us externally as well as internally, so it's not safe to mark him as staff for now.

