### PR TITLE
Remove unused elastic related common config vals

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -11,11 +11,6 @@ import scala.util.Try
 
 
 abstract class CommonConfig(val configuration: Configuration) extends AwsClientBuilderUtils with StrictLogging {
-  final val elasticsearchStack = "media-service"
-
-  final val elasticsearchApp = "elasticsearch"
-  final val elasticsearch6App = "elasticsearch6"
-
   final val stackName = "media-service"
 
   final val sessionId = UUID.randomUUID().toString


### PR DESCRIPTION
## What does this change?

 Thrall and Media API both configure Elastic themselves without reference to these vals.

## How can success be measured?


## Screenshots (if applicable)


## Who should look at this?
<!-- reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally
- [ ] on TEST
