### PR TITLE
remove uri-templates

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -17195,11 +17195,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "uri-templates": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.1.5.tgz",
-      "integrity": "sha1-TTpz/m8MTeET8skLnXo8wyO3cK4="
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -27,8 +27,7 @@
     "theseus": "0.5.2",
     "theseus-angular": "^0.3.1",
     "titip": "guardian/titip#1.0.0",
-    "ui-router-extras": "^0.1.3",
-    "uri-templates": "0.1.5"
+    "ui-router-extras": "^0.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
## What does this change?

It looks like we removed `uri-templates` [a while back](https://github.com/guardian/grid/commit/59a05a06c23300682d6dfb2e5334cdcfcb502525) and now Snyk is [complaining that it needs updating](https://github.com/guardian/grid/pull/3135) but there's [no changelog etc.](https://github.com/geraintluff/uri-templates/issues/26) for that build. 

Anyway, this closes #3135.

## How can success be measured?

Note that `uri-templates` and `uriTemplates` both come up without other results when you search. 

## Screenshots

<img width="693" alt="image" src="https://user-images.githubusercontent.com/2670496/106638693-0c33bf00-657c-11eb-850a-1bdd63d1ffe9.png">
<img width="569" alt="image" src="https://user-images.githubusercontent.com/2670496/106638699-0dfd8280-657c-11eb-9c59-76f3ae12a4ed.png">

<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
