### PR TITLE
More Getty exclusions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -169,13 +169,15 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
       "S&G and Barratts/EMPICS Sport", "EMPICS Sport", "EMPICS SPORT", "EMPICS Sports Photo Agency",
       "Empics Sports Photography Ltd.", "EMPICS Entertainment", "Empics Entertainment", "MatchDay Images Limited",
       "S&G and Barratts/EMPICS Archive", "PPAUK", "SWNS.COM", "Euan Cherry", "Plumb Images", "Mercury Press", "SWNS",
-      "Athena Pictures", "Flick.digital", "Matthew Horwood"
+      "Athena Pictures", "Flick.digital", "Matthew Horwood", "Focus Images Ltd", "www.scottishphotographer.com",
+      "ZUMAPRESS.com"
     )
 
     val excludedSource = List(
       "www.capitalpictures.com", "Replay Images", "UKTV", "PinPep", "Pinnacle Photo Agency Ltd", "News Images",
       "London News Pictures Ltd", "Showtime", "Propaganda", "Equinox Features", "Athena Picture Agency Ltd",
-      "www.edinburghelitemedia.co.uk", "WALES NEWS SERVICE", "Sports Inc", "UK Sports Pics Ltd"
+      "www.edinburghelitemedia.co.uk", "WALES NEWS SERVICE", "Sports Inc", "UK Sports Pics Ltd", "Blitz Pictures",
+      "Consolidated News Photos"
     )
 
     val isExcludedByCredit = image.metadata.credit.exists(isExcluded(_, excludedCredit))


### PR DESCRIPTION
Encouraged by the amazing https://github.com/guardian/grid/pull/3064, I decided to play a lil’ librarian. We really need to sort out our stinky Getty sniffing.

![image](https://user-images.githubusercontent.com/6032869/103832070-61f87280-5075-11eb-85e5-4242e7754ec2.png)
