### PR TITLE
Downgrade test library to fix JSON ordering

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val commonSettings = Seq(
 
   testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports")),
   libraryDependencies ++= Seq(
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
     "org.mockito" % "mockito-core" % "2.18.0" % Test
   )
 )

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonOrderingTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonOrderingTest.scala
@@ -1,0 +1,65 @@
+package com.gu.mediaservice.lib.json
+
+import com.gu.mediaservice.model.{Asset, FileMetadata, Handout, Image, ImageMetadata, UploadInfo}
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.Inside.inside
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.libs.json.{JsObject, JsString, Json}
+
+import java.net.URI
+
+class JsonOrderingTest extends FreeSpec with Matchers {
+  /**
+    * The order of JSON documents is not strictly in accordance with the RFC but the Play library did maintain it
+    * until 2.6.11 and does again from 2.8.0. See https://github.com/playframework/play-json/pull/253
+    * This is helpful for debugging and for the super-power-users that look at the API as it means that related fields
+    * are grouped together throughout our API.
+    * This test (which fails with play-json 2.6.14 is here to prevent a further regression. It does mean that we'll
+    * need to jump to Play 2.8 for our next upgrade (which is likely to be what we do anyway...)
+    */
+  "Play Json writes maintain ordering" in {
+    val dt = new DateTime(2021,1,20,12,0,0, DateTimeZone.forID("America/New_York"))
+    val image = Image(id = "id",
+      uploadTime = dt,
+      identifiers = Map.empty,
+      uploadedBy = "Biden",
+      lastModified = None,
+      uploadInfo = UploadInfo(None),
+      source = Asset(new URI("fileUri"), None, None, None),
+      optimisedPng = None,
+      originalUsageRights = Handout(None),
+      originalMetadata = ImageMetadata(),
+      fileMetadata = FileMetadata(),
+      userMetadata = None,
+      thumbnail = None,
+      metadata = ImageMetadata(),
+      usageRights = Handout(None),
+    )
+    val json = Json.toJson(image)
+    inside(json) {
+      case jso: JsObject =>
+        /* this only seems to break when an extra field is added to the JsObject
+         * presumably this is done somewhere inside Play which was causing the mis-ordering */
+        val newJso = jso + ("extraField" -> JsString("value"))
+        newJso.fields.map(_._1) shouldBe Seq(
+        "id",
+        "uploadTime",
+        "uploadedBy",
+        "identifiers",
+        "uploadInfo",
+        "source",
+        "fileMetadata",
+        "metadata",
+        "originalMetadata",
+        "usageRights",
+        "originalUsageRights",
+        "exports",
+        "usages",
+        "leases",
+        "collections",
+        "extraField"
+      )
+    }
+  }
+
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/FileMetadataTest.scala
@@ -1,10 +1,10 @@
 package com.gu.mediaservice.model
 
+import org.scalatest.prop.{Checkers, PropertyChecks}
 import org.scalatest.{FreeSpec, Matchers}
-import org.scalatestplus.scalacheck.{Checkers, ScalaCheckPropertyChecks}
 import play.api.libs.json.Json
 
-class FileMetadataTest extends FreeSpec with Matchers with Checkers with ScalaCheckPropertyChecks {
+class FileMetadataTest extends FreeSpec with Matchers with Checkers with PropertyChecks {
 
   "Dehydrate a non-empty object" - {
     "Leave all short values alone" in {

--- a/cropper/test/lib/CropsTest.scala
+++ b/cropper/test/lib/CropsTest.scala
@@ -2,8 +2,7 @@ package lib
 
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.model._
-import org.scalatestplus.mockito.MockitoSugar
-
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
 class CropsTest extends FunSpec with Matchers with MockitoSugar {

--- a/image-loader/test/scala/model/ImageUploadTest.scala
+++ b/image-loader/test/scala/model/ImageUploadTest.scala
@@ -14,7 +14,7 @@ import com.gu.mediaservice.model.{FileMetadata, Jpeg, MimeType, Png, Tiff, Uploa
 import lib.imaging.MimeTypeDetection
 import model.upload.{OptimiseWithPngQuant, UploadRequest}
 import org.joda.time.DateTime
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
 import test.lib.ResourceHelpers
 

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -13,7 +13,7 @@ import com.gu.mediaservice.model.leases.LeasesByMedia
 import lib.DigestedFile
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FunSuite, Matchers}
 import play.api.libs.json.{JsArray, JsString}

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -16,7 +16,7 @@ import lib.querysyntax._
 import lib.{MediaApiConfig, MediaApiMetrics}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.Eventually
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.{Configuration, Mode}
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc.AnyContent

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -5,7 +5,7 @@ import com.gu.mediaservice.model._
 import lib.usagerights.CostCalculator
 import org.joda.time.DateTime
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class ImageExtrasTest extends FunSpec with Matchers with MockitoSugar {
 

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -3,7 +3,7 @@ package lib.usagerights
 import com.gu.mediaservice.model._
 import lib.UsageQuota
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
 class CostCalculatorTest extends FunSpec with Matchers with MockitoSugar {
 

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import com.contxt.kinesis.KinesisRecord
 import lib.kinesis.ThrallEventConsumer
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 import scala.concurrent.duration._

--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -9,7 +9,7 @@ import com.gu.mediaservice.model.{Edits, ImageMetadata}
 import lib.{MetadataEditorNotifications, ThrallStore}
 import lib.elasticsearch.{ElasticSearchTestBase, ElasticSearchUpdateResponse, SyndicationRightsOps}
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.JsArray
 
 import scala.concurrent.{Await, Future}


### PR DESCRIPTION
## What does this change?
This fixes the JSON re-ordering side effect introduced in #3058.

The play-json library mangles the order of fields from `2.6.11` until `2.8.0`. See https://github.com/playframework/play-json/issues/236. This solves the issue by downgrading the scalatest library that puled in the later version. At some stage we'll upgrade Play and will need to jump to 2.8 to avoid this behaviour.

There is also a test to detect any future inadvertent upgrade of the play-json library.

## Contention
Some people disagreed with the need for this, but it does make manual viewing of the API significantly easier. There are also now tests upstream so this shouldn't break again.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
Before:
<img width="1276" alt="Screenshot 2021-01-19 at 17 34 01" src="https://user-images.githubusercontent.com/1236466/105166448-5db96400-5b0f-11eb-9fd3-380f777979f2.png">

After (ordering maintained in API):
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/1236466/105166457-601bbe00-5b0f-11eb-96b7-9368588f5cec.png">

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally by committer
- [X] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
