### PR TITLE
Add check for date format

### DIFF
--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -18,6 +18,7 @@ import lib.ThrallMetrics
 import org.joda.time.DateTime
 import play.api.MarkerContext
 import play.api.libs.json._
+import java.time.LocalDateTime
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -123,6 +124,15 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
        | """)
 
     val lastModifiedParameter = lastModified.toOption.map(_.as[String])
+
+    def checkDateIsParseable(label: String, date: String, id: String) = try {
+      LocalDateTime.parse(date, ISO_DATE_TIME)
+    } catch {
+      case e: DateTimeParseException => throw new Exception(s"The $label date $lastModified on $id is not ISO 8601", e)
+    }
+
+    // Last modified param should be a string representation of a date
+    checkDateIsParseable("lastModified", lastModifiedParameter, id)
 
     val params = Map(
       "usages" -> usages.map(i => asNestedMap(Json.toJson(i))),

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -19,8 +19,10 @@ import org.joda.time.DateTime
 import play.api.MarkerContext
 import play.api.libs.json._
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter,ISO_DATE_TIME
 
 import scala.concurrent.{ExecutionContext, Future}
+import java.time.format.DateTimeParseException
 
 object ImageNotDeletable extends Throwable("Image cannot be deleted")
 
@@ -132,7 +134,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
     }
 
     // Last modified param should be a string representation of a date
-    checkDateIsParseable("lastModified", lastModifiedParameter, id)
+    checkDateIsParseable("lastModified", lastModifiedParameter.getOrElse("None"), id)
 
     val params = Map(
       "usages" -> usages.map(i => asNestedMap(Json.toJson(i))),

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -19,7 +19,7 @@ import org.joda.time.DateTime
 import play.api.MarkerContext
 import play.api.libs.json._
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter,ISO_DATE_TIME
+import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 
 import scala.concurrent.{ExecutionContext, Future}
 import java.time.format.DateTimeParseException


### PR DESCRIPTION
## What does this change?

Adds a check that a date is in ISO 8601 format, follows #3077

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
