### PR TITLE
Disallow "date taken" values in the future

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -137,16 +137,12 @@ object ImageMetadataConverter extends GridLogging {
   private[metadata] def parseRandomDate(str: String, maxDate: Option[DateTime] = None): Option[DateTime] = {
     dateTimeFormatters.foldLeft[Option[DateTime]](None){
       case (successfulDate@Some(_), _) => successfulDate
-      case (None, formatter) => safeParsing(
-        formatter.parseDateTime(str) match {
-          // NB We refuse parse results which result in future dates, if a max date is provided.
-          // eg If we get a pic today (22nd January 2021) with a date string of 20211201 we can be pretty sure
-          // that it should be parsed as (eg) US (12th Jan 2021), not EU (1st Dec 2021).
-          // So we refuse the (apparently successful) EU parse result.
-          case d if maxDate.forall(d.isBefore(_)) => d
-          case d => throw new IllegalArgumentException(s"Date $d is after $maxDate")
-        }
-      )
+      // NB We refuse parse results which result in future dates, if a max date is provided.
+      // eg If we get a pic today (22nd January 2021) with a date string of 20211201 we can be pretty sure
+      // that it should be parsed as (eg) US (12th Jan 2021), not EU (1st Dec 2021).
+      // So we refuse the (apparently successful) EU parse result.
+      case (None, formatter) => safeParsing(formatter.parseDateTime(str))
+        .filter(d => maxDate.forall(md => d.isBefore(md)))  
     }.map(_.withZone(DateTimeZone.UTC))
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -40,7 +40,7 @@ object ImageMetadataConverter extends GridLogging {
     (xmpIptcPeople ++ xmpGettyPeople).toSet
   }
 
-  def fromFileMetadata(fileMetadata: FileMetadata, currentDateTime: Option[DateTime] = None): ImageMetadata = {
+  def fromFileMetadata(fileMetadata: FileMetadata, latestAllowedDateTime: Option[DateTime] = None): ImageMetadata = {
     val xmp = fileMetadata.xmp
     val readXmpHeadStringProp: String => Option[String] = (name: String) => {
       val res = xmp.get(name) match {
@@ -53,9 +53,9 @@ object ImageMetadataConverter extends GridLogging {
     }
 
     ImageMetadata(
-      dateTaken           = (fileMetadata.exifSub.get("Date/Time Original Composite") flatMap (parseRandomDate(_, currentDateTime))) orElse
-                            (fileMetadata.iptc.get("Date Time Created Composite") flatMap (parseRandomDate(_, currentDateTime))) orElse
-                            (readXmpHeadStringProp("photoshop:DateCreated") flatMap (parseRandomDate(_, currentDateTime))),
+      dateTaken           = (fileMetadata.exifSub.get("Date/Time Original Composite") flatMap (parseRandomDate(_, latestAllowedDateTime))) orElse
+                            (fileMetadata.iptc.get("Date Time Created Composite") flatMap (parseRandomDate(_, latestAllowedDateTime))) orElse
+                            (readXmpHeadStringProp("photoshop:DateCreated") flatMap (parseRandomDate(_, latestAllowedDateTime))),
       description         = readXmpHeadStringProp("dc:description") orElse
                             fileMetadata.iptc.get("Caption/Abstract") orElse
                             fileMetadata.exif.get("Image Description"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -40,7 +40,7 @@ object ImageMetadataConverter extends GridLogging {
     (xmpIptcPeople ++ xmpGettyPeople).toSet
   }
 
-  def fromFileMetadata(fileMetadata: FileMetadata): ImageMetadata = {
+  def fromFileMetadata(fileMetadata: FileMetadata, currentDateTime: Option[DateTime] = None): ImageMetadata = {
     val xmp = fileMetadata.xmp
     val readXmpHeadStringProp: String => Option[String] = (name: String) => {
       val res = xmp.get(name) match {
@@ -52,7 +52,6 @@ object ImageMetadataConverter extends GridLogging {
       res
     }
 
-    val currentDateTime = Some(DateTime.now(DateTimeZone.UTC))  // We expect dateTaken to be before this date.
     ImageMetadata(
       dateTaken           = (fileMetadata.exifSub.get("Date/Time Original Composite") flatMap (parseRandomDate(_, currentDateTime))) orElse
                             (fileMetadata.iptc.get("Date Time Created Composite") flatMap (parseRandomDate(_, currentDateTime))) orElse

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -445,5 +445,15 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
 
   }
 
+  it("should refuse future dates, if a 'maximum' date is provided which is before the image date") {
+    val yesterday = ImageMetadataConverter.parseRandomDate("2020-12-31").get
+    val parsedDate = ImageMetadataConverter.parseRandomDate("2021-01-01", Some(yesterday))
+    parsedDate.isDefined should be (false)
+  }
 
+  it("should accept past dates, if a 'maximum' date is provided which is after the image date") {
+    val tomorrow = ImageMetadataConverter.parseRandomDate("2021-01-01").get
+    val parsedDate = ImageMetadataConverter.parseRandomDate("2020-12-31", Some(tomorrow))
+    parsedDate.isDefined should be (true)
+  }
 }

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -159,7 +159,7 @@ object Uploader extends GridLogging {
       colourModel <- colourModelFuture
     } yield {
       val fullFileMetadata = fileMetadata.copy(colourModel = colourModel)
-      val metadata = ImageMetadataConverter.fromFileMetadata(fullFileMetadata)
+      val metadata = ImageMetadataConverter.fromFileMetadata(fullFileMetadata, s3Source.metadata.objectMetadata.lastModified)
 
       val sourceAsset = Asset.fromS3Object(s3Source, sourceDimensions)
       val thumbAsset = Asset.fromS3Object(s3Thumb, thumbDimensions)


### PR DESCRIPTION
## What does this change?
In an attempt to be strict on our date parsing, we have worked out one possible way in which we could wrongly load a date:

If we get a pic today (22nd January 2021) with a date string of 20211201, it cannot have been taken in the future!
Therefore we can choose to parse as (eg) US (12th Jan 2021), not EU (1st Dec 2021).

So we can refuse the (apparently successful) EU parse result, which comes first in the list.

## How can success be measured?
Future dates will not be accepted.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
