### PR TITLE
That’s not my name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.html]
+indent_size = 4

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -82,7 +82,7 @@ class DynamoDB(config: CommonConfig, tableName: String) {
     if (value) booleanSet(id, key, value)
     else removeKey(id, key)
 
-  def stringSet(id: String, key: String, value: String)
+  def stringSet(id: String, key: String, value: JsValue)
                 (implicit ex: ExecutionContext): Future[JsObject] =
     update(
       id,
@@ -121,7 +121,7 @@ class DynamoDB(config: CommonConfig, tableName: String) {
       get(id, key).map(item => asJsObject(item))
 
   // We cannot update, so make sure you send over the WHOLE document
-  def jsonAdd(id: String, key: String, value: Map[String, String])
+  def jsonAdd(id: String, key: String, value: Map[String, JsValue])
              (implicit ex: ExecutionContext): Future[JsObject] =
     update(
       id,
@@ -238,10 +238,10 @@ class DynamoDB(config: CommonConfig, tableName: String) {
     case value => value
   }
 
-  def valueMapWithNullForEmptyString(value: Map[String, String]) = {
+  def valueMapWithNullForEmptyString(value: Map[String, JsValue]) = {
     val valueMap = new ValueMap()
-    value.map     { case(k, v) => (k, if (v == "") null else v) }
-         .foreach { case(k, v) => valueMap.withString(k, v) }
+    value.map     { case(k, v) => (k, if (v == JsNull) null else v) }
+         .foreach { case(k, v) => valueMap.withJSON(k, Json.stringify(v)) }
 
     valueMap
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -25,7 +25,7 @@ case class ImageMetadata(
   state:               Option[String]   = None,
   country:             Option[String]   = None,
   subjects:            List[String]     = Nil,
-  peopleInImage:       Set[String]      = Set()
+  peopleInImage:       Set[String]      = Set(),
 )
 
 object ImageMetadata {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/DynamoDBTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/DynamoDBTest.scala
@@ -10,7 +10,7 @@ class DynamoDBTest extends FunSpec with Matchers {
 
   describe("jsonToValueMap") {
     it ("should convert a simple JsObject to a valueMap") {
-      val json = Json.toJson(SimpleDynamoDBObj("this is a string", 100, true)).as[JsObject]
+      val json = Json.toJson(SimpleDynamoDBObj("this is a string", 100, true, List("list"))).as[JsObject]
       val valueMap = DynamoDB.jsonToValueMap(json)
 
 
@@ -19,15 +19,17 @@ class DynamoDBTest extends FunSpec with Matchers {
       val s: String = valueMap.get("s").asInstanceOf[String]
       val d: BigDecimal = valueMap.get("d").asInstanceOf[java.math.BigDecimal]
       val b: Boolean = valueMap.get("b").asInstanceOf[Boolean]
+      val a: List[String] = List(valueMap.get("a").asInstanceOf[java.util.ArrayList[String]].toArray(): _*).asInstanceOf[List[String]]
 
 
       s should be ("this is a string")
       d should be (100)
       b should equal(true)
+      a should equal(List("list"))
     }
 
     it ("should convert a nested JsObject to a valueMap") {
-      val nestedObj = NestedDynamoDBObj("string", 100, false, SimpleDynamoDBObj("strang", 500, true))
+      val nestedObj = NestedDynamoDBObj("string", 100, false, SimpleDynamoDBObj("strang", 500, true, List("list")))
       val json = Json.toJson(nestedObj).as[JsObject]
       val valueMap = DynamoDB.jsonToValueMap(json)
 
@@ -40,6 +42,7 @@ class DynamoDBTest extends FunSpec with Matchers {
       val s: String = simpleMap.get("s").asInstanceOf[String]
       val d: BigDecimal = simpleMap.get("d").asInstanceOf[java.math.BigDecimal]
       val b: Boolean = simpleMap.get("b").asInstanceOf[Boolean]
+      val a: List[String] = List(simpleMap.get("a").asInstanceOf[java.util.ArrayList[String]].toArray: _*).asInstanceOf[List[String]]
 
 
       ss should be ("string")
@@ -49,6 +52,7 @@ class DynamoDBTest extends FunSpec with Matchers {
       s should be ("strang")
       d should be (500)
       b should equal(true)
+      a should equal(List("list"))
     }
 
     it ("should convert a Collection to ValueMap") {
@@ -69,7 +73,7 @@ class DynamoDBTest extends FunSpec with Matchers {
 
 }
 
-case class SimpleDynamoDBObj(s: String, d: BigDecimal, b: Boolean)
+case class SimpleDynamoDBObj(s: String, d: BigDecimal, b: Boolean, a: List[String])
 object SimpleDynamoDBObj {
   implicit def formats: Format[SimpleDynamoDBObj] = Json.format[SimpleDynamoDBObj]
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
@@ -50,6 +50,6 @@ trait MetadataHelper {
       subLocation         = metadata.get("subLocation"),
       city                = metadata.get("city"),
       state               = metadata.get("state"),
-      country             = metadata.get("country")
+      country             = metadata.get("country"),
     )
 }

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -235,19 +235,34 @@
                 </span>
             </dd>
 
-            <dt ng:if="ctrl.metadata.peopleInImage.length > 0"
-                class="image-info__group--dl__key metadata-line__key image-info__wrap">
+            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">
                 People
             </dt>
-            <dd ng:if="ctrl.metadata.peopleInImage.length > 0"
-                class="image-info__group--dl__value metadata-line__info">
+            <dd class="image-info__wrap image-info__group--dl__value metadata-line__info">
+                <button data-cy="it-edit-people-button"
+                        class="image-info__edit"
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="peopleEditForm.$show()"
+                        ng-hide="peopleEditForm.$visible"
+                    >✎</button>
                 <span class="metadata-line__info">
+                    <span class="image-info__people"
+                          editable-text="ctrl.metadata.peopleInImage"
+                          ng-hide="peopleEditForm.$visible"
+                          onbeforesave="ctrl.updateMetadataField('peopleInImage', $data)"
+                          e:ng-class="{'image-info__editor--error': $error,
+                                        'image-info__editor--saving': peopleEditForm.$waiting,
+                                        'text-input': true}"
+                          e:form="peopleEditForm">
                     <span ng:repeat="person in ctrl.metadata.peopleInImage">
-                      <span class="metadata-line__info--nowrap">
-                        <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a><span ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">, </span>
+                        <span class="metadata-line__info--nowrap">
+                            <a ui:sref="search.results({query: (person | queryFilter:'person')})">{{person}}</a><span ng-if="ctrl.metadata.peopleInImage.length > 1 && $index != ctrl.metadata.peopleInImage.length - 1">, </span>
                       </span>
                     </span>
-                </span>
+                    <span ng-if="! ctrl.metadata.peopleInImage.length > 0">
+                        Unknown (click ✎ to add)
+                    </span>
+                  </span>
             </dd>
         </dl>
     </div>

--- a/kahuna/public/js/edits/metadataDiff.js
+++ b/kahuna/public/js/edits/metadataDiff.js
@@ -1,3 +1,6 @@
+const areSetsEqual = (a, b) => a.size === b.size && [...a].every(value => b.has(value));
+
+
 export const getMetadataDiff = (image, metadata) => {
   const diff = {};
   const originalMetadata = image.data.originalMetadata;
@@ -7,8 +10,15 @@ export const getMetadataDiff = (image, metadata) => {
   );
 
   keys.forEach((key) => {
-    if (JSON.stringify(originalMetadata[key]) === JSON.stringify(metadata[key])) {
+    if (originalMetadata[key] === metadata[key]) {
       return;
+    }
+
+    // Arrays cannot be compared with simple equality
+    if (Array.isArray(metadata[key]) || Array.isArray(originalMetadata[key])) {
+      if (areSetsEqual(new Set(originalMetadata[key]), new Set(metadata[key]))) {
+        return;
+      }
     }
 
     // if the user has provided an override of '' (e.g. they want remove the title),

--- a/kahuna/public/js/edits/metadataDiff.js
+++ b/kahuna/public/js/edits/metadataDiff.js
@@ -7,12 +7,7 @@ export const getMetadataDiff = (image, metadata) => {
   );
 
   keys.forEach((key) => {
-    if (originalMetadata[key] === metadata[key]) {
-      return;
-    }
-
-    //This only works with string fields and does not support arrays
-    if (Array.isArray(metadata[key]) || Array.isArray(originalMetadata[key])) {
+    if (JSON.stringify(originalMetadata[key]) === JSON.stringify(metadata[key])) {
       return;
     }
 

--- a/kahuna/public/js/edits/metadataDiff.spec.js
+++ b/kahuna/public/js/edits/metadataDiff.spec.js
@@ -20,15 +20,15 @@ describe('metadataDiff', () => {
   it("finds a changed string field in the presence of an array", () => {
     const initial = { field: "value", array1: ["value 2"] };
     const changed = { field: "changed", array2: ["value 2"] };
-    const expected = { field: "changed" };
+    const expected = { field: "changed", array1: "", array2: ["value 2"] };
     const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
     expect(diff).toStrictEqual(expected);
    });
 
-  it("discards an array field", () => {
+  it("handles an array field", () => {
     const initial = { field: "value", keywords: ["value 2"] };
     const changed = { field: "changed", keywords: ["value 2","value 3"] };
-    const expected = { field: "changed" };
+    const expected = { field: "changed", keywords: ["value 2","value 3"] };
     const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
     expect(diff).toStrictEqual(expected);
   });

--- a/kahuna/public/js/edits/metadataDiff.spec.js
+++ b/kahuna/public/js/edits/metadataDiff.spec.js
@@ -19,8 +19,8 @@ describe('metadataDiff', () => {
 
   it("finds a changed string field in the presence of an array", () => {
     const initial = { field: "value", array1: ["value 2"] };
-    const changed = { field: "changed", array2: ["value 2"] };
-    const expected = { field: "changed", array1: "", array2: ["value 2"] };
+    const changed = { field: "changed", array1: ["value 2"] };
+    const expected = { field: "changed" };
     const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
     expect(diff).toStrictEqual(expected);
    });
@@ -29,6 +29,30 @@ describe('metadataDiff', () => {
     const initial = { field: "value", keywords: ["value 2"] };
     const changed = { field: "changed", keywords: ["value 2","value 3"] };
     const expected = { field: "changed", keywords: ["value 2","value 3"] };
+    const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
+    expect(diff).toStrictEqual(expected);
+  });
+
+  it('handles multiple array fields', () => {
+    const initial = { array1: ["value"], array2: ["value 2", "value 3"] };
+    const changed = { array1: ["changed"], array2: ["value 2","value 3"] };
+    const expected = { array1: ["changed"] };
+    const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
+    expect(diff).toStrictEqual(expected);
+  });
+
+  it('handles an unsorted array field', () => {
+    const initial = { array: ["value 1", "value 2", "value 3"] };
+    const changed = { array: ["value 3", "value 2", "value 1"] };
+    const expected = { };
+    const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
+    expect(diff).toStrictEqual(expected);
+  });
+
+  it('handles an empty array field', () => {
+    const initial = { array: ["value"] };
+    const changed = { array: [] };
+    const expected = { array: [] };
     const diff = getMetadataDiff({ data: { originalMetadata: initial } }, changed);
     expect(diff).toStrictEqual(expected);
   });

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -259,7 +259,7 @@ service.factory('editsService',
         proposedMetadata[field] = value;
 
         // peopleInImage is a special case. This turns a comma-separated string into an array trimmed of whitespace
-        if(field === 'peopleInImage' ) {
+        if (field === 'peopleInImage' ) {
           proposedMetadata[field] = value.toString().split(',')
             .map(s => s.trim())
             .filter(s => s !== "");

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -259,7 +259,7 @@ service.factory('editsService',
         proposedMetadata[field] = value;
 
         // peopleInImage is a special case. This turns a comma-separated string into an array trimmed of whitespace
-        if (field === 'peopleInImage' ) {
+        if (field === 'peopleInImage' || field === 'keywords' ) {
           proposedMetadata[field] = value.toString().split(',')
             .map(s => s.trim())
             .filter(s => s !== "");

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -258,6 +258,13 @@ service.factory('editsService',
         var proposedMetadata = angular.copy(metadata);
         proposedMetadata[field] = value;
 
+        // peopleInImage is a special case. This turns a comma-separated string into an array trimmed of whitespace
+        if(field === 'peopleInImage' ) {
+          proposedMetadata[field] = value.toString().split(',')
+            .map(s => s.trim())
+            .filter(s => s !== "");
+        }
+
         var changed = getMetadataDiff(image, proposedMetadata);
 
         return update(image.data.userMetadata.data.metadata, changed, image)

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -228,9 +228,8 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
     edits
   }
 
-  // FIXME: At the moment we can't accept keywords as it is a list
   def metadataAsMap(metadata: ImageMetadata) = {
-    (Json.toJson(metadata).as[JsObject]-"keywords").as[Map[String, JsValue]]
+    (Json.toJson(metadata).as[JsObject]).as[Map[String, JsValue]]
   }
 
 

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -215,8 +215,8 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
   }
 
   // TODO: Move this to the dynamo lib
-  def caseClassToMap[T](caseClass: T)(implicit tjs: Writes[T]): Map[String, String] =
-    Json.toJson[T](caseClass).as[JsObject].as[Map[String, String]]
+  def caseClassToMap[T](caseClass: T)(implicit tjs: Writes[T]): Map[String, JsValue] =
+    Json.toJson[T](caseClass).as[JsObject].as[Map[String, JsValue]]
 
   def labelsCollection(id: String, labels: Set[String]): (URI, Seq[EmbeddedEntity[String]]) =
     (labelsUri(id), labels.map(setUnitEntity(id, "labels", _)).toSeq)
@@ -229,8 +229,9 @@ class EditsController(auth: Authentication, store: EditsStore, notifications: No
   }
 
   // FIXME: At the moment we can't accept keywords as it is a list
-  def metadataAsMap(metadata: ImageMetadata) =
-    (Json.toJson(metadata).as[JsObject]-"keywords").as[Map[String, String]]
+  def metadataAsMap(metadata: ImageMetadata) = {
+    (Json.toJson(metadata).as[JsObject]-"keywords").as[Map[String, JsValue]]
+  }
 
 
 }


### PR DESCRIPTION
## What does this change?

Adds the ability to edit the People in an image. Developed with @zeek01 as part of Hack Day 2020.

Some of the “prompted change” alluded to in [Mistakes with identities have dismayed our readers – and prompted change](https://www.theguardian.com/commentisfree/2020/aug/09/mistakes-identities-dismayed-readers-change).

This required to change the underlying Scala type from `Map[String, String]` &rarr; `Map[String, JsValue]`. The `service.js` also handle the `peopleInImage` field differently than other.

## How can success be measured?

Picture editors should be able to correct this metadata if it is wrong.

## Screenshots

![joe-to-john-real](https://user-images.githubusercontent.com/76776/100385851-d6a9ad00-2ff1-11eb-95a4-8e8f57b0ac2c.gif)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->

@paperboyo, @akash1810, @guardian/digital-cms

## Tested?
- [X] locally
- [x] on TEST
