### PR TITLE
Add a comment about the nature of standard metadata fields

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -6,6 +6,8 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class ImageMetadata(
+/* these are standard metadata fields that exist in multiple schemas,
+most canonical being https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata */
   dateTaken:           Option[DateTime] = None,
   description:         Option[String]   = None,
   credit:              Option[String]   = None,

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -5,9 +5,9 @@ import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class ImageMetadata(
-/* these are standard metadata fields that exist in multiple schemas,
+/* following are standard metadata fields that exist in multiple schemas,
 most canonical being https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata */
+case class ImageMetadata(
   dateTaken:           Option[DateTime] = None,
   description:         Option[String]   = None,
   credit:              Option[String]   = None,


### PR DESCRIPTION
For the record, they are being read and we reconcile them [here](https://github.com/guardian/grid/blob/85db4bc41d79d5906bb09f53a8279dd1bf40e68f/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala#L13-L97). We (mostly) try to follow [MWG guidelines](https://github.com/guardian/grid/files/4113995/mwg_guidance2.0.pdf).