### PR TITLE
Hide alternative crop options when a valid cropType is set.

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -52,11 +52,13 @@ crop.controller('ImageCropCtrl', [
         ? `${cropOption.key} (${cropOption.ratioString})`
         : cropOption.key;
 
-      ctrl.cropOptions = cropOptions.map(option => Object.assign(option, {
-        value: cropOptionDisplayValue(option),
-        tooltip: `${option.key} [${option.key.charAt(0)}]`,
-        disabled: storageCropType && storageCropType !== option.key
-      }));
+      ctrl.cropOptions = cropOptions
+        .filter(option => !storageCropType || storageCropType === option.key)
+        .map(option => Object.assign(option, {
+          value: cropOptionDisplayValue(option),
+          tooltip: `${option.key} [${option.key.charAt(0)}]`,
+          disabled: storageCropType && storageCropType !== option.key
+        }));
 
       ctrl.cropType = storageCropType || defaultCrop.key;
 


### PR DESCRIPTION
## What does this change?
This modifies the UI of the grid so that if the `cropType` param is set - which locks the grid session to a specific crop size - the other crop size options are hidden. 

This was raisd as a possible UX improvement following discussions triggered by this PR https://github.com/guardian/grid/pull/3017

## How can success be measured?
Happier users?

## Screenshots (if applicable)
Before:
<img width="966" alt="Screenshot 2020-09-30 at 15 31 15" src="https://user-images.githubusercontent.com/3606555/94699464-3e18e880-0332-11eb-903f-1a065eadb3ad.png">

After:
<img width="603" alt="Screenshot 2020-09-30 at 15 28 23" src="https://user-images.githubusercontent.com/3606555/94699082-d9f62480-0331-11eb-805a-b964e9d09701.png">


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms 

## Tested?
- [x] locally
- [ ] on TEST
