### PR TITLE
isInferred may not be in document

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SyndicationRights.scala
@@ -25,7 +25,8 @@ object SyndicationRights {
       (__ \ "published").readNullable[String].map(parseOptDateTime) ~
       (__ \ "suppliers").read[Seq[Supplier]] ~
       (__ \ "rights").read[Seq[Right]] ~
-      (__ \ "isInferred").read[Boolean])(SyndicationRights.apply _)
+      (__ \ "isInferred").readNullable[Boolean].map(_.getOrElse(false))
+    )(SyndicationRights.apply _)
 
   val writes: Writes[SyndicationRights] = (
     (__ \ "published").writeNullable[DateTime] ~


### PR DESCRIPTION
## What does this change?

If isInferred isn't present in the elasticsearch document, which is the case for some old images. 
(See thread for example) then parsing it fails. 

We used to parse it implicitly until #3088 where we inferred false, but #2299 would imply that we should do otherwise. 


## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->
Afaict we don't have many invalid json tests, this should go with them.
Also, I'm not sure if this is the correct fix- but it should provide similar behaivour to before #3088 

## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [X] not really possible (we could really do with something that pulled whole grid documents into local by id)