### PR TITLE
Remove node from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 brew "awscli"
 brew "sbt"
-brew "node"
 brew "nginx"
 brew "libgd"
 brew "graphicsmagick"


### PR DESCRIPTION
## What does this change?

Removes node from the Brewfile.

Many devs use `fnm` or `nvm` to handle their installation of Node and its multiple versions.

## How can success be measured?

Brew bundle is more robust.

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

@akash1810 

## Tested?
- [X] locally -- this does not solve the whole issue yet
- [ ] on TEST
