### PR TITLE
document cerebro

### DIFF
--- a/docs/02-running/01-running-locally.md
+++ b/docs/02-running/01-running-locally.md
@@ -53,3 +53,9 @@ This is the [oidc-provider](../../dev/oidc-provider) and we can login to Grid us
 [`users.json`](../../dev/config/users.json), for example `grid-demo-account@guardian.co.uk`. There isn't a password, so enter any value.
 
 If you haven't used the `--with-local-auth` flag, you'll begin a Google authentication flow.
+
+## Cerebro
+
+To inspect the elasticsearch database, cerebro is included as part of the grids local stack.
+It can be accessed http://localhost:9090/#/connect?host=http:%2F%2Felasticsearch:9200
+For cerebro, the address of the elasticsearch instance is `http://elasticsearch:9200`


### PR DESCRIPTION
## What does this change?

we have cerebro installed, but nothing on how to access it 

## How can success be measured?

that we can now access it without archeology or guesswork

## Screenshots (if applicable)
<img width="660" alt="image" src="https://user-images.githubusercontent.com/2670496/101380323-413dd100-38ad-11eb-9e1d-c6ab5a17b100.png">


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally
- [ ] on TEST
