### PR TITLE
We will always have (results for) Paris

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/IndexSettings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/IndexSettings.scala
@@ -22,9 +22,9 @@ object IndexSettings {
     )
 
     val filters: List[TokenFilter] = List(
-// I (Justin) don't think we need to specify these, but can just refer to them by name (below)
-//      LowercaseTokenFilter,
-//      AsciiFoldingTokenFilter,
+      // I (Justin) don't think we need to specify these, but can just refer to them by name (below)
+      // LowercaseTokenFilter,
+      // AsciiFoldingTokenFilter,
       StemmerTokenFilter(name = english_possessive_stemmer, lang = "possessive_english"),
       StopTokenFilter(name = gu_stopwords, stopwords = Seq("_english_")),
       StemmerTokenFilter(name = s_stemmer, lang = "minimal_english")

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -20,8 +20,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
   private def makeMultiQuery(value: Value, fields: Seq[String]): MultiMatchQuery = value match {
     case Words(value) => ElasticDsl.multiMatchQuery(value).fields(fields).
       operator(Operator.AND).
-      matchType(MultiMatchQueryBuilderType.CROSS_FIELDS).
-      analyzer(IndexSettings.englishSStemmerAnalyzerName)
+      matchType(MultiMatchQueryBuilderType.CROSS_FIELDS)
     case Phrase(string) => multiMatchPhraseQuery(string, fields)
     // That's OK, we only do date queries on a single field at a time
     case e => throw InvalidQuery(s"Cannot do multiQuery on $e")

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -135,7 +135,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     case "publication" => MultipleField(List("publicationName", "publicationCode"))
     case "section" => MultipleField(List("sectionId","sectionCode"))
     case "reference" => MultipleField(List("references.uri", "references.name").map(usagesField))
-    case "in" => MultipleField(List("location", "city", "state", "country").map(getFieldPath))
+    case "in" => MultipleField(List("subLocation", "city", "state", "country").map(getFieldPath))
     case field => SingleField(getFieldPath(field))
   }
 

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -111,7 +111,6 @@ class QueryBuilderTest extends FunSpec with Matchers with ConditionFixtures {
       multiMatchClause.text shouldBe "cats dogs"
       multiMatchClause.fields.map(_.field) shouldBe matchFields
       multiMatchClause.operator shouldBe Some(Operator.AND)
-      multiMatchClause.analyzer shouldBe Some("english_s_stemmer")
       multiMatchClause.`type` shouldBe Some(MultiMatchQueryBuilderType.CROSS_FIELDS)
     }
 

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -373,7 +373,7 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
     }
 
     it("should match aliases to multiple fields") {
-      Parser.run("in:berlin") should be (List(Match(MultipleField(List("location", "city", "state", "country").map(getFieldPath)), Words("berlin"))))
+      Parser.run("in:berlin") should be (List(Match(MultipleField(List("subLocation", "city", "state", "country").map(getFieldPath)), Words("berlin"))))
     }
 
     it("should match #terms as labels") {


### PR DESCRIPTION
## What does this change?

The BBC mentioned that searches for `in:Paris` were failing unless it was quoted `in:"Paris"`. These quotes trigger the `Phrase` analyser to be used instead of `Words`. This was deliberately setting a stemmer, which appeared to be stemming Paris to Pari. (pronounced same) 

This removes the explicit setting of the english S stemmer for multi queries. In [elastics docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html) this allows fields with heterogeneous analysers to be combined in cross match queries (allowing a match to be located in any one of the fields present). However, [these are all](https://github.com/guardian/grid/blob/b24a767c4150ff25418a5f13eaf7ba25778a7ebd/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala#L96) `standardAnalysed` fields- which would suggest only applying the stemmer.

## ~Questions~ Answers

1. Are we stemming when we write the fields? 
	- Yes, but to the `englishAnalysedCatchAll` field, I don't think this query would read that unless ✨elasticsearch✨ was doing magic.
2. Here https://github.com/guardian/grid/blob/2a2303bcdf112628f8b9ae7a651f8b2871eb4ea9/media-api/app/lib/querysyntax/QuerySyntax.scala#L123-L140 where `in` maps to `location`, why doesn't it actually map to `subLocation`.
	- Cannot find a good reason for this, so I've gone and fixed it.
	- There is no mapping for `location` apart from `subLocation`.
3. Is the test (changed in this PR) deliberate about it's need for the stemmer or does the test just match the existing code?
	- Discussed with @mbarton and we can't see a reason this stemmer would have been applied to the query.
	- Looks like it came across in the es migration.
4. Are we correctly constructing the query here, what is the _right_ stemmer etc to use for our mappings?
	- We could outsource more of this to es defaults, but that's a lot of pain for marginal (if any) gain.

## How can success be measured?

Number of images in:Paris.

This may be related to https://github.com/guardian/grid/issues/1523 

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![image](https://user-images.githubusercontent.com/2670496/105841749-0adb2300-5fcd-11eb-846b-8c29017d8880.png)
![image](https://user-images.githubusercontent.com/2670496/105878618-22300580-5ff9-11eb-86bd-f157b1cded9e.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
