### PR TITLE
Bump localstack to fix kinesis physical IDs

### DIFF
--- a/dev/imgops/nginx.conf
+++ b/dev/imgops/nginx.conf
@@ -32,7 +32,7 @@ http {
       image_filter resize $arg_w $arg_h;
 
       # connect to the localstack docker container
-      proxy_pass http://localstack:4572$request_uri;
+      proxy_pass http://localstack:4566$request_uri;
     }
   }
 }

--- a/dev/nginx-mappings.yml.template
+++ b/dev/nginx-mappings.yml.template
@@ -38,8 +38,8 @@ mappings:
   # vanity domains for localstack S3 buckets
   # the localstack container needs to expose port 4572 to the host
   - prefix: public.media
-    port: 4572
+    port: 4566
     path: /@IMAGE-ORIGIN-BUCKET/
   - prefix: images.media
-    port: 4572
+    port: 4566
     path: /@IMAGE-BUCKET/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,12 @@ services:
     ports:
       - "9090:9000"
   localstack:
-    image: localstack/localstack:0.11.0
+    image: localstack/localstack:0.11.6
     ports:
       - "4566:4566" # localstack's service proxy endpoint
       - "4572:4572" # localstack's direct S3 endpoint, needed for image and image-origin buckets (see nginx-mappings.yml)
     expose:
-      - 4572 # provide the imgops container with access to localstack's direct S3 endpoint
+      - 4566 # provide the imgops container with access to localstack's direct S3 endpoint
     environment:
       SERVICES: cloudformation,cloudwatch,dynamodb,kinesis,s3,sns,sqs
       DEFAULT_REGION: eu-west-1


### PR DESCRIPTION
## What does this change?
With the previous version of localstack the configuration was not being properly populated as the localstack API was not returning the `PhysicalId` for Kinesis streams. This is working in the latest version of localstack.

[Localstack 11.6](https://github.com/localstack/localstack/releases/tag/v0.11.6) drops support for the S3 service ports so we switch to the main port.

## How can success be measured?
Can spin up a cleanly configured stack using `setup.sh --clean`

## Tested?
- [X] locally
