### PR TITLE
Feature/bbc authentication provider

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.typesafe.play" %% "filters-helpers" % "2.6.20",
     akkaHttpServer,
     ws,
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.8.2",
+    "com.gu" %% "pan-domain-auth-play_2-6" % "0.9.2-SNAPSHOT",
     "com.gu" %% "editorial-permissions-client" % "2.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -33,7 +33,7 @@ authentication.providers {
   }
   # TODO: short term we put panda here for backwards compatibility but the default provider should be something better
   user {
-    className = "com.gu.mediaservice.lib.guardian.auth.PandaAuthenticationProvider"
+    className = "com.gu.mediaservice.lib.bbc.auth.BBCAuthenticationProvider"
     config {
       # all of the things relating to pan domain auth (these are currently sensibly defaulted in code)
       # panda.system = media-service

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -33,11 +33,11 @@ authentication.providers {
   }
   # TODO: short term we put panda here for backwards compatibility but the default provider should be something better
   user {
-    className = "com.gu.mediaservice.lib.bbc.auth.BBCAuthenticationProvider"
+    className = "com.gu.mediaservice.lib.guardian.auth.PandaAuthenticationProvider"
     config {
       # all of the things relating to pan domain auth (these are currently sensibly defaulted in code)
       # panda.system = media-service
-      panda.bucketName = "@BBC_PANDA_BUCKETNAME"
+      # panda.bucketName = <s3-bucket-with-config>
       # panda.settingsFileKey = <s3-key-with-config>
     }
   }

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -37,7 +37,7 @@ authentication.providers {
     config {
       # all of the things relating to pan domain auth (these are currently sensibly defaulted in code)
       # panda.system = media-service
-      # panda.bucketName = <s3-bucket-with-config>
+      panda.bucketName = "@BBC_PANDA_BUCKETNAME"
       # panda.settingsFileKey = <s3-key-with-config>
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/auth/BBCAuthenticationProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/auth/BBCAuthenticationProvider.scala
@@ -38,13 +38,11 @@ class BBCAuthenticationProvider(resources: AuthenticationProviderResources, prov
   }
 
 
-  // Should this go here?
   val validEmailsStore = new BBCValidEmailsStore(resources.commonConfig.permissionsBucket, resources.commonConfig)
 
   validEmailsStore.scheduleUpdates(resources.actorSystem.scheduler)
 
   private val usePermissionsValidation = resources.commonConfig.stringOpt("panda.usePermissionsValidation").getOrElse("false").toBoolean
-  /////////////////////////////////////////////
 
 
   val loginLinks = List(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/auth/BBCAuthenticationProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/auth/BBCAuthenticationProvider.scala
@@ -1,0 +1,188 @@
+package com.gu.mediaservice.lib.bbc.auth
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.argo.model.Link
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.{GridUser, Principal}
+import com.gu.mediaservice.lib.auth.provider.AuthenticationProvider.RedirectUri
+import com.gu.mediaservice.lib.auth.provider._
+import com.gu.mediaservice.lib.aws.S3Ops
+import com.gu.mediaservice.lib.bbc.components.BBCValidEmailsStore
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.action.AuthActions
+import com.gu.pandomainauth.model.{AuthenticatedUser, User, Authenticated => PandaAuthenticated, Expired => PandaExpired, GracePeriod => PandaGracePeriod, InvalidCookie => PandaInvalidCookie, NotAuthenticated => PandaNotAuthenticated, NotAuthorized => PandaNotAuthorised}
+import com.gu.pandomainauth.service.OAuthException
+import com.typesafe.scalalogging.StrictLogging
+import play.api.Configuration
+import play.api.http.HeaderNames
+import play.api.libs.typedmap.{TypedEntry, TypedKey, TypedMap}
+import play.api.libs.ws.{DefaultWSCookie, WSClient, WSRequest}
+import play.api.mvc.{ControllerComponents, Cookie, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class BBCAuthenticationProvider(resources: AuthenticationProviderResources, providerConfiguration: Configuration)
+  extends UserAuthenticationProvider with AuthActions with StrictLogging with ArgoHelpers with HeaderNames {
+
+  implicit val ec: ExecutionContext = controllerComponents.executionContext
+
+  final override def authCallbackUrl: String = s"${resources.commonConfig.services.authBaseUri}/oauthCallback"
+  override lazy val panDomainSettings: PanDomainAuthSettingsRefresher = buildPandaSettings()
+  override def wsClient: WSClient = resources.wsClient
+  override def controllerComponents: ControllerComponents = resources.controllerComponents
+  override def cacheValidation: Boolean = true  //dont call 'validateUser' every api request if user has a valid session
+  override def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {
+    logger.info(message)
+    Forbidden("You are not authorised to access The Grid, to get authorisation please email The Grid support team")
+  }
+
+
+  // Should this go here?
+  val validEmailsStore = new BBCValidEmailsStore(resources.commonConfig.permissionsBucket, resources.commonConfig)
+
+  validEmailsStore.scheduleUpdates(resources.actorSystem.scheduler)
+
+  private val usePermissionsValidation = resources.commonConfig.stringOpt("panda.usePermissionsValidation").getOrElse("false").toBoolean
+  /////////////////////////////////////////////
+
+
+  val loginLinks = List(
+    Link("login", resources.commonConfig.services.loginUriTemplate)
+  )
+
+  /**
+    * Establish the authentication status of the given request header. This can return an authenticated user or a number
+    * of reasons why a user is not authenticated.
+    *
+    * @param request The request header containing cookies and other request headers that can be used to establish the
+    *                authentication status of a request.
+    * @return An authentication status expressing whether the
+    */
+  override def authenticateRequest(request: RequestHeader): AuthenticationStatus = {
+    val pandaStatus = extractAuth(request)
+    val providerStatus = pandaStatus match {
+      case PandaNotAuthenticated => NotAuthenticated
+      case PandaInvalidCookie(e) => Invalid("error checking user's auth, clear cookie and re-auth", Some(e))
+      case PandaExpired(authedUser) => Expired(gridUserFrom(authedUser.user, request))
+      case PandaGracePeriod(authedUser) => GracePeriod(gridUserFrom(authedUser.user, request))
+      case PandaNotAuthorised(authedUser) => NotAuthorised(s"${authedUser.user.email} not authorised to use application")
+      case PandaAuthenticated(authedUser) => Authenticated(gridUserFrom(authedUser.user, request))
+    }
+    logger.info(s"Authenticating request ${request.uri}. Panda $pandaStatus Provider $providerStatus")
+    providerStatus
+  }
+
+  /**
+    * If this provider supports sending a user that is not authorised to a federated auth provider then it should
+    * provide a function here to redirect the user.
+    */
+  override def sendForAuthentication: Option[RequestHeader => Future[Result]] = Some({ requestHeader: RequestHeader =>
+    val maybePrincipal = authenticateRequest(requestHeader) match {
+      case Expired(principal) => Some(principal)
+      case GracePeriod(principal) => Some(principal)
+      case Authenticated(principal: GridUser) => Some(principal)
+      case _ => None
+    }
+    val email = maybePrincipal.map(_.email)
+    sendForAuth(requestHeader, email)
+  })
+
+  /**
+    * If this provider supports sending a user that is not authorised to a federated auth provider then it should
+    * provide an Play action here that deals with the return of a user from a federated provider. This should be
+    * used to set a cookie or similar to ensure that a subsequent call to authenticateRequest will succeed. If
+    * authentication failed then this should return an appropriate 4xx result.
+    */
+  override def processAuthentication: Option[(RequestHeader, Option[RedirectUri]) => Future[Result]] =
+    Some({ (requestHeader: RequestHeader, maybeUri: Option[RedirectUri]) =>
+      // We use the `Try` here as the `GoogleAuthException` are thrown before we
+      // get to the asynchronicity of the `Future` it returns.
+      // We then have to flatten the Future[Future[T]]. Fiddly...
+      Future.fromTry(Try(processOAuthCallback()(requestHeader))).flatten.recover {
+        // This is when session session args are missing
+        case e: OAuthException => respondError(BadRequest, "google-auth-exception", e.getMessage, loginLinks)
+
+        // Class `missing anti forgery token` as a 4XX
+        // see https://github.com/guardian/pan-domain-authentication/blob/master/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala#L63
+        case e: IllegalArgumentException if e.getMessage == "The anti forgery token did not match" => {
+          logger.error("Anti-forgery exception encountered", e)
+          respondError(BadRequest, "google-auth-exception", e.getMessage, loginLinks)
+        }
+      }.map {
+        // not very elegant, but this will override the redirect from panda with any alternative destination
+        case overrideRedirect if overrideRedirect.header.headers.contains(LOCATION) && maybeUri.nonEmpty =>
+          val uri = maybeUri.get
+          Redirect(uri).copy(newCookies = overrideRedirect.newCookies, newSession = overrideRedirect.newSession)
+        case other => other
+      }
+    })
+
+  /**
+    * If this provider is able to clear user tokens (i.e. by clearing cookies) then it should provide a function to
+    * do that here which will be used to log users out and also if the token is invalid.
+    *
+    * @return
+    */
+  override def flushToken: Option[RequestHeader => Result] = Some(processLogout(_))
+
+  val PandaCookieKey: TypedKey[Cookie] = TypedKey[Cookie]("PandaCookie")
+
+  /**
+    * A function that allows downstream API calls to be made using the credentials of the inflight request
+    *
+    * @param request The request header of the inflight call
+    * @return A function that adds appropriate data to a WSRequest
+    */
+  override def onBehalfOf(request: Principal): Either[String, WSRequest => WSRequest] = {
+    val cookieName = panDomainSettings.settings.cookieSettings.cookieName
+    request.attributes.get(PandaCookieKey) match {
+      case Some(cookie) => Right { wsRequest: WSRequest =>
+        wsRequest.addCookies(DefaultWSCookie(cookieName, cookie.value))
+      }
+      case None => Left(s"Pan domain cookie $cookieName is missing in principal.")
+    }
+  }
+
+  private def gridUserFrom(pandaUser: User, request: RequestHeader): GridUser = {
+    val maybePandaCookie: Option[TypedEntry[Cookie]] = request.cookies.get(panDomainSettings.settings.cookieSettings.cookieName).map(TypedEntry[Cookie](PandaCookieKey, _))
+    val attributes = TypedMap.empty + (maybePandaCookie.toSeq:_*)
+    GridUser(
+      firstName = pandaUser.firstName,
+      lastName = pandaUser.lastName,
+      email = pandaUser.email,
+      attributes = attributes
+    )
+  }
+
+  private def buildPandaSettings() = {
+    new PanDomainAuthSettingsRefresher(
+      domain = resources.commonConfig.services.domainRoot,
+      system = providerConfiguration.getOptional[String]("panda.system").getOrElse("media-service"),
+      bucketName = providerConfiguration.getOptional[String]("panda.bucketName").getOrElse("pan-domain-auth-settings"),
+      settingsFileKey = providerConfiguration.getOptional[String]("panda.settingsFileKey").getOrElse(s"${resources.commonConfig.services.domainRoot}.settings"),
+      s3Client = S3Ops.buildS3Client(resources.commonConfig, localstackAware=resources.commonConfig.useLocalAuth)
+    )
+  }
+
+  private val userValidationEmailDomain = resources.commonConfig.stringOpt("panda.userDomain").getOrElse("guardian.co.uk")
+
+  final override def validateUser(authedUser: AuthenticatedUser): Boolean = {
+    val validEmails = validEmailsStore.getValidEmails
+    val isValidEmail = validEmails match {
+      case Some(emails) => emails.contains(authedUser.user.email.toLowerCase)
+      case _ => false
+    }
+    val isValidDomain = authedUser.user.email.endsWith("@" + userValidationEmailDomain)
+    val passesMultifactor = if(multifactorChecker.nonEmpty) { authedUser.multiFactor } else { true }
+
+    val inAccessGroup = authedUser.permissions.exists(_.toLowerCase.contains("grid access"))
+
+    val isValid = ((usePermissionsValidation && inAccessGroup) || (!usePermissionsValidation && isValidEmail)) && isValidDomain && passesMultifactor
+
+    logger.info(s"Validated user ${authedUser.user.email} as ${if(isValid) "valid" else "invalid"} using " +
+      s"${if(usePermissionsValidation) "permissions" else "white list"} validation")
+    isValid
+  }
+
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/components/BBCValidEmailsStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/bbc/components/BBCValidEmailsStore.scala
@@ -1,0 +1,56 @@
+package com.gu.mediaservice.lib.bbc.components
+
+import com.gu.mediaservice.lib.BaseStore
+import com.gu.mediaservice.lib.config.CommonConfig
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.Json
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+class BBCValidEmailsStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext)
+  extends BaseStore[String, List[String]](bucket, config)(ec) {
+
+  val emailKey = "validEmails"
+  val emailListFileName = "valid_emails.json"
+
+  fetchAll match {
+    case Some(_) => Logger.info("Valid emails read in from config bucket")
+    case None => throw FailedToLoadEmailStore
+  }
+
+  def update() {
+    lastUpdated.send(_ => DateTime.now())
+    fetchAll match {
+      case Some(emailList) => store.send(_ => emailList)
+      case None => Logger.warn("Could not parse valid email list JSON")
+    }
+  }
+
+  private def fetchAll: Option[Map[String, List[String]]] = {
+    getS3Object(emailListFileName) match {
+      case Some(fileContents) => Try(Json.parse(fileContents).as[List[String]]) match {
+        case Success(json) => Some(Map(emailKey -> json))
+        case Failure(_) => None
+      }
+      case None => None
+    }
+  }
+
+  def getValidEmails: Option[List[String]] = store.get().get(emailKey)
+}
+
+object BBCValidEmailsStore {
+  def apply(bucket: String, config: CommonConfig)(implicit ec: ExecutionContext): BBCValidEmailsStore = {
+    val store = new BBCValidEmailsStore(bucket, config)(ec)
+    store.fetchAll match {
+      case Some(_) => Logger.info("Valid emails config read in from config bucket")
+      case None => throw FailedToLoadEmailStore
+    }
+    store
+  }
+}
+
+
+case object FailedToLoadEmailStore extends Exception("Failed to load valid emails from S3 permissions bucket on start up")

--- a/dev/config/valid_emails.json
+++ b/dev/config/valid_emails.json
@@ -1,0 +1,3 @@
+[
+  "grid-demo-account@guardian.co.uk"
+]

--- a/dev/config/valid_emails.json.template
+++ b/dev/config/valid_emails.json.template
@@ -1,0 +1,3 @@
+[
+  "grid-demo-account@@EMAIL_DOMAIN"
+]

--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -181,7 +181,7 @@ setupValidEmailsConfiguration() {
 }
 
 setupApplicationConfiguration() {
-  if [[ $BUILD_ORG != "bbc" ]]; then
+  if [[ $LOCAL_AUTH != true || $BUILD_ORG != "bbc" ]]; then
     return
   fi
 
@@ -191,7 +191,13 @@ setupApplicationConfiguration() {
 
   target="$ROOT_DIR/common-lib/src/main/resources/application.conf"
 
-  sed -i "s/@BBC_PANDA_BUCKETNAME/$panDomainBucket/g" "$target"
+  guardianProviderClassName="com.gu.mediaservice.lib.guardian.auth.PandaAuthenticationProvider"
+
+  bbcProviderClassName="com.gu.mediaservice.lib.bbc.auth.BBCAuthenticationProvider"
+
+  sed -i "s/$guardianProviderClassName/$bbcProviderClassName/g" "$target"
+
+  sed -i "s/# panda.bucketName = <s3-bucket-with-config>/panda.bucketName = \"$panDomainBucket\"/g" "$target"
 }
 
 setupPhotographersConfiguration() {

--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -159,6 +159,41 @@ setupPermissionConfiguration() {
   echo "  uploaded file to $permissionsBucket"
 }
 
+setupValidEmailsConfiguration() {
+  if [[ $LOCAL_AUTH != true || $BUILD_ORG != "bbc" ]]; then
+    return
+  fi
+
+  echo "setting up valid emails configuration for local auth in bbc"
+
+  permissionsBucket=$(getStackResource "$AUTH_STACK_NAME" PermissionsBucket)
+
+  target="$ROOT_DIR/dev/config/valid_emails.json"
+
+  sed -e "s/@EMAIL_DOMAIN/$EMAIL_DOMAIN/g" \
+    "$target.template" > "$target"
+
+  aws s3 cp "$target" \
+    "s3://$permissionsBucket/" \
+    --endpoint-url $LOCALSTACK_ENDPOINT
+
+  echo "  uploaded file to $permissionsBucket"
+}
+
+setupApplicationConfiguration() {
+  if [[ $BUILD_ORG != "bbc" ]]; then
+    return
+  fi
+
+  echo "setting up valid application.conf for bbc"
+
+  panDomainBucket=$(getStackResource "$AUTH_STACK_NAME" PanDomainBucket)
+
+  target="$ROOT_DIR/common-lib/src/main/resources/application.conf"
+
+  sed -i "s/@BBC_PANDA_BUCKETNAME/$panDomainBucket/g" "$target"
+}
+
 setupPhotographersConfiguration() {
   echo "setting up photographers configuration"
 
@@ -293,7 +328,9 @@ main() {
   if [[ $LOCAL_AUTH == true ]]; then
     createLocalAuthStack
     setupPermissionConfiguration
+    setupValidEmailsConfiguration
     setupPanDomainConfiguration
+    setupApplicationConfiguration
   fi
 
   setupPhotographersConfiguration


### PR DESCRIPTION
## What does this change?
This PR implements a `UserAuthenticationProvider` for the BBC, to be able to have a BBC specific authentication. It is based off of https://github.com/guardian/grid/pull/3058.

There's also been a change in the `setup.sh` script so that it checks in an environment variable if the organization is BBC, and then modifies configuration files to reflect that.

## How can success be measured?
BBC grid authenticates successfully with BBC Login, while not affecting Guardian's authentication process.

## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
