### PR TITLE
Add more better error checking

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
@@ -26,8 +26,14 @@ object ElasticSearchException {
 
           override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "causedBy" -> c.toString())
         }
-      case ElasticError(t, r, _, _, _, s, _, _, _, _) =>
+      case ElasticError(t, r, _, _, _, s, None, _, _, _) =>
         new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}") with ElasticSearchError {
+          override def error: ElasticError = e
+
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "))
+        }
+      case ElasticError(t, r, _, _, _, s, Some(c), _, _, _) =>
+        new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}, caused by $c") with ElasticSearchError {
           override def error: ElasticError = e
 
           override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
@@ -36,7 +36,7 @@ object ElasticSearchException {
         new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}, caused by $c") with ElasticSearchError {
           override def error: ElasticError = e
 
-          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "))
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "), "causedBy" -> c.toString())
         }
       case _ => new Exception(s"query failed because: unknown error") with ElasticSearchError {
         override def error: ElasticError = e


### PR DESCRIPTION
## What does this change?
Exposes a `caused by` section in the Elastic Error in logs _even if_ there is a `root cause`.

Often we have script failures which have a root cause which is entirely unhelpful.  If we have a root cause, we do not currently log the caused by field, whether or not it is populated.  This change adds more logging to clarify if there is a caused by error.

## How can success be measured?
More information in logs.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
