### PR TITLE
Aa gha cache 2

### DIFF
--- a/.github/actions/sbt/Dockerfile
+++ b/.github/actions/sbt/Dockerfile
@@ -1,9 +1,0 @@
-FROM mozilla/sbt
-
-RUN apt-get -y update
-
-RUN apt-get -y install graphicsmagick
-RUN apt-get -y install graphicsmagick-imagemagick-compat
-RUN apt-get -y install exiftool
-
-ENTRYPOINT ["sbt"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: Grid CI
 on:
+  workflow_dispatch:
   pull_request:
 
   # triggering CI default branch improves caching

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: Grid CI
-on: [pull_request]
+on:
+  pull_request:
+
+  # triggering CI default branch improves caching
+  # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  push:
+    branches:
+      - main
 jobs:
   JSBuild:
     runs-on: ubuntu-18.04
@@ -57,6 +64,17 @@ jobs:
           --health-retries 10
     steps:
     - uses: actions/checkout@v1
+
+    # see https://github.com/actions/cache/blob/master/examples.md#scala---sbt
+    - name: Cache SBT
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.ivy2/cache
+          ~/.sbt
+          ~/.coursier
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
     - name: SBT
       uses: ./.github/actions/sbt
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,9 @@ jobs:
           ~/.coursier
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
-    - name: SBT
-      uses: ./.github/actions/sbt
-      env:
-        USE_DOCKER_FOR_TESTS: false
-        ES6_TEST_URL: http://elasticsearch:9200
-        LOCALSTACK_ENDPOINT: http://localstack:4566
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
       with:
-        args: clean compile test
+        java-version: 1.8
+    - run: |
+        sbt clean compile test


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/grid/pull/2948 take 2.

Not entirely sure this will work, however inspired by https://github.com/guardian/sbt-riffraff-artifact/pull/52 to give it a go!

This change should reduce the duration of CI in GitHub Actions by adding caching for sbt dependencies.

## How can success be measured?
Faster builds in GHA.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
