### PR TITLE
fix build.sbt bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,10 +227,7 @@ def project(projectName: String, path: Option[String] = None): Project =
 val buildInfo = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,
-    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse {
-      val gitCommitId="git rev-parse HEAD" #|| "echo unknown" !!<
-        gitCommitId
-    })
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse("git rev-parse HEAD" #|| "echo unknown" !!<))    ))
   ),
   buildInfoPackage := "utils.buildinfo",
   buildInfoOptions := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -227,7 +227,10 @@ def project(projectName: String, path: Option[String] = None): Project =
 val buildInfo = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,
-    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse("git rev-parse HEAD" #|| "echo unknown" !!<))
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse {
+      val gitCommitId=Process("git rev-parse HEAD") #|| Process("echo unknown") !!<
+        gitCommitId
+    })
   ),
   buildInfoPackage := "utils.buildinfo",
   buildInfoOptions := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -227,7 +227,7 @@ def project(projectName: String, path: Option[String] = None): Project =
 val buildInfo = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,
-    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse("git rev-parse HEAD" #|| "echo unknown" !!<))    ))
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse("git rev-parse HEAD" #|| "echo unknown" !!<))
   ),
   buildInfoPackage := "utils.buildinfo",
   buildInfoOptions := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -227,11 +227,7 @@ def project(projectName: String, path: Option[String] = None): Project =
 val buildInfo = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,
-    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse (try {
-      "git rev-parse HEAD".!!.trim
-    } catch {
-      case e: Exception => "unknown"
-    }))
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse("git rev-parse HEAD" #|| "echo unknown" !!<))
   ),
   buildInfoPackage := "utils.buildinfo",
   buildInfoOptions := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -228,7 +228,7 @@ val buildInfo = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,
     BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse {
-      val gitCommitId=Process("git rev-parse HEAD") #|| Process("echo unknown") !!<
+      val gitCommitId="git rev-parse HEAD" #|| "echo unknown" !!<
         gitCommitId
     })
   ),


### PR DESCRIPTION
## What does this change?
This PR fixes a bug in built.sbt. It removes the try..catch. The idea is to either get the gitCommitId string value or return "Unknown" string.
## How can success be measured?

## Screenshots (if applicable)
<img width="772" alt="Screenshot 2020-09-14 at 14 57 27" src="https://user-images.githubusercontent.com/12300986/93083181-e70ce580-f69a-11ea-855c-c72a50a6c2b1.png">
<img width="772" alt="Screenshot 2020-09-14 at 14 58 15" src="https://user-images.githubusercontent.com/12300986/93083362-2804fa00-f69b-11ea-9089-15b0d4b882ea.png">


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
