### PR TITLE
[BBC] Search on the value of arbitrary fields

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -22,13 +22,13 @@ object Mappings {
       val maximumStringLengthToStore = (maximumBytesOfKeywordInUnderlyingLuceneIndex * .9).toInt
 
       dynamicTemplate("file_metadata_fields_as_keywords").
-        mapping(dynamicKeywordField().index(false).store(true).ignoreAbove(maximumStringLengthToStore)).
+        mapping(dynamicKeywordField().index(true).store(true).ignoreAbove(maximumStringLengthToStore)).
         pathMatch("fileMetadata.*").matchMappingType("string")
     }
 
     def storedJsonObjectTemplate: DynamicTemplateRequest = {
       dynamicTemplate("stored_json_object_template").
-        mapping(dynamicType().index(false).store(true)).
+        mapping(dynamicType().index(true).store(true)).
         pathMatch("fileMetadata.*")
     }
 

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -345,7 +345,7 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
       // TODO: or better, return parse error to client?
       it("should ignore an invalid date argument") {
         Parser.run("date:NAZGUL") should be (List(
-          Match(AnyField, Words("date:NAZGUL"))
+          Match(SingleField("date"), Words("NAZGUL"))
         ))
       }
 
@@ -498,7 +498,47 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
 
     it("should not match unrelated file types") {
       Parser.run("fileType:catsdogs") should be (List(
-        Match(AnyField, Words("fileType:catsdogs"))
+        Match(SingleField("fileType"), Words("catsdogs"))
+      ))
+    }
+  }
+
+  describe("quoted field search") {
+    it("should match a quoted field search") {
+      Parser.run(""""fieldDogs":cats""") should be (List(
+        Match(SingleField("fieldDogs"), Words("cats"))
+      ))
+    }
+
+    it("should match a quoted field search with  colons") {
+      Parser.run(""""fieldDogs:dinosaur:lemur":cats""") should be (List(
+        Match(SingleField("fieldDogs:dinosaur:lemur"), Words("cats"))
+      ))
+    }
+
+    it("should match a quoted field search colons, and a search term with quotes and colons") {
+      Parser.run(""""fieldDogs":"cats:are:fun"""") should be (List(
+        Match(SingleField("fieldDogs"), Phrase("cats:are:fun"))
+      ))
+    }
+
+    it("should match a quoted field search with colons and spaces") {
+      Parser.run(""""fieldDogs: dinosaur:lemur":cats""") should be (List(
+        Match(SingleField("fieldDogs: dinosaur:lemur"), Words("cats"))
+      ))
+    }
+
+    it("should match a field search with colons and spaces") {
+      Parser.run("fieldDogs : dinosaur:lemur:cats") should be (List(
+        Match(AnyField,Words("fieldDogs :")),
+        Match(SingleField("dinosaur"),Words("lemur:cats"))
+      ))
+    }
+
+    it("should match two field queries") {
+      Parser.run("fieldDogs:dinosaur lemur:cats") should be (List(
+        Match(SingleField("fieldDogs"),Words("dinosaur")),
+        Match(SingleField("lemur"),Words("cats"))
       ))
     }
   }


### PR DESCRIPTION
## What does this change?

It introduces the search of arbitrary fields with the syntax `field:value` or with quotes on the field or on the value, so it is possible to search `"field":value`, `field:"value"` or `"field":"value"`. When search without quotes, the parser will not with colons on either _field_ or _value_
This solves https://github.com/guardian/grid/issues/3100 while adopting the syntax suggested on the discussion of the issue.

PS: Created as draft because I'll be introducing some more testing.

## How can success be measured?
Try to search some fields that are not currently covered by past solutions and ensure that past search terms are not affected.

## Screenshots
![newSyntaxSrch3](https://user-images.githubusercontent.com/128418/105937908-3abe1100-6035-11eb-8dfc-7883a47a64f7.PNG)


## Who should look at this?
@guardian/digital-cms @wainaina 


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
