### PR TITLE
update json writers for optional fields

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
@@ -72,8 +72,8 @@ object Property {
   val reads: Reads[Property] = Json.reads[Property]
   val writes: Writes[Property] = (
     (__ \ "propertyCode").write[String] ~
-    (__ \ "expiresOn").write[Option[DateTime]] ~
-    (__ \ "value").write[Option[String]]
+    (__ \ "expiresOn").writeNullable[DateTime] ~
+    (__ \ "value").writeNullable[String]
   ){ r: Property => (r.propertyCode, r.expiresOn, r.value) }
 
   implicit val formats: Format[Property] = Format(reads, writes)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
@@ -22,7 +22,7 @@ object SyndicationRights {
   val reads: Reads[SyndicationRights] = Json.using[Json.WithDefaultValues].reads[SyndicationRights]
 
   val writes: Writes[SyndicationRights] = (
-    (__ \ "published").write[Option[DateTime]] ~
+    (__ \ "published").writeNullable[DateTime] ~
     (__ \ "suppliers").write[Seq[Supplier]] ~
     (__ \ "rights").write[Seq[Right]] ~
     (__ \ "isInferred").write[Boolean]
@@ -38,9 +38,9 @@ case class Supplier(
 object Supplier {
   val reads: Reads[Supplier] = Json.reads[Supplier]
   val writes: Writes[Supplier] = (
-    (__ \ "supplierName").write[Option[String]] ~
-    (__ \ "supplierId").write[Option[String]] ~
-    (__ \ "prAgreement").write[Option[Boolean]]
+    (__ \ "supplierName").writeNullable[String] ~
+    (__ \ "supplierId").writeNullable[String] ~
+    (__ \ "prAgreement").writeNullable[Boolean]
   ){ s: Supplier => (s.supplierName, s.supplierId, s.prAgreement) }
 
   implicit val formats: Format[Supplier] = Format(reads, writes)
@@ -54,7 +54,7 @@ object Right {
   val reads: Reads[Right] = Json.reads[Right]
   val writes: Writes[Right] = (
     (__ \ "rightCode").write[String] ~
-    (__ \ "acquired").write[Option[Boolean]] ~
+    (__ \ "acquired").writeNullable[Boolean] ~
     (__ \ "properties").write[Seq[Property]]
   ){ r: Right => (r.rightCode, r.acquired, r.properties) }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/PropertyTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/PropertyTest.scala
@@ -1,0 +1,20 @@
+package com.gu.mediaservice.model
+
+import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.Json
+
+class PropertyTest extends FunSpec with Matchers {
+  it("should omit None values from written json") {
+    val property = Property("foo", None, None)
+    val actual = Json.stringify(Json.toJson(property))
+    val expected = """{"propertyCode":"foo"}"""
+    actual should be (expected)
+  }
+
+  it("should write optional fields that have a value") {
+    val property = Property("foo", None, Some("bar"))
+    val actual = Json.stringify(Json.toJson(property))
+    val expected = """{"propertyCode":"foo","value":"bar"}"""
+    actual should be (expected)
+  }
+}

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -254,7 +254,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
         .contramap(leasesEntity(id, _: LeasesByMedia)) ~
       (__ \ "collections").write[List[EmbeddedEntity[CollectionResponse]]]
         .contramap((collections: List[Collection]) => collections.map(c => collectionsEntity(id, c))) ~
-      (__ \ "syndicationRights").write[Option[SyndicationRights]] ~
+      (__ \ "syndicationRights").writeNullable[SyndicationRights] ~
       (__ \ "usermetaDataLastModified").writeNullable[DateTime]
 
     ) (unlift(Image.unapply))


### PR DESCRIPTION
## What does this change?
Omit a property when it does not exist rather than writing `null`.

This was causing issues with the grid-client library which types `expiresOn` in a Syndication Property as `Date | undefined` (using `io-ts`) ([source](https://github.com/guardian/grid-client/blob/11e01c96a1f213c1d24f80d745de98885f64502e/src/types/syndication/property.ts#L9)).

Includes tests.

**Before**
```json
{
  "propertyCode":"TERRITORYPRIORAPPROVAL",
  "expiresOn":null,
  "value":null
}
```

**After**
```json
{
  "propertyCode":"TERRITORYPRIORAPPROVAL"
}
```

This PR also replaces all other instances of `write[Option[T]]` with `writeNullable[T]` for the same reason.

Related:
- https://github.com/guardian/editions-card-builder/pull/88
- https://github.com/guardian/editions-card-builder/pull/90
- https://github.com/guardian/grid-client/pull/11

## How can success be measured?
API returns more accurately shaped data.

## Screenshots (if applicable)
n/a

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->
@guardian/digital-cms, @philmcmahon 

## Tested?
- [x] locally
- [ ] on TEST
