### PR TITLE
Delete versioned

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -15,7 +15,7 @@ object ImageIngestOperations {
   def optimisedPngKeyFromId(id: String): String = "optimised/" + fileKeyFromId(id: String)
 }
 
-class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config: CommonConfig)
+class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config: CommonConfig, isVersionedS3: Boolean = false)
   extends S3ImageStorage(config) {
 
   import ImageIngestOperations.{fileKeyFromId, optimisedPngKeyFromId}
@@ -31,8 +31,8 @@ class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config
   def storeOptimisedPng(id: String, file: File)
                        (implicit logMarker: LogMarker): Future[S3Object] =
     storeImage(imageBucket, optimisedPngKeyFromId(id), file, Some(Png))
-
-  def deleteOriginal(id: String): Future[Unit] = deleteVersionedImage(imageBucket, fileKeyFromId(id))
+  
+  def deleteOriginal(id: String): Future[Unit] = if(isVersionedS3) deleteVersionedImage(imageBucket, fileKeyFromId(id)) else deleteImage(imageBucket, fileKeyFromId(id))
   def deleteThumbnail(id: String): Future[Unit] = deleteImage(thumbnailBucket, fileKeyFromId(id))
   def deletePng(id: String): Future[Unit] = deleteImage(imageBucket, optimisedPngKeyFromId(id))
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -32,8 +32,7 @@ class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config
                        (implicit logMarker: LogMarker): Future[S3Object] =
     storeImage(imageBucket, optimisedPngKeyFromId(id), file, Some(Png))
 
-  def deleteOriginal(id: String): Future[Unit] = deleteImage(imageBucket, fileKeyFromId(id))
+  def deleteOriginal(id: String): Future[Unit] = deleteVersionedImage(imageBucket, fileKeyFromId(id))
   def deleteThumbnail(id: String): Future[Unit] = deleteImage(thumbnailBucket, fileKeyFromId(id))
   def deletePng(id: String): Future[Unit] = deleteImage(imageBucket, optimisedPngKeyFromId(id))
-
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/S3ImageStorage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/S3ImageStorage.scala
@@ -24,6 +24,12 @@ class S3ImageStorage(config: CommonConfig) extends S3(config) with ImageStorage 
     log.info(s"Deleted image $id from bucket $bucket")
   }
 
+  def deleteVersionedImage(bucket: String, id: String) = Future {
+    val objectVersion = client.getObjectMetadata(bucket, id).getVersionId
+    client.deleteVersion(bucket, id, objectVersion)
+    log.info(s"Deleted image $id from bucket $bucket (version: $objectVersion)")
+  }
+
   def deleteFolder(bucket: String, id: String) = Future {
 		val files = client.listObjects(bucket, id).getObjectSummaries.asScala
 		files.foreach(file => client.deleteObject(bucket, file.getKey))

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -44,9 +44,11 @@ class ThrallConfig(override val configuration: Configuration) extends CommonConf
   lazy val elasticsearch6Replicas: Int = properties("es6.replicas").toInt
 
   lazy val metadataTopicArn: String = properties("indexed.image.sns.topic.arn")
-
+  
   lazy val rewindFrom: Option[DateTime] = properties.get("thrall.kinesis.stream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
   lazy val lowPriorityRewindFrom: Option[DateTime] = properties.get("thrall.kinesis.lowPriorityStream.rewindFrom").map(ISODateTimeFormat.dateTime.parseDateTime)
+
+  lazy val isVersionedS3: Boolean = properties.getOrElse("s3.image.versioned", "false").toBoolean
 
   def kinesisConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisStream, rewindFrom, this)
   def kinesisLowPriorityConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)

--- a/thrall/app/lib/ThrallStore.scala
+++ b/thrall/app/lib/ThrallStore.scala
@@ -2,4 +2,4 @@ package lib
 
 import com.gu.mediaservice.lib
 
-class ThrallStore(config: ThrallConfig) extends lib.ImageIngestOperations(config.imageBucket, config.thumbnailBucket, config)
+class ThrallStore(config: ThrallConfig) extends lib.ImageIngestOperations(config.imageBucket, config.thumbnailBucket, config, config.isVersionedS3)


### PR DESCRIPTION
**NB: This is #2692 with conflicts resolved (as we unfortunately cannot edit the original PR**

Original description from @jamie-pitts:

## What does this change?

We (the BBC) use a versioned S3 bucket so that we can have CRR enabled. We found that deleting images doesn't actually delete the image (and so save storage space), instead it places a delete marker on top of the image. This PR is too permanently delete the image instead of place the delete marker. It is configurable so that you can say if the bucket is versioned or not (default is not, keep things how they are currently).

This of course isn't the only way of tackling this problem - you can add a lifecycle rule to your bucket to delete old versions and clear delete markers after a certain period of time. But as this has been done with a config param, then that could also be done and this disabled.


## How can success be measured?
Bucket size + number of objects should decrease over time once enabled


## Tested?
- [ x ] locally
- [ x ] on TEST
