### PR TITLE
Change pingler to use watch so it doesn't scroll

### DIFF
--- a/dev/script/the_pingler.sh
+++ b/dev/script/the_pingler.sh
@@ -1,36 +1,50 @@
 #!/bin/zsh
 
-set -o shwordsplit
+function pingle() {
+  set -o shwordsplit
 
-API="https://api.media.local.dev-gutools.co.uk/management/healthcheck"
-THRALL="https://thrall.media.local.dev-gutools.co.uk/management/healthcheck"
-IMAGE_LOADER="https://loader.media.local.dev-gutools.co.uk/management/healthcheck"
-KAHUNA="https://media.local.dev-gutools.co.uk/management/healthcheck"
-CROPPER="https://cropper.media.local.dev-gutools.co.uk/management/healthcheck"
-METADATA="https://media-metadata.local.dev-gutools.co.uk/management/healthcheck"
-USAGE="https://media-usage.local.dev-gutools.co.uk/management/healthcheck"
-COLLECTIONS="https://media-collections.local.dev-gutools.co.uk/management/healthcheck"
-AUTH="https://media-auth.local.dev-gutools.co.uk/management/healthcheck"
-LEASES="https://media-leases.local.dev-gutools.co.uk/management/healthcheck"
-ADMIN_TOOLS="https://admin-tools.media.local.dev-gutools.co.uk/management/healthcheck"
+  API="https://api.media.local.dev-gutools.co.uk/management/healthcheck"
+  THRALL="https://thrall.media.local.dev-gutools.co.uk/management/healthcheck"
+  IMAGE_LOADER="https://loader.media.local.dev-gutools.co.uk/management/healthcheck"
+  KAHUNA="https://media.local.dev-gutools.co.uk/management/healthcheck"
+  CROPPER="https://cropper.media.local.dev-gutools.co.uk/management/healthcheck"
+  METADATA="https://media-metadata.local.dev-gutools.co.uk/management/healthcheck"
+  USAGE="https://media-usage.local.dev-gutools.co.uk/management/healthcheck"
+  COLLECTIONS="https://media-collections.local.dev-gutools.co.uk/management/healthcheck"
+  AUTH="https://media-auth.local.dev-gutools.co.uk/management/healthcheck"
+  LEASES="https://media-leases.local.dev-gutools.co.uk/management/healthcheck"
+  ADMIN_TOOLS="https://admin-tools.media.local.dev-gutools.co.uk/management/healthcheck"
 
-lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"
+  lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"
 
-echo "You have started the Pingler!"
-echo
+  echo "      \033[35mPingling!\033[m"
+  for URL in $lu
+  do
+    # Curl each endpoint waiting a maximum of 300ms for a response
+    STATUS=`curl --fail -s -m 0.3 -w "%{http_code}" $URL -o /dev/null`
+    EXITCODE=$?
 
-while true; do
-    echo "\033[1;95mPingling!\033[m\n"
-    for URL in $lu
-    do
-        STATUS=`curl --fail -s -w "%{http_code} %{url_effective}\\n" $URL -o /dev/null`
+    # If the status is 000 then this means a connect timeout
+    if [[ "${STATUS}" == "000" ]]
+    then
+      STATUS="T/O"
+    fi
 
-        if [ "$?" -eq "0" ]
-        then
-            echo "\033[1;92m$STATUS\033[m\n"
-        else
-            echo "\033[1;41m$STATUS\033[m\n"
-        fi
-    done
-    sleep 2
-done
+    # Any error in red, otherwise green
+    if [[ "${EXITCODE}" -eq "0" ]]
+    then
+      echo "\033[30m\033[42m $STATUS \033[m \033[32m${URL}\033[m"
+    else
+      echo "\033[30m\033[41m $STATUS \033[m \033[31;1m${URL}\033[m"
+    fi
+  done
+}
+
+if [[ "${1}" == "--pingle" ]]
+then
+  pingle
+  exit 0
+fi
+
+SCRIPT=${0:A}
+watch --color ${SCRIPT} --pingle


### PR DESCRIPTION
## What does this change?
Pingler's constant scrolling is a distraction when developing. By using watch we can make the status information stay still.

Some notes:
 - Watch's `--color` param doesn't support the 256 color pallette so I've changed the escape codes to still work
 - I've made it denser so it takes up less real estate
 - Watch doesn't show anything until it has the complete output, to make this work better I've limited the curl time to 300ms

## How can success be measured?
Better dev experience everywhere.

## Screenshots (if applicable)
![Old pingler](https://user-images.githubusercontent.com/1236466/94144629-51771000-fe69-11ea-9d0b-bdaebc15b73e.gif)

![new_pingler(1)](https://user-images.githubusercontent.com/1236466/94144637-5340d380-fe69-11ea-984c-571043deb067.gif)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
