### PR TITLE
Switch usage to use low priority stream config

### DIFF
--- a/usage/app/lib/UsageNotifier.scala
+++ b/usage/app/lib/UsageNotifier.scala
@@ -12,7 +12,7 @@ import rx.lang.scala.Observable
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class UsageNotifier(config: UsageConfig, usageTable: UsageTable)
-  extends ThrallMessageSender(config.thrallKinesisStreamConfig) with GridLogging {
+  extends ThrallMessageSender(config.thrallKinesisLowPriorityStreamConfig) with GridLogging {
 
   def build(mediaId: String) = Observable.from(
     usageTable.queryByImageId(mediaId).map((usages: Set[MediaUsage]) => {


### PR DESCRIPTION
## What does this change?
This untangles a confusing bit of config where the usage config sets the high priority stream config item to the low priority stream name. Previously usage didn't use the low priority config item, despite using the low priority stream. This makes it all much most explicit throughout.

 - [ ] Merge this
 - [ ] Change usage config so that the thrall streams are consistent with other apps

## How can success be measured?
Consistent configuration between applications.

## Who should look at this?
@guardian/digital-cms

## Tested?
- [X] locally
- [x] on TEST
