### PR TITLE
More detailed elastic exceptions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
@@ -12,6 +12,13 @@ trait ElasticSearchError {
 }
 
 object ElasticSearchException {
+
+  def causes(c: ElasticError.CausedBy):Seq[(String, String)] = {
+    val script = c.other("script").getOrElse("no script")
+    val lang = c.other("lang").getOrElse("no language")
+    List("causedBy" -> c.toString(), "scriptStack" ->  c.scriptStack.mkString("\n"), "script" -> script, "lang" -> lang )
+  }
+
   def apply(e: ElasticError): Exception with ElasticSearchError = {
     e match {
       case ElasticError(t, r, _, _, _, Seq(), None, _, _, _) => // No root causes provided.
@@ -23,20 +30,19 @@ object ElasticSearchException {
       case ElasticError(t, r, _, _, _, Seq(), Some(c), _, _, _) =>
         new Exception(s"query failed because: $r type: $t caused by $c") with ElasticSearchError {
           override def error: ElasticError = e
-
-          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "causedBy" -> c.toString())
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, causes(c):_*)
         }
       case ElasticError(t, r, _, _, _, s, None, _, _, _) =>
-        new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}") with ElasticSearchError {
+        new Exception(s"query failed because: $r type: $t root cause ${s.mkString(",\n ")}") with ElasticSearchError {
           override def error: ElasticError = e
 
-          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "))
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(",\n"))
         }
       case ElasticError(t, r, _, _, _, s, Some(c), _, _, _) =>
         new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}, caused by $c") with ElasticSearchError {
           override def error: ElasticError = e
 
-          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(", "), "causedBy" -> c.toString())
+          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(",\n"), "causedBy" -> c.toString(), causes(c):_*)
         }
       case _ => new Exception(s"query failed because: unknown error") with ElasticSearchError {
         override def error: ElasticError = e

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchException.scala
@@ -13,7 +13,7 @@ trait ElasticSearchError {
 
 object ElasticSearchException {
 
-  def causes(c: ElasticError.CausedBy):Seq[(String, String)] = {
+  def causes(c: ElasticError.CausedBy):List[(String, Any)] = {
     val script = c.other("script").getOrElse("no script")
     val lang = c.other("lang").getOrElse("no language")
     List("causedBy" -> c.toString(), "scriptStack" ->  c.scriptStack.mkString("\n"), "script" -> script, "lang" -> lang )
@@ -30,7 +30,7 @@ object ElasticSearchException {
       case ElasticError(t, r, _, _, _, Seq(), Some(c), _, _, _) =>
         new Exception(s"query failed because: $r type: $t caused by $c") with ElasticSearchError {
           override def error: ElasticError = e
-          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, causes(c):_*)
+          override def markerContents: Map[String, Any] = (List("reason" -> r, "type" -> t) ::: causes(c)).toMap
         }
       case ElasticError(t, r, _, _, _, s, None, _, _, _) =>
         new Exception(s"query failed because: $r type: $t root cause ${s.mkString(",\n ")}") with ElasticSearchError {
@@ -42,7 +42,7 @@ object ElasticSearchException {
         new Exception(s"query failed because: $r type: $t root cause ${s.mkString(", ")}, caused by $c") with ElasticSearchError {
           override def error: ElasticError = e
 
-          override def markerContents: Map[String, Any] = Map("reason" -> r, "type" -> t, "rootCause" -> s.mkString(",\n"), "causedBy" -> c.toString(), causes(c):_*)
+          override def markerContents: Map[String, Any] = (List("reason" -> r, "type" -> t, "rootCause" -> s.mkString(",\n"), "causedBy" -> c.toString()) ::: causes(c)).toMap
         }
       case _ => new Exception(s"query failed because: unknown error") with ElasticSearchError {
         override def error: ElasticError = e


### PR DESCRIPTION
## What does this change?

Add more detail to exceptions from elastic search. 

Previously, this was missing the scriptStack. We're seeing errors in a painless script, and this field will allow us to see where the failure was observed. 

script and lang were already in the markers as part of `c.toString` but this just takes the opportunity to bring them out to their own fields.

## How can success be measured?

That more detail is received in the exceptions from elastic search.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
