### PR TITLE
Read XMP and IPTC country code fields before verbal names

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -89,7 +89,9 @@ object ImageMetadataConverter extends GridLogging {
                             fileMetadata.iptc.get("City"),
       state               = readXmpHeadStringProp("photoshop:State") orElse
                             fileMetadata.iptc.get("Province/State"),
-      country             = readXmpHeadStringProp("photoshop:Country") orElse
+      country             = readXmpHeadStringProp("Iptc4xmpCore:CountryCode") orElse
+                            fileMetadata.iptc.get("Country/Primary Location Code") orElse
+                            readXmpHeadStringProp("photoshop:Country") orElse
                             fileMetadata.iptc.get("Country/Primary Location Name"),
       subjects            = extractSubjects(fileMetadata),
       peopleInImage       = extractPeople(fileMetadata)


### PR DESCRIPTION
Every broken thing blocks fixing something else. `+in:Paris -in:France` search revealed that some images do not have country verbal names fields in XMP or IPTC, but do have [respective country code fields](https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#country-code-legacy): `Iptc4xmpCore:CountryCode` (XMP) and `Country/Primary Location Code` (IPTC). As we already have [a parser](https://github.com/guardian/grid/blob/878cc90e2e74fe183831e7c822cc143275179127/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala) for both two- and three-letter country codes, in this PR they are read first now (as usual: XMP, then IPTC). Only if they are missing, and attempt is made to read verbal names.

This reduces the number of images without the `Country` field present and allows more robust location-based searches. As the comment indicates, we should read the [newer location shown](https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#location-shown-in-the-image) metadata over the legacy one we read currently, but as this has [its own structure](https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#location-structure), it may require a change in our own model and, even if not, it requires its own parser, so is too hard a nut to crack for this Sunday committer.

# Before
<img width="271" alt="image" src="https://user-images.githubusercontent.com/6032869/106217065-57408180-61cc-11eb-9255-57cc97faa1d6.png">

# After
<img width="263" alt="image" src="https://user-images.githubusercontent.com/6032869/106217092-67586100-61cc-11eb-89f0-8db2cac30e1c.png">

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
