### PR TITLE
Log messages with missing last modified date

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -1,13 +1,13 @@
 package com.gu.mediaservice.lib.aws
 
 import com.gu.mediaservice.lib.config.CommonConfig
-import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.LogstashMarker
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
 import play.api.libs.json.{JodaReads, JodaWrites, Json, __}
 
 // TODO MRB: replace this with the simple Kinesis class once we migrate off SNS
@@ -29,7 +29,7 @@ object BulkIndexRequest {
   implicit val writes = Json.writes[BulkIndexRequest]
 }
 
-object UpdateMessage {
+object UpdateMessage extends GridLogging {
   implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
   implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
   implicit val unw = Json.writes[UsageNotice]
@@ -43,7 +43,13 @@ object UpdateMessage {
         (__ \ "usageNotice").readNullable[UsageNotice] ~
         (__ \ "edits").readNullable[Edits] ~
         // We seem to get messages from _somewhere which don't have last modified on them.
-        (__ \ "lastModified").readNullable[DateTime].map(_.getOrElse(DateTime.now(DateTimeZone.UTC))) ~
+        (__ \ "lastModified").readNullable[DateTime].map{ d => d match {
+          case Some(date) => date
+          case None => {
+            logger.warn("Message received without a last modified date", __.toJsonString)
+            DateTime.now(DateTimeZone.UTC)
+          }
+        }} ~
         (__ \ "collections").readNullable[Seq[Collection]] ~
         (__ \ "leaseId").readNullable[String] ~
         (__ \ "crops").readNullable[Seq[Crop]] ~


### PR DESCRIPTION
## What does this change?
After a recent change to date handling, we had a live issue with messages which did not have a last modified date.  The change had made this mandatory rather than optional.  A fix was applied to default in a value of `now()` if needed, but it would be good to know more about this unexpected error condition.

This PR only adds logging at `warn` level to enable further analysis.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
