### PR TITLE
Make ImageProcessor pluggable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,6 +90,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
     "com.typesafe.play" %% "play-logback" % "2.6.15", // needed when running the scripts
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
     "org.scalacheck" %% "scalacheck" % "1.14.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
     // needed to parse conditional statements in `logback.xml`

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -18,3 +18,8 @@ es {
   cluster: media-service
   port: 9300
 }
+
+image.processors = [
+  "com.gu.mediaservice.lib.cleanup.GuardianMetadataCleaners",
+  "com.gu.mediaservice.lib.cleanup.SupplierProcessors$"
+]

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromByline.scala
@@ -2,6 +2,12 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * A generally useful cleaner that assigns credits based on bylines.
+  * TODO: Make this more usefully configurable from config or similar?
+  * @param bylines
+  * @param credit
+  */
 case class AttributeCreditFromByline(bylines: List[String], credit: String) extends MetadataCleaner {
 
   val lowercaseBylines = bylines.map(_.toLowerCase)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromByline.scala
@@ -16,4 +16,14 @@ case class AttributeCreditFromByline(bylines: List[String], credit: String) exte
     case Some(byline) if lowercaseBylines.contains(byline.toLowerCase) => metadata.copy(credit = Some(credit))
     case _ => metadata
   }
+
+  override def description: String = s"AttributeCreditFromByline($credit)"
+}
+
+object AttributeCreditFromByline {
+  def fromCreditBylineMap(creditBylineMap: Map[String, List[String]]): ImageProcessor = {
+    ImageProcessor.compose("AttributeCreditFromBylines", creditBylineMap.map { case (credit, bylines) =>
+      AttributeCreditFromByline(bylines, credit)
+    }.toSeq:_*)
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -2,6 +2,10 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/*
+ Generic cleaner that normalises the byline and credit fields. They can come in various formats such as
+ Photographer via Agency or Photographer/Agency or even Photographer via Agency/OtherAgency into the dedicated fields.
+ */
 object BylineCreditReorganise extends MetadataCleaner {
   type Field = Option[String]
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CapitaliseProperty.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CapitaliseProperty.scala
@@ -2,6 +2,9 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/*
+ * Generic cleaner to fix up byline capitalisation
+ */
 object CapitaliseByline extends MetadataCleaner with CapitalisationFixer {
   // Note: probably not exhaustive list
   override val joinWords = List("van", "der", "den", "dem", "von", "de", "du", "la", "et")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CleanRubbishLocation.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CleanRubbishLocation.scala
@@ -2,6 +2,10 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/*
+  Cleans a small number of values that denote 'no value' - these are dropped to None
+  TODO: This could be applied to all fields in metadata (according to Akash/Mateusz)
+ */
 object CleanRubbishLocation extends MetadataCleaner {
 
   val Rubbish = """(\s*[.-]*\s*)""".r

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala
@@ -5,6 +5,9 @@ import java.util.Locale
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * Cleaner that maps 2/3 letter country codes onto country names
+  */
 object CountryCode extends MetadataCleaner with GridLogging {
 
   val TwoLetterCode   = """([A-Z]{2})""".r

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/DropRedundantTitle.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/DropRedundantTitle.scala
@@ -2,7 +2,9 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
-
+/**
+  * Generic data cleaner that drops the title from an image if the text matches the start of the description.
+  */
 object DropRedundantTitle extends MetadataCleaner {
   override def clean(metadata: ImageMetadata): ImageMetadata = (metadata.title, metadata.description) match {
     case (Some(title), Some(description)) => metadata.copy(title = cleanTitle(title, description))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ExtractGuardianCreditFromByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ExtractGuardianCreditFromByline.scala
@@ -2,6 +2,9 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * Super Guardian-specific - really only important for old pictures.
+  */
 object ExtractGuardianCreditFromByline extends MetadataCleaner {
 
   val BylineForTheGuardian = """(?i)(.+) for the (Guardian|Observer)[.]?""".r

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/GuardianStyleByline.scala
@@ -2,6 +2,9 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * TODO: Split this into two cleaners?
+  */
 object GuardianStyleByline extends MetadataCleaner {
   override def clean(metadata: ImageMetadata): ImageMetadata = {
     metadata.copy(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ImageProcessor.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ImageProcessor.scala
@@ -1,0 +1,51 @@
+package com.gu.mediaservice.lib.cleanup
+
+import com.gu.mediaservice.model.Image
+
+/**
+  * An image processor has a single apply method that takes an `Image` and returns an `Image`. This can be used
+  * to modify the image in any number of ways and is primarily used to identify and allocate images from different
+  * suppliers and also to clean and conform metadata.
+  */
+trait ImageProcessor {
+  def apply(image: Image): Image
+  def description: String = getClass.getCanonicalName
+}
+
+trait ComposedImageProcessor extends ImageProcessor {
+  def processors: Seq[ImageProcessor]
+}
+
+object ImageProcessor {
+  val identity: ImageProcessor = new ImageProcessor {
+    override def apply(image: Image): Image = image
+    override def description: String = "identity"
+  }
+  /** A convenience method that creates a new ComposedImageProcessor from the provided image processors
+    * @param name The string name used to identify this composition
+    * @param imageProcessors the underlying image processors that are to be composed
+    * @return a new image processor that composes the provided image processors in order
+    * */
+  def compose(name: String, imageProcessors: ImageProcessor*): ComposedImageProcessor = new ComposedImageProcessor {
+    def apply(image: Image): Image =
+      imageProcessors
+        .foldLeft(image) { case (i, processor) => processor(i) }
+
+    override def description: String = imageProcessors
+      .map(_.description)
+      .mkString(s"$name(", "; ", ")")
+
+    override def processors: Seq[ImageProcessor] = imageProcessors
+  }
+}
+
+/**
+  * An image processor that simply composes a number of other image processors together.
+  * @param imageProcessors the underlying image processors that are to be applied when this imageProcessor is used
+  */
+class ComposeImageProcessors(val imageProcessors: ImageProcessor*) extends ComposedImageProcessor {
+  val underlying: ComposedImageProcessor = ImageProcessor.compose(getClass.getCanonicalName, imageProcessors:_*)
+  override def apply(image: Image): Image = underlying.apply(image)
+  override def description: String = underlying.description
+  override def processors: Seq[ImageProcessor] = underlying.processors
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerByline.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InitialJoinerByline.scala
@@ -2,6 +2,9 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * Guardian style, depends on the GuardianStyleByline and the CapitaliseByline processors
+  */
 object InitialJoinerByline extends MetadataCleaner {
   // Squish together pairs of dangling initials. For example: "C P Scott" -> "CP Scott"
   override def clean(metadata: ImageMetadata): ImageMetadata = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.cleanup
 
-import com.gu.mediaservice.model.ImageMetadata
+import com.gu.mediaservice.lib.config.MetadataConfig
+import com.gu.mediaservice.model.{Image, ImageMetadata}
 
 trait MetadataCleaner extends ImageProcessor {
   def clean(metadata: ImageMetadata): ImageMetadata
@@ -8,20 +9,17 @@ trait MetadataCleaner extends ImageProcessor {
   override def apply(image: Image): Image = image.copy(metadata = clean(image.metadata))
 }
 
-class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
+class GuardianMetadataCleaners extends MetadataCleaners(MetadataConfig.allPhotographersMap)
 
-  val attrCreditFromBylineCleaners = creditBylineMap.map { case (credit, bylines) =>
-    AttributeCreditFromByline(bylines, credit)
-  }
-
-  val allCleaners: List[MetadataCleaner] = List(
+class MetadataCleaners(creditBylineMap: Map[String, List[String]])
+  extends ComposeImageProcessors(
     CleanRubbishLocation,
     StripCopyrightPrefix,
     RedundantTokenRemover,
     BylineCreditReorganise,
     UseCanonicalGuardianCredit,
-    ExtractGuardianCreditFromByline
-  ) ++ attrCreditFromBylineCleaners ++ List(
+    ExtractGuardianCreditFromByline,
+    AttributeCreditFromByline.fromCreditBylineMap(creditBylineMap),
     CountryCode,
     GuardianStyleByline,
     CapitaliseByline,
@@ -33,12 +31,6 @@ class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {
     DropRedundantTitle,
     PhotographerRenamer
   )
-
-  def clean(inputMetadata: ImageMetadata): ImageMetadata =
-    allCleaners.foldLeft(inputMetadata) {
-      case (metadata, cleaner) => cleaner.clean(metadata)
-    }
-}
 
 // By vague order of importance:
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -2,8 +2,10 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
-trait MetadataCleaner {
+trait MetadataCleaner extends ImageProcessor {
   def clean(metadata: ImageMetadata): ImageMetadata
+
+  override def apply(image: Image): Image = image.copy(metadata = clean(image.metadata))
 }
 
 class MetadataCleaners(creditBylineMap: Map[String, List[String]]) {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/PhotographerRenamer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/PhotographerRenamer.scala
@@ -2,9 +2,15 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/*
+  Mapping of names used by agencies to the names which is correct by some measure.
+  TODO: Largely generic and we can make it completely so.
+ */
 object PhotographerRenamer extends MetadataCleaner {
+  val dependencies: Seq[Class[_]] = Seq(BylineCreditReorganise.getClass)
+
   val names = Map(
-    "WPA Pool" -> "WPA",
+    "WPA Pool" -> "WPA", // this is a bit guardian specific
     "Lipnitzki" -> "Boris Lipnitzki",
     "Abdullah Coskun" -> "Abdullah Coşkun",
     "Adam Warzawa" -> "Adam Warżawa",
@@ -443,7 +449,7 @@ object PhotographerRenamer extends MetadataCleaner {
     "Venturelli" -> "Daniele Venturelli",
     "Veronique de Viguerie" -> "Véronique de Viguerie",
     "Veronique Durruty" -> "Véronique Durruty",
-    "Victor R Caivano" -> "Víctor R Caivano",
+    "Victor R Caivano" -> "Víctor R Caivano", // relies on a previous cleaner having removed the '.' from 'R.' (GuardianStyleByline and InitialJoiner?)
     "Villar Lopez" -> "Villar López",
     "Vincent Perez" -> "Vincent Pérez",
     "Vit Simanek" -> "Vít Šimánek",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -1,6 +1,9 @@
 package com.gu.mediaservice.lib.cleanup
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * Possibly generic cleaner that removes common tokens from byline/credit that are meaningless. Will never leave the credit empty.
+  */
 object RedundantTokenRemover extends MetadataCleaner {
   val toRemove = List(
     "Handout",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/StripCopyrightPrefix.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/StripCopyrightPrefix.scala
@@ -2,6 +2,10 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/**
+  * Remove any explicit copyright character or string.
+  * TODO: Remove processing from copyright field (see PR#2778)
+  */
 object StripCopyrightPrefix extends MetadataCleaner {
 
   // Prefix-match any combination of copyright (separated by whitespace)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -1,17 +1,13 @@
 package com.gu.mediaservice.lib.cleanup
 
-import com.gu.mediaservice.model.{NoRights, Agencies, Agency, Image, StaffPhotographer, ContractPhotographer}
+import com.gu.mediaservice.model.{Agencies, Agency, Image, StaffPhotographer, ContractPhotographer}
 import com.gu.mediaservice.lib.config.PhotographersList
-
-trait ImageProcessor {
-  def apply(image: Image): Image
-}
 
 /**
   * This is largely generic or close to generic processing aside from the Guardian Photographer parser.
   */
-object SupplierProcessors {
-  val all: List[ImageProcessor] = List(
+object SupplierProcessors
+  extends ComposeImageProcessors(
     GettyXmpParser,
     GettyCreditParser,
     AapParser,
@@ -27,10 +23,6 @@ object SupplierProcessors {
     RonaldGrantParser,
     PhotographerParser
   )
-
-  def process(image: Image): Image =
-    all.foldLeft(image) { case (im, processor) => processor(im) }
-}
 
 /**
   * Guardian specific logic to correctly identify Guardian and Observer photographers and their contracts

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -7,6 +7,9 @@ trait ImageProcessor {
   def apply(image: Image): Image
 }
 
+/**
+  * This is largely generic or close to generic processing aside from the Guardian Photographer parser.
+  */
 object SupplierProcessors {
   val all: List[ImageProcessor] = List(
     GettyXmpParser,
@@ -29,6 +32,9 @@ object SupplierProcessors {
     all.foldLeft(image) { case (im, processor) => processor(im) }
 }
 
+/**
+  * Guardian specific logic to correctly identify Guardian and Observer photographers and their contracts
+  */
 object PhotographerParser extends ImageProcessor {
   def apply(image: Image): Image = {
     image.metadata.byline.flatMap { byline =>

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/UseCanonicalGuardianCredit.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/UseCanonicalGuardianCredit.scala
@@ -2,6 +2,10 @@ package com.gu.mediaservice.lib.cleanup
 
 import com.gu.mediaservice.model.ImageMetadata
 
+/*
+ * Guardian specific logic for internal consistency (possibly originally for importing old images)
+ * TODO: Merge into styleguide rule?
+ */
 object UseCanonicalGuardianCredit extends MetadataCleaner {
 
   // Map "Guardian" credit (old style) to canonical "The Guardian"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -10,7 +10,7 @@ import play.api.Configuration
 import scala.util.Try
 
 
-abstract class CommonConfig(configuration: Configuration) extends AwsClientBuilderUtils with StrictLogging {
+abstract class CommonConfig(val configuration: Configuration) extends AwsClientBuilderUtils with StrictLogging {
   final val elasticsearchStack = "media-service"
 
   final val elasticsearchApp = "elasticsearch"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ImageProcessorLoader.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ImageProcessorLoader.scala
@@ -1,0 +1,109 @@
+package com.gu.mediaservice.lib.config
+
+import com.gu.mediaservice.lib.cleanup.ImageProcessor
+import com.typesafe.config.ConfigException.BadValue
+import com.typesafe.config.{Config, ConfigObject, ConfigOrigin, ConfigValue, ConfigValueType}
+import com.typesafe.scalalogging.StrictLogging
+import play.api.{ConfigLoader, Configuration}
+
+import scala.collection.JavaConverters._
+import scala.language.existentials
+import scala.util.Try
+import scala.util.control.NonFatal
+
+object ImageProcessorLoader extends StrictLogging {
+  case class ImageProcessorConfigDetails(className: String, config: Option[Configuration], origin: ConfigOrigin, path: String)
+
+  implicit val imageProcessorsConfigLoader: ConfigLoader[Seq[ImageProcessor]] = (config: Config, path: String) => {
+    config
+      .getList(path)
+      .iterator()
+      .asScala.map { configValue =>
+      parseConfigValue(configValue, path)
+    }.map(loadImageProcessor).toList
+  }
+
+  implicit val imageProcessorConfigLoader: ConfigLoader[ImageProcessor] = (config: Config, path: String) => {
+    val configDetails = parseConfigValue(config.getValue(path), path)
+    loadImageProcessor(configDetails)
+  }
+
+  private def parseConfigValue(configValue: ConfigValue, path: String): ImageProcessorConfigDetails = {
+    configValue match {
+      case plainClass if plainClass.valueType == ConfigValueType.STRING =>
+        ImageProcessorConfigDetails(plainClass.unwrapped.asInstanceOf[String], None, plainClass.origin, path)
+      case withConfig:ConfigObject if validConfigObject(withConfig) =>
+        val config = withConfig.toConfig
+        val className = config.getString("className")
+        val processorConfig = config.getConfig("config")
+        ImageProcessorConfigDetails(className, Some(Configuration(processorConfig)), withConfig.origin, path)
+      case _ =>
+        throw new BadValue(configValue.origin, path, s"An image processor can either a class name (string) or object with className (string) and config (object) fields. This ${configValue.valueType} is not valid.")
+    }
+  }
+
+  private def validConfigObject(configObject: ConfigObject): Boolean = {
+    val config = configObject.toConfig
+    config.hasPath("className") && config.hasPath("config")
+  }
+
+  private def loadImageProcessor(details: ImageProcessorConfigDetails): ImageProcessor = {
+    ImageProcessorLoader
+      .loadImageProcessor(details.className, details.config.getOrElse(Configuration.empty))
+      .getOrElse { error =>
+        val configError = s"Unable to instantiate image processor from config: $error"
+        logger.error(configError)
+        throw new BadValue(details.origin, details.path, configError)
+      }
+  }
+
+  def loadImageProcessor(className: String, config: Configuration): Either[String, ImageProcessor] = {
+    for {
+      imageProcessorClass <- loadClass(className)
+      imageProcessorInstance <- instantiate(imageProcessorClass, config)
+    } yield imageProcessorInstance
+  }
+
+  private def loadClass(className: String): Either[String, Class[_]] = catchNonFatal(Class.forName(className)) {
+    case _: ClassNotFoundException => s"Unable to find image processor class $className"
+    case other =>
+      logger.error(s"Error whilst loading $className", other)
+      s"Unknown error whilst loading $className, check logs"
+  }
+
+  private def instantiate(imageProcessorClass: Class[_], config: Configuration): Either[String, ImageProcessor] = {
+    // Fail fast if config is provided but the specified image processor ignores it
+    def assertNoConfiguration[T](ok: Right[String, T]): Either[String, T] = {
+      if (config.keys.nonEmpty) {
+        Left(s"Attempt to initialise image processor ${imageProcessorClass.getCanonicalName} failed as configuration is provided but the constructor does not take configuration as an argument.")
+      } else {
+        ok
+      }
+    }
+
+    val maybeCompanionObject = Try(imageProcessorClass.getField("MODULE$").get(imageProcessorClass)).toOption
+    val maybeNoArgCtor = Try(imageProcessorClass.getDeclaredConstructor()).toOption
+    val maybeConfigCtor = Try(imageProcessorClass.getDeclaredConstructor(classOf[Configuration])).toOption
+    for {
+      instance <- (maybeCompanionObject, maybeNoArgCtor, maybeConfigCtor) match {
+        case (Some(companionObject), _, _) => assertNoConfiguration(Right(companionObject))
+        case (_, _, Some(configCtor)) => Right(configCtor.newInstance(config))
+        case (_, Some(noArgCtor), None) => assertNoConfiguration(Right(noArgCtor.newInstance()))
+        case (None, None, None) => Left(s"Unable to find a suitable constructor for ${imageProcessorClass.getCanonicalName}. Must either have a no arg constructor or a constructor taking one argument of type ImageProcessorConfig.")
+      }
+      castInstance <- try {
+        Right(instance.asInstanceOf[ImageProcessor])
+      } catch {
+        case _: ClassCastException => Left(s"Failed to cast ${imageProcessorClass.getCanonicalName} to an ImageProcessor")
+      }
+    } yield castInstance
+  }
+
+  private def catchNonFatal[T](block: => T)(error: Throwable => String): Either[String, T] = {
+    try {
+      Right(block)
+    } catch {
+      case NonFatal(e) => Left(error(e))
+    }
+  }
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -418,7 +418,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
 
 
   def applyProcessors(image: Image): Image =
-    SupplierProcessors.process(image)
+    SupplierProcessors.apply(image)
 
 
 }

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.mediaservice.lib.imaging.ImageOperations
+import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.ImageLoaderController
 import lib._
@@ -7,8 +8,13 @@ import model.{Projector, Uploader}
 import play.api.ApplicationLoader.Context
 import router.Routes
 
-class ImageLoaderComponents(context: Context) extends GridComponents(context, new ImageLoaderConfig(_)) {
+class ImageLoaderComponents(context: Context) extends GridComponents(context, new ImageLoaderConfig(_)) with GridLogging {
   final override val buildInfo = utils.buildinfo.BuildInfo
+
+  logger.info(s"Loaded ${config.imageProcessor.processors.size} image processors:")
+  config.imageProcessor.processors.zipWithIndex.foreach { case (processor, index) =>
+    logger.info(s" $index -> ${processor.description}")
+  }
 
   val store = new ImageLoaderStore(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -2,11 +2,13 @@ package lib
 
 import java.io.File
 
-import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.cleanup.{ComposedImageProcessor, ImageProcessor}
+import com.gu.mediaservice.lib.config.{CommonConfig, ImageProcessorLoader}
 import com.gu.mediaservice.model._
+import com.typesafe.scalalogging.StrictLogging
 import play.api.Configuration
 
-class ImageLoaderConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
+class ImageLoaderConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) with StrictLogging {
   val imageBucket: String = string("s3.image.bucket")
 
   val thumbnailBucket: String = string("s3.thumb.bucket")
@@ -23,4 +25,37 @@ class ImageLoaderConfig(playAppConfiguration: Configuration) extends CommonConfi
   val transcodedMimeTypes: List[MimeType] = getStringSet("transcoded.mime.types").toList.map(MimeType(_))
   val supportedMimeTypes: List[MimeType] = List(Jpeg, Png) ::: transcodedMimeTypes
 
+  /**
+    * Load in the chain of image processors from config. This can be a list of
+    * companion objects, class names, both with and without config.
+    * For example:
+    * {{{
+    * image.processors = [
+    *   // simple class
+    *   "com.gu.mediaservice.lib.cleanup.GuardianMetadataCleaners",
+    *   // a companion object
+    *   "com.gu.mediaservice.lib.cleanup.SupplierProcessors$",
+    *   "com.yourdomain.YourImageProcessor",
+    *   // a class with a single arg constructor taking a play Configuration object
+    *   {
+    *     className: "com.yourdomain.YourImageProcessorWithConfig"
+    *     config: {
+    *       configKey1: value1
+    *     }
+    *   }
+    * ]
+    * }}}
+    *
+    * Depending on the type it will be loaded differently using reflection. Companion objects will be looked up
+    * and the singleton instance added to the list. Classes will be looked up and will be examined for an appropriate
+    * constructor. The constructor can either be no-arg or have a single argument of `play.api.Configuration`.
+    *
+    * If configuration is specified but not used (a companion object or class with no arg constructor is specified)
+    * then loading the image processor will fail so as to avoid configuration errors.
+    */
+  val imageProcessor: ComposedImageProcessor = {
+    val processors = configuration
+      .get[Seq[ImageProcessor]]("image.processors")(ImageProcessorLoader.imageProcessorsConfigLoader)
+    ImageProcessor.compose("ImageConfigLoader-imageProcessor", processors:_*)
+  }
 }

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
 import com.gu.mediaservice.lib.{ImageIngestOperations, StorableOptimisedImage, StorableOriginalImage, StorableThumbImage}
 import com.gu.mediaservice.lib.aws.S3Ops
+import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.LogMarker
 import com.gu.mediaservice.lib.net.URI
@@ -27,7 +28,7 @@ object Projector {
   import Uploader.toImageUploadOpsCfg
 
   def apply(config: ImageLoaderConfig, imageOps: ImageOperations)(implicit ec: ExecutionContext): Projector
-  = new Projector(toImageUploadOpsCfg(config), S3Ops.buildS3Client(config), imageOps)
+  = new Projector(toImageUploadOpsCfg(config), S3Ops.buildS3Client(config), imageOps, config.imageProcessor)
 }
 
 case class S3FileExtractedMetadata(
@@ -62,9 +63,10 @@ object S3FileExtractedMetadata {
 
 class Projector(config: ImageUploadOpsCfg,
                 s3: AmazonS3,
-                imageOps: ImageOperations) {
+                imageOps: ImageOperations,
+                processor: ImageProcessor) {
 
-  private val imageUploadProjectionOps = new ImageUploadProjectionOps(config, imageOps)
+  private val imageUploadProjectionOps = new ImageUploadProjectionOps(config, imageOps, processor)
 
   def projectS3ImageById(imageUploadProjector: Projector, imageId: String, tempFile: File, requestId: UUID)
                         (implicit ec: ExecutionContext, logMarker: LogMarker): Future[Option[Image]] = {
@@ -122,7 +124,8 @@ class Projector(config: ImageUploadOpsCfg,
 }
 
 class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
-                               imageOps: ImageOperations) {
+                               imageOps: ImageOperations,
+                               processor: ImageProcessor) {
 
   import Uploader.{fromUploadRequestShared, toMetaMap}
 
@@ -131,7 +134,7 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
                                    (implicit ec: ExecutionContext, logMarker: LogMarker): Future[Image] = {
     val dependenciesWithProjectionsOnly = ImageUploadOpsDependencies(config, imageOps,
     projectOriginalFileAsS3Model, projectThumbnailFileAsS3Model, projectOptimisedPNGFileAsS3Model)
-    fromUploadRequestShared(uploadRequest, dependenciesWithProjectionsOnly)
+    fromUploadRequestShared(uploadRequest, dependenciesWithProjectionsOnly, processor)
   }
 
   private def projectOriginalFileAsS3Model(storableOriginalImage: StorableOriginalImage)

--- a/image-loader/test/scala/lib/ImageProcessorLoaderTest.scala
+++ b/image-loader/test/scala/lib/ImageProcessorLoaderTest.scala
@@ -1,0 +1,176 @@
+package scala.lib
+
+import com.gu.mediaservice.lib.cleanup.ImageProcessor
+import com.gu.mediaservice.lib.config.ImageProcessorLoader
+import com.gu.mediaservice.model.Image
+import com.typesafe.config.ConfigException.BadValue
+import com.typesafe.config.ConfigFactory
+import org.joda.time.DateTime
+import org.scalatest.Inside.inside
+import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import play.api.Configuration
+
+object ObjectImageProcessor extends ImageProcessor {
+  override def apply(image: Image): Image = image.copy(id = "object-image-processed")
+}
+
+class NoArgImageProcessor extends ImageProcessor {
+  override def apply(image: Image): Image = image.copy(id = "no-arg-image-processed")
+}
+
+case class ConfigImageProcessor(config: Configuration) extends ImageProcessor {
+  override def apply(image: Image): Image = image.copy(id = s"config-image-processed ${config.hashCode}")
+}
+
+class NotAnImageProcessor {
+  def apply(image: Image): Image = image.copy(id = "not-image-processed")
+}
+
+class ImageProcessorWithStringConstructor(configString: String) extends ImageProcessor {
+  def apply(image: Image): Image = image.copy(id = "not-image-processed")
+}
+
+class ImageProcessorLoaderTest extends FreeSpec with Matchers with EitherValues {
+  val testImage: Image = Image("image", DateTime.now(), "Test", None, Map.empty, null, null, null, null, null, null, null, null, null, null)
+  val testConfig: Configuration = Configuration.empty
+  val testNonEmptyConfig: Configuration = Configuration.from(Map("someConfig" -> "my value"))
+
+  "The class reflector" - {
+    "should successfully load a no arg ImageProcessor instance" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NoArgImageProcessor].getCanonicalName, testConfig)
+      instance.right.value.apply(testImage).id shouldBe "no-arg-image-processed"
+    }
+
+    "should successfully load a config arg ImageProcessor instance" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[ConfigImageProcessor].getCanonicalName, testConfig)
+      instance.right.value.apply(testImage).id shouldBe s"config-image-processed ${testConfig.hashCode}"
+    }
+
+    "should successfully load a companion object ImageProcessor" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(ObjectImageProcessor.getClass.getCanonicalName, testConfig)
+      instance.right.value.apply(testImage).id shouldBe s"object-image-processed"
+    }
+
+    "should fail to load something that isn't an ImageProcessor" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NotAnImageProcessor].getCanonicalName, testConfig)
+      instance.left.value shouldBe "Failed to cast scala.lib.NotAnImageProcessor to an ImageProcessor"
+    }
+
+    "should fail to load something that doesn't have a suitable constructor" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[ImageProcessorWithStringConstructor].getCanonicalName, testConfig)
+      instance.left.value shouldBe "Unable to find a suitable constructor for scala.lib.ImageProcessorWithStringConstructor. Must either have a no arg constructor or a constructor taking one argument of type ImageProcessorConfig."
+    }
+
+    "should fail to load something that doesn't exist" in {
+      val instance = ImageProcessorLoader.loadImageProcessor("scala.lib.ImageProcessorThatDoesntExist", testConfig)
+      instance.left.value shouldBe "Unable to find image processor class scala.lib.ImageProcessorThatDoesntExist"
+    }
+
+    "should fail to load a no arg processor that doesn't take configuration with non-empty configuration" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(classOf[NoArgImageProcessor].getCanonicalName, testNonEmptyConfig)
+      instance.left.value shouldBe "Attempt to initialise image processor scala.lib.NoArgImageProcessor failed as configuration is provided but the constructor does not take configuration as an argument."
+    }
+
+    "should fail to load an object processor that doesn't take configuration with non-empty configuration" in {
+      val instance = ImageProcessorLoader.loadImageProcessor(ObjectImageProcessor.getClass.getCanonicalName, testNonEmptyConfig)
+      instance.left.value shouldBe "Attempt to initialise image processor scala.lib.ObjectImageProcessor$ failed as configuration is provided but the constructor does not take configuration as an argument."
+    }
+  }
+
+  import ImageProcessorLoader._
+
+  "The config loader" - {
+    "should load an image processor from a classname" in {
+      val conf:Configuration = Configuration.from(Map(
+        "some.path" -> List(
+          "scala.lib.NoArgImageProcessor"
+        )
+      ))
+      val processors = conf.get[Seq[ImageProcessor]]("some.path")
+      processors.head shouldBe a[NoArgImageProcessor]
+    }
+
+    "should load an image processor which has configuration" in {
+      val conf:Configuration = Configuration.from(Map(
+        "some.path" -> List(
+          Map(
+            "className" -> "scala.lib.ConfigImageProcessor",
+            "config" -> Map("parameter" -> "value")
+          )
+        )
+      ))
+      val processors = conf.get[Seq[ImageProcessor]]("some.path")
+      val processor = processors.head
+      inside(processor) {
+        case ConfigImageProcessor(config) => config.get[String]("parameter") shouldBe "value"
+      }
+    }
+
+    "should load multiple image processors of mixed config types" in {
+      val conf:Configuration = Configuration.from(Map(
+        "some.path" -> List(
+          "scala.lib.NoArgImageProcessor",
+          Map(
+            "className" -> "scala.lib.ConfigImageProcessor",
+            "config" -> Map("parameter" -> "value")
+          )
+        )
+      ))
+      val processors = conf.get[Seq[ImageProcessor]]("some.path")
+      processors.length shouldBe 2
+      processors.toList should matchPattern {
+        case (_:NoArgImageProcessor) :: ConfigImageProcessor(_) :: Nil =>
+      }
+    }
+
+    "should load multiple image processors of mixed config types from HOCON" in {
+      val conf:Configuration = Configuration(ConfigFactory.parseString(
+        """
+          |some.path: [
+          |  scala.lib.NoArgImageProcessor,
+          |  {
+          |    className: scala.lib.ConfigImageProcessor
+          |    config: {
+          |      parameter: value
+          |    }
+          |  }
+          |]
+          |""".stripMargin))
+      val processors = conf.get[Seq[ImageProcessor]]("some.path")
+      processors.length shouldBe 2
+      processors.toList should matchPattern {
+        case (_:NoArgImageProcessor) :: ConfigImageProcessor(_) :: Nil =>
+      }
+    }
+
+    "should fail to load multiple image processors if they don't meet the spec" in {
+      val conf:Configuration = Configuration.from(Map(
+        "some.path" -> List(
+          "scala.lib.NoArgImageProcessor",
+          Map(
+            "noClassName" -> "scala.lib.ConfigImageProcessor",
+            "config" -> Map("parameter" -> "value")
+          )
+        )
+      ))
+      val thrown = the[BadValue] thrownBy {
+        conf.get[Seq[ImageProcessor]]("some.path")
+      }
+      thrown.getMessage should include ("An image processor can either a class name (string) or object with className (string) and config (object) fields. This OBJECT is not valid.")
+    }
+
+    "should fail to an image processors it isn't a string" in {
+      val conf:Configuration = Configuration.from(Map(
+        "some.path" -> List(
+          List("fred")
+        )
+      ))
+      val thrown = the[BadValue] thrownBy {
+        conf.get[Seq[ImageProcessor]]("some.path")
+      }
+      thrown.getMessage should include ("An image processor can either a class name (string) or object with className (string) and config (object) fields. This LIST is not valid")
+    }
+
+
+  }
+}

--- a/image-loader/test/scala/model/ImageUploadTest.scala
+++ b/image-loader/test/scala/model/ImageUploadTest.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 import com.drew.imaging.ImageProcessingException
 import com.gu.mediaservice.lib.{StorableImage, StorableOptimisedImage, StorableOriginalImage, StorableThumbImage}
 import com.gu.mediaservice.lib.aws.{S3Metadata, S3Object, S3ObjectMetadata, S3Ops}
+import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.LogMarker
 import com.gu.mediaservice.model.{FileMetadata, Jpeg, MimeType, Png, Tiff, UploadInfo}
@@ -88,7 +89,8 @@ class ImageUploadTest extends AsyncFunSuite with Matchers with MockitoSugar {
       OptimiseWithPngQuant,
       uploadRequest,
       mockDependencies,
-      FileMetadata()
+      FileMetadata(),
+      ImageProcessor.identity
     )
 
     // Assertions; Failure will auto-fail

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -5,6 +5,7 @@ import java.net.URI
 import java.util.UUID
 
 import com.amazonaws.services.s3.AmazonS3
+import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.RequestLoggingContext
 import com.gu.mediaservice.model._
@@ -33,7 +34,7 @@ class ProjectorTest extends FunSuite with Matchers with ScalaFutures with Mockit
   private val config = ImageUploadOpsCfg(new File("/tmp"), 256, 85d, Nil, "img-bucket", "thumb-bucket")
 
   private val s3 = mock[AmazonS3]
-  private val projector = new Projector(config, s3, imageOperations)
+  private val projector = new Projector(config, s3, imageOperations, ImageProcessor.identity)
 
   // FIXME temporary ignored as test is not executable in CI/CD machine
   // because graphic lib files like srgb.icc, cmyk.icc are in root directory instead of resources


### PR DESCRIPTION
## What does this change?
This is a PR that makes image processors configurable via late binding (i.e. you can include an ImageProcessor in the configuration file even if it wasn't available at the time the grid was compiled).

## Background
As the Grid becomes used by more than one organisation it is becoming apparent that we need to introduce a higher degree of customisation in a few areas, most notably authentication, authorisation and image processing business logic.

There are a couple of different approaches to this. One simple approach is to have different options baked into the Grid and selected via configuration. At the Guardian we use [Pan Domain Authentication](https://github.com/guardian/pan-domain-authentication) for authentication and [Permissions](https://github.com/guardian/permissions) for authorisation. We could do an internal refactor and add options for other users selected via config. 

Similarly we have a lot of code that transforms the metadata of images. A series of PRs extract this logic and make it configurable via JSON data files stored in S3. This approach mimics existing behaviour for API keys and quota configuration but is not ideal for a number of reasons:
 - JSON isn't a syntax designed for use by humans (it doesn't support comments and has a lot of quotes)
 - JSON config limits the flexibility to what is available in the code that applies the config whilst Scala code is Turing complete
 - The validation and testing story of Scala code is somewhat better as there is a compiler and test suites

An alternative to configuration and external data files is to create API hooks to allow users downstream of the main Grid codebase to confirgure the Grid to load their custom code at initialisation using late binding.

## Configuring image processing using late binding
First of all every image-processor-like entity is re-written to conform to the `ImageProcessor` interface (there were a couple of interfaces that essentially implemented `Image => Image` but used a different function name or only operated on a single field of `Image`). A `ComposedImageProcessor` is also created to make it trivial to chain a number of processors together into an `ImageProcessor` in code.

We then introduce a configuration option that allows you to specify which processors should be run. They will be applied in the order that you list them in the `image.processors` property. Each processor can take extra configuration if desired. The property will take a list that can be a mix of simple strings that denote imapge processors to load and richer objects that are able to include configuration.

`ImageProcessor`s are loaded by reflection. We can load companion object, classes that have a no arg constructor and classes that have a constructor with a single parameter of type `play.api.Configuration` which will receive the configuration for that processor.

### Example configurations
The current default config looks like this:
```
image.processors = [
  // no arg class
  "com.gu.mediaservice.lib.cleanup.GuardianMetadataCleaners",
  // companion object (note the trailing $)
  "com.gu.mediaservice.lib.cleanup.SupplierProcessors$"
]
```

You could also override this entirely - in this case mixing existing standard processors with your own processors, one of which takes futher HOCON configuration that is passed into the constructor as an instance of `play.api.Configuration`:
```
image.processors = [
  "com.gu.mediaservice.lib.cleanup.GettyXmpParser$",
  "com.yourdomain.YourImageProcessor",
  // a class with a single arg constructor taking a play Configuration object
  {
    className: "com.yourdomain.YourImageProcessorWithConfig"
    config: {
      configKey1: value1
      configKey2: {
        map: of
        values: "for fun and profit"
      }
    }
  }
]
```

## How can success be measured?
Can the BBC subsequently apply the logic from their series of image processing PRs without having to convert our own config to JSON or similar.

## Remaining work
 - [x] Figure out a better way to allow configuration of custom plugins (converting all config to Typesafe Config and passing in a sub-tree of config looks promising)
 - [ ] Move existing builtin processors into a guardian subproject
 - [ ] Spike applying the BBC PRs into a BBC subproject as an alternate set of processors

## Tested?
- [X] locally
- [ ] on TEST