### PR TITLE
Split the S3 clients so we can use V4 signing

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -88,7 +88,7 @@ class Authentication(config: CommonConfig, actorSystem: ActorSystem,
       system = config.stringOpt("panda.system").getOrElse("media-service"),
       bucketName = config.stringOpt("panda.bucketName").getOrElse("pan-domain-auth-settings"),
       settingsFileKey = config.stringOpt("panda.settingsFileKey").getOrElse(s"${config.services.domainRoot}.settings"),
-      s3Client = S3Ops.buildS3Client(config, config.useLocalAuth)
+      s3Client = S3Ops.buildS3Client(config, localstackAware=config.useLocalAuth)
     )
   }
 }

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -12,8 +12,6 @@ case class StoreConfig(
 )
 
 class MediaApiConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
-  val keyStoreBucket: String = string("auth.keystore.bucket")
-
   val configBucket: String = string("s3.config.bucket")
   val usageMailBucket: String = string("s3.usagemail.bucket")
 

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -8,7 +8,6 @@ import play.api.Configuration
 class EditsConfig(playAppConfiguration: Configuration) extends CommonConfig(playAppConfiguration) {
   val dynamoRegion: Region = RegionUtils.getRegion(string("aws.region"))
 
-  val keyStoreBucket = string("auth.keystore.bucket")
   val collectionsBucket: String = string("s3.collections.bucket")
 
   val editsTable = string("dynamo.table.edits")


### PR DESCRIPTION
## What does this change?
The grid has a very noisy error (`Attempting to re-send the request to <bucket>.s3.eu-west-1.amazonaws.com with AWS V4 authentication. To avoid this warning in the future, please use region-specific endpoint to access buckets located in regions that require V4 signing.`). One part of our code needs to use the legacy v2 signing at the moment due to the way that signed URLs are proxied through nginx. 

In order to get around this we create two clients for different purposes. Most of the time we can happily use V4 signing. When we can't we use the legacy client which disables it. This also avoids redirects so should improve performance.

## How can success be measured?
Far fewer (possibly zero) errors like the above in the grid logs. We currently log over 12,000 of these errors per day.

## Who should look at this?
@guardian/digital-cms

## Tested?
- [X] locally
- [X] on TEST
