### PR TITLE
various angular fixes

### DIFF
--- a/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
+++ b/kahuna/public/js/components/gr-batch-export-original-images/gr-batch-export-original-images.js
@@ -6,8 +6,8 @@ import { trackAll } from '../../util/batch-tracking';
 export const batchExportOriginalImages = angular.module('gr.batchExportOriginalImages', []);
 
 batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
-    '$scope', '$rootScope', '$state', 'mediaCropper',
-    function($scope, $rootScope, $state, mediaCropper) {
+    '$q', '$scope', '$rootScope', '$state', 'mediaCropper',
+    function($q, $scope, $rootScope, $state, mediaCropper) {
         let ctrl = this;
 
         const checkForFullCrops = () => ctrl.images.every(
@@ -42,7 +42,7 @@ batchExportOriginalImages.controller('grBatchExportOriginalImagesCtrl', [
           ctrl.cropping = true;
           ctrl.needsConfirmation = false;
 
-          const cropImages = trackAll($rootScope, "crop", ctrl.images, async (image) => {
+          const cropImages = trackAll($q, $rootScope, "crop", ctrl.images, async (image) => {
             const crop = await mediaCropper.createFullCrop(image);
             return {
               image,

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -299,7 +299,7 @@ service.factory('editsService',
 
 
     function batchUpdateMetadataField(images, field, value, editOption = overwrite.key) {
-        return trackAll($rootScope, field, images, image => {
+        return trackAll($q, $rootScope, field, images, image => {
             const newFieldValue = getNewFieldValue(image, field, value, editOption);
             return updateMetadataField(image, field, newFieldValue, true);
         },'images-updated');

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -1,6 +1,9 @@
+<span>
+    <span ng-if="ctrl.receivingBatch">Updating...</span>
+ </span>
 <button ng-class="{'small': ctrl.grSmall}"
         ng-click="ctrl.editing = true"
-        ng-if="ctrl.userCanEdit"
+        ng-if="ctrl.userCanEdit && !ctrl.receivingBatch"
         gr-tooltip="Add lease"
         gr-tooltip-position="bottom">
 
@@ -112,7 +115,7 @@
 </form>
 
 
-<div class="leases__wrapper image-info__wrap">
+<div class="leases__wrapper image-info__wrap" ng-if="!ctrl.receivingBatch">
   <div class="image-info__lease" ng-if="ctrl.totalImages > 1">
     {{ctrl.activeLeases(ctrl.leases)}} current leases + {{ctrl.inactiveLeases(ctrl.leases)}} inactive leases
   </div>

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -196,8 +196,14 @@ leases.controller('LeasesCtrl', [
             return leasedBy;
         };
 
-        ctrl.inactiveLeases = (leases) => leases.leases.filter((l) => !ctrl.isCurrent(l)).length;
-        ctrl.activeLeases = (leases) => leases.leases.filter((l) => ctrl.isCurrent(l)).length;
+        ctrl.inactiveLeases = (leases) => {
+            console.log(leases)
+            leases.leases.filter((l) => !ctrl.isCurrent(l)).length;
+        }
+        ctrl.activeLeases = (leases) => {
+            console.log(leases)
+            leases.leases.filter((l) => ctrl.isCurrent(l)).length;
+        }
 
         ctrl.resetLeaseForm = () => {
             ctrl.newLease = {

--- a/kahuna/public/js/services/api/leases-helper.js
+++ b/kahuna/public/js/services/api/leases-helper.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 function readLeases(image) {
   return image.data.leases.data;
 }
@@ -18,9 +16,9 @@ export function getApiImageAndApiLeasesIfUpdated(image, apiImage) {
       }
     } else {
       const apiImageLeasesAreUpdated = function() {
-        const currentLastModified = moment(apiLeases.lastModified);
-        const previousLastModified = moment(leases.lastModified);
-        return currentLastModified.isAfter(previousLastModified);
+        const currentLastModified = new Date(apiLeases.lastModified);
+        const previousLastModified = new Date(leases.lastModified);
+        return currentLastModified > previousLastModified;
       };
       if (apiImageLeasesAreUpdated()) {
         return apiImageAndApiLeases;

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -4,100 +4,94 @@ import '../../services/image-list';
 
 import {service} from '../../edits/service';
 import { trackAll } from '../../util/batch-tracking';
-import { getApiImageAndApiLeasesIfUpdated, readLeases } from './leases-helper';
+import { getApiImageAndApiLeasesIfUpdated } from './leases-helper';
+import { Subject } from 'rx';
 
 var leaseService = angular.module('kahuna.services.lease', [
   service.name
   ]);
 
 leaseService.factory('leaseService', [
-  '$rootScope',
-  '$q',
-  'imageAccessor',
-  'imageList',
-  'mediaApi',
-  'editsService',
-  'apiPoll',
-  function ($rootScope, $q, imageAccessor, imageList, mediaApi, editsService, apiPoll) {
-    let leasesRoot;
-    function getLeasesRoot() {
-        if (!leasesRoot) {
-            leasesRoot = mediaApi.root.follow('leases');
-        }
-        return leasesRoot;
-    }
-
-      // Compare a lease from the server with one created here
-      function sameLease(a, b) {
-          return a.startDate == b.startDate &&
-              a.endDate == b.endDate &&
-              a.access == b.access;
-      }
-
-    function getLeases(images) {
-      // search page has fancy image list
-      if (angular.isDefined(images.toArray)) {
-        images = images.toArray();
-      }
-      return $q.all(images.map(i => i.get()))
-          .then((images) => imageList.getLeases(images));
-      }
-
-    function clear(image) {
-        const images = [image];
-        const currentLeases = getLeases(images);
-        return currentLeases.then(() => {
-          return image
-              .perform('delete-leases').then(() => {
-              pollLeasesAndUpdateUI(images, imageList.getLeases(images));
-          });
-        });
-    }
-
-    function replace(image, leases) {
-        const images = [image];
-        const currentLeasesPromise = getLeases(images);
-
-        return currentLeasesPromise.then((currentLeases) => {
-
-            const updatedLeases = leases.map((lease) => {
-                var newLease = angular.copy(lease);
-                newLease.mediaId = image.data.id;
-                return newLease;
-            });
-            if (JSON.stringify(currentLeases.leases) === JSON.stringify(updatedLeases)) {
-                console.log("THE SAME");
-                return image;
+    '$rootScope',
+    '$q',
+    'imageAccessor',
+    'imageList',
+    'mediaApi',
+    'editsService',
+    'apiPoll',
+    function ($rootScope, $q, imageAccessor, imageList, mediaApi, editsService, apiPoll) {
+        let leasesRoot;
+        function getLeasesRoot() {
+            if (!leasesRoot) {
+                leasesRoot = mediaApi.root.follow('leases');
             }
+            return leasesRoot;
+        }
 
-            return image
-              .perform('replace-leases', {body: updatedLeases})
-              .then(() => {
-                  pollLeasesAndUpdateUI(images);
-              });
-        });
-    }
+        function getLeases(images) {
+            // search page has fancy image list
+            if (angular.isDefined(images.toArray)) {
+                images = images.toArray();
+            }
+            return $q.all(images.map(i => i.get()))
+                .then((images) => imageList.getLeases(images));
+        }
 
-    function add(image, lease) {
-      const newLease = angular.copy(lease);
-      newLease.mediaId = image.data.id;
+        function clear(image) {
+            return refreshImages([image]).then(images => {
+                const currentLeases = getLeases(images);
+                return currentLeases.then(() => {
+                    return image
+                        .perform('delete-leases').then(() => {
+                            pollLeasesAndUpdateUI(images, imageList.getLeases(images));
+                        });
+                });
+            });
+        }
 
-      if (angular.isDefined(newLease.notes) && newLease.notes.trim().length === 0) {
-        newLease.notes = null;
-      }
+        function replace(image, leases) {
+            const images = [image];
+            const currentLeasesPromise = getLeases(images);
 
-      return image.perform('add-lease', {body: newLease});
-    }
+            return currentLeasesPromise.then((currentLeases) => {
 
-      function batchAdd(lease, images) {
-          console.log(lease);
-        return trackAll($q, $rootScope, "leases", images, [image => { return add(image, lease); }, image =>
-            apiPoll(() => untilLeasesMatch(image, (apiLeases) => {
-                console.log(apiLeases.some(apiLease => sameLease(apiLease, lease)), "AAAA");
-                return apiLeases.some(apiLease => sameLease(apiLease, lease));
-            })),
-            (_,[{image}])=> image
-        ], ['images-updated', 'leases-updated']);
+                const updatedLeases = leases.map((lease) => {
+                    var newLease = angular.copy(lease);
+                    newLease.mediaId = image.data.id;
+                    return newLease;
+                });
+
+                // Don't update the leases if they're "the same"
+                if (JSON.stringify(currentLeases.leases) === JSON.stringify(updatedLeases)) {
+                    return image;
+                }
+
+                return image
+                    .perform('replace-leases', { body: updatedLeases })
+                    .then(() => pollLeasesAndUpdateUI(images));
+            });
+        }
+
+        function add(image, lease) {
+            const newLease = angular.copy(lease);
+            newLease.mediaId = image.data.id;
+
+            if (angular.isDefined(newLease.notes) && newLease.notes.trim().length === 0) {
+                newLease.notes = null;
+            }
+            return image.perform('add-lease', { body: newLease });
+        }
+
+        function batchAdd(lease, images) {
+            //We check whether the leases in the image have a later lastModified date,
+            //so make sure that we don't have anything in the pipeline.
+            console.log(images);
+            return refreshImages(images).then(updatedImages =>
+                trackAll($q, $rootScope, "leases", updatedImages, [
+                    image => add(image, lease),
+                    image => apiPoll(() => untilLeasesChange([image])).then(([{ image }]) => image ) //Extract the image from untilLeasesChange
+                ], ['images-updated', 'leases-updated'])
+            );
     }
 
     function canUserEdit(image){
@@ -109,9 +103,10 @@ leaseService.factory('leaseService', [
      * This method does not support batch deletion, because a
      * uuid will only ever match one lease.
      */
-    function deleteLease(lease, images) {
-      return getLeasesRoot().follow('leases', {id: lease.id}).delete()
-        .then(() => pollLeasesAndUpdateUI(images));
+        function deleteLease(lease, images) {
+        return refreshImages(images).then(images =>
+       getLeasesRoot().follow('leases', {id: lease.id}).delete()
+                .then(() => pollLeasesAndUpdateUI(images)));
     }
 
     function getByMediaId(image) {
@@ -122,21 +117,48 @@ leaseService.factory('leaseService', [
       apiPoll(() => {
         return untilLeasesChange(images);
       }).then(results => {
-        $rootScope.$emit('images-updated', results.map(({image})=>image));
-        $rootScope.$emit('leases-updated');
-
-        return results.map(({leases}) => leases);
+          console.log(results);
+          return results.map(({ image, leases }) => {
+              emitLeaseUpdate(leases);
+              console.log(images, leases);
+                emitImageUpdate(image);
+          });
       });
     }
 
+    const imageUpdates$ = new Subject();
+        imageUpdates$.bufferWithTime(1000).subscribe((images) => {
+            if (images.length == 0) {
+                return;
+            }
+            console.log(images);
+            $rootScope.$emit('images-updated', images);
+        });
+
+    function emitImageUpdate(lease) {
+        imageUpdates$.onNext(lease);
+    }
+    const leaseUpdates$ = new Subject();
+        leaseUpdates$.bufferWithTime(1000).subscribe((leases) => {
+            if (leases.length == 0) { return; }
+            console.log("DUCK", leases, leases.length);
+            $rootScope.$emit('leases-updated');
+    });
+
+    function emitLeaseUpdate(lease) {
+        leaseUpdates$.onNext(lease);
+    }
+
       //This is a race condition, but I think it's a rare one.
+        //Mitigate by refreshing images with refreshImages before posting.
     function untilLeasesChange(images) {
       const imagesArray = images.toArray ? images.toArray() : images;
       return $q.all(imagesArray.map(image => {
         return image.get().then(apiImage => {
           const apiImageAndApiLeases = getApiImageAndApiLeasesIfUpdated(image, apiImage);
           if (apiImageAndApiLeases) {
-            image = apiImage;
+              image = apiImage;
+              console.log(apiImageAndApiLeases);
             return apiImageAndApiLeases;
           } else {
             // returning $q.reject() will make apiPoll function to poll again
@@ -147,27 +169,12 @@ leaseService.factory('leaseService', [
       }));
     }
 
-      //This fails when two identical leases are addded.
-      function untilLeasesMatch(image, predicate) {
-        return image.get().then(apiImage => {
-
-            const leases = apiImage.data.leases.data;
-            console.log(leases, predicate(leases.leases));
-            if (predicate(leases.leases)) {
-                console.log("I WORKED");
-                return ({ image: apiImage, leases });
-            } else {
-
-
-                // returning $q.reject() will make apiPoll function to poll again
-                // until api call will return image with updated leases
-                return $q.reject();
-            }
-
-          });
-
-      }
-
+        // untilLeasesChange checks lastModified, make sure we always have the latest image before starting
+    function refreshImages(images) {
+        const x = $q.all(images.map(_ => _.get()));
+        console.log(x);
+        return x;
+    }
 
     function flattenLeases(leaseByMedias) {
       return {

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -85,12 +85,19 @@ leaseService.factory('leaseService', [
         function batchAdd(lease, images) {
             //We check whether the leases in the image have a later lastModified date,
             //so make sure that we don't have anything in the pipeline.
+                        // search page has fancy image list
+                        if (angular.isDefined(images.toArray)) {
+                            images = images.toArray();
+                        }
             console.log(images);
-            return refreshImages(images).then(updatedImages =>
-                trackAll($q, $rootScope, "leases", updatedImages, [
+            return refreshImages(images).then(updatedImages => {
+                console.log(images);
+                console.log(images.map);
+                return trackAll($q, $rootScope, "leases", updatedImages, [
                     image => add(image, lease),
-                    image => apiPoll(() => untilLeasesChange([image])).then(([{ image }]) => image ) //Extract the image from untilLeasesChange
+                    image => apiPoll(() => untilLeasesChange([image])).then(([{ image }]) => image) //Extract the image from untilLeasesChange
                 ], ['images-updated', 'leases-updated'])
+            }
             );
     }
 
@@ -104,6 +111,10 @@ leaseService.factory('leaseService', [
      * uuid will only ever match one lease.
      */
         function deleteLease(lease, images) {
+                        // search page has fancy image list
+                        if (angular.isDefined(images.toArray)) {
+                            images = images.toArray();
+                        }
         return refreshImages(images).then(images =>
        getLeasesRoot().follow('leases', {id: lease.id}).delete()
                 .then(() => pollLeasesAndUpdateUI(images)));

--- a/kahuna/public/js/services/archive.js
+++ b/kahuna/public/js/services/archive.js
@@ -36,7 +36,7 @@ archiveService.factory('archiveService',
     }
 
     function batchArchive (images) {
-        return trackAll($rootScope, "library", images, image => {
+        return trackAll($q, $rootScope, "library", images, image => {
             // only make a PUT request to images that are not archived
             if (! imageAccessor.isArchived(image)) {
                 return archive(image);
@@ -47,7 +47,7 @@ archiveService.factory('archiveService',
     }
 
     function batchUnarchive (images) {
-        return trackAll($rootScope, "library", images, image => {
+        return trackAll($q, $rootScope, "library", images, image => {
             // only make a PUT request to images that are archived
             if (imageAccessor.isArchived(image)) {
                 return unarchive(image);

--- a/kahuna/public/js/services/label.js
+++ b/kahuna/public/js/services/label.js
@@ -52,6 +52,7 @@ labelService.factory("labelService", [
         apiPoll(() => untilLabelsEqual(image, result.data));
 
       return trackAll(
+        $q,
         $rootScope,
         "label",
         images,
@@ -73,6 +74,7 @@ labelService.factory("labelService", [
       }
 
       return trackAll(
+        $q,
         $rootScope,
         "label",
         imagesWithLabel,

--- a/kahuna/public/js/services/photoshoot.js
+++ b/kahuna/public/js/services/photoshoot.js
@@ -25,6 +25,7 @@ photoshootService.factory('photoshootService', [
               })
             );
           return trackAll(
+            $q,
             $rootScope,
             "photoshoot",
             images,
@@ -39,6 +40,7 @@ photoshootService.factory('photoshootService', [
         const waitForPhotoshootRemovedInApi = (image) =>
           apiPoll(() => untilEqual({ image, expectedPhotoshoot: undefined }));
         return trackAll(
+          $q,
           $rootScope,
           "photoshoot",
           images,

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -1,3 +1,7 @@
+<div class="flex-container section-heading current-uploads">
+    <h2 class="flex-spacer">Your current uploads <em ng-if="ctrl.remaining">({{ctrl.remaining}} remaining)</em></h2>
+    <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
+</div>
 <ul>
     <li ng-repeat="job in ctrl.jobs | orderBy: 'name'"  class="upload-result">
 

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -38,6 +38,8 @@ jobs.controller('UploadJobsCtrl', [
     var ctrl = this;
     const presetLabels = presetLabelService.getLabels();
 
+    ctrl.remaining = ctrl.jobs.length;
+
     // State machine-esque async transitions
     const eventName = 'Image upload';
 
@@ -56,6 +58,8 @@ jobs.controller('UploadJobsCtrl', [
                 jobItem.status = 'uploaded';
                 jobItem.image = image;
                 jobItem.thumbnail = image.data.thumbnail;
+
+                ctrl.remaining -= 1;
 
                 imageService(image).states.canDelete.then(deletable => {
                     jobItem.canBeDeleted = deletable;

--- a/kahuna/public/js/upload/recent/recent-uploads.js
+++ b/kahuna/public/js/upload/recent/recent-uploads.js
@@ -39,8 +39,8 @@ recentUploads.controller('RecentUploadsCtrl', [
                   const images = ctrl.myUploads.data;
                   images.forEach((originalImage, index) => {
                     const maybeImage = updatedImages.find(updatedImage => originalImage.data.id === updatedImage.data.id);
-                    if (maybeImage) {
-                      images[index] = maybeImage;
+                      if (maybeImage) {
+                        images[index] = maybeImage;
                     }
                   });
                 });

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -13,10 +13,7 @@
     <section class="section"
              ng-if="ctrl.latestJob && ctrl.latestJob.length > 0">
 
-        <div class="flex-container section-heading current-uploads">
-            <h2 class="flex-spacer">Your current uploads</h2>
-            <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
-        </div>
+
 
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
     </section>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -159,7 +159,7 @@ usageRightsEditor.controller(
     ctrl.cancel = () => ctrl.onCancel();
 
     function save(data) {
-      return trackAll($rootScope, "rights", ctrl.usageRights, [
+      return trackAll($q, $rootScope, "rights", ctrl.usageRights, [
         ({ image }) => {
           const resource = image.data.userMetadata.data.usageRights;
           return editsService.update(resource, data, image, true);

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -54,7 +54,8 @@ async.factory("race", [
 
 const queue = new PQueue({ concurrency: 10 });
 async.factory("apiPoll", [
-  () => {
+  "$q",
+  ($q) => {
     const wait = () => new Promise(resolve => {
       setTimeout(() => resolve(), 500);
     });
@@ -65,7 +66,7 @@ async.factory("apiPoll", [
         })
       ]);
       if (status === 'fulfilled') {
-        return value;
+        return $q.resolve(value);
       }
       await wait();
       return poll(func, n + 1);

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -33,7 +33,6 @@ export const trackAll = async ($q, $rootScope, key, input, tasks, emit) => {
     total: input.size ? input.size : input.length
   });
     const process = async (item, result, [fn, ...remaining]) => {
-        console.log(fn, remaining);
     if (fn == undefined) {
       completed++;
       $rootScope.$broadcast("events:batch-operations:progress", {
@@ -57,7 +56,6 @@ export const trackAll = async ($q, $rootScope, key, input, tasks, emit) => {
   });
 
   $rootScope.$broadcast("events:batch-operations:complete", { key });
-console.log("DONE");
   const emitNames = Array.isArray(emit) ? emit : [emit];
   emitNames.map(name => $rootScope.$emit(name, successes));
   idleTimeout(() => { $rootScope.$apply(); });

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -32,7 +32,8 @@ export const trackAll = async ($q, $rootScope, key, input, tasks, emit) => {
     completed,
     total: input.size ? input.size : input.length
   });
-  const process = async (item, result, [fn, ...remaining]) => {
+    const process = async (item, result, [fn, ...remaining]) => {
+        console.log(fn, remaining);
     if (fn == undefined) {
       completed++;
       $rootScope.$broadcast("events:batch-operations:progress", {
@@ -56,7 +57,7 @@ export const trackAll = async ($q, $rootScope, key, input, tasks, emit) => {
   });
 
   $rootScope.$broadcast("events:batch-operations:complete", { key });
-
+console.log("DONE");
   const emitNames = Array.isArray(emit) ? emit : [emit];
   emitNames.map(name => $rootScope.$emit(name, successes));
   idleTimeout(() => { $rootScope.$apply(); });


### PR DESCRIPTION
@jonathonherbert this is my branch from earlier. going to keep on it on monday but mostly just tidy up and rationalise my changes to the lease service.

ps @paperboyo this adds a counter when uploading, is this useful?


## What does this change?

- Wraps `trackAll` and `apiPoll` in $q to make angular happier.
- Makes leases play better with the digest loop. 
- Changes to lease batching on upload
	- Batches the sending of update events in the batch handler to prevent quadratics. 
	- This is done with rx because we don't have lodash, I'm very sorry.
	- Adds an updating state to the lease to make it obvious that a batch update is happening. 
- Lease updates already handled by lease updated event handler refreshing leases¹ so trying to make sure this is the _way_ for leases².
	1. On upload this means every lease for every lease, yikes.
	2. Image updates are mostly handled by the images-updated event, I think this too should be the way, and we should delete the comments disparaging this and embrace as a single way of doing angular updates as it appears to work much more reliably than just randomly mutating scope variables in controllers- which appears to be what we wanted to do.
	- Maybe this event should be specific for which lease is updated.
	- It isn't.
- A progress counter for image uploads, because testing this locally without one was tedious. 
- Running `image.get()` before all lease updates because we only check that there's a more recent lease on the server than we currently have, and this is all kinds of race condition- which causes the UI to display semi-stale¹ update results.
	1. Stale enough to make breadcrumbs from, too stale to toast.
	-  Feeding this value through the batch tracker would have been a _little_ gnarly, so it's in a parent promise instead. 
- Replacing `moment` with the Date constructor in the date comparison, as it's not needed and seemed to be giving `moment(date).isAfter(moment(date)) == true` which was not helping the stale race condition.
- TrackAll can now emit multiple events, maybe this is not useful as we actually want to emit different event data for images and leases.
- Loads of new console.log statements 
- Loads of whitespace changes that vscode just randomly adds whenever I make a change. 

## How can success be measured?

Leases can be reliably updated on the upload screen.

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/2670496/105014131-f5e41a00-5a37-11eb-91bb-4c93459f8d88.png)



## Who should look at this?
@guardian/digital-cms 


## Tested?
- [X] locally
- [X] on TEST (thank you @paperboyo)
