### PR TITLE
Make country extraction more reliable.

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala
@@ -22,7 +22,16 @@ object CountryCode extends ImageProcessor with GridLogging {
       localeCodesAndNames.map(c => c.threeCode -> c.displayName).toMap ++
       Map(
         "UK" -> "United Kingdom",
-        "GB" -> "United Kingdom"
+        "GB" -> "United Kingdom",
+        "GDR" -> "German Democratic Republic",
+        "GRG" -> "Georgia",
+        "KOS" -> "Kosovo",
+        "POR" -> "Portugal",
+        "ROM" -> "Romania",
+        "SAR" -> "Saudi Arabia",
+        "SER" -> "Serbia",
+        "UAE" -> "United Arab Emirates",
+        "XKO" -> "Kosovo",
       )
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/CountryCode.scala
@@ -1,44 +1,64 @@
 package com.gu.mediaservice.lib.cleanup
 
 import java.util.Locale
-
 import com.gu.mediaservice.lib.logging.GridLogging
-import com.gu.mediaservice.model.ImageMetadata
+import com.gu.mediaservice.model.{FileMetadata, Image, ImageMetadata}
+import play.api.libs.json.{JsArray, JsString}
 
 /**
   * Cleaner that maps 2/3 letter country codes onto country names
   */
-object CountryCode extends MetadataCleaner with GridLogging {
+object CountryCode extends ImageProcessor with GridLogging {
 
-  val TwoLetterCode   = """([A-Z]{2})""".r
-  val ThreeLetterCode = """([A-Z]{3})""".r
 
-  val allLocales = Locale.getISOCountries.map(new Locale("", _))
+  private val codes = {
+    case class CountryWithCodes(twoCode: String, threeCode: String, displayName: String)
+    val localeCodesAndNames = Locale.getISOCountries.map(twoCode => {
+      val locale = new Locale("", twoCode)
+      CountryWithCodes(twoCode, locale.getISO3Country, locale.getDisplayName)
+    }).toList
 
-  def mapTwoLetterCode(code: String): String = {
-    new Locale("", canonicalTwoLetterCode(code)).getDisplayName
+    localeCodesAndNames.map(c => c.twoCode -> c.displayName).toMap ++
+      localeCodesAndNames.map(c => c.threeCode -> c.displayName).toMap ++
+      Map(
+        "UK" -> "United Kingdom",
+        "GB" -> "United Kingdom"
+      )
   }
 
-  def mapThreeLetterCode(code: String): String = {
-    // Rather inefficient O(n) lookup, seemingly no built-in lookup for ISO3 codes
-    val matchingLocale = allLocales.find(_.getISO3Country == code)
-    matchingLocale.map(_.getDisplayName) getOrElse {
-      logger.warn(s"Failed to map three-letter code to country name: $code")
-      code
+  def findCode(code: String): Option[String] = {
+    codes.get(code) match {
+      case None => {
+        logger.warn(s"Failed to map code to country name: $code")
+        None
+      }
+      case Some(string) => Some(string)
     }
+
   }
 
-  def canonicalTwoLetterCode(code: String): String = code match {
-    // Map erroneous "UK" code to its correct equivalent
-    case "UK" => "GB"
-    case c    => c
+  def getCountryName(countryOrCode: String): Option[String] = countryOrCode match {
+    case code if code.length <= 3 => findCode(countryOrCode)
+    // longer than 3 letters, just pass through
+    // nb, say if we made this 4 to allow USSR then we'd warn on Chad
+    // 5 is left as an exercise for the reader
+    case _ => None
   }
 
-  override def clean(metadata: ImageMetadata): ImageMetadata = metadata.country match {
-    case Some(TwoLetterCode(code))   => metadata.copy(country = Some(mapTwoLetterCode(code)))
-    case Some(ThreeLetterCode(code)) => metadata.copy(country = Some(mapThreeLetterCode(code)))
-    // No country or not a code, just pass through
-    case Some(country) => metadata
-    case None          => metadata
+  def clean(metadata: ImageMetadata, fileMetadata: FileMetadata): ImageMetadata = {
+    // These are the locations we check (in order) for the country code.
+    val maybeCountries = (List(
+      fileMetadata.readXmpHeadStringProp("photoshop:Country"),
+      fileMetadata.iptc.get("Country/Primary Location Name"),
+      fileMetadata.readXmpHeadStringProp("Iptc4xmpCore:CountryCode"),
+      fileMetadata.iptc.get("Country/Primary Location Code")
+    )).flatten.flatMap(getCountryName)
+    val country = maybeCountries.headOption orElse metadata.country
+
+
+    metadata.copy(country = country)
   }
+
+
+  override def apply(image: Image): Image = image.copy(metadata = clean(image.metadata, image.fileMetadata))
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/FileMetadata.scala
@@ -33,6 +33,16 @@ case class FileMetadata(
 
     MarkerMap(markers)
   }
+
+  def readXmpHeadStringProp: (String) => Option[String] = (name: String) => {
+    val res = xmp.get(name) match {
+      case Some(JsString(value)) => Some(value.toString)
+      case Some(JsArray(value)) =>
+        value.find(_.isInstanceOf[JsString]).map(_.as[String])
+      case _ => None
+    }
+    res
+  }
 }
 
 object FileMetadata {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/CountryCodeTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/CountryCodeTest.scala
@@ -1,59 +1,93 @@
 package com.gu.mediaservice.lib.cleanup
 
+import com.gu.mediaservice.model.FileMetadata
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.{JsArray, JsString}
 
 
 class CountryCodeTest extends FunSpec with Matchers with MetadataHelper {
 
   it("should not change a correct country name") {
-    clean("Switzerland") should be (Some("Switzerland"))
+    // no matter where you put Switzerland, it should come out as Switzerland
+    all(clean("Switzerland", "Switzerland")) should be(Some("Switzerland"))
   }
 
   it("should not change an uppercase country name") {
-    clean("SWITZERLAND") should be (Some("SWITZERLAND"))
+    all(clean("SWITZERLAND", "SWITZERLAND")) should be(Some("SWITZERLAND"))
   }
 
   it("should map a 2-letter country code to its name") {
-    clean("CH") should be (Some("Switzerland"))
+    all(clean("CH", "Confoederatio Helvetica")) should be(Some("Switzerland"))
   }
 
   it("should not change an invalid 2-letter country code") {
-    clean("XX") should be (Some("XX"))
+    all(clean("XX", "XX")) should be(Some("XX"))
   }
 
   it("should map a 3-letter country code to its name") {
-    clean("CHN") should be (Some("China"))
+    all(clean("CHN", "")) should be(Some("China"))
   }
 
   it("should not change an invalid 3-letter country code") {
-    clean("XXX") should be (Some("XXX"))
+    all(clean("XXX", "XXX")) should be(Some("XXX"))
   }
 
   // Exception: United Kingdom
 
   it("should map the UK country code to United Kingdom") {
-    clean("UK") should be (Some("United Kingdom"))
+    all(clean("UK", "Plague Island")) should be(Some("United Kingdom"))
   }
 
   it("should map the GB country code to United Kingdom") {
-    clean("GB") should be (Some("United Kingdom"))
+    all(clean("GB", "Brittany")) should be(Some("United Kingdom"))
   }
 
   // Exception: United States
 
   it("should map the US country code to United States") {
-    clean("US") should be (Some("United States"))
+    all(clean("US", "America")) should be(Some("United States"))
   }
 
   it("should map the USA country code to United States") {
-    clean("USA") should be (Some("United States"))
+    all(clean("USA", "America")) should be(Some("United States"))
   }
 
 
-  def clean(country: String): Option[String] = {
-    CountryCode.clean(createImageMetadata("country" -> country)).country
+  def clean(code: String, name: String): List[Option[String]] = {
+    List(
+      CountryCode.clean(
+        createImageMetadata("country" -> name),
+        fileMetadata(maybeIptcCountryCode = Some(code), maybeIptcCountryName = Some(name))).country,
+      CountryCode.clean(
+        createImageMetadata("country" -> name),
+        fileMetadata(maybeIptcXmpCountryCode = Some(code), maybeIptcCountryName = Some(name))).country,
+      CountryCode.clean(
+        createImageMetadata("country" -> name),
+        fileMetadata(maybeIptcCountryCode = Some(code), maybePhotoshopCountry = Some(name))).country,
+      CountryCode.clean(
+        createImageMetadata("country" -> name),
+        fileMetadata(maybePhotoshopCountry = Some(code), maybeIptcCountryName = Some(name))).country
+    )
   }
 
+  def fileMetadata(maybeIptcCountryName: Option[String] = None,
+                   maybeIptcCountryCode: Option[String] = None,
+                   maybeIptcXmpCountryCode: Option[String] = None,
+                   maybePhotoshopCountry: Option[String] = None
+                  ): FileMetadata = {
+    FileMetadata(
+      iptc = List(
+        maybeIptcCountryName.map("Country/Primary Location Name" -> _),
+        maybeIptcCountryCode.map("Country/Primary Location Code" -> _)
+      ).flatten.toMap,
+      exif = Map(),
+      exifSub = Map(),
+      xmp = List(
+        maybePhotoshopCountry.map(c => "photoshop:Country" -> JsString(c)),
+        maybeIptcXmpCountryCode.map(c => "Iptc4xmpCore:CountryCode" -> JsString(c))
+      ).flatten.toMap
+    )
+  }
 }
 
 


### PR DESCRIPTION
## What does this change?

This seperates the logic for finding a fallback country _name_ from finding a country name from an ISO code. 

This also swaps our weird Locale array search for a pair of `Map`s for 2 and 3 letter codes. 

The ordering remains the same, and the same fields are pulled for each check. Previously, this mattered because we would take the first `Some` and populate `metadata.country` from it. The order was tweaked to attempt to get a country name before an unidentifiable country code.  

Now, we check each field where a country may be for a code- and then see whether of those are hits. If one is a hit, then it's used. If nothing hits, then the first of them in the extractor is used. 

We could thus, drop the 'code' extractors from the extractor, and the 'name' ones from the cleaner. I'm not sure whether image data backs this up- so have left all in for completeness. 

Also, now these are maps instead of `Locales` then we can add support for more esoteric country codes- and probably drop the 2-3 letter code distinction by just testing all of the names against the maps. 

## How can success be measured?

Better country metadata. 
Hopefully the existing tests for this cleaner will both just work, validating this change. 🤞🏻

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->
@paperboyo what ordering should we use for this?

## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
