### PR TITLE
Switch from individuals to BBC GitHub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # for any changes to BBC specific logic they should have sign off too
 # (we assume that it is BBC logic if it is under a package/directory
 # called bbc)
-bbc/ @RichardLe @wainaina @ochiengolanga
+bbc/ @bbc/cpw-grid-development


### PR DESCRIPTION
## What does this change?
This uses a BBC GitHub team instead of individuals as code owners for parts of the Grid that are specific to the BBC.

## How can success be measured?
Easier to contact appropriate people when a PR touches their code (possible in refactorings).

## How to test
 - [ ] Merge this
 - [ ] Raise a PR with a change to something under `bbc/`
 - [ ] Confirm that the BBC team received a notification about the PR