### PR TITLE
Changes import to get MockitoSugar from scalatestplus

### DIFF
--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -9,7 +9,7 @@ import com.gu.mediaservice.model.{Edits, ImageMetadata}
 import lib.{MetadataEditorNotifications, ThrallStore}
 import lib.elasticsearch.{ElasticSearchTestBase, ElasticSearchUpdateResponse, SyndicationRightsOps}
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.JsArray
 
 import scala.concurrent.{Await, Future}


### PR DESCRIPTION
## What does this change?
This PR fixes an import which was changed in a previous PR: https://github.com/guardian/grid/pull/3088/files#diff-9843f1a9d6badf3fd076af2478cb3bec4987ce80fc08742c1af95e07b2c72b21L13

## How can success be measured?
The TC builds complete successfully.

## Tested?
- [x] locally
- [ ] on TEST
