### PR TITLE
Filters deleted collections from collection children

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -102,6 +102,7 @@ grCollectionsPanel.controller('GrNodeCtrl',
 
     const pathId = ctrl.node.data.data.pathId;
 
+    ctrl.children = ctrl.node.data.children.filter(node => !!node.data.data);
     ctrl.saving = false;
     ctrl.removing = false;
     ctrl.deletable = false;
@@ -174,7 +175,7 @@ grCollectionsPanel.controller('GrNodeCtrl',
 grCollectionsPanel.directive('grNode', ['$parse', '$compile', function($parse, $compile) {
     const templateString = `<gr-nodes
                                 ng:if="ctrl.showChildren && ctrl.node.data.children.length > 0"
-                                gr:nodes="ctrl.node.data.children"
+                                gr:nodes="ctrl.children"
                                 ></gr-nodes>`;
     return {
         restrict: 'E',

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -102,7 +102,9 @@ grCollectionsPanel.controller('GrNodeCtrl',
 
     const pathId = ctrl.node.data.data.pathId;
 
+    //This filter remove child nodes with missing data, preventing display errors from occurring
     ctrl.children = ctrl.node.data.children.filter(node => !!node.data.data);
+
     ctrl.saving = false;
     ctrl.removing = false;
     ctrl.deletable = false;


### PR DESCRIPTION
## What does this change?
This PR aims to fix the issue whereby all sub-collections wouldn't render if there was an orphaned sub-collection.

## How can success be measured?
When an orphaned sub-collection exists, the other collections still render correctly.

## Tested?
- [x] locally
- [ ] on TEST
