### PR TITLE
Get rid of clone calls in Painless

### DIFF
--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -518,11 +518,14 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
   }
 
   private val refreshMetadataScript = """
-      | ctx._source.metadata = ctx._source.originalMetadata.clone();
+      | ctx._source.metadata = new HashMap();
+      | if (ctx._source.originalMetadata != null) {
+      |   ctx._source.metadata.putAll(ctx._source.originalMetadata);
+      | }
       | if (ctx._source.userMetadata != null && ctx._source.userMetadata.metadata != null) {
       |   ctx._source.metadata.putAll(ctx._source.userMetadata.metadata);
-      |   ctx._source.metadata = ctx._source.metadata.entrySet().stream().filter(x -> x.value != "").collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       | }
+      | ctx._source.metadata = ctx._source.metadata.entrySet().stream().filter(x -> x.value != "").collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     """.stripMargin
 
   private val refreshUsageRightsScript = """

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -527,12 +527,12 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
 
   private val refreshUsageRightsScript = """
                                    | if (ctx._source.userMetadata != null && ctx._source.userMetadata.usageRights != null) {
-                                   |   ctx._source.usageRights = {};
+                                   |   ctx._source.usageRights = new HashMap();
                                    |   ctx._source.usageRights.putAll(ctx._source.userMetadata.usageRights);
                                    | } else if (ctx._source.originalUsageRights == null){
                                    |   ctx._source.usageRights = null;
                                    | } else {
-                                   |   ctx._source.usageRights = {};
+                                   |   ctx._source.usageRights = new HashMap();
                                    |   ctx._source.usageRights.putAll(ctx._source.originalUsageRights);
                                    | }
                                  """.stripMargin

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -527,11 +527,13 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
 
   private val refreshUsageRightsScript = """
                                    | if (ctx._source.userMetadata != null && ctx._source.userMetadata.usageRights != null) {
-                                   |   ctx._source.usageRights = ctx._source.userMetadata.usageRights.clone();
+                                   |   ctx._source.usageRights = {}
+                                   |   ctx._source.usageRights.putAll(ctx._source.userMetadata.usageRights);
                                    | } else if (ctx._source.originalUsageRights == null){
                                    |   ctx._source.usageRights = null;
                                    | } else {
-                                   |   ctx._source.usageRights = ctx._source.originalUsageRights.clone();
+                                   |   ctx._source.usageRights = {}
+                                   |   ctx._source.usageRights.putAll(ctx._source.originalUsageRights);
                                    | }
                                  """.stripMargin
 

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -527,12 +527,12 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
 
   private val refreshUsageRightsScript = """
                                    | if (ctx._source.userMetadata != null && ctx._source.userMetadata.usageRights != null) {
-                                   |   ctx._source.usageRights = {}
+                                   |   ctx._source.usageRights = {};
                                    |   ctx._source.usageRights.putAll(ctx._source.userMetadata.usageRights);
                                    | } else if (ctx._source.originalUsageRights == null){
                                    |   ctx._source.usageRights = null;
                                    | } else {
-                                   |   ctx._source.usageRights = {}
+                                   |   ctx._source.usageRights = {};
                                    |   ctx._source.usageRights.putAll(ctx._source.originalUsageRights);
                                    | }
                                  """.stripMargin


### PR DESCRIPTION
## What does this change?

Replaces our calls to `.clone()` in painless code (which is actually bizzaro java) with a proper new hashmap and `putAll`. This is because sometimes it seemed that the maps did not implement `Clonable`. This was an absolute mystery and we've nothing useful to say regarding our investigations. 

https://discuss.elastic.co/t/painless-map-copies-are-painful/106258 

Except that elastic don't mention cloning where it would be obvious and recommend using puts instead. 

## How can success be measured?

Reliable rights updates.

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
