### PR TITLE
Handle upload failures better

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -3,6 +3,7 @@ package controllers
 import java.io.File
 import java.net.URI
 
+import akka.http.scaladsl.model.EntityStreamException
 import com.drew.imaging.ImageProcessingException
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
@@ -174,6 +175,7 @@ class ImageLoaderController(auth: Authentication,
           case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
           case _: IllegalArgumentException => FailureResponse.invalidUri
           case e: UserImageLoaderException => FailureResponse.badUserInput(e)
+          case e: EntityStreamException => FailureResponse.uploadFailed(e)
           case NonFatal(_) => FailureResponse.failedUriDownload
       }
     }

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -1,5 +1,6 @@
 package lib
 
+import akka.http.scaladsl.model.EntityStreamException
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.model.{MimeType, UnsupportedMimeTypeException}
@@ -22,6 +23,14 @@ object FailureResponse extends ArgoHelpers {
     respondError(BadRequest, "failed-uri-download", s"The provided 'uri' could not be downloaded")
   }
 
+  def uploadFailed(e: EntityStreamException): Result = {
+    logger.info("Unable to process file, possibly network issues", e)
+    respondError(
+      UnprocessableEntity,
+      "incomplete-upload",
+      s"Incomplete upload - is this a very large file, or a bad network?"
+    )
+  }
   def unsupportedMimeType(unsupported: UnsupportedMimeTypeException, supportedMimeTypes: List[MimeType]): Result = {
     logger.info(s"Rejected request to load file: mime-type is not supported", unsupported)
     respondError(


### PR DESCRIPTION
## What does this change?
Grid image upload currently logs server errors, several times a day, as follows:
```
play.api.UnexpectedException: Unexpected exception[EntityStreamException: Entity stream truncation]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:247)
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:178)
	at play.filters.cors.AbstractCORSPolicy$$anonfun$1.applyOrElse(AbstractCORSPolicy.scala:125)
	at play.filters.cors.AbstractCORSPolicy$$anonfun$1.applyOrElse(AbstractCORSPolicy.scala:123)
	at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:417)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
```
These are believed to be upload failures, caused by flaky networks.  Therefore they should not be considered 5XX errors but 4XX errors.

This change traps those errors and returns `422 - Unprocessable Entity` which will not be logged at ERROR.

## How can success be measured?
Fewer errors in logs, no changes to user experience.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
