### PR TITLE
Revert "Switch from individuals to BBC GitHub team"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # for any changes to BBC specific logic they should have sign off too
 # (we assume that it is BBC logic if it is under a package/directory
 # called bbc)
-bbc/ @bbc/cpw-grid-development
+bbc/ @RichardLe @wainaina @ochiengolanga


### PR DESCRIPTION
Unfortunately this is not supported so I'm reverting guardian/grid#3111

GitHub support got back to me saying:

> Although `@org/team-name` is part of the permitted syntax for adding CODEOWNERS, I'm afraid that your use case is not currently supported. As teams are per organization and code owners are per repository, there is no cross-over in allowing CODEOWNER access in one organizations team to another.

So for now we'll have to maintain a list of interested individual handles.