### PR TITLE
Add image quarantine notification

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsMessageConsumer.scala
@@ -66,17 +66,17 @@ abstract class SqsMessageConsumer(queueUrl: String, config: CommonConfig, metric
   private def deleteOnSuccess(msg: SQSMessage)(f: Future[Any]): Unit =
     f.foreach { _ => deleteMessage(msg) }
 
-  private def getMessages(waitTime: Int, maxMessages: Int): Seq[SQSMessage] =
+  def getMessages(waitTime: Int, maxMessages: Int): Seq[SQSMessage] =
     client.receiveMessage(
       new ReceiveMessageRequest(queueUrl)
         .withWaitTimeSeconds(waitTime)
         .withMaxNumberOfMessages(maxMessages)
     ).getMessages.asScala.toList
 
-  private def extractSNSMessage(sqsMessage: SQSMessage): Option[SNSMessage] =
+  def extractSNSMessage(sqsMessage: SQSMessage): Option[SNSMessage] =
     Json.fromJson[SNSMessage](Json.parse(sqsMessage.getBody)) <| logParseErrors |> (_.asOpt)
 
-  private def deleteMessage(message: SQSMessage): Unit =
+  def deleteMessage(message: SQSMessage): Unit =
     client.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle))
 }
 

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -134,6 +134,16 @@ Resources:
         Protocol: sqs
   IndexedImageMetadataQueue:
     Type: AWS::SQS::Queue
+
+  ImageQuarantineTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+        - Endpoint: !GetAtt 'ImageQuarantineQueue.Arn'
+          Protocol: sqs
+  ImageQuarantineQueue:
+    Type: AWS::SQS::Queue
+
   UsageRecordTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -112,6 +112,7 @@ function getMediaApiConfig(config) {
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false
         |image.record.download=false
+        |quarantine.notification.sqs.queue.url=${config.coreStackProps.ImageQuarantineQueue.replace("http://localhost:4576", `https://localstack.media.${config.DOMAIN}`)}
         |`;
 }
 
@@ -121,7 +122,7 @@ function getMetadataEditorConfig(config) {
         |s3.collections.bucket="${config.coreStackProps.CollectionsBucket}"
         |aws.local.endpoint="https://localstack.media.${config.DOMAIN}"
         |dynamo.table.edits="EditsTable"
-        |indexed.images.sqs.queue.url="${config.coreStackProps.IndexedImageMetadataQueue.replace("http://localhost:4576", `https://localstack.media.${config.DOMAIN}`)}"
+        |indexed.images.sqs.queue.url=${config.coreStackProps.IndexedImageMetadataQueue.replace("http://localhost:4576", `https://localstack.media.${config.DOMAIN}`)}
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false
         |`;

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -66,6 +66,11 @@ mediaApi.factory('mediaApi',
         return root.follow('image', {id: id}).get();
     }
 
+    function createResource(endpoint) {
+        const uri = mediaApiUri + endpoint;
+        return client.resource(uri);
+    }
+
     function getSession() {
         // TODO: workout how we might be able to memoize this function but still
         // play nice with changes that might occur in the API (cache-header?).
@@ -92,6 +97,7 @@ mediaApi.factory('mediaApi',
         root,
         search,
         find,
+        createResource,
         getSession,
         metadataSearch,
         labelSearch,

--- a/kahuna/public/js/upload/jobs/upload-jobs.css
+++ b/kahuna/public/js/upload/jobs/upload-jobs.css
@@ -1,0 +1,16 @@
+.quarantine-notification {
+  margin-top: 6px;
+  margin-right: -50px;
+  float: right;
+  padding: 8px;
+}
+
+.hide-quarantine-notification{
+    -webkit-transition: opacity 5s ease-in-out;
+    -moz-transition: opacity 5s ease-in-out;
+    -ms-transition: opacity 5s ease-in-out;
+    -o-transition: opacity 5s ease-in-out;
+     opacity: 0;
+}
+
+

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -3,6 +3,8 @@
         <a class="top-bar-item side-padded"
            ui-sref="search"><gr-icon>search</gr-icon>
            <span class="top-bar-item__label">Search</span></a>
+        <span id="quarantine-notification" class="quarantine-notification"></span>
+
     </gr-top-bar-nav>
     <gr-top-bar-actions></gr-top-bar-actions>
 </gr-top-bar>

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -43,5 +43,9 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
   val elasticSearchHealthCheck = new ElasticSearchHealthCheck(controllerComponents, elasticSearch)
   val healthcheckController = new ManagementWithPermissions(controllerComponents, mediaApi, buildInfo)
 
-  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController)
+  val metrics = new MediaApiMetrics(config)
+  val quarantineNotificationSqsConsumer = new QuarantineNotificationSqsConsumer(config, metrics)
+  val notificationController = new NotificationController(auth, quarantineNotificationSqsConsumer, config, controllerComponents)
+
+  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController, notificationController)
 }

--- a/media-api/app/controllers/NotificationController.scala
+++ b/media-api/app/controllers/NotificationController.scala
@@ -1,0 +1,21 @@
+package controllers
+
+import play.api.mvc._
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.PandaUser
+import lib.{MediaApiConfig, QuarantineNotificationSqsConsumer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class NotificationController(auth: Authentication, consumer: QuarantineNotificationSqsConsumer, config: MediaApiConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext) extends  BaseController {
+
+
+  def getQuarantineNotification = auth.async { request =>
+
+    val user =  request.user match {
+      case user: PandaUser => Some(user.user.email.toLowerCase())
+      case _ => None
+    }
+    Future(Ok(consumer.getNotificationMsg(user.getOrElse(""))))
+  }
+}

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -32,6 +32,8 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfig(resour
   val imageBucket: String = string("s3.image.bucket")
   val thumbBucket: String = string("s3.thumb.bucket")
 
+  lazy val quarantineNotificationSqsQueueUrl= string("quarantine.notification.sqs.queue.url")
+
   val cloudFrontPrivateKeyLocations: Seq[String] = Seq(
     "/etc/grid/ssl/private/cloudfront.pem",
     "/etc/gu/ssl/private/cloudfront.pem" // TODO - remove once migrated away from

--- a/media-api/app/lib/MediaApiMetrics.scala
+++ b/media-api/app/lib/MediaApiMetrics.scala
@@ -7,6 +7,7 @@ import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 class MediaApiMetrics(config: MediaApiConfig) extends CloudWatchMetrics(s"${config.stage}/MediaApi", config) {
 
   val searchQueries = new TimeMetric("ElasticSearch")
+  val sqsMessage = new CountMetric("SQSMessage")
 
   def searchTypeDimension(value: String): Dimension =
     new Dimension().withName("SearchType").withValue(value)

--- a/media-api/app/lib/QuarantineNotificationSqsConsumer.scala
+++ b/media-api/app/lib/QuarantineNotificationSqsConsumer.scala
@@ -1,0 +1,32 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.SqsMessageConsumer
+import play.api.libs.json._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class QuarantineNotificationSqsConsumer(config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics) extends SqsMessageConsumer(
+  config.quarantineNotificationSqsQueueUrl, config, mediaApiMetrics.sqsMessage) {
+
+  override def chooseProcessor(subject: String): Option[JsValue => Future[Any]] =
+    PartialFunction.condOpt(subject) {
+      case _ => JsValue => Future{}
+    }
+
+
+  def getNotificationMsg(user: String): JsValue = {
+    getMessages(waitTime = 3, maxMessages = 1) match {
+      case message::Nil => {
+        extractSNSMessage(message) match {
+          case Some(msg) if ( msg.body \ "metadata" \ "uploaded_by").as[String] == user => {
+            deleteMessage(message)
+            msg.body
+          }
+          case _ => Json.obj()
+        }
+      }
+      case Nil =>  Json.obj()
+    }
+  }
+}

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -39,3 +39,6 @@ GET     /management/imageCounts                       com.gu.mediaservice.lib.ma
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.ManagementWithPermissions.disallowRobots
+
+#Quarantine Notification
+GET     /quarantine/notification                               controllers.NotificationController.getQuarantineNotification


### PR DESCRIPTION
## What does this change?

-SNS topic for quarantine notification events
-SQS queue subscribed to quarantine notification topic
-an endpoint to consume notification from notification sqs queue
-update upload-jobs to poll quarantine notification


## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally
- [ ] on TEST
