### PR TITLE
Put Photoshoot editing behind edit_metadata permission

### DIFF
--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,6 +1,7 @@
 <section ng-if="! ctrl.editInline">
     <button data-cy="it-photoshoot-edit-button"
             class="image-info__edit"
+            ng-if="ctrl.userCanEdit"
             ng-click="photoshootEditForm.$show()"
             ng-hide="photoshootEditForm.$visible">
         ✎

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -1,7 +1,6 @@
 <section ng-if="! ctrl.editInline">
     <button data-cy="it-photoshoot-edit-button"
             class="image-info__edit"
-            ng-if="ctrl.userCanEdit"
             ng-click="photoshootEditForm.$show()"
             ng-hide="photoshootEditForm.$visible">
         ✎
@@ -16,7 +15,7 @@
                        'text-input': true}"
           e:placeholder="describing a set of related images, e.g. for syndication purposes"
           onbeforesave="ctrl.save($data)">
-        <span ng-if="! ctrl.hasPhotoshootData">
+        <span ng-if="! ctrl.hasPhotoshootData || ctrl.userCanEdit">
             Unknown (click ✎ to add)
         </span>
 


### PR DESCRIPTION
As all other metadata (but Labels and Collections), Photoshoot editing is now behind the usual permission. It looks like an oversight on our part. There may be an argument to be made that more of non-crucial metadata shouldn’t be permissioned, but that’s a different discussion.

We will quickly know if anyone depends on this loophole.

This makes metadata editing rules more consistent and predictable.

## Tested?
- [ ] locally
- [ ] on TEST
