### PR TITLE
Refactor to make lambda work

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -2,7 +2,8 @@ package com.gu.mediaservice
 
 import java.io.IOException
 import java.net.URL
-import com.gu.mediaservice.lib.auth.provider.ApiKeyAuthenticationProvider
+
+import com.gu.mediaservice.lib.auth.provider.ApiKeyAuthentication
 import com.typesafe.scalalogging.LazyLogging
 import okhttp3._
 import play.api.libs.json.{JsValue, Json}
@@ -38,7 +39,7 @@ object GridClient {
   def apply(maxIdleConnections: Int, debugHttpResponse: Boolean = true): GridClient = new GridClient(maxIdleConnections, debugHttpResponse)
 }
 
-class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends LazyLogging {
+class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends ApiKeyAuthentication with LazyLogging {
 
   import java.util.concurrent.TimeUnit
 
@@ -51,7 +52,7 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends La
     .build()
 
   def makeGetRequestSync(url: URL, apiKey: String): ResponseWrapper = {
-    val request = new Request.Builder().url(url).header(ApiKeyAuthenticationProvider.apiKeyHeaderName, apiKey).build
+    val request = new Request.Builder().url(url).header(apiKeyHeaderName, apiKey).build
     val response = httpClient.newCall(request).execute
     processResponse(response, url)
   }
@@ -127,7 +128,7 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends La
   }
 
   private def makeRequestAsync(url: URL, apiKey: String): Future[Response] = {
-    val request = new Request.Builder().url(url).header(ApiKeyAuthenticationProvider.apiKeyHeaderName, apiKey).build
+    val request = new Request.Builder().url(url).header(apiKeyHeaderName, apiKey).build
     val promise = Promise[Response]()
     httpClient.newCall(request).enqueue(new Callback {
       override def onFailure(call: Call, e: IOException): Unit = promise.failure(e)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/ApiKeyAuthenticationProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/ApiKeyAuthenticationProvider.scala
@@ -9,9 +9,12 @@ import play.api.mvc.RequestHeader
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object ApiKeyAuthenticationProvider {
-  val ApiKeyHeader: TypedKey[(String, String)] = TypedKey[(String, String)]("ApiKeyHeader")
+trait ApiKeyAuthentication {
   val apiKeyHeaderName = "X-Gu-Media-Key"
+}
+
+object ApiKeyAuthenticationProvider extends ApiKeyAuthentication {
+  val ApiKeyHeader: TypedKey[(String, String)] = TypedKey[(String, String)]("ApiKeyHeader")
 }
 
 class ApiKeyAuthenticationProvider(configuration: Configuration, resources: AuthenticationProviderResources) extends MachineAuthenticationProvider with StrictLogging {


### PR DESCRIPTION
## What does this change?
Admin tools lambda has the (large) play library explicitly removed from it after build.  Recently this became a problem because there was some bleed from play into common-lib - more precisely into the bits of common lib that are used by the admin lambda.

The ultimate solution to this would be to split common-lib into play-using and non-play-using common libraries.

In the shorter term, however, a small refactoring will enable the build to work.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
