### PR TITLE
Fix batch tracking on upload page (and speed it up)

### DIFF
--- a/kahuna/public/js/edits/labeller.js
+++ b/kahuna/public/js/edits/labeller.js
@@ -59,7 +59,7 @@ labeller.controller('LabellerCtrl', [
             })
             .catch(saveFailed)
             .finally(() => {
-                ctrl.labelsBeingRemoved.remove(label);
+                ctrl.labelsBeingRemoved.delete(label);
             });
     };
 

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -29,7 +29,7 @@
       ng-show="!ctrl.adding && ctrl.editing"
       ng-submit="ctrl.save()">
 
-  <select id="access-select" ng-model="ctrl.access" ng-required="required">
+  <select ng-model="ctrl.access" ng-required="required">
       <option ng-selected="true" value="">Please select access</option>
       <optgroup label="Cropping">
           <option value="allow-use">Allow cropping</option>

--- a/kahuna/public/js/services/label.js
+++ b/kahuna/public/js/services/label.js
@@ -35,11 +35,11 @@ labelService.factory("labelService", [
     }
 
     function remove(image, label) {
-      return batchRemove([image], label);
+      return batchRemove([image], label).then(([image])=>image);
     }
 
     function add(image, labels) {
-      return batchAdd([image], labels);
+      return batchAdd([image], labels).then(([image])=>image);
     }
 
     function batchAdd(images, labels) {

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -56,7 +56,7 @@ const queue = new PQueue({ concurrency: 10 });
 async.factory("apiPoll", [
   () => {
     const wait = () => new Promise(resolve => {
-      setTimeout(() => resolve(), 4000);
+      setTimeout(() => resolve(), 500);
     });
     const poll = async (func, n) => {
       const [{ status, value }] = await Promise.allSettled([

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -1,4 +1,5 @@
 import PQueue from "p-queue";
+import { idleTimeout } from "./idleTimeout";
 
 const concurrency = 30;
 
@@ -58,5 +59,6 @@ export const trackAll = async ($rootScope, key, input, tasks, emit) => {
   $rootScope.$broadcast("events:batch-operations:complete", { key });
 
   $rootScope.$emit(emit, successes);
+  idleTimeout(() => { $rootScope.$apply(()=>console.log("HEY")); });
   return successes;
 };

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -59,6 +59,6 @@ export const trackAll = async ($rootScope, key, input, tasks, emit) => {
   $rootScope.$broadcast("events:batch-operations:complete", { key });
 
   $rootScope.$emit(emit, successes);
-  idleTimeout(() => { $rootScope.$apply(()=>console.log("HEY")); });
+  idleTimeout(() => { $rootScope.$apply(); });
   return successes;
 };

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -59,6 +59,8 @@ export const trackAll = async ($rootScope, key, input, tasks, emit) => {
   $rootScope.$broadcast("events:batch-operations:complete", { key });
 
   $rootScope.$emit(emit, successes);
+  //As this is a promise and not an angular js magical promise:
+  //we need to convince angular that it's time to run the dispatch loop.
   idleTimeout(() => { $rootScope.$apply(); });
   return successes;
 };

--- a/kahuna/public/js/util/idleTimeout.js
+++ b/kahuna/public/js/util/idleTimeout.js
@@ -1,0 +1,6 @@
+export const idleTimeout = (f) => {
+  if ('requestIdleCallback' in window) {
+    return window.requestIdleCallback(() => { f(); });
+  }
+  return window.setTimeout(() => { f(); }, 100);
+};


### PR DESCRIPTION
## What does this change?

Reduces the timeout for polling to .5 seconds, reducing min time from 4s. 

Also calls the dispatch loop because batchTracking uses native promises.

(Also includes #3092)

## How can success be measured?

- Updates from upload page work properly
- single updates are fast


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
