### PR TITLE
Add customRatio parameter to allow custom crop ratios.

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -21,7 +21,6 @@ crop.controller('ImageCropCtrl', [
   'optimisedImageUri',
   'keyboardShortcut',
   'defaultCrop',
-  'cropOptions',
   'cropSettings',
   'square',
   'freeform',
@@ -36,7 +35,6 @@ crop.controller('ImageCropCtrl', [
     optimisedImageUri,
     keyboardShortcut,
     defaultCrop,
-    cropOptions,
     cropSettings,
     square,
     freeform) {
@@ -201,7 +199,7 @@ crop.controller('ImageCropCtrl', [
           callback: () => ctrl.callCrop()
         });
 
-      cropOptions.forEach(option => {
+      cropSettings.getCropOptions().forEach(option => {
         keyboardShortcut.bindTo($scope).add({
           combo: option.key.charAt(0),
           description: `Start ${option.key} crop`,

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -22,7 +22,7 @@ crop.controller('ImageCropCtrl', [
   'keyboardShortcut',
   'defaultCrop',
   'cropOptions',
-  'cropTypeUtil',
+  'cropSettings',
   'square',
   'freeform',
   function(
@@ -37,22 +37,23 @@ crop.controller('ImageCropCtrl', [
     keyboardShortcut,
     defaultCrop,
     cropOptions,
-    cropTypeUtil,
+    cropSettings,
     square,
     freeform) {
 
       const ctrl = this;
       const imageId = $stateParams.imageId;
 
-      cropTypeUtil.set($stateParams);
+    cropSettings.set($stateParams);
+      const allCropOptions = cropSettings.getCropOptions();
 
-      const storageCropType = cropTypeUtil.get();
+      const storageCropType = cropSettings.getCropType();
 
       const cropOptionDisplayValue = cropOption => cropOption.ratioString
         ? `${cropOption.key} (${cropOption.ratioString})`
         : cropOption.key;
 
-      ctrl.cropOptions = cropOptions
+    ctrl.cropOptions = allCropOptions
         .filter(option => !storageCropType || storageCropType === option.key)
         .map(option => Object.assign(option, {
           value: cropOptionDisplayValue(option),

--- a/kahuna/public/js/crop/index.js
+++ b/kahuna/public/js/crop/index.js
@@ -18,7 +18,7 @@ crop.config(['$stateProvider',
              function($stateProvider) {
 
     $stateProvider.state('crop', {
-        url: '/images/:imageId/crop?cropType',
+        url: '/images/:imageId/crop?cropType&customRatio',
         template: cropTemplate,
         controller: 'ImageCropCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -15,7 +15,8 @@ cropBox.directive('uiCropBox', [
   'nextTick',
   'delay',
   'cropOptions',
-  function($timeout, $parse, safeApply, nextTick, delay, cropOptions) {
+  'cropSettings',
+  function($timeout, $parse, safeApply, nextTick, delay, cropOptions, cropSettings) {
 
     return {
         restrict: 'A',
@@ -95,7 +96,8 @@ cropBox.directive('uiCropBox', [
             // Once initialised, sync all options to cropperjs
             function postInit(cropper) {
                 scope.$watch('cropType', function(cropType) {
-                    const cropSpec = cropOptions.find(_ => _.key === cropType);
+                    const allCropOptions = cropSettings.getCropOptions();
+                    const cropSpec = allCropOptions.find(_ => _.key === cropType);
                     cropper.setAspectRatio(cropSpec.ratio);
                 });
 

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -14,9 +14,8 @@ cropBox.directive('uiCropBox', [
   'safeApply',
   'nextTick',
   'delay',
-  'cropOptions',
   'cropSettings',
-  function($timeout, $parse, safeApply, nextTick, delay, cropOptions, cropSettings) {
+  function($timeout, $parse, safeApply, nextTick, delay, cropSettings) {
 
     return {
         restrict: 'A',

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -70,7 +70,7 @@ image.controller('ImageCtrl', [
   'imageService',
   'imageUsagesService',
   'keyboardShortcut',
-  'cropTypeUtil',
+  'cropSettings',
   'cropOptions',
 
   function ($rootScope,
@@ -90,7 +90,7 @@ image.controller('ImageCtrl', [
             imageService,
             imageUsagesService,
             keyboardShortcut,
-            cropTypeUtil,
+            cropSettings,
             cropOptions) {
 
     let ctrl = this;
@@ -170,8 +170,8 @@ image.controller('ImageCtrl', [
 
     ctrl.image.allCrops = [];
 
-    cropTypeUtil.set($stateParams);
-    ctrl.cropType = cropTypeUtil.get();
+    cropSettings.set($stateParams);
+    ctrl.cropType = cropSettings.getCropType();
     ctrl.capitalisedCropType = ctrl.cropType ?
       ctrl.cropType[0].toUpperCase() + ctrl.cropType.slice(1) :
       '';

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -23,7 +23,7 @@ image.config(['$stateProvider',
               function($stateProvider) {
 
     $stateProvider.state('image', {
-        url: '/images/:imageId?crop?cropType',
+        url: '/images/:imageId?crop?cropType&customRatio',
         template: imageTemplate,
         controller: 'ImageCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -62,7 +62,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     $stateProvider.state('search', {
         // FIXME [1]: This state should be abstract, but then we can't navigate to
         // it, which we need to do to access it's deeper / remembered chile state
-        url: '/?cropType',
+        url: '/?cropType&customRatio',
         template: searchTemplate,
         deepStateRedirect: {
             // Inject a transient $stateParams for the results state
@@ -77,13 +77,13 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         controllerAs: 'ctrl',
         controller: [
             '$scope', '$window', '$stateParams', 'panels', 'shortcutKeys', 'keyboardShortcut',
-            'panelService', 'cropTypeUtil',
+            'panelService', 'cropSettings',
             function($scope, $window, $stateParams, panels, shortcutKeys, keyboardShortcut,
-                     panelService, cropTypeUtil) {
+                     panelService, cropSettings) {
 
             const ctrl = this;
 
-            cropTypeUtil.set($stateParams);
+            cropSettings.set($stateParams);
 
             ctrl.collectionsPanel = panels.collectionsPanel;
             ctrl.metadataPanel = panels.metadataPanel;

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 
-const STORAGE_KEY = 'cropType';
+const CROP_TYPE_STORAGE_KEY = 'cropType';
+const CUSTOM_CROP_STORAGE_KEY = 'customCrop';
 
 // `ratioString` is sent to the server, being `undefined` for `freeform` is expected 🙈
 const landscape = {key: 'landscape', ratio: 5 / 3, ratioString: '5:3'};
@@ -8,6 +9,10 @@ const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
 const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
 const square = {key: 'square', ratio: 1, ratioString: '1:1'};
 const freeform = {key: 'freeform', ratio: null};
+
+const customCrop = (label, xRatio, yRatio) => {
+  return { key:label, ratio: xRatio / yRatio, ratioString: `${xRatio}:${yRatio}`};
+};
 
 const cropOptions = [landscape, portrait, video, square, freeform];
 
@@ -21,30 +26,67 @@ cropUtil.constant('freeform', freeform);
 cropUtil.constant('cropOptions', cropOptions);
 cropUtil.constant('defaultCrop', landscape);
 
-cropUtil.factory('cropTypeUtil', ['storage', function(storage) {
+cropUtil.factory('cropSettings', ['storage', function(storage) {
   const isValidCropType = cropType => cropOptions.some(_ => _.key === cropType);
 
-  function set({cropType}) {
-    if (!cropType) {
-      return;
+  const isValidRatio = ratio => {
+    const splitRatio = ratio.split(',');
+    return !(splitRatio.length < 3 || isNaN(splitRatio[1]) || isNaN(splitRatio[2]));
+  };
+
+  const parseRatio = ratio => {
+    // example ratio 'longcrop,1,5'
+    if (isValidRatio(ratio)) {
+      const splitRatio = ratio.split(',');
+      return {
+        label: splitRatio[0],
+        x: parseInt(splitRatio[1], 10),
+        y: parseInt(splitRatio[2], 10)
+      };
+    }
+  };
+
+  const setCropType = (cropType) => {
+    if (isValidCropType(cropType)) {
+      storage.setJs(CROP_TYPE_STORAGE_KEY, cropType, true);
+    } else {
+      storage.clearJs(CROP_TYPE_STORAGE_KEY);
+    }
+  };
+
+  const setCustomCrop = customRatio => {
+    const parsedRatio = parseRatio(customRatio);
+    if (parsedRatio) {
+      storage.setJs(CUSTOM_CROP_STORAGE_KEY, customCrop(parsedRatio.label, parsedRatio.x, parsedRatio.y), true);
+    } else {
+      storage.clearJs(CUSTOM_CROP_STORAGE_KEY);
+    }
+  };
+
+  function set({cropType, customRatio}) {
+    if (cropType) {
+      setCropType(cropType);
     }
 
-    if (isValidCropType(cropType)) {
-      storage.setJs(STORAGE_KEY, cropType, true);
-    } else {
-      storage.clearJs(STORAGE_KEY);
+    if (customRatio) {
+      setCustomCrop(customRatio);
     }
   }
 
-  function get() {
-    const cropType = storage.getJs(STORAGE_KEY, true);
+  function getCropOptions() {
+    const customCrop =  storage.getJs(CUSTOM_CROP_STORAGE_KEY, true);
+    return customCrop ? cropOptions.concat(customCrop) : cropOptions;
+  }
+
+  function getCropType() {
+    const cropType = storage.getJs(CROP_TYPE_STORAGE_KEY, true);
 
     if (isValidCropType(cropType)) {
       return cropType;
     }
   }
 
-  return { set, get };
+  return { set, getCropType, getCropOptions };
 }]);
 
 cropUtil.filter('asCropType', function() {

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -35,8 +35,8 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
   const isValidCropType = cropType => getCropOptions().some(_ => _.key === cropType);
 
   const isValidRatio = ratio => {
-    const splitRatio = ratio.split(',');
-    return !(splitRatio.length < 3 || isNaN(splitRatio[1]) || isNaN(splitRatio[2]));
+    const [label, x, y, ...rest] = ratio.split(',');
+    return label && !isNaN(x) && !isNaN(y);
   };
 
   const parseRatio = ratio => {

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -27,7 +27,12 @@ cropUtil.constant('cropOptions', cropOptions);
 cropUtil.constant('defaultCrop', landscape);
 
 cropUtil.factory('cropSettings', ['storage', function(storage) {
-  const isValidCropType = cropType => cropOptions.some(_ => _.key === cropType);
+  function getCropOptions() {
+    const customCrop =  storage.getJs(CUSTOM_CROP_STORAGE_KEY, true);
+    return customCrop ? cropOptions.concat(customCrop) : cropOptions;
+  }
+
+  const isValidCropType = cropType => getCropOptions().some(_ => _.key === cropType);
 
   const isValidRatio = ratio => {
     const splitRatio = ratio.split(',');
@@ -64,18 +69,15 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
   };
 
   function set({cropType, customRatio}) {
+    // set customRatio first in case cropType relies on a custom crop
+    if (customRatio) {
+      setCustomCrop(customRatio);
+    }
+
     if (cropType) {
       setCropType(cropType);
     }
 
-    if (customRatio) {
-      setCustomCrop(customRatio);
-    }
-  }
-
-  function getCropOptions() {
-    const customCrop =  storage.getJs(CUSTOM_CROP_STORAGE_KEY, true);
-    return customCrop ? cropOptions.concat(customCrop) : cropOptions;
   }
 
   function getCropType() {

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -35,18 +35,18 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
   const isValidCropType = cropType => getCropOptions().some(_ => _.key === cropType);
 
   const isValidRatio = ratio => {
-    const [label, x, y, ...rest] = ratio.split(',');
+    const [label, x, y] = ratio.split(',');
     return label && !isNaN(x) && !isNaN(y);
   };
 
   const parseRatio = ratio => {
     // example ratio 'longcrop,1,5'
     if (isValidRatio(ratio)) {
-      const splitRatio = ratio.split(',');
+      const [label, x, y] = ratio.split(',');
       return {
-        label: splitRatio[0],
-        x: parseInt(splitRatio[1], 10),
-        y: parseInt(splitRatio[2], 10)
+        label,
+        x: parseInt(x, 10),
+        y: parseInt(y, 10)
       };
     }
   };


### PR DESCRIPTION
## What does this change?
Following from advice given on https://github.com/guardian/grid/pull/2990 this PR adds a query string parameter `customRatio` to the grid which will add an additional crop ratio to the UI. The format is `customRatio=<label>,<x ratio>,<y ratio>` 

So visiting `https://media.local.dev-gutools.co.uk/search?customRatio=cover%20card1,2` and opening the cropper results in something looking like this:
<img width="1130" alt="Screenshot 2020-09-29 at 15 52 29" src="https://user-images.githubusercontent.com/3606555/94575258-f760bb00-026b-11eb-93a7-53e33dd366b0.png">

The 'custom crop' gets stored in session storage, so opening a new grid tab throws it away.

## How can success be measured?
I don't break the grid! And long term the editions cover card builder can use this in it's links to the grid so that the production team can crop an image exactly the same way that the card builder will do it

## Screenshots (if applicable)
see above

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms 

## Tested?
- [x] locally
- [x] on TEST
