### PR TITLE
Improve the failure logging to include more context

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -60,6 +60,6 @@ case class UpdateMessage(
       "id" -> id.getOrElse(image.map(_.id).getOrElse("none")),
       "size" -> message.getBytes.length,
       "length" -> message.length
-    )
+    ) ++ image.map("fileName" -> _.source.file.toString)
   }
 }


### PR DESCRIPTION
## What does this change?
Some payloads we send to kinesis are too large. We log that this happens but this PR adds more context to make it easier to understand what's happening.

## How can success be measured?
We can track oversized payload errors more easily.

## Tested?
- [x] locally
- [x] on TEST
