### PR TITLE
Second attempt at handling missing last-modified dates on update messages

### DIFF
--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -51,7 +51,7 @@ class ThrallStreamProcessor(
 
   def createStream(): Source[(TaggedRecord, Stopwatch, Option[UpdateMessage]), NotUsed] = {
     mergedKinesisSource.map{ taggedRecord =>
-      taggedRecord -> consumer.parseRecord(taggedRecord.record.data.toArray, taggedRecord.record.approximateArrivalTimestamp)
+      taggedRecord -> ThrallEventConsumer.parseRecord(taggedRecord.record.data.toArray, taggedRecord.record.approximateArrivalTimestamp)
     }.mapAsync(1) { result =>
       val stopwatch = Stopwatch.start
       result match {

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -36,27 +36,6 @@ class ThrallEventConsumer(es: ElasticSearch,
   private implicit val executionContext: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
 
-  def parseRecord(r: Array[Byte], timestamp: Instant):Option[UpdateMessage] = {
-    implicit val yourJodaDateReads: Reads[DateTime] = JodaReads.DefaultJodaDateTimeReads
-    implicit val unr = Json.reads[UsageNotice]
-    implicit val umr = Json.reads[UpdateMessage]
-
-    Try(JsonByteArrayUtil.fromByteArray[UpdateMessage](r)) match {
-      case Success(Some(updateMessage: UpdateMessage)) => {
-        logger.info(updateMessage.toLogMarker, s"Received ${updateMessage.subject} message at $timestamp")
-        Some(updateMessage)
-      }
-      case Success(None)=> {
-        logger.error(s"No message present in record at $timestamp")
-        None //No message received
-      }
-      case Failure(e) => {
-        logger.error(s"Exception during process record block at $timestamp", e)
-        None
-      }
-    }
-  }
-
   def processUpdateMessage(updateMessage: UpdateMessage): Future[UpdateMessage]  = {
     val marker = updateMessage
 
@@ -104,4 +83,25 @@ class ThrallEventConsumer(es: ElasticSearch,
         }
       }
 
+}
+
+object ThrallEventConsumer extends GridLogging {
+
+
+  def parseRecord(r: Array[Byte], timestamp: Instant):Option[UpdateMessage] = {
+    Try(JsonByteArrayUtil.fromByteArray[UpdateMessage](r)) match {
+      case Success(Some(updateMessage: UpdateMessage)) => {
+        logger.info(updateMessage.toLogMarker, s"Received ${updateMessage.subject} message at $timestamp")
+        Some(updateMessage)
+      }
+      case Success(None)=> {
+        logger.warn(s"No message present in record at $timestamp", new String(r))
+        None //No message received
+      }
+      case Failure(e) => {
+        logger.error(s"Exception during process record block at $timestamp", e)
+        None
+      }
+    }
+  }
 }

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -36,10 +36,6 @@ class ThrallEventConsumer(es: ElasticSearch,
   private implicit val executionContext: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
 
-<<<<<<< HEAD
-=======
-
->>>>>>> main
   def processUpdateMessage(updateMessage: UpdateMessage): Future[UpdateMessage]  = {
     val marker = updateMessage
 

--- a/thrall/test/lib/kinesis/ThrallEventConsumerTest.scala
+++ b/thrall/test/lib/kinesis/ThrallEventConsumerTest.scala
@@ -1,0 +1,35 @@
+package lib.kinesis
+
+import com.gu.mediaservice.lib.aws.UpdateMessage
+import lib.elasticsearch.ElasticSearchTestBase
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.Json
+
+class ThrallEventConsumerTest extends ElasticSearchTestBase with MockitoSugar {
+  "parse message" - {
+    "parse minimal message" in {
+      val j =
+        """
+          |{
+          | "subject":"test"
+          |}
+          |""".stripMargin.getBytes()
+      val m2 = ThrallEventConsumer.parseRecord(j, java.time.Instant.EPOCH)
+      m2.isDefined shouldEqual (true)
+      m2.get.subject shouldBe "test"
+    }
+    "parse near minimal message" in {
+      val j =
+        """
+          |{
+          | "subject":"test",
+          | "lastModified":"2021-01-25T10:21:18.006Z"
+          |}
+          |""".stripMargin.getBytes()
+      val m2 = ThrallEventConsumer.parseRecord(j, java.time.Instant.EPOCH)
+      m2.isDefined shouldEqual (true)
+      m2.get.subject shouldBe "test"
+    }
+  }
+}
+


### PR DESCRIPTION
## What does this change?
Update Messages have recently been seen which do not contain a last modified date.  A change was introduced to handle this correctly, but did not succeed.  Analysis shows that this is due to a second json reader for Update Message.  This has been removed in this PR and more tests added.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
