### PR TITLE
Handle upload failures better v2

### DIFF
--- a/image-loader/app/lib/BodyParsers.scala
+++ b/image-loader/app/lib/BodyParsers.scala
@@ -79,7 +79,9 @@ object DigestBodyParser extends ArgoHelpers {
             validate(request, to, md)
           }
         } catch {
-          case e:Exception => Accumulator.done(failValidation(uploadFailed, e.getMessage))
+          case e:Exception =>
+          logger.info("Upload failed", e)
+            Accumulator.done(failValidation(uploadFailed, e.getMessage))
         }
       }
     }


### PR DESCRIPTION
## What does this change?
Grid image upload currently logs server errors, several times a day, as follows:
```
play.api.UnexpectedException: Unexpected exception[EntityStreamException: Entity stream truncation]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:247)
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:178)
	at play.filters.cors.AbstractCORSPolicy$$anonfun$1.applyOrElse(AbstractCORSPolicy.scala:125)
	at play.filters.cors.AbstractCORSPolicy$$anonfun$1.applyOrElse(AbstractCORSPolicy.scala:123)
	at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:417)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
```
These are believed to be upload failures, caused by flaky networks.  Therefore they should not be considered 5XX errors but 4XX errors.

This change traps those errors and returns `422 - Unprocessable Entity` which will not be logged at ERROR.

## How can success be measured?
Fewer errors in logs, no changes to user experience.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
