### PR TITLE
Revert "update cropperjs"

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -5367,8 +5367,8 @@
       "integrity": "sha512-yzcHpPMLQl0232nDzm5P4iAFTFQ9dMw0QgFLuKYbDj9M0xJ62z0oudYD/Lvh1pWfRsukiytP4Xj6BHOSrSXP8A=="
     },
     "angular-ui-router": {
-      "version": "git+ssh://git@github.com/angular-ui/ui-router.git#ef38bc78495ec7719dcd6876886cf5a27420f330",
-      "from": "angular-ui-router@angular-ui/ui-router#0.4.3",
+      "version": "github:angular-ui/ui-router#ef38bc78495ec7719dcd6876886cf5a27420f330",
+      "from": "github:angular-ui/ui-router#0.4.3",
       "requires": {
         "angular": "^1.0.8"
       }
@@ -7267,9 +7267,9 @@
       }
     },
     "cropperjs": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.9.tgz",
-      "integrity": "sha512-aPWlg43sLIcYN4GBXIdyvM09wNPgn1ug+vNVwV8jlb3dbgEX/B34Iw6hrjGSajkUDQBmaCi6uPOevFb7N0yUsw=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-0.7.2.tgz",
+      "integrity": "sha1-atinHbAGKbqULZzt5lKyeXXp50o="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -16918,8 +16918,8 @@
       }
     },
     "titip": {
-      "version": "git+ssh://git@github.com/guardian/titip.git#7309889a1747e85cbe58345621f911c36b68decd",
-      "from": "titip@guardian/titip#1.0.0"
+      "version": "github:guardian/titip#7309889a1747e85cbe58345621f911c36b68decd",
+      "from": "github:guardian/titip#1.0.0"
     },
     "tmp": {
       "version": "0.0.33",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -11,7 +11,7 @@
     "angular-xeditable": "^0.8.1",
     "any-http-angular": "^0.1.0",
     "any-promise-angular": "^0.1.1",
-    "cropperjs": "^1.5.9",
+    "cropperjs": "^0.7.0",
     "immutable": "^3.7.5",
     "javascript-detect-element-resize": "^0.5.3",
     "jszip": "2.6.1",

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -58,7 +58,7 @@ cropBox.directive('uiCropBox', [
                     responsive: false,
                     autoCropArea: 1,
                     crop: update,
-                    ready: getRatio
+                    built: getRatio
                 };
 
                 cropper = new Cropper(image, options);


### PR DESCRIPTION
Reverts guardian/grid#3144. Users are reporting Crop button not doing anything if pressed **without** any adjustments to the size or position of a crop frame. I have validated it works before the update to cropper.