### PR TITLE
Adds watch to node children, to update if new collections are added

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -123,8 +123,12 @@ grCollectionsPanel.controller('GrNodeCtrl',
     ctrl.getCollectionQuery = path => getCollection(path);
 
     $scope.$watch('ctrl.showChildren', onValChange(show => {
-            collectionsTreeState.setState(pathId, show);
+      collectionsTreeState.setState(pathId, show);
     }));
+
+    $scope.$watch('ctrl.node.data.children', children => {
+      ctrl.children = children.filter(node => !!node.data.data);
+    });
 
     ctrl.init = function(grCollectionTreeCtrl) {
         const selectedImages$ = grCollectionTreeCtrl.selectedImages$;

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -103,11 +103,11 @@ grCollectionsPanel.controller('GrNodeCtrl',
     const pathId = ctrl.node.data.data.pathId;
 
     //This filter remove child nodes with missing data, preventing display errors from occurring
-    $scope.filterChildren = children => children.filter(node => !!node.data.data);
+    ctrl.filterChildren = children => children.filter(node => !!node.data.data);
 
-    ctrl.children = $scope.filterChildren(ctrl.node.data.children);
+    ctrl.children = ctrl.filterChildren(ctrl.node.data.children);
     $scope.$watch('ctrl.node.data.children', children => {
-      ctrl.children = $scope.filterChildren(children);
+      ctrl.children = ctrl.filterChildren(children);
     });
 
     ctrl.saving = false;

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -103,7 +103,12 @@ grCollectionsPanel.controller('GrNodeCtrl',
     const pathId = ctrl.node.data.data.pathId;
 
     //This filter remove child nodes with missing data, preventing display errors from occurring
-    ctrl.children = ctrl.node.data.children.filter(node => !!node.data.data);
+    $scope.filterChildren = children => children.filter(node => !!node.data.data);
+
+    ctrl.children = $scope.filterChildren(ctrl.node.data.children);
+    $scope.$watch('ctrl.node.data.children', children => {
+      ctrl.children = $scope.filterChildren(children);
+    });
 
     ctrl.saving = false;
     ctrl.removing = false;
@@ -125,10 +130,6 @@ grCollectionsPanel.controller('GrNodeCtrl',
     $scope.$watch('ctrl.showChildren', onValChange(show => {
       collectionsTreeState.setState(pathId, show);
     }));
-
-    $scope.$watch('ctrl.node.data.children', children => {
-      ctrl.children = children.filter(node => !!node.data.data);
-    });
 
     ctrl.init = function(grCollectionTreeCtrl) {
         const selectedImages$ = grCollectionTreeCtrl.selectedImages$;


### PR DESCRIPTION
## What does this change?
This PR fixes an issue where new sub-collections were not being displayed in the UI until the page was refreshed(see gif). This issue was due to nothing watching the node children for changes, meaning the sub-collections were not being updated. 

This [PR](#3074) introduced a change which would filter out collections with no data associated with them (causing all sibling collections to disappear). The children used to be passed directly to the "gr-nodes". The PR changed this to use a filtered collection, however nothing was watching the actual collection for changes. Therefore, new collections were not reflected in the UI. A new watch on the actual children is now being used to check for changes and update the UI.

![unnamed](https://user-images.githubusercontent.com/4633246/105031532-56318680-5a4d-11eb-98e7-b5ede39e2286.gif)

## How can success be measured?
Adding a new sub-collection appears in the UI immediately. 

## Tested?
- [x] locally
- [ ] on TEST
