### PR TITLE
Implement image upload-status endpoint and changing upload status on load and import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val commonLib = project("common-lib").settings(
     // needed to parse conditional statements in `logback.xml`
     // i.e. to only log to disk in DEV
     // see: https://logback.qos.ch/setup.html#janino
-    "org.codehaus.janino" % "janino" % "3.0.6"
+    "org.codehaus.janino" % "janino" % "3.0.6",
+    "com.gu" %% "scanamo" % "1.0.0-M8"
   ),
 
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
@@ -131,11 +132,7 @@ lazy val imageLoader = playProject("image-loader", 9003).settings {
 
 lazy val kahuna = playProject("kahuna", 9005)
 
-lazy val leases = playProject("leases", 9012).settings(
-  libraryDependencies ++= Seq(
-    "com.gu" %% "scanamo" % "1.0.0-M8"
-  )
-)
+lazy val leases = playProject("leases", 9012)
 
 lazy val mediaApi = playProject("media-api", 9001).settings(
   libraryDependencies ++= Seq(

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -42,3 +42,5 @@ authentication.providers {
     }
   }
 }
+
+uploadStatus.recordExpiry = "1 hour"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/ArgoHelpers.scala
@@ -79,7 +79,7 @@ trait ArgoHelpers extends Results with GridLogging {
   }
 
 
-  private def serializeAndWrap[T](response: T, status: Status)(implicit writes: Writes[T]): Result = {
+  protected def serializeAndWrap[T](response: T, status: Status)(implicit writes: Writes[T]): Result = {
     val json = Json.toJson(response)
     status(json).as(ArgoMediaType)
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -270,4 +270,6 @@ object DynamoDB {
     }
     valueMap
   }
+  def caseClassToMap[T](caseClass: T)(implicit tjs: Writes[T]): Map[String, JsValue] =
+    Json.toJson[T](caseClass).as[JsObject].as[Map[String, JsValue]]
 }

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -181,6 +181,7 @@ Resources:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1
 
+
   PreviewContentPollTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -194,6 +195,23 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1
+
+  UploadStatusTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: UploadStatusTable
+      AttributeDefinitions:
+      - AttributeName: id
+        AttributeType: S
+      KeySchema:
+      - AttributeName: id
+        KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
+      TimeToLiveSpecification:
+        AttributeName: expires
+        Enabled: true
 
 Outputs:
   ImageBucket:
@@ -234,3 +252,5 @@ Outputs:
     Value: !Ref 'LiveContentPollTable'
   PreviewContentPollTable:
     Value: !Ref 'PreviewContentPollTable'
+  UploadStatusTable:
+    Value: !Ref 'UploadStatusTable'

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -58,6 +58,7 @@ function getImageLoaderConfig(config) {
         |s3.thumb.bucket="${config.coreStackProps.ThumbBucket}"
         |s3.quarantine.bucket="${config.coreStackProps.QuarantineBucket}"
         |s3.config.bucket="${config.coreStackProps.ConfigBucket}"
+        |dynamo.table.upload.status="UploadStatusTable"
         |aws.local.endpoint="https://localstack.media.${config.DOMAIN}"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -1,7 +1,8 @@
+import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.lib.play.GridComponents
-import controllers.ImageLoaderController
+import controllers.{ImageLoaderController, UploadStatusController}
 import lib._
 import lib.storage.{ImageLoaderStore, QuarantineStore}
 import model.{Projector, Uploader, QuarantineUploader}
@@ -17,6 +18,7 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
   }
 
   val store = new ImageLoaderStore(config)
+  val uploadStatusTable = new UploadStatusTable(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
   val notifications = new Notifications(config)
   val downloader = new Downloader()
@@ -31,7 +33,8 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
     case (false, _) => None
   }
   val controller = new ImageLoaderController(
-    auth, downloader, store, notifications, config, uploader, quarantineUploader, projector, controllerComponents, wsClient)
+    auth, downloader, store, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, wsClient)
+  val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, controllerComponents)
 
-  override lazy val router = new Routes(httpErrorHandler, controller, management)
+  override lazy val router = new Routes(httpErrorHandler, controller, uploadStatusController, management)
 }

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -2,29 +2,35 @@ package controllers
 
 import java.io.File
 import java.net.URI
-
 import com.drew.imaging.ImageProcessingException
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth._
+import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.lib.logging.{FALLBACK, GridLogging, LogMarker, RequestLoggingContext}
 import com.gu.mediaservice.lib.{DateTimeUtils, ImageIngestOperations}
 import com.gu.mediaservice.model.UnsupportedMimeTypeException
-import lib._
+import com.gu.scanamo.error.ConditionNotMet
+import lib.FailureResponse.Response
+import lib.{FailureResponse, _}
 import lib.imaging.{NoSuchImageExistsInS3, UserImageLoaderException}
 import lib.storage.ImageLoaderStore
-import model.{Projector, Uploader, QuarantineUploader}
+import model.{Projector, QuarantineUploader, StatusType, UploadStatus, UploadStatusRecord, Uploader}
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import model.upload.UploadRequest
+import org.joda.time.DateTime
+
+import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 class ImageLoaderController(auth: Authentication,
                             downloader: Downloader,
                             store: ImageLoaderStore,
+                            uploadStatusTable: UploadStatusTable,
                             notifications: Notifications,
                             config: ImageLoaderConfig,
                             uploader: Uploader,
@@ -49,7 +55,7 @@ class ImageLoaderController(auth: Authentication,
   def quarantineOrStoreImage(uploadRequest: UploadRequest)(implicit logMarker: LogMarker) = {
     quarantineUploader.map(_.quarantineFile(uploadRequest)).getOrElse(uploader.storeFile(uploadRequest))
   }
-  
+
   def loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String]): Action[DigestedFile] =  {
 
     implicit val context: RequestLoggingContext = RequestLoggingContext(
@@ -69,15 +75,21 @@ class ImageLoaderController(auth: Authentication,
     val parsedBody = DigestBodyParser.create(tempFile)
 
     auth.async(parsedBody) { req =>
+      val uploadTimeToRecord = DateTimeUtils.fromValueOrNow(uploadTime)
+      val uploadedByToRecord = uploadedBy.getOrElse(Authentication.getIdentity(req.user))
+
+      val uploadStatus = if(config.uploadToQuarantineEnabled) StatusType.Pending else StatusType.Completed
+      val uploadExpiry = Instant.now.getEpochSecond + config.uploadStatusExpiry.toSeconds
+      val record = UploadStatusRecord(req.body.digest, filename, uploadedByToRecord, printDateTime(uploadTimeToRecord), identifiers, uploadStatus, None, uploadExpiry)
       val result = for {
         uploadRequest <- uploader.loadFile(
           req.body,
-          req.user,
-          uploadedBy,
+          uploadedByToRecord,
           identifiers,
-          DateTimeUtils.fromValueOrNow(uploadTime),
+          uploadTimeToRecord,
           filename.flatMap(_.trim.nonEmptyOpt),
           context.requestId)
+        _ <- uploadStatusTable.setStatus(record)
         result <- quarantineOrStoreImage(uploadRequest)
       } yield result
       result.onComplete( _ => Try { deleteTempFile(tempFile) } )
@@ -87,16 +99,15 @@ class ImageLoaderController(auth: Authentication,
         logger.info("loadImage request end")
         result
       } recover {
-        case e =>
+        case NonFatal(e) =>
           logger.error("loadImage request ended with a failure", e)
-          (e match {
+          val response = e match {
             case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
-            case e: ImageProcessingException => FailureResponse.notAnImage(e, config.supportedMimeTypes).as(ArgoMediaType)
-            case e: java.io.IOException => FailureResponse.badImage(e).as(ArgoMediaType)
-            case _ => 
-              logger.error("Failed upload", e) 
-              InternalServerError(Json.obj("error" -> e.getMessage)).as(ArgoMediaType)
-          }).as(ArgoMediaType)
+            case e: ImageProcessingException => FailureResponse.notAnImage(e, config.supportedMimeTypes)
+            case e: java.io.IOException => FailureResponse.badImage(e)
+            case other => FailureResponse.internalError(other)
+          }
+          FailureResponse.responseToResult(response)
       }
     }
   }
@@ -150,36 +161,74 @@ class ImageLoaderController(auth: Authentication,
       logger.info("importImage request start")
 
       val tempFile = createTempFile("download")
-      val result = for {
+      val digestedFileFuture = for {
         validUri <- Future { URI.create(uri) }
         digestedFile <- downloader.download(validUri, tempFile)
+      } yield digestedFile
+
+      val uploadedByForImport = uploadedBy.getOrElse(Authentication.getIdentity(request.user))
+
+      val importResult: Future[Result] = for {
+        digestedFile <- digestedFileFuture
+        uploadStatusResult <- uploadStatusTable.getStatus(digestedFile.digest)
+        maybeStatus = uploadStatusResult.flatMap(_.toOption)
         uploadRequest <- uploader.loadFile(
           digestedFile,
-          request.user,
-          uploadedBy,
-          identifiers,
-          DateTimeUtils.fromValueOrNow(uploadTime),
-          filename.flatMap(_.trim.nonEmptyOpt),
+          maybeStatus.map(_.uploadedBy).getOrElse(uploadedByForImport),
+          maybeStatus.flatMap(_.identifiers).orElse(identifiers),
+          DateTimeUtils.fromValueOrNow(maybeStatus.map(_.uploadTime).orElse(uploadTime)),
+          maybeStatus.flatMap(_.fileName).orElse(filename).flatMap(_.trim.nonEmptyOpt),
           context.requestId)
         result <- uploader.storeFile(uploadRequest)
-      } yield result
+      } yield {
+        logger.info("importImage request end")
+        // NB This return code (202) is explicitly required by s3-watcher
+        // Anything else (eg 200) will be logged as an error. DAMHIKIJKOK.
+        Accepted(result).as(ArgoMediaType)
+      }
 
-      result.onComplete( _ => Try { deleteTempFile(tempFile) } )
+      // under all circumstances, remove the temp files
+      importResult.onComplete { _ =>
+        Try { deleteTempFile(tempFile) }
+      }
 
-      result
-        .map {
-          r => {
-            logger.info("importImage request end")
-            // NB This return code (202) is explicitly required by s3-watcher
-            // Anything else (eg 200) will be logged as an error. DAMHIKIJKOK.
-            Accepted(r).as(ArgoMediaType)
-          }
+      /* combine the import result and digest file together into a single future
+       * note that we use transformWith instead of zip here as we are still interested in value of
+       * digestedFile even if the import fails */
+      val fileAndMaybeResult: Future[(DigestedFile, Try[Result])] = importResult.transformWith{ result =>
+        digestedFileFuture.map(file => file -> result)
+      }
+
+      // this is an unusual way of generating a result due to the need to put the error message both in the upload
+      // status table and also provide it in the response to the client.
+      fileAndMaybeResult.flatMap { case (digestedFile, importResult) =>
+        // convert exceptions to failure responses
+        val res = importResult match {
+          case Failure(e: UnsupportedMimeTypeException) => Left(FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes))
+          case Failure(_: IllegalArgumentException) => Left(FailureResponse.invalidUri)
+          case Failure(e: UserImageLoaderException) => Left(FailureResponse.badUserInput(e))
+          case Failure(NonFatal(_)) => Left(FailureResponse.failedUriDownload)
+          case Success(result) => Right(result)
         }
-        .recover {
-          case e: UnsupportedMimeTypeException => FailureResponse.unsupportedMimeType(e, config.supportedMimeTypes)
-          case _: IllegalArgumentException => FailureResponse.invalidUri
-          case e: UserImageLoaderException => FailureResponse.badUserInput(e)
-          case NonFatal(_) => FailureResponse.failedUriDownload
+        // update the upload status with the error or completion
+        val status = res match {
+          case Left(Response(_, response)) => UploadStatus(StatusType.Failed, Some(s"${response.errorKey}: ${response.errorMessage}"))
+          case Right(_) => UploadStatus(StatusType.Completed, None)
+        }
+        uploadStatusTable.updateStatus(digestedFile.digest, status).flatMap{status =>
+          status match {
+            case Left(_: ConditionNotMet) => logger.info(s"no image upload status to update for image ${digestedFile.digest}")
+            case Left(error) => logger.error(s"an error occurred while updating image upload status, image-id:${digestedFile.digest}, error:${error}")
+            case Right(_) => logger.info(s"image upload status updated successfully, image-id: ${digestedFile.digest}")
+          }
+          Future.successful(res)
+        }
+      }.transform {
+        // create a play result out of what has happened
+        case Success(Right(result)) => Success(result)
+        case Success(Left(failure)) => Success(FailureResponse.responseToResult(failure))
+        case Failure(NonFatal(e)) => Success(FailureResponse.responseToResult(FailureResponse.internalError(e)))
+        case Failure(other) => Failure(other)
       }
     }
   }

--- a/image-loader/app/controllers/UploadStatusController.scala
+++ b/image-loader/app/controllers/UploadStatusController.scala
@@ -1,0 +1,48 @@
+package controllers
+
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth._
+import com.gu.scanamo.error.{ConditionNotMet, DynamoReadError, ScanamoError}
+import lib._
+import model.{StatusType, UploadStatus}
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UploadStatusController(auth: Authentication,
+                             store: UploadStatusTable,
+                             override val controllerComponents: ControllerComponents,
+                            )
+                            (implicit val ec: ExecutionContext)
+  extends BaseController with ArgoHelpers {
+
+  def getUploadStatus(imageId: String) = auth.async {
+    store.getStatus(imageId)
+      .map {
+        case Some(Right(record)) => respond(UploadStatus(record.status, record.errorMessage))
+        case Some(Left(error)) => respondError(BadRequest, "cannot-get", s"Cannot get upload status ${error}")
+        case None => respondNotFound(s"No upload status found for image id: ${imageId}")
+      }
+      .recover{ case error => respondError(InternalServerError, "cannot-get", s"Cannot get upload status ${error}") }
+  }
+
+  def updateUploadStatus(imageId: String) = auth.async(parse.json[UploadStatus]) { request =>
+    request.body match {
+      case UploadStatus(StatusType.Failed, None) =>
+        Future.successful(respondError(
+          BadRequest,
+          "missing-error-message",
+          "When an upload status is being set to FAILED an errorMessage must be provided"
+        ))
+      case uploadStatus =>
+        store
+          .updateStatus(imageId, uploadStatus)
+          .map{
+            case Right(record) => respond(UploadStatus(record.status, record.errorMessage))
+            case Left(_: ConditionNotMet) => respondError(BadRequest, "cannot-update", s"Cannot update as no upload status for $imageId exists")
+            case Left(error: ScanamoError) => respondError(BadRequest, "cannot-update", s"Cannot update upload status ${error}")
+          }
+    }
+  }
+}

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -1,52 +1,68 @@
 package lib
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.argo.model.ErrorResponse
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.model.{MimeType, UnsupportedMimeTypeException}
 import lib.imaging.UserImageLoaderException
-import play.api.mvc.Result
+import play.api.libs.json.Writes
+import play.api.mvc.{Result, Results}
 
-object FailureResponse extends ArgoHelpers {
-  val invalidUri: Result = {
+
+object FailureResponse extends ArgoHelpers with Results {
+
+  case class Response(status: Status, errorResponse: ErrorResponse[Int])
+  object Response {
+    def apply(status: Status, key: String, message: String): Response = Response(status, ErrorResponse[Int](errorKey = key, errorMessage = message, data=None))
+  }
+
+  val invalidUri: Response = {
     logger.warn("importImage request failed; invalid uri")
-    respondError(BadRequest, "invalid-uri", s"The provided 'uri' is not valid")
+    Response(BadRequest, "invalid-uri", s"The provided 'uri' is not valid")
   }
 
-  def badUserInput(e: UserImageLoaderException): Result = {
+  def badUserInput(e: UserImageLoaderException): Response = {
     logger.warn("importImage request failed; bad user input", e)
-    BadRequest(e.getMessage)
+    Response(BadRequest, "bad-user-data", "bad user input: ${e.getMessage}")
   }
 
-  val failedUriDownload: Result = {
+  val failedUriDownload: Response = {
     logger.warn("importImage request failed")
-    respondError(BadRequest, "failed-uri-download", s"The provided 'uri' could not be downloaded")
+    Response(BadRequest, "failed-uri-download", s"The provided 'uri' could not be downloaded")
   }
 
-  def unsupportedMimeType(unsupported: UnsupportedMimeTypeException, supportedMimeTypes: List[MimeType]): Result = {
+  def unsupportedMimeType(unsupported: UnsupportedMimeTypeException, supportedMimeTypes: List[MimeType]): Response = {
     logger.info(s"Rejected request to load file: mime-type is not supported", unsupported)
-    respondError(
-      UnsupportedMediaType,
-      "unsupported-type",
-      s"Unsupported mime-type: ${unsupported.mimeType}. Supported: ${supportedMimeTypes.mkString(", ")}"
-    )
+    Response(UnsupportedMediaType, "unsupported-type", s"Unsupported mime-type: ${unsupported.mimeType}. Supported: ${supportedMimeTypes.mkString(", ")}")
   }
-  def notAnImage(exception: Exception, supportedMimeTypes: List[MimeType]): Result = {
+  def notAnImage(exception: Exception, supportedMimeTypes: List[MimeType]): Response = {
     logger.info(s"Rejected request to load file: file type is not supported", exception)
-
-    respondError(
+    Response(
       UnsupportedMediaType,
       "unsupported-file-type",
       s"Unsupported file type: not a valid image type. Supported: ${supportedMimeTypes.mkString(", ")}"
     )
   }
 
-  def badImage(exception: Exception): Result = {
+  def badImage(exception: Exception): Response = {
     logger.info(s"Rejected request to load file: image file is not good", exception)
 
-    respondError(
+    Response(
       UnsupportedMediaType,
       "bad-file",
       s"Bad file: not a valid image file."
     )
   }
+
+  def internalError(exception: Throwable): Response = {
+    logger.info(s"Unhandled exception", exception)
+
+    Response(
+      UnsupportedMediaType,
+      "internal-error",
+      s"Unhandled error: ${exception.getMessage}"
+    )
+  }
+
+  def responseToResult(response: Response): Result = serializeAndWrap(response.errorResponse, response.status)
 }

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -6,6 +6,8 @@ import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources, ImageP
 import com.gu.mediaservice.model._
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.concurrent.duration.FiniteDuration
+
 class ImageLoaderConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) with StrictLogging {
   val imageBucket: String = string("s3.image.bucket")
 
@@ -24,6 +26,9 @@ class ImageLoaderConfig(resources: GridConfigResources) extends CommonConfig(res
 
   val transcodedMimeTypes: List[MimeType] = getStringSet("transcoded.mime.types").toList.map(MimeType(_))
   val supportedMimeTypes: List[MimeType] = List(Jpeg, Png) ::: transcodedMimeTypes
+
+  val uploadStatusTable: String = string("dynamo.table.upload.status")
+  val uploadStatusExpiry: FiniteDuration = configuration.get[FiniteDuration]("uploadStatus.recordExpiry")
 
   /**
     * Load in the chain of image processors from config. This can be a list of

--- a/image-loader/app/lib/UploadStatusTable.scala
+++ b/image-loader/app/lib/UploadStatusTable.scala
@@ -1,0 +1,38 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.scanamo._
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.syntax._
+import model.{UploadStatus, UploadStatusRecord}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class UploadStatusTable(config: ImageLoaderConfig) extends DynamoDB(config, config.uploadStatusTable) {
+
+  private val uploadStatusTable = Table[UploadStatusRecord](config.uploadStatusTable)
+
+  def getStatus(imageId: String) = {
+    ScanamoAsync.exec(client)(uploadStatusTable.get('id -> imageId))
+  }
+
+  def setStatus(uploadStatus: UploadStatusRecord) = {
+    ScanamoAsync.exec(client)(uploadStatusTable.put(uploadStatus))
+  }
+
+  def updateStatus(imageId: String, updateRequest: UploadStatus) = {
+    val updateExpression = updateRequest.errorMessage match {
+      case Some(error) => set('status -> updateRequest.status) and set('errorMessages -> error)
+      case None => set('status -> updateRequest.status)
+    }
+    ScanamoAsync.exec(client)(
+      uploadStatusTable
+        .given(attributeExists('id))
+        .update(
+          'id -> imageId,
+          update = updateExpression
+        )
+    )
+  }
+}

--- a/image-loader/app/model/UploadStatus.scala
+++ b/image-loader/app/model/UploadStatus.scala
@@ -1,0 +1,47 @@
+package model
+
+import play.api.libs.json._
+
+case class UploadStatusRecord(
+                               id: String,
+                               fileName: Option[String],
+                               uploadedBy: String,
+                               uploadTime: String,
+                               identifiers: Option[String],
+                               status: StatusType,
+                               errorMessage: Option[String],
+                               expires: Long
+                             )
+
+object UploadStatusRecord {
+  implicit val formats: Format[UploadStatusRecord] = Json.format[UploadStatusRecord]
+}
+
+case class UploadStatus(status: StatusType, errorMessage: Option[String])
+
+object UploadStatus {
+  implicit val formats: Format[UploadStatus] = Json.format[UploadStatus]
+}
+
+sealed trait StatusType { def name: String }
+object StatusType {
+  case object Pending extends StatusType { val name = "PENDING" }
+  case object Completed extends StatusType { val name = "COMPLETED" }
+  case object Failed extends StatusType { val name = "FAILED" }
+
+  implicit val reads: Reads[StatusType] = new Reads[StatusType] {
+    override def reads(json: JsValue): JsResult[StatusType] = json match {
+      case JsString("PENDING") => JsSuccess(Pending)
+      case JsString("COMPLETED") => JsSuccess(Completed)
+      case JsString("FAILED") => JsSuccess(Failed)
+      case _ => JsError("Bad Status")
+    }
+  }
+  implicit val writer: Writes[StatusType] = (statusType: StatusType) => JsString(statusType.name)
+
+  def apply(statusType: String): StatusType = statusType match {
+    case "PENDING" => Pending
+    case "COMPLETED" => Completed
+    case "FAILED" => Failed
+  }
+}

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -287,8 +287,7 @@ class Uploader(val store: ImageLoaderStore,
                                  (implicit logMarker: LogMarker) = store.store(storableOptimisedImage)
 
   def loadFile(digestedFile: DigestedFile,
-               user: Principal,
-               uploadedBy: Option[String],
+               uploadedBy: String,
                identifiers: Option[String],
                uploadTime: DateTime,
                filename: Option[String],
@@ -312,7 +311,7 @@ class Uploader(val store: ImageLoaderStore,
           tempFile = tempFile,
           mimeType = Some(mimeType),
           uploadTime = uploadTime,
-          uploadedBy = uploadedBy.getOrElse(Authentication.getIdentity(user)),
+          uploadedBy = uploadedBy,
           identifiers = identifiersMap,
           uploadInfo = UploadInfo(filename)
         )

--- a/image-loader/conf/routes
+++ b/image-loader/conf/routes
@@ -3,6 +3,12 @@ POST    /images                     controllers.ImageLoaderController.loadImage(
 POST    /imports                    controllers.ImageLoaderController.importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
 GET     /images/project/:imageId    controllers.ImageLoaderController.projectImageBy(imageId: String)
 
+# Upload Status
+GET     /uploadStatus/:imageId      controllers.UploadStatusController.getUploadStatus(imageId: String)
+POST    /uploadStatus/:imageId      controllers.UploadStatusController.updateUploadStatus(imageId: String)
+
+
+
 # Management
 GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest


### PR DESCRIPTION
## What does this change?

This adds a Dynamo DB Table which is used to store images upload status 
```
case class UploadStatusRecord(
                               id: String,
                               fileName: Option[String],
                               uploadedBy: String,
                               uploadTime: String,
                               identifiers: Option[String],
                               status: StatusType,
                               errorMessage: Option[String],
                               expires: Long
                             )
```
and two endpoints 
- `GET       /uploadStatus/:imageId` , Kahuna will be polling it to Get Image upload status
- `POST    /uploadStatus/:imageId` A virus alert lambda will send an update upload Status request to it

also, Update upload status for POST /images 
- in case quarantining isn't enabled

## How can success be measured?
**When doing a curl request** to`POST https://loader.local.dev-gutools.co.uk/uploadStatus/:imageId`
with body
`{"uploadStatus":
{"id":"<imageId>", "uploadedBy":"<uploaded_by>", "fileName":"<file_name>","status":"<status>"}}`

**The expected response should be:**
`{"data":{"id":"<image_id>","uploadedBy":"<uploaded_by>","fileName":"<file_name>","status":"<status>"}}`

**When doing a curl request** to`GET https://loader.local.dev-gutools.co.uk/uploadStatus/:imageId`

**The expected response should be**
`{"data":{"id":"<image_id>","uploadedBy":"<uploaded_by>","fileName":"<file_name>","status":"<status>"}}`


This is an implementation to this proposal opened as an issue [here](https://github.com/guardian/grid/issues/3123).
## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?



## Tested?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment

## Pre-merge deployment checklist (for Guardian)
 - [x] Deploy CFN update to PROD (see https://github.com/guardian/editorial-tools-platform/pull/480)
 - [x] Add configuration for new table to PROD env configuration