### PR TITLE
use new dev-nginx command to ensure nginx is running

### DIFF
--- a/dev/script/start.sh
+++ b/dev/script/start.sh
@@ -122,12 +122,17 @@ checkForJavaHome() {
   fi
 }
 
+ensureNginxIsRunning() {
+  dev-nginx start -g
+}
+
 main() {
   checkForJavaHome
   hasCredentials
   checkRequirements
   checkNodeVersion
   startDockerContainers
+  ensureNginxIsRunning
   buildJs
   startPlayApps
 }


### PR DESCRIPTION
## What does this change?
This avoids the slightly annoying behaviour of restarting your machine (i.e. not having nginx running), starting grid, opening the browser and being greeted with the `ERR_CONNECTION_REFUSED` error as you've forgotten to start nginx.

Scripting nginx allows us to be lazy.

Requires an update to `dev-nginx`: `brew upgrade guardian/devtools/dev-nginx`.

See:
- https://github.com/guardian/dev-nginx/pull/22
- https://github.com/guardian/homebrew-devtools/pull/59

## How can success be measured?
Fewer manual steps.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested?
- [x] locally
- [ ] on TEST
