### PR TITLE
Apipoll error

### DIFF
--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -70,7 +70,7 @@ async.factory("apiPoll", [
       }
       // Something has gone wrong, so we can let the user know
       if (n > 100) {
-        throw new Error('apiPoll failed - Please try again.');
+        throw new Error('gave up after 100 tries (apiPoll failed)');
       }
       await wait();
       return poll(func, n + 1);

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -70,7 +70,7 @@ async.factory("apiPoll", [
       }
       // Something has gone wrong, so we can let the user know
       if (n > 100) {
-        throw new Error('failed');
+        throw new Error('apiPoll failed - Please try again.');
       }
       await wait();
       return poll(func, n + 1);

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -68,6 +68,10 @@ async.factory("apiPoll", [
       if (status === 'fulfilled') {
         return $q.resolve(value);
       }
+      // Something has gone wrong, so we can let the user know
+      if (n > 100) {
+        throw new Error('failed');
+      }
       await wait();
       return poll(func, n + 1);
     };


### PR DESCRIPTION
## What does this change?

If apiPoll tries too many times (in this case, 100) it throws an error. In the case of batch uploads, this error appears under the image on the upload page.

Further work to show an error modal to the user when other batch processes fail, listing the failed images, but this is for a future PR.

## How can success be measured?
The user sees an error when apiPoll is taking too long to upload an image.

## Screenshots

![image](https://user-images.githubusercontent.com/15648334/105172992-4df24d80-5b18-11eb-8cfa-bdbcec3bef75.png)

## Who should look at this?
@guardian/digital-cms


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
