### PR TITLE
Use correct cropOptions in image controller

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -89,8 +89,7 @@ image.controller('ImageCtrl', [
             imageService,
             imageUsagesService,
             keyboardShortcut,
-            cropSettings,
-) {
+            cropSettings) {
 
     let ctrl = this;
 

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -71,7 +71,6 @@ image.controller('ImageCtrl', [
   'imageUsagesService',
   'keyboardShortcut',
   'cropSettings',
-  'cropOptions',
 
   function ($rootScope,
             $scope,
@@ -91,7 +90,7 @@ image.controller('ImageCtrl', [
             imageUsagesService,
             keyboardShortcut,
             cropSettings,
-            cropOptions) {
+) {
 
     let ctrl = this;
 
@@ -182,7 +181,7 @@ image.controller('ImageCtrl', [
 
     ctrl.allowCropSelection = (crop) => {
       if (ctrl.cropType) {
-        const cropSpec = cropOptions.find(_ => _.key === ctrl.cropType);
+        const cropSpec = cropSettings.getCropOptions().find(_ => _.key === ctrl.cropType);
         return crop.specification.aspectRatio === cropSpec.ratioString;
       }
 


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/grid/pull/3017 everywhere that currently uses `cropOptions` needs to start using cropSettings.getCropOptions in order to pick up any 'custom crops' that have been added by query string parameter (cropOptions only includes the defaults).

This PR includes changes that should have been made in the original PR, and fixes an issue where crops are failing when the customCrop parameter is included

## How can success be measured?
Cover card tool grid crops will be working again!


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms 

## Tested?
- [x] locally
- [x] on TEST
