### PR TITLE
Log warning if a deprecated file is used

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigLoader.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigLoader.scala
@@ -46,6 +46,9 @@ object GridConfigLoader extends StrictLogging {
   private def loadConfiguration(file: File): Configuration = {
     if (file.exists) {
       logger.info(s"Loading config from $file")
+      if (file.getPath.endsWith(".properties")) {
+        logger.warn(s"Configuring the Grid with Java properties files is deprecated as of #3011, please switch to .conf files. See #3037 for a conversion utility.")
+      }
       Configuration(ConfigFactory.parseFile(file))
     } else {
       logger.info(s"Skipping config file $file as it doesn't exist")


### PR DESCRIPTION
## What does this change?
Instead of failing fast in #3043, this PR simply logs a warning when it encounters a legacy file.

## How can success be measured?
This should go some way to helping us eventually deal with #3109. 