### PR TITLE
Make sportsphoto regex more explicit

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -92,7 +92,7 @@ object AllstarSportsphotoParser extends CanonicalisingImageProcessor {
   override def getAgencyName = "Allstar Picture Library"
   override def getCanonicalName: String = "Sportsphoto"
 
-  private val SportsphotoInSlashDelimitedString = "((.*)/)?(Sportsphoto( Ltd.?)?( Limited)?)(/(.*))?".r
+  private val SportsphotoInSlashDelimitedString = "((.*)/)?(Sportsphoto( Ltd\\.?)?( Limited)?)(/(.*))?".r
   override def getPrefixAndSuffix(s: Option[String]): Option[RegexResult] = {
     s match {
       case Some(SportsphotoInSlashDelimitedString(_, prefix, _, _, _, _, suffix)) => Some(RegexResult(toOption(prefix), toOption(suffix)))

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -116,6 +116,13 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
       processedImage.metadata.credit should be(Some("Sportsphoto/Allstar"))
     }
 
+    it("should match not 'Sportsphoto LtdX/Allstar' credit - but will fix case!") {
+      val image = createImageFromMetadata("credit" -> "Sportsphoto LtdX/Allstar")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be (Agency("Allstar Picture Library", Some("Sportsphoto Ltdx")))
+      processedImage.metadata.credit should be(Some("Sportsphoto Ltdx/Allstar"))
+    }
+
     it("should remove a prefix of 'Allstar' from a credit and append it to the end of the credit") {
       val image = createImageFromMetadata("credit" -> "Allstar/UNIVERSAL")
       val processedImage = applyProcessors(image)


### PR DESCRIPTION
## What does this change?
There is a mistake in the existing regex, in that it matches a dot with an _unescaped_ dot.

## How can success be measured?
See test.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
