### PR TITLE
Read country verbal names before falling back to country codes

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -92,7 +92,7 @@ object ImageMetadataConverter extends GridLogging {
       country             = readXmpHeadStringProp("photoshop:Country") orElse
                             fileMetadata.iptc.get("Country/Primary Location Name") orElse
                             readXmpHeadStringProp("Iptc4xmpCore:CountryCode") orElse
-                            fileMetadata.iptc.get("Country/Primary Location Code") orElse,
+                            fileMetadata.iptc.get("Country/Primary Location Code"),
       subjects            = extractSubjects(fileMetadata),
       peopleInImage       = extractPeople(fileMetadata)
     )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -89,10 +89,10 @@ object ImageMetadataConverter extends GridLogging {
                             fileMetadata.iptc.get("City"),
       state               = readXmpHeadStringProp("photoshop:State") orElse
                             fileMetadata.iptc.get("Province/State"),
-      country             = readXmpHeadStringProp("Iptc4xmpCore:CountryCode") orElse
-                            fileMetadata.iptc.get("Country/Primary Location Code") orElse
-                            readXmpHeadStringProp("photoshop:Country") orElse
-                            fileMetadata.iptc.get("Country/Primary Location Name"),
+      country             = readXmpHeadStringProp("photoshop:Country") orElse
+                            fileMetadata.iptc.get("Country/Primary Location Name") orElse
+                            readXmpHeadStringProp("Iptc4xmpCore:CountryCode") orElse
+                            fileMetadata.iptc.get("Country/Primary Location Code") orElse,
       subjects            = extractSubjects(fileMetadata),
       peopleInImage       = extractPeople(fileMetadata)
     )


### PR DESCRIPTION
https://github.com/guardian/grid/pull/3140/ introduced reading country codes and that’s useful if verbal names are not there. But it turns out, if unrecognised codes are encountered, the verbal names are not read at all now, because our CountryCode cleaner operates on the first values encountered.

And we are seeing some images with unrecognised codes (eg. `POR`, `ROM`, `GZA`), but with correct (or just more useful) verbal names (respectively, `Portugal`, `Romania`, `Gaza`).

This won’t be perfect, but we can be only as good when trying to clean the data provided. It will fail when a verbal name contains gibberish, but a country code is correct. We are taking a leap of faith that this is a less common scenario than what this PR tries to solve.

It should provide better location data.