### PR TITLE
Handle image file failures as exceptions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -134,11 +134,11 @@ class ImageOperations(playPath: String) {
 
   def transformImage(sourceFile: File, sourceMimeType: Option[MimeType], tempDir: File): Future[File] = {
     for {
-      outputFile  <- createTempFile(s"transformed-", ".png", tempDir)
+      outputFile      <- createTempFile(s"transformed-", ".png", tempDir)
       transformSource = addImage(sourceFile)
-      addOutput    = addDestImage(transformSource)(outputFile)
-      _           <- runConvertCmd(addOutput, useImageMagick = sourceMimeType.contains(Tiff))
-      _           <- checkForOutputFileChange(outputFile)
+      addOutput       = addDestImage(transformSource)(outputFile)
+      _               <- runConvertCmd(addOutput, useImageMagick = sourceMimeType.contains(Tiff))
+      _               <- checkForOutputFileChange(outputFile)
     } yield outputFile
   }
 

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -86,9 +86,12 @@ class ImageLoaderController(auth: Authentication,
         case e =>
           Logger.error("loadImage request ended with a failure", e)
           (e match {
-            case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
-            case _: ImageProcessingException => FailureResponse.notAnImage(config.supportedMimeTypes)
-            case e => println(e.getMessage); InternalServerError(Json.obj("error" -> e.getMessage))
+
+            case e: ImageProcessingException => FailureResponse.notAnImage(e, config.supportedMimeTypes).as(ArgoMediaType)
+            case e: java.io.IOException => FailureResponse.badImage(e).as(ArgoMediaType)
+            case e =>
+              Logger.error("Failed upload", e)
+              InternalServerError(Json.obj("error" -> e.getMessage)).as(ArgoMediaType)
           }).as(ArgoMediaType)
       }
     }

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -86,7 +86,7 @@ class ImageLoaderController(auth: Authentication,
         case e =>
           Logger.error("loadImage request ended with a failure", e)
           (e match {
-
+            case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
             case e: ImageProcessingException => FailureResponse.notAnImage(e, config.supportedMimeTypes).as(ArgoMediaType)
             case e: java.io.IOException => FailureResponse.badImage(e).as(ArgoMediaType)
             case e =>

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -30,13 +30,23 @@ object FailureResponse extends ArgoHelpers {
       s"Unsupported mime-type: ${unsupported.mimeType}. Supported: ${supportedMimeTypes.mkString(", ")}"
     )
   }
-  def notAnImage(supportedMimeTypes: List[MimeType]): Result = {
-    Logger.info(s"Rejected request to load file: file type is not supported")
+  def notAnImage(exception: Exception, supportedMimeTypes: List[MimeType]): Result = {
+    Logger.info(s"Rejected request to load file: file type is not supported", exception)
 
     respondError(
       UnsupportedMediaType,
-      "unsupported-type",
-      s"Unsupported file type: not an image type. Supported: ${supportedMimeTypes.mkString(", ")}"
+      "unsupported-file-type",
+      s"Unsupported file type: not a valid image type. Supported: ${supportedMimeTypes.mkString(", ")}"
+    )
+  }
+
+  def badImage(exception: Exception): Result = {
+    Logger.info(s"Rejected request to load file: image file is not good")
+
+    respondError(
+      UnsupportedMediaType,
+      "bad-file",
+      s"Bad file: not a valid image file."
     )
   }
 }

--- a/image-loader/app/model/ImageUpload.scala
+++ b/image-loader/app/model/ImageUpload.scala
@@ -47,7 +47,8 @@ case object OptimisedPng {
 
 object OptimisedPngOps {
 
-  def build(file: File, uploadRequest: UploadRequest,
+  def build(file: File,
+            uploadRequest: UploadRequest,
             fileMetadata: FileMetadata,
             config: ImageUploadOpsCfg,
             storeOrProject: (UploadRequest, File) => Future[S3Object])
@@ -164,8 +165,6 @@ class Uploader(val store: ImageLoaderStore,
               (implicit ec:ExecutionContext,
                logMarker: LogMarker): Future[UploadRequest] = Future {
     val DigestedFile(tempFile, id) = digestedFile
-
-    println(logMarker)
 
     // TODO: should error if the JSON parsing failed
     val identifiersMap = identifiers.map(Json.parse(_).as[Map[String, String]]) getOrElse Map()
@@ -293,7 +292,7 @@ object Uploader {
         fileMetadata,
         config,
         storeOrProjectOptimisedPNG)(ec, logMarker)
-      Logger.info("optimised image created")
+      Logger.info(s"optimised image ($toOptimiseFile) created")
 
       bracket(thumbFuture)(_.delete) { thumb =>
         // Run the operations in parallel
@@ -379,8 +378,7 @@ object Uploader {
 
   private def toFileMetadata(f: File, imageId: String, mimeType: Option[MimeType]): Future[FileMetadata] = {
     mimeType match {
-      case Some(Png) => FileMetadataReader.fromICPTCHeadersWithColorInfo(f, imageId, mimeType.get)
-      case Some(Tiff) => FileMetadataReader.fromICPTCHeadersWithColorInfo(f, imageId, mimeType.get)
+      case Some(Png | Tiff) => FileMetadataReader.fromICPTCHeadersWithColorInfo(f, imageId, mimeType.get)
       case _ => FileMetadataReader.fromIPTCHeaders(f, imageId)
     }
   }


### PR DESCRIPTION
## What does this change?
Implements better error handling and logging in the event of an image being provided which cannot be loaded.

## How can success be measured?
Clearer exceptions in logs.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
