### PR TITLE
Add Eric Wadsworth to (past) staff photographers

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/MetadataConfig.scala
@@ -75,7 +75,8 @@ object MetadataConfig {
     "Tom Stuttard"          -> "The Guardian",
     "Tricia De Courcy Ling" -> "The Guardian",
     "Walter Doughty"        -> "The Guardian",
-
+    "Eric Wadsworth"        -> "The Guardian",
+    
     "David Newell Smith"    -> "The Observer",
     "Tony McGrath"          -> "The Observer",
     "Catherine Shaw"        -> "The Observer",


### PR DESCRIPTION
Ronseal. At the request of the Archive.