### PR TITLE
Fix link-to-search for Copyright in the Info panel

### DIFF
--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -325,7 +325,7 @@
 
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
                             <span ng-if="ctrl.metadata.copyright">
-                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'by')})">{{ctrl.metadata.copyright}}</a>
+                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
                             </span>
 
                             <span ng-if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add the copyright)</span>


### PR DESCRIPTION
Clicking Copyright values links to Byline ones. Fixed.

Before
<img width="503" alt="image" src="https://user-images.githubusercontent.com/6032869/104394381-6a055600-553e-11eb-8f03-23a2ace2693d.png">

After:
<img width="501" alt="image" src="https://user-images.githubusercontent.com/6032869/104394510-adf85b00-553e-11eb-9f82-cc3f35f1613b.png">

## Tested?
- [ ] locally
- [ ] on TEST
