### PR TITLE
respect max query in ui

### DIFF
--- a/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
+++ b/kahuna/public/js/components/gu-lazy-table/gu-lazy-table.js
@@ -25,6 +25,8 @@ export var lazyTable = angular.module('gu.lazyTable', [
     'util.seq'
 ]);
 
+// Set in ElasticSearchModel.scala
+const maxSize = 200;
 
 
 function asInt(string) {
@@ -97,6 +99,13 @@ lazyTable.controller('GuLazyTableCtrl', ['range', function(range) {
             filter(({$start, $end}) => $start !== -1 && $end !== -1).
             // Ignore if $start after $end (incomplete combine$ state)
             filter(({$start, $end}) => $start <= $end).
+            // Max query size
+            map(({$start, $end})=> {
+              if (($end - $start) < maxSize) {
+                return {$start, $end};
+              }
+              return {$start, $end: $start + maxSize - 1};
+            }).
             distinctUntilChanged(({$start, $end}) => `${$start}-${$end}`);
 
         // Placeholders

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -189,6 +189,8 @@ object SearchParams {
 
   type SearchParamValidation = Validation[InvalidUriParams, SearchParams]
   type SearchParamValidations = ValidationNel[InvalidUriParams, SearchParams]
+
+  // Also adjust in gu-lazy-table.js
   val maxSize = 200
 
   def validate(searchParams: SearchParams): SearchParamValidations = {


### PR DESCRIPTION
## What does this change?

Media-Api sets a limit of 200 to the query size, but kahuna doesn't respect it. This causes it to fail to fetch search results if more than 200 images fit in the user viewport. 

This restricts the maximum query size that gu-lazy-table can make, this allows kahuna to repeat the query and get all the results.

Fixes https://github.com/guardian/grid/issues/3138

## How can success be measured?

Load the grid, zoom out until >200 images are displayed.
Reload the page. 

Before: no images will be shown.
After: works as expected. 

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
Let's presume a special version of the grid for these screenshots, called the 'gr'. 
For some reason the max query size is 5.

Before:
![image](https://user-images.githubusercontent.com/2670496/106269862-014bf800-6225-11eb-8c18-8f028ce325c7.png)
After:
![image](https://user-images.githubusercontent.com/2670496/106270434-e8901200-6225-11eb-9cd9-4220716a57a7.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
