### PR TITLE
Implement generic error handling to cope with failed uploads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,6 @@ val okHttpVersion = "3.12.1"
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
-    "com.typesafe.play" %% "play" % "2.6.20", ws,
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
     "com.typesafe.play" %% "filters-helpers" % "2.6.20",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.8.2",
@@ -97,6 +96,8 @@ lazy val commonLib = project("common-lib").settings(
     // i.e. to only log to disk in DEV
     // see: https://logback.qos.ch/setup.html#janino
     "org.codehaus.janino" % "janino" % "3.0.6",
+    akkaHttpServer,
+    ws
 ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ val okHttpVersion = "3.12.1"
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
+    "com.typesafe.play" %% "play" % "2.6.20",   
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
     "com.typesafe.play" %% "filters-helpers" % "2.6.20",
     "com.gu" %% "pan-domain-auth-play_2-6" % "0.8.2",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -5,15 +5,17 @@ import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.{GridLogging, LogConfig}
 import com.gu.mediaservice.lib.management.{BuildInfo, Management}
 import play.api.ApplicationLoader.Context
-import play.api.{BuiltInComponentsFromContext, Configuration}
+import play.api.Logger.logger
+import play.api.http.{DefaultHttpErrorHandler, HttpErrorHandler}
+import play.api.{BuiltInComponentsFromContext, Configuration, UnexpectedException}
 import play.api.libs.ws.ahc.AhcWSComponents
-import play.api.mvc.EssentialFilter
+import play.api.mvc.{EssentialFilter, RequestHeader, Result, Results}
 import play.filters.HttpFiltersComponents
 import play.filters.cors.CORSConfig.Origins
 import play.filters.cors.{CORSComponents, CORSConfig}
 import play.filters.gzip.GzipFilterComponents
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class GridComponents[Config <: CommonConfig](context: Context, val loadConfig: Configuration => Config) extends BuiltInComponentsFromContext(context)
   with AhcWSComponents with HttpFiltersComponents with CORSComponents with GzipFilterComponents {
@@ -22,6 +24,9 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
   // next thing is to set up log shipping
   LogConfig.initKinesisLogging(config)
   LogConfig.initLocalLogShipping(config)
+
+  override lazy val httpErrorHandler: HttpErrorHandler = new GridHttpErrorHandler(environment, configuration, sourceMapper,
+    Some(router))
 
   def buildInfo: BuildInfo
 
@@ -37,4 +42,14 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
 
   lazy val management = new Management(controllerComponents, buildInfo)
   val auth = new Authentication(config, actorSystem, defaultBodyParser, wsClient, controllerComponents, executionContext)
+}
+
+class GridHttpErrorHandler extends DefaultHttpErrorHandler with Results {
+  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = exception match {
+    case e:UnexpectedException if e.cause.getClass.getCanonicalName == "akka.http.scaladsl.model.EntityStreamException" => {
+      logger.info(s"Upload failed? Request = $request", e)
+      Future.successful(UnprocessableEntity("The upload did not complete"))
+    }
+    case x => super.onServerError(request, x)
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -6,8 +6,8 @@ import com.gu.mediaservice.lib.logging.{GridLogging, LogConfig}
 import com.gu.mediaservice.lib.management.{BuildInfo, Management}
 import play.api.ApplicationLoader.Context
 import play.api.Logger.logger
-import play.api.http.{DefaultHttpErrorHandler, HttpErrorHandler}
-import play.api.{BuiltInComponentsFromContext, Configuration, UnexpectedException}
+import play.api.http.{DefaultHttpErrorHandler, HttpErrorConfig, HttpErrorHandler}
+import play.api.{BuiltInComponentsFromContext, Configuration, Environment, Mode, UnexpectedException}
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{EssentialFilter, RequestHeader, Result, Results}
 import play.filters.HttpFiltersComponents
@@ -25,8 +25,8 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
   LogConfig.initKinesisLogging(config)
   LogConfig.initLocalLogShipping(config)
 
-  override lazy val httpErrorHandler: HttpErrorHandler = new GridHttpErrorHandler(environment, configuration, sourceMapper,
-    Some(router))
+  lazy val hiddenHttpErrorHandler: HttpErrorHandler = new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
+  override lazy val httpErrorHandler: HttpErrorHandler = new GridHttpErrorHandler(hiddenHttpErrorHandler)
 
   def buildInfo: BuildInfo
 
@@ -44,12 +44,17 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
   val auth = new Authentication(config, actorSystem, defaultBodyParser, wsClient, controllerComponents, executionContext)
 }
 
-class GridHttpErrorHandler extends DefaultHttpErrorHandler with Results {
+// Ugly wrapper class.  Sorry.
+class GridHttpErrorHandler(httpErrorHandler: HttpErrorHandler) extends HttpErrorHandler with Results {
+
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = exception match {
     case e:UnexpectedException if e.cause.getClass.getCanonicalName == "akka.http.scaladsl.model.EntityStreamException" => {
       logger.info(s"Upload failed? Request = $request", e)
       Future.successful(UnprocessableEntity("The upload did not complete"))
     }
-    case x => super.onServerError(request, x)
+    case x => httpErrorHandler.onServerError(request, x)
   }
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] =
+    httpErrorHandler.onClientError(request, statusCode, message)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -48,9 +48,10 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
 class GridHttpErrorHandler(httpErrorHandler: HttpErrorHandler) extends HttpErrorHandler with Results {
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = exception match {
-    case e:UnexpectedException if e.cause.getClass.getCanonicalName == "akka.http.scaladsl.model.EntityStreamException" => {
+    case e:UnexpectedException => {
       logger.info(s"Upload failed? Request = $request", e)
-      Future.successful(UnprocessableEntity("The upload did not complete"))
+      httpErrorHandler.onServerError(request, e)
+//      Future.successful(UnprocessableEntity("The upload did not complete"))
     }
     case x => httpErrorHandler.onServerError(request, x)
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -49,7 +49,7 @@ class GridHttpErrorHandler(httpErrorHandler: HttpErrorHandler) extends HttpError
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = exception match {
     case e:EntityStreamException => {
-      logger.info(s"Upload failed? Request = $request", e)
+      logger.info(s"Upload failed with EntityStreamException. Request = $request")
       Future.successful(UnprocessableEntity("The upload did not complete"))
     }
     case e  =>

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
@@ -1,5 +1,6 @@
 package com.gu.mediaservice.lib.play
 
+import akka.http.scaladsl.model.EntityStreamException
 import akka.stream.Materializer
 import com.gu.mediaservice.lib.auth.Authentication
 import net.logstash.logback.marker.Markers.appendEntries
@@ -71,6 +72,9 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
 
     val markers = MarkerContext(appendEntries((mandatoryMarkers ++ optionalMarkers).asJava))
     logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ERROR "$referer" ${duration}ms""")(markers)
-    logger.error(s"Error for ${request.method} ${request.uri}", throwable)
+    throwable match {
+      case _: EntityStreamException => logger.info(s"Upload failed with EntityStreamException. Request = $request")(markers)
+      case _ => logger.error(s"Error for ${request.method} ${request.uri}", throwable)(markers)
+    }
   }
 }


### PR DESCRIPTION
## What does this change?
Grid image upload currently logs server errors, several times a day, as follows:
```
play.api.UnexpectedException: Unexpected exception[EntityStreamException: Entity stream truncation]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:247)
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:178)
	at play.filters.cors.AbstractCORSPolicy$$anonfun$1.applyOrElse(AbstractCORSPolicy.scala:125)
	at play.filters.cors.AbstractCORSPolicy$$anonfun$1.applyOrElse(AbstractCORSPolicy.scala:123)
	at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:417)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
```
These are believed to be upload failures, caused by flaky networks.  Therefore they should not be considered 5XX errors but 4XX errors.

This change traps those errors and returns `422 - Unprocessable Entity` which will not be logged at ERROR.

## How can success be measured?
Fewer errors in logs, no changes to user experience.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
