### PR TITLE
remove id that's not being used and isn't unique

### DIFF
--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -29,7 +29,7 @@
       ng-show="!ctrl.adding && ctrl.editing"
       ng-submit="ctrl.save()">
 
-  <select id="access-select" ng-model="ctrl.access" ng-required="required">
+  <select ng-model="ctrl.access" ng-required="required">
       <option ng-selected="true" value="">Please select access</option>
       <optgroup label="Cropping">
           <option value="allow-use">Allow cropping</option>


### PR DESCRIPTION
## What does this change?

removes `id="access-select"` from select component that's used for each uploaded image and isn't used anywhere

## How can success be measured?

not spamming console on upload page

## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
