### PR TITLE
Canonicalise and dedupe Sportsphoto in Allstar credit

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -136,10 +136,11 @@ trait CanonicalisingImageProcessor extends ImageProcessor {
       case Some(credit) => {
         val creditAcc = credit.split(Slash)
           .foldLeft((List[String](),false))((acc, s) => {
-            s match {
-              case regexResultExtractor(_) if !acc._2 => (acc._1 :+ canonicalName, true)
-              case regexResultExtractor(_) if acc._2 => acc
-              case _ => (acc._1 :+ s, acc._2)
+            val (creditList, foundFlag) = acc
+            getPrefixAndSuffix(Some(s)) match {
+              case Some(_) if !foundFlag => (creditList :+ canonicalName, true)
+              case Some(_) if foundFlag => acc
+              case None => (creditList :+ s, foundFlag)
             }
           })
           val creditString = creditAcc._1.mkString(Slash)

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -187,7 +187,23 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.byline should be (None)
     }
 
+    it ("should canonicalise and dedupe 'Sportsphoto' in credit") {
+      val image = createImageFromMetadata("credit" -> "Sportsphoto/Sportsphoto Ltd.")
+      val processedImage = applyProcessors(image)
+      processedImage.metadata.credit should be (Some("Sportsphoto"))
+    }
 
+    it ("should append 'Allstar' when 'Sportsphoto' is in credit") {
+      val image = createImageFromMetadata("credit" -> "Sportsphoto/Allstar/Sportsphoto Ltd.")
+      val processedImage = applyProcessors(image)
+      processedImage.metadata.credit should be (Some("Sportsphoto/Allstar"))
+    }
+
+    it ("should maintain order of rest of credit") {
+      val image = createImageFromMetadata("credit" -> "A/B/C/D/Sportsphoto/E/F/G/H/Sportsphoto Ltd./I/J/K/L")
+      val processedImage = applyProcessors(image)
+      processedImage.metadata.credit should be (Some("A/B/C/D/E/F/G/H/I/J/K/L/Sportsphoto"))
+    }
   }
 
   describe("AP") {


### PR DESCRIPTION
Co-authored-by: Justin Rowles <justin.rowles.freelance@guardian.co.uk>

## What does this change?
This PR follows on from the ['Fix Allstar credit' PR](https://github.com/guardian/grid/pull/3086). Here:

- we add deduping for 'Allstar' and 'Sportsphoto' in the credit, so each term only appears once. 'Sportsphoto/Sportsphoto Ltd.' -> 'Sportsphoto'
- we ensure that if both 'Sportsphoto' and 'Allstar' are present in the credit, 'Allstar' is placed at the end, so that the credit ends with '/Sportsphoto/Allstar'
- we transform 'Sportsphoto Ltd' and 'Sportsphoto Ltd.' into the canonical name 'Sportsphoto'.

## How can success be measured?

Credits for Allstar/Sportsphoto are correctly formatted.

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
