### PR TITLE
[image-loader]: Add markers to kinesis error logging on failure

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -51,7 +51,7 @@ class Kinesis(config: KinesisSenderConfig) extends GridLogging{
       logger.info(s"Published kinesis message: $result")
     } catch {
       case e: Exception =>
-        logger.error(s"kinesis putRecord exception message: ${e.getMessage}")
+        logger.error(markers, s"kinesis putRecord exception message: ${e.getMessage}")
         // propagate error forward to the client
         throw e
     }


### PR DESCRIPTION
## What does this change?

Add the standard `UpdateMessage` log markers to the kinesis error logging when a kinesis putRecord operation fails. This makes it easier for us to recover an image that can't be enqueued for analysis.

## How can success be measured?

We have an easier time recovering images that can't be enqueued.

## Screenshots (if applicable)

![download](https://user-images.githubusercontent.com/7767575/102805909-dc599f00-43b3-11eb-8b22-2e2703f872bc.jpg)

## Tested?
- [ ] locally
- [ ] on TEST
