### PR TITLE
Add deserialise tests for syndication rights

### DIFF
--- a/common-lib/src/test/scala/com/gu/mediaservice/model/SyndicationRightsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/SyndicationRightsTest.scala
@@ -1,0 +1,54 @@
+package com.gu.mediaservice.model
+
+import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.Json
+
+class SyndicationRightsTest extends FunSpec with Matchers {
+
+  it("should deserialise with all fields") {
+    val serialisedRights =
+      """
+        |{
+        |  "published": "2021-1-21T21:21:21.21Z",
+        |  "suppliers": [],
+        |  "rights": [],
+        |  "isInferred": false
+        |}
+        |""".stripMargin
+    val parsedRightsJson = Json.parse(serialisedRights)
+    println(parsedRightsJson)
+    val rights: SyndicationRights = Json.fromJson[SyndicationRights](parsedRightsJson).get
+    rights.isInferred should be (false)
+  }
+
+  it("should deserialise with all fields except published") {
+    val serialisedRights =
+      """
+        |{
+        |  "suppliers": [],
+        |  "rights": [],
+        |  "isInferred": false
+        |}
+        |""".stripMargin
+    val parsedRightsJson = Json.parse(serialisedRights)
+    println(parsedRightsJson)
+    val rights: SyndicationRights = Json.fromJson[SyndicationRights](parsedRightsJson).get
+    rights.isInferred should be (false)
+  }
+
+  it("should deserialise with all fields except isInferred") {
+    val serialisedRights =
+      """
+        |{
+        |  "published": "2021-1-21T21:21:21.21Z",
+        |  "suppliers": [],
+        |  "rights": []
+        |}
+        |""".stripMargin
+    val parsedRightsJson = Json.parse(serialisedRights)
+    println(parsedRightsJson)
+    val rights: SyndicationRights = Json.fromJson[SyndicationRights](parsedRightsJson).get
+    rights.isInferred should be (false)
+  }
+
+}


### PR DESCRIPTION
## What does this change?
Only tests.

We recently had a failure when syndication rights deserialisation was altered to parse the date, which accidentally removed the defaulting from `isInferred`.  This was corrected in an earlier PR.  This PR represents the 'missing test' to prevent this error.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
