### PR TITLE
Rename `Staff image` to `GNM-owned` in tooltip

### DIFF
--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -49,7 +49,7 @@ image.controller('uiPreviewImageCtrl', [
     ctrl.states = imageService(ctrl.image).states;
 
     ctrl.imageDescription = ctrl.states.isStaffPhotographer ?
-        `Staff Image: ${ctrl.image.data.metadata.description}` :
+        `GNM-owned: ${ctrl.image.data.metadata.description}` :
         ctrl.image.data.metadata.description;
 
     ctrl.flagState = ctrl.states.costState;


### PR DESCRIPTION
@JonnyWeeks thinks this is confusing as it applies also to Commissioned:

<img width="242" alt="image" src="https://user-images.githubusercontent.com/6032869/93583267-854ec300-f99b-11ea-9f95-9f76a7ca0d9d.png">

Since it applies to all these:

<img width="181" alt="image" src="https://user-images.githubusercontent.com/6032869/93583375-ad3e2680-f99b-11ea-8981-8e317cd311d3.png">

let’s rename it to `GNM-owned`. Slight problem is: this is Guardian-specific. But we have this problem in the chip too, so can change it in all the places one day (?).

Opinions welcomed.