### PR TITLE
Allow no last modified date on json UpdateMessages for Thrall

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -7,7 +7,8 @@ import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.LogstashMarker
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.json.{JodaReads, JodaWrites, Json}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JodaReads, JodaWrites, Json, __}
 
 // TODO MRB: replace this with the simple Kinesis class once we migrate off SNS
 class ThrallMessageSender(config: KinesisSenderConfig) {
@@ -34,7 +35,23 @@ object UpdateMessage {
   implicit val unw = Json.writes[UsageNotice]
   implicit val unr = Json.reads[UsageNotice]
   implicit val writes = Json.writes[UpdateMessage]
-  implicit val reads = Json.reads[UpdateMessage]
+  implicit val reads =
+    (
+      (__ \ "subject").read[String] ~
+        (__ \ "image").readNullable[Image] ~
+        (__ \ "id").readNullable[String] ~
+        (__ \ "usageNotice").readNullable[UsageNotice] ~
+        (__ \ "edits").readNullable[Edits] ~
+        // We seem to get messages from _somewhere which don't have last modified on them.
+        (__ \ "lastModified").readNullable[DateTime].map(_.getOrElse(DateTime.now(DateTimeZone.UTC))) ~
+        (__ \ "collections").readNullable[Seq[Collection]] ~
+        (__ \ "leaseId").readNullable[String] ~
+        (__ \ "crops").readNullable[Seq[Crop]] ~
+        (__ \ "mediaLease").readNullable[MediaLease] ~
+        (__ \ "leases").readNullable[Seq[MediaLease]] ~
+        (__ \ "syndicationRights").readNullable[SyndicationRights] ~
+        (__ \ "bulkIndexRequest").readNullable[BulkIndexRequest]
+    )(UpdateMessage.apply _)
 }
 
 // TODO add RequestID

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ThrallMessageSenderTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ThrallMessageSenderTest.scala
@@ -17,6 +17,13 @@ class ThrallMessageSenderTest extends FunSpec with Matchers {
       m2 shouldEqual m
     }
 
+    it ("should convert a message from an external source which does not have last modified") {
+      val subject = "test"
+      val j = s"""{"subject":"$subject"}"""
+      val m = Json.parse(j).as[UpdateMessage]
+      m.lastModified.getZone.toString should be ("UTC")
+    }
+
     it ("should convert a message last modified with an offset timezone to UTC") {
       val now = DateTime.now(DateTimeZone.forOffsetHours(9))
       val nowUtc = new DateTime(now.getMillis()).toDateTime(DateTimeZone.UTC)


### PR DESCRIPTION
## What does this change?
As the code creation of `UpdateMessage` will ensure a `lastModified` date is present, it was thought that it could be treated as a field which would always be present in the json.

However, it appears that there are sources of `UpdateMessage` which do not send a `lastModified` date (and so presumably do not use the Grid code to construct their json).

As a result, we have errors in logs stating the message could not be parsed as it does not have a lastModified date.

This change allows a message without a `lastModified` date to be deserialised, and provides a `lastModified` date of `Now` in UTC.

## How can success be measured?
No more errors.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
