### PR TITLE
Add file data to markers when we put files to S3

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -123,10 +123,17 @@ class S3(config: CommonConfig) extends GridLogging {
       cacheControl.foreach(metadata.setCacheControl)
       metadata.setUserMetadata(meta.asJava)
 
+      val fileMarkers = Map(
+        "bucket" -> bucket,
+        "fileName" -> id,
+        "mimeType" -> mimeType.getOrElse("none"),
+      )
+      val markers = logMarker ++ fileMarkers
+
       val req = new PutObjectRequest(bucket, id, file).withMetadata(metadata)
       Stopwatch(s"S3 client.putObject ($req)"){
         client.putObject(req)
-      }
+      }(markers)
     }
 
   def list(bucket: Bucket, prefixDir: String)


### PR DESCRIPTION
## What does this change?

We had some recent logs related to a failed S3 put request that didn't include [as much data as we'd like](https://logs.gutools.co.uk/s/editorial-tools/goto/853289df90299ea285045e984f5758c0).

This PR adds the bucket name, id, and mimeType to log markers, so it should be easier to see what went wrong when it does.

## How can success be measured?

We have an easier time linking put failures to specific images.

## Tested?
- [x] locally
- [ ] on TEST
