### PR TITLE
Bump eslint and include standard plugin

### DIFF
--- a/s3watcher/lambda/package.json
+++ b/s3watcher/lambda/package.json
@@ -12,7 +12,8 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "eslint": "^3.19.0",
+    "eslint": "^7.9.0",
+    "eslint-plugin-standard": "^4.0.1",
     "node-lambda": "^0.7.1",
     "node-riffraff-artefact": "^2.0.1"
   },


### PR DESCRIPTION
## What does this change?
Inspired by #2983, this makes sure the linter still runs. In a separate module and is a devDep so is low risk.
