### PR TITLE
remove internal props from postMessage data

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -259,10 +259,11 @@ kahuna.factory('getEntity', ['$q', function($q) {
 kahuna.run(['$rootScope', '$window', '$q', 'getEntity',
             function($rootScope, $window, $q, getEntity) {
 
-    // Note: we target all domains because we don't know who
-    // may be embedding us.
-    var postMessage = message => $window.parent.postMessage(message, '*');
-    var cropMessage = function(image, crop) {return { image, crop };};
+    // Note: we target all domains because we don't know who may be embedding us.
+    // Wrap message in `angular.toJson` to remove internal fields with a `$$` prefix.
+    // See https://docs.angularjs.org/api/ng/function/angular.toJson
+    const postMessage = message => $window.parent.postMessage(JSON.parse(angular.toJson(message)), '*');
+    const cropMessage = function(image, crop) {return { image, crop };};
 
     // These interfaces are used when the app is embedded as an iframe
     $rootScope.$on('events:crop-selected', (_, params) => {


### PR DESCRIPTION
## What does this change?
Removes redundant angular internal props (prefixed with `$$`) from the postMessage payload. This data isn't needed by consumers, remove it to keep the payload to relevant data.

From the angular [docs](https://docs.angularjs.org/api/ng/function/angular.toJson), `angular.toJson`:

> Serializes input into a JSON-formatted string. Properties with leading $$ characters will be stripped since AngularJS uses this notation internally.

The return type is `string`, so we further wrap this in `JSON.parse` to keep it as JSON.

This also creates a smaller payload, though the benefit of this is negligible as the data isn't going over the wire as it's in the postMessage.

To observe the extra props:
- Run an app that iframes Grid (Composer, editions-card-builder, facia-tool or even [the demo app](https://github.com/guardian/grid-embed-demo))
- Add the following event listener on the window to log any `message` received:

```js
// Tweak this according to what stage you're using
const GRID_ORIGIN = "https://media.some-domain.co.uk"

window.addEventListener("message", msg => {
  if(msg.origin === GRID_ORIGIN) {
    console.log(msg.data)
  }
})
```
- Select a crop from embedded Grid
- Look at the payload and observe extraneous props, as seen in the screenshot below

This was noticed whilst the grid-client library was being [updated](https://github.com/guardian/grid-client/pull/2) to add [io-ts](https://github.com/gcanti/io-ts) to provide runtime type checking. The extra props in the postMessage was causing the tests to fail.

## How can success be measured?
Simpler, more obvious payload.

## Screenshots (if applicable)
### Before
![image](https://user-images.githubusercontent.com/836140/93742574-43658d00-fbe6-11ea-8059-8b70990344c0.png)

### After
![image](https://user-images.githubusercontent.com/836140/93742977-077ef780-fbe7-11ea-8dcd-921fb72a7589.png)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [x] on TEST
