### PR TITLE
Don't cache error responses to make reponse logging work correctly

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/ApiAccessor.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/ApiAccessor.scala
@@ -19,7 +19,7 @@ object Tier {
 
 case class ApiAccessor(identity: String, tier: Tier)
 object ApiAccessor extends ArgoHelpers {
-  val unauthorizedResult: Result = respondError(Forbidden, "forbidden", "Unauthorized - the API key is not allowed to perform this operation", List.empty)
+  def unauthorizedResult: Result = respondError(Forbidden, "forbidden", "Unauthorized - the API key is not allowed to perform this operation", List.empty)
 
   def apply(content: String): ApiAccessor = {
     val rows = content.split("\n")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -33,7 +33,7 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
   )
 
   // API key errors
-  val invalidApiKeyResult = respondError(Unauthorized, "invalid-api-key", "Invalid API key provided", loginLinks)
+  def invalidApiKeyResult = respondError(Unauthorized, "invalid-api-key", "Invalid API key provided", loginLinks)
 
   val keyStore = new KeyStore(config.authKeyStoreBucket, config)
 

--- a/image-loader/app/lib/BodyParsers.scala
+++ b/image-loader/app/lib/BodyParsers.scala
@@ -22,13 +22,13 @@ object DigestedFile {
 
 object DigestBodyParser extends ArgoHelpers {
 
-  private val missingContentLengthError = respondError(
+  private def missingContentLengthError = respondError(
     Status(411),
     "missing-content-length",
     s"Missing content-length. Please specify a correct 'Content-Length' header"
   )
 
-  private val incorrectContentLengthError = respondError(
+  private def incorrectContentLengthError = respondError(
     Status(400),
     "incorrect-content-length",
     s"Incorrect content-length. The specified content-length does match that of the received file."

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -73,11 +73,11 @@ class MediaApi(
     respond(indexData, indexLinks)
   }
 
-  private val ImageCannotBeDeleted = respondError(MethodNotAllowed, "cannot-delete", "Cannot delete persisted images")
-  private val ImageDeleteForbidden = respondError(Forbidden, "delete-not-allowed", "No permission to delete this image")
-  private val ImageEditForbidden = respondError(Forbidden, "edit-not-allowed", "No permission to edit this image")
+  private def ImageCannotBeDeleted = respondError(MethodNotAllowed, "cannot-delete", "Cannot delete persisted images")
+  private def ImageDeleteForbidden = respondError(Forbidden, "delete-not-allowed", "No permission to delete this image")
+  private def ImageEditForbidden = respondError(Forbidden, "edit-not-allowed", "No permission to edit this image")
   private def ImageNotFound(id: String) = respondError(NotFound, "image-not-found", s"No image found with the given id $id")
-  private val ExportNotFound = respondError(NotFound, "export-not-found", "No export found with the given id")
+  private def ExportNotFound = respondError(NotFound, "export-not-found", "No export found with the given id")
 
   def index = auth { indexResponse }
 


### PR DESCRIPTION
## What does this change?
Inside the error reponse method we log details of the error response we are going to make. However if we cache the response in a val then we get the error at start up and not when it is used. In particular we will see the API authentication errors which is useful from a security perspective.

This shouldn't impact performance significantly.

## How can success be measured?
Errors are not logged when an app starts up.

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

## Tested?
- [X] locally
- [x] on TEST
