### PR TITLE
Add tooltips to thumbnails

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -90,7 +90,8 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
 
     <div class="preview__bottom-bar bottom-bar">
         <div class="bottom-bar__meta">
-            <span class="preview__upload-time">
+            <span class="preview__upload-time" title="Uploaded: {{::ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm'}}
+      Taken: {{::(ctrl.image.data.metadata.dateTaken | date:'d MMM yyyy, HH:mm') || '[none]'}}">
                 {{::ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
                 {{::ctrl.image.data.uploadTime | date:'HH:mm'}}
             </span>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -80,7 +80,9 @@
         </div>
 
         <p class="preview__description"
-           title="{{ctrl.image.data.metadata.description || ctrl.image.data.metadata.title}}">
+           title="{{ctrl.image.data.metadata.description || ctrl.image.data.metadata.title}}
+      By: {{ctrl.image.data.metadata.byline || '[none]'}}
+Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
             <!-- Ensure contents in P to maintain height -->
             {{ctrl.image.data.metadata.description || ctrl.image.data.metadata.title || '&nbsp;'}}
         </p>


### PR DESCRIPTION
This adds some tooltips on a Browser’s thumbnails:
- `By` and `Credit` when hovering over Description-or-Title bottom text
- `Uploaded` and `Taken` when hovering over Date text

It displays eg. `Credit: [none]` when values are empty. One reason for that is that it’s useful for it to be clear that the value is empty. Another reason is that it would take me a year to learn how to hide something when it’s not there. A happy coincidence, I think.

This allows to quickly glance more metadata by hovering over a thumbnail without the need to resort to selecting a picture or going into the Viewer. Additionally, hovering over a date makes it clear we only ever display the date a picture was uploaded on. 

Tooltips are bad for accessibility and do not work on touch devices, but Grid is poor on touch devices and we use them tooltips anyway. This doesn’t contain any information that is not otherwise accessible.

## Before:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/6032869/105782956-45ad6e80-5f6d-11eb-8b89-1a6e9e469db2.png">

## After:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/6032869/105782987-5a8a0200-5f6d-11eb-80bb-e133c8aee270.png">

## New:

<img width="240" alt="image" src="https://user-images.githubusercontent.com/6032869/105783032-74c3e000-5f6d-11eb-9055-07b40602607c.png">

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
