### PR TITLE
some tweaks to the batch api

### DIFF
--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -53,7 +53,7 @@ async.service("queue", ['$timeout', ($timeout) => {
   console.log("queue created!");
   return createQueue({
     timeout: $timeout,
-    maxWorkers: 2
+    maxWorkers: 4
   });
 }]);
 

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -53,7 +53,7 @@ async.service("queue", ['$timeout', ($timeout) => {
   console.log("queue created!");
   return createQueue({
     timeout: $timeout,
-    maxWorkers: 1
+    maxWorkers: 2
   });
 }]);
 

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -53,7 +53,7 @@ async.service("queue", ['$timeout', ($timeout) => {
   console.log("queue created!");
   return createQueue({
     timeout: $timeout,
-    maxWorkers: 8
+    maxWorkers: 4
   });
 }]);
 

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -53,7 +53,7 @@ async.service("queue", ['$timeout', ($timeout) => {
   console.log("queue created!");
   return createQueue({
     timeout: $timeout,
-    maxWorkers: 4
+    maxWorkers: 8
   });
 }]);
 

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -50,8 +50,10 @@ async.factory("race", [
 ]);
 
 async.service("queue", ['$timeout', ($timeout) => {
+  console.log("queue created!");
   return createQueue({
-    timeout: $timeout
+    timeout: $timeout,
+    maxWorkers: 1
   });
 }]);
 

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -53,7 +53,7 @@ async.service("queue", ['$timeout', ($timeout) => {
   console.log("queue created!");
   return createQueue({
     timeout: $timeout,
-    maxWorkers: 4
+    maxWorkers: 30
   });
 }]);
 

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -5,7 +5,7 @@ export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
-  const queue = createQueue({ maxWorkers: 30 });
+  const queue = createQueue({ maxWorkers: 15 });
   const results = input.map(item => {
     return new Promise((resolve, reject) =>
       queue.add({

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -5,7 +5,7 @@ export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
-  const queue = createQueue({ maxWorkers: 60 });
+  const queue = createQueue({ maxWorkers: 30 });
   const results = input.map(item => {
     return new Promise((resolve, reject) =>
       queue.add({

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -5,7 +5,7 @@ export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
-  const queue = createQueue({ maxWorkers: 8 });
+  const queue = createQueue({ maxWorkers: 4 });
   const results = input.map(item => {
     return new Promise((resolve, reject) =>
       queue.add({

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -5,7 +5,7 @@ export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
-  const queue = createQueue({ maxWorkers: 30 });
+  const queue = createQueue({ maxWorkers: 60 });
   const results = input.map(item => {
     return new Promise((resolve, reject) =>
       queue.add({

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -5,7 +5,7 @@ export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
-  const queue = createQueue({ maxWorkers: 4 });
+  const queue = createQueue({ maxWorkers: 30 });
   const results = input.map(item => {
     return new Promise((resolve, reject) =>
       queue.add({

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -5,7 +5,7 @@ export function trackAll($rootScope, key, input, fn) {
     let completed = 0;
     $rootScope.$broadcast("events:batch-operations:start",
         { key, completed: 0, total: input.size ? input.size : input.length });
-  const queue = createQueue({ maxWorkers: 15 });
+  const queue = createQueue({ maxWorkers: 8 });
   const results = input.map(item => {
     return new Promise((resolve, reject) =>
       queue.add({

--- a/kahuna/public/js/util/queue.js
+++ b/kahuna/public/js/util/queue.js
@@ -78,7 +78,7 @@ export const createQueue = ({
         // ensuring it is run in a new call stack.
         setTimeout(() => {
           startWorker();
-        }, 0);
+        }, 100);
       });
   };
 


### PR DESCRIPTION
## What does this change?

I _think_ some of the difficulty in batch edits is that the check queue is causing some contention. This adds a 100ms between workers taking things off the queue. 

This does 30 in five seconds, and 136 in four minutes. This is a ten times slowdown. I have no idea. 


## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
