### PR TITLE
Add People to Info panel and Upload page

### DIFF
--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -333,6 +333,40 @@
                     </span>
                 </dd>
 
+                <dt ng-if="ctrl.rawMetadata.peopleInImage || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">People</dt>
+                <dd ng-if="ctrl.rawMetadata.peopleInImage || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                    <button class="image-info__edit"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="peopleInImageEditForm.$show()"
+                            ng-hide="peopleInImageEditForm.$visible"
+                    >✎</button>
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.peopleInImage)}"
+                          editable-text="ctrl.metadata.peopleInImage"
+                          ng-hide="peopleInImageEditForm.$visible"
+                          onbeforesave="ctrl.updateMetadataField('peopleInImage', $data)"
+                          e:form="peopleInImageEditForm"
+                          e:ng-class="{'image-info__editor--error': $error,
+                                       'image-info__editor--saving': peopleInImageEditForm.$waiting,
+                                       'text-input': true}">
+
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.peopleInImage) && ctrl.userCanEdit">
+                            Multiple people (click ✎ to edit <strong>all</strong>)
+                        </span>
+
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.peopleInImage) && !ctrl.userCanEdit">
+                            Multiple people
+                        </span>
+
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.peopleInImage)">
+                            <span ng-if="ctrl.metadata.peopleInImage">
+                                <a ui-sref="search.results({query: (ctrl.metadata.peopleInImage | queryFilter:'by')})">{{ctrl.metadata.peopleInImage}}</a>
+                            </span>
+
+                            <span ng-if="!ctrl.metadata.peopleInImage && ctrl.userCanEdit">Unknown (click ✎ to add the people)</span>
+                        </span>
+                    </span>
+                </dd>
+
                 <dt ng-if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Filename</dt>
                 <dd ng-if="ctrl.extraInfo.filename" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                     <span ng-if="ctrl.hasMultipleValues(ctrl.extraInfo.filename)">Multiple filenames</span>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -117,6 +117,26 @@
                 ng-click="ctrl.batchApplyMetadata('specialInstructions')"
             >⇔</button>
         </label>
+        <label ng-if="ctrl.peopleInImageWasInitiallyThere" class="job-info--editor__field flex-center">
+            <div class="job-info--editor__label text-small">People</div>
+            <input
+                type="text"
+                name="peopleInImage"
+                class="text-input job-info--editor__input job-info--editor__input--peopleInImage"
+                ng-model="ctrl.metadata.peopleInImage"
+                ng-change="ctrl.save()"
+                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+            />
+
+            <button
+                class="job-editor__apply-to-all"
+                title="Apply this field to all your current uploads"
+                type="button"
+                ng-if="ctrl.withBatch"
+                ng-click="ctrl.batchApplyMetadata('peopleInImage')"
+            >⇔</button>
+        </label>
     </div>
     <!-- Angular doesn't submit a form without a submit element, bonza!
     see: https://docs.angularjs.org/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action -->

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -23,9 +23,10 @@ jobs.controller('RequiredMetadataEditorCtrl',
     ctrl.saving = false;
     ctrl.disabled = () => Boolean(ctrl.saving || ctrl.externallyDisabled);
     ctrl.saveOnTime = 750; // ms
-    // We do this check to ensure the copyright field doesn't disappear
-    // if we set it to "".
+    // We do this check to ensure the copyright and peopleInImage fields don't disappear
+    // if we set them to "".
     ctrl.copyrightWasInitiallyThere = !!ctrl.originalMetadata.copyright;
+    ctrl.peopleInImageWasInitiallyThere = !!ctrl.originalMetadata.peopleInImage;
 
     ctrl.save = function() {
         ctrl.saving = true;
@@ -77,7 +78,8 @@ jobs.controller('RequiredMetadataEditorCtrl',
             credit: originalMetadata.credit,
             copyright: originalMetadata.copyright,
             specialInstructions: originalMetadata.specialInstructions,
-            description: originalMetadata.description
+            description: originalMetadata.description,
+            peopleInImage: originalMetadata.peopleInImage
         };
     }
 }]);


### PR DESCRIPTION
This follows the amazing https://github.com/guardian/grid/pull/3048.
- It adds People field on the Upload page in the similar, conditional, way as Copyright: it’s there **only** if the uploaded image already has `peopleInImage` field present (whether we want it conditional should be confirmed with PIcture Desk before this gets merged)
- It adds People field to the Info panel

This should make editing People metadata more accessible, convenient, consistent and should raise the profile of this field.

This is the draft as I have hit the limit of my abilities: all having to do with the array nature of the data.

## Current unresolved issues:

1. Editing People on the Upload page doesn’t work (strangely, it works in the Info panel):
`400: List((/peopleInImage,List(JsonValidationError(List(error.expected.jsarray),WrappedArray()))))`

2. When only one person in one selected image is present in the field, Info panel shows it in square brackets:

    <img width="201" alt="image" src="https://user-images.githubusercontent.com/6032869/104140531-a2bff680-53a9-11eb-9b48-a1a78d6af6b3.png">

3. Even for **one image**, if there are multiple people in the field, Info panel shows what’s usually shown for multiple images unreconcilable data:

    <img width="264" alt="image" src="https://user-images.githubusercontent.com/6032869/104140558-d69b1c00-53a9-11eb-81e7-e51b99d4f661.png">

4. The same as above is shown for multiple images having exactly the same one person in their People fields.

Ideally, we would add reconciliation UI for multiple “tokens” here exactly as we have for labels just grey like keywords (common ones could be removed from all selected images, those present only on some images, could be added to all etc.). We would use the same UI for (editing) keywords and other fields holding multiple values too (per spec, XMP `dc:creator` can contain an array, even though **no** suppliers are using it, really).

<img width="159" alt="image" src="https://user-images.githubusercontent.com/6032869/104140779-0565c200-53ab-11eb-9d29-45f2fd3394db.png">

<img width="166" alt="image" src="https://user-images.githubusercontent.com/6032869/104140785-0c8cd000-53ab-11eb-8e15-2e4796dbafe8.png">

But even without this extra UI work, I hope pts. 2–4 can be fixed, so that they at least work correctly.

## Tested?
- [x] locally and exhibits problems like described above
- [ ] on TEST
