### PR TITLE
Alter Alamy rights generation

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -66,7 +66,7 @@ object ActionImagesParser extends ImageProcessor {
 
 object AlamyParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Alamy") | Some("Alamy Stock Photo") => image.copy(
+    case Some(credit) if credit.contains("Alamy") && !credit.contains("Alamy Live News") => image.copy(
       usageRights = Agencies.get("alamy")
     )
     case _ => image

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -67,7 +67,8 @@ object ActionImagesParser extends ImageProcessor {
 object AlamyParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     case Some(credit) if credit.contains("Alamy") && !credit.contains("Alamy Live News") => image.copy(
-      usageRights = Agencies.get("alamy")
+      usageRights = Agencies.get("alamy"),
+      metadata = image.metadata.copy(credit = Some(credit.replace("Alamy Stock Photo", "Alamy")))
     )
     case _ => image
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -79,18 +79,18 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.credit should be(Some("Alamy"))
     }
 
-    it("should match 'Alamy Stock Photo' credit") {
+    it("should match 'Alamy Stock Photo' credit, and replace 'Alamy Stock Photo' with 'Alamy'") {
       val image = createImageFromMetadata("credit" -> "Alamy Stock Photo")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be (Agency("Alamy"))
-      processedImage.metadata.credit should be(Some("Alamy Stock Photo"))
+      processedImage.metadata.credit should be(Some("Alamy"))
     }
 
     it("should match credit with Alamy as a suffix with '/'") {
       val image = createImageFromMetadata("credit" -> "Prod.DB/Alamy Stock Photo")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be (Agency("Alamy"))
-      processedImage.metadata.credit should be(Some("Prod.DB/Alamy Stock Photo"))
+      processedImage.metadata.credit should be(Some("Prod.DB/Alamy"))
     }
 
     it("should not match credit with Alamy when the credit contains 'Alamy Live News', because we only have rights after 48 hours, and there's no provision to add a 'deny' lease for that period yet") {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -85,6 +85,20 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.usageRights should be (Agency("Alamy"))
       processedImage.metadata.credit should be(Some("Alamy Stock Photo"))
     }
+
+    it("should match credit with Alamy as a suffix with '/'") {
+      val image = createImageFromMetadata("credit" -> "Prod.DB/Alamy Stock Photo")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be (Agency("Alamy"))
+      processedImage.metadata.credit should be(Some("Prod.DB/Alamy Stock Photo"))
+    }
+
+    it("should not match credit with Alamy when the credit contains 'Alamy Live News', because we only have rights after 48 hours, and there's no provision to add a 'deny' lease for that period yet") {
+      val image = createImageFromMetadata("credit" -> "Alamy Live News/Alamy Live News")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be (NoRights)
+      processedImage.metadata.credit should be(Some("Alamy Live News/Alamy Live News"))
+    }
   }
 
   describe("Allstar") {


### PR DESCRIPTION
## What does this change?

This PR universally catches Alamy in image credits and add the appropriate rights, unless images come from Alamy Live News.

## How can success be measured?

The automated tests reflect that logic, and it's respected when Alamy images are ingested.

## Tested?
- [x] locally
- [x] on TEST
