### PR TITLE
Image quarantine

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageQuarantineOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageQuarantineOperations.scala
@@ -1,0 +1,21 @@
+package com.gu.mediaservice.lib
+
+import java.io.File
+
+import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.aws.S3Object
+import com.gu.mediaservice.lib.logging.LogMarker
+import com.gu.mediaservice.model.MimeType
+
+import scala.concurrent.Future
+
+class ImageQuarantineOperations(quarantineBucket: String, config: CommonConfig, isVersionedS3: Boolean = false)
+  extends S3ImageStorage(config) {
+
+  def storeQuarantineImage(id: String, file: File, mimeType: Option[MimeType], meta: Map[String, String] = Map.empty)
+                       (implicit logMarker: LogMarker): Future[S3Object] =
+    storeImage(quarantineBucket, ImageIngestOperations.fileKeyFromId(id), file, mimeType, meta)
+}
+
+
+

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -30,6 +30,9 @@ Resources:
   ThumbBucket:
     Type: AWS::S3::Bucket
 
+  QuarantineBucket:
+    Type: AWS::S3::Bucket
+
   KeyBucket:
     Type: AWS::S3::Bucket
 

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -56,11 +56,13 @@ function getImageLoaderConfig(config) {
         |aws.region="${config.AWS_DEFAULT_REGION}"
         |s3.image.bucket="${config.coreStackProps.ImageBucket}"
         |s3.thumb.bucket="${config.coreStackProps.ThumbBucket}"
+        |s3.quarantine.bucket="${config.coreStackProps.QuarantineBucket}"
         |s3.config.bucket="${config.coreStackProps.ConfigBucket}"
         |aws.local.endpoint="https://localstack.media.${config.DOMAIN}"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false
         |transcoded.mime.types="image/tiff"
+        |upload.quarantine.enabled=false
         |`;
 }
 

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -3,8 +3,8 @@ import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.ImageLoaderController
 import lib._
-import lib.storage.ImageLoaderStore
-import model.{Projector, Uploader}
+import lib.storage.{ImageLoaderStore, QuarantineStore}
+import model.{Projector, Uploader, QuarantineUploader}
 import play.api.ApplicationLoader.Context
 import router.Routes
 
@@ -18,15 +18,20 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
 
   val store = new ImageLoaderStore(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
-
   val notifications = new Notifications(config)
   val downloader = new Downloader()
   val uploader = new Uploader(store, config, imageOperations, notifications)
-
   val projector = Projector(config, imageOperations)
-
+  val quarantineUploader: Option[QuarantineUploader] = (config.uploadToQuarantineEnabled, config.quarantineBucket) match {
+    case (true, Some(bucketName)) =>{
+      val quarantineStore = new QuarantineStore(config)
+      Some(new QuarantineUploader(quarantineStore, config))
+    }
+    case (true, None) => throw new IllegalArgumentException(s"Quarantining is enabled. upload.quarantine.enabled = ${config.uploadToQuarantineEnabled} but no bucket is configured. s3.quarantine.bucket isn't configured.")
+    case (false, _) => None
+  }
   val controller = new ImageLoaderController(
-    auth, downloader, store, notifications, config, uploader, projector, controllerComponents, wsClient)
+    auth, downloader, store, notifications, config, uploader, quarantineUploader, projector, controllerComponents, wsClient)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management)
 }

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -13,11 +13,11 @@ import com.gu.mediaservice.model.UnsupportedMimeTypeException
 import lib._
 import lib.imaging.{NoSuchImageExistsInS3, UserImageLoaderException}
 import lib.storage.ImageLoaderStore
-import model.{Projector, Uploader}
-import play.api.libs.json.Json
+import model.{Projector, Uploader, QuarantineUploader}
+import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-
+import model.upload.UploadRequest
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -28,6 +28,7 @@ class ImageLoaderController(auth: Authentication,
                             notifications: Notifications,
                             config: ImageLoaderConfig,
                             uploader: Uploader,
+                            quarantineUploader: Option[QuarantineUploader],
                             projector: Projector,
                             override val controllerComponents: ControllerComponents,
                             wSClient: WSClient)
@@ -45,7 +46,12 @@ class ImageLoaderController(auth: Authentication,
 
   def index: Action[AnyContent] = auth { indexResponse }
 
-  def loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]): Action[DigestedFile] = {
+  def quarantineOrStoreImage(uploadRequest: UploadRequest)(implicit logMarker: LogMarker) = {
+    quarantineUploader.map(_.quarantineFile(uploadRequest)).getOrElse(uploader.storeFile(uploadRequest))
+  }
+  
+  def loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]): Action[DigestedFile] =  {
+
     implicit val context: RequestLoggingContext = RequestLoggingContext(
       initialMarkers = Map(
         "requestType" -> "load-image",
@@ -72,9 +78,8 @@ class ImageLoaderController(auth: Authentication,
           DateTimeUtils.fromValueOrNow(uploadTime),
           filename.flatMap(_.trim.nonEmptyOpt),
           context.requestId)
-        result <- uploader.storeFile(uploadRequest)
+        result <- quarantineOrStoreImage(uploadRequest)
       } yield result
-
       result.onComplete( _ => Try { deleteTempFile(tempFile) } )
 
       result map { r =>
@@ -88,8 +93,8 @@ class ImageLoaderController(auth: Authentication,
             case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
             case e: ImageProcessingException => FailureResponse.notAnImage(e, config.supportedMimeTypes).as(ArgoMediaType)
             case e: java.io.IOException => FailureResponse.badImage(e).as(ArgoMediaType)
-            case e =>
-              logger.error("Failed upload", e)
+            case _ => 
+              logger.error("Failed upload", e) 
               InternalServerError(Json.obj("error" -> e.getMessage)).as(ArgoMediaType)
           }).as(ArgoMediaType)
       }

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -10,6 +10,8 @@ class ImageLoaderConfig(resources: GridConfigResources) extends CommonConfig(res
   val imageBucket: String = string("s3.image.bucket")
 
   val thumbnailBucket: String = string("s3.thumb.bucket")
+  val quarantineBucket: Option[String] = stringOpt("s3.quarantine.bucket")
+  val uploadToQuarantineEnabled: Boolean = boolean("upload.quarantine.enabled")
 
   val tempDir: File = new File(stringDefault("upload.tmp.dir", "/tmp"))
 

--- a/image-loader/app/lib/QuarantineStore.scala
+++ b/image-loader/app/lib/QuarantineStore.scala
@@ -1,0 +1,6 @@
+package lib.storage
+
+import lib.ImageLoaderConfig
+import com.gu.mediaservice.lib
+
+class QuarantineStore(config: ImageLoaderConfig) extends lib.ImageQuarantineOperations(config.quarantineBucket.get, config)

--- a/image-loader/app/model/QuarantineUploader.scala
+++ b/image-loader/app/model/QuarantineUploader.scala
@@ -1,0 +1,53 @@
+package model
+
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.Principal
+import com.gu.mediaservice.lib.aws.{S3Object, UpdateMessage}
+import com.gu.mediaservice.lib.imaging.ImageOperations
+import com.gu.mediaservice.lib.logging.{LogMarker, Stopwatch, addLogMarkers}
+import com.gu.mediaservice.lib.logging.MarkerMap
+import com.gu.mediaservice.lib.resource.FutureResources._
+import com.gu.mediaservice.model._
+import lib.ImageLoaderConfig
+import lib.storage.QuarantineStore
+import net.logstash.logback.marker.LogstashMarker
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.{JsObject, Json}
+import com.gu.mediaservice.lib.formatting._
+import model.upload.UploadRequest
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import scala.concurrent.{ExecutionContext, Future}
+
+class QuarantineUploader(val store: QuarantineStore,
+               val config: ImageLoaderConfig)
+              (implicit val ec: ExecutionContext) extends ArgoHelpers {
+
+  private def storeQuarantineFile(uploadRequest: UploadRequest)
+                         (implicit logMarker: LogMarker) = {
+    val meta = Uploader.toMetaMap(uploadRequest)
+    store.storeQuarantineImage(
+      uploadRequest.imageId,
+      uploadRequest.tempFile,
+      uploadRequest.mimeType,
+      meta
+    )
+  }
+  
+  def quarantineFile(uploadRequest: UploadRequest)(
+    implicit ec: ExecutionContext,
+    logMarker: LogMarker): Future[JsObject] = {
+
+    logger.info("Quarantining file")
+
+    for {
+      _ <- storeQuarantineFile(uploadRequest)
+      uri = s"${config.apiUri}/images/${uploadRequest.imageId}"
+    } yield {
+      Json.obj("uri" -> uri)
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

This adds an AWS S3 bucket which is used to quarantine images before the are scanned by the chosen scanner..The aim of the quarantine bucket is to make sure no virus infected images are allowed into the ingest bucket.  From the quarantine bucket, the selected installed scanner should scan images then import them into the ingest bucket if they are virus free. 

## How can success be measured?

When images are uploaded onto the grid, ImageLoader pushes the images to quarantine bucket:

- Sling-scanner (selected scanner for bbc grid) downloads the image from the quarantine bucket.
- Sling-scanner scans the image.
- If clean, the image is uploaded by sling-scanner to the ingest bucket and deleted from the quarantine bucket. If the image is not clean (i.e contains a virus), a notification is raised and the image is deleted from the quarantine bucket.
- The ingest lambda receives the scanned image upload event in the ingest bucket via SNS and does a POST request to ImageLoader which downloads and processes the image.

This is an implementation to this proposal opened as an issue [here](https://github.com/guardian/grid/issues/3123). 
## Screenshots (if applicable)

## Who should look at this?
@guardian/digital-cms 


## Tested?
- [X] locally by contributor
- [x] locally by Guardian team
- [x] on Guardian TEST environment
