### PR TITLE
Sanitise creation and reading of S3 user metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -246,6 +246,15 @@ lazy val usage = playProject("usage", 9009).settings(
 
 lazy val scripts = project("scripts")
   .dependsOn(commonLib)
+  .enablePlugins(JavaAppPackaging, UniversalPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      // V2 of the AWS SDK as it's easier to use for scripts and won't leak to the rest of the project from here
+      "software.amazon.awssdk" % "s3" % "2.15.81",
+      // bump jcommander explicitly as AWS SDK is pulling in a vulnerable version
+      "com.beust" % "jcommander" % "1.75"
+    )
+  )
 
 lazy val migration = project("migration")
   .dependsOn(commonLib).

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageStorage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageStorage.scala
@@ -13,9 +13,9 @@ import com.gu.mediaservice.model.MimeType
 object ImageStorageProps {
   val cacheDuration: Duration = 365 days
   val cacheForever: String = s"max-age=${cacheDuration.toSeconds}"
-  val filenameMetadataKey: String = "file_name"
-  val uploadTimeMetadataKey: String = "upload_time"
-  val uploadedByMetadataKey: String = "uploaded_by"
+  val filenameMetadataKey: String = "file-name"
+  val uploadTimeMetadataKey: String = "upload-time"
+  val uploadedByMetadataKey: String = "uploaded-by"
   val identifierMetadataKeyPrefix: String = "identifier!"
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageStorage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageStorage.scala
@@ -13,6 +13,10 @@ import com.gu.mediaservice.model.MimeType
 object ImageStorageProps {
   val cacheDuration: Duration = 365 days
   val cacheForever: String = s"max-age=${cacheDuration.toSeconds}"
+  val filenameMetadataKey: String = "file_name"
+  val uploadTimeMetadataKey: String = "upload_time"
+  val uploadedByMetadataKey: String = "uploaded_by"
+  val identifierMetadataKeyPrefix: String = "identifier!"
 }
 
 trait ImageStorage {

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -2,10 +2,9 @@ package model
 
 import java.io.{File, FileOutputStream}
 import java.util.UUID
-
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
-import com.gu.mediaservice.lib.{ImageIngestOperations, StorableOptimisedImage, StorableOriginalImage, StorableThumbImage}
+import com.gu.mediaservice.lib.{ImageIngestOperations, ImageStorageProps, StorableOptimisedImage, StorableOriginalImage, StorableThumbImage}
 import com.gu.mediaservice.lib.aws.S3Ops
 import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
@@ -35,28 +34,32 @@ case class S3FileExtractedMetadata(
   uploadedBy: String,
   uploadTime: DateTime,
   uploadFileName: Option[String],
-  picdarUrn: Option[String]
+  identifiers: Map[String, String]
 )
 
 object S3FileExtractedMetadata {
   def apply(s3ObjectMetadata: ObjectMetadata): S3FileExtractedMetadata = {
     val lastModified = s3ObjectMetadata.getLastModified.toInstant.toString
     val fileUserMetadata = s3ObjectMetadata.getUserMetadata.asScala.toMap
+      // The values can be URL encoded in S3 metadata and it is safe to decode everything (based on the tested corpus)
+      .mapValues(URI.decode)
 
-    val uploadedBy = fileUserMetadata.getOrElse("uploaded_by", "re-ingester")
-    val uploadedTimeRaw = fileUserMetadata.getOrElse("upload_time", lastModified)
+    val uploadedBy = fileUserMetadata.getOrElse(ImageStorageProps.uploadedByMetadataKey, "re-ingester")
+    val uploadedTimeRaw = fileUserMetadata.getOrElse(ImageStorageProps.uploadTimeMetadataKey, lastModified)
     val uploadTime = new DateTime(uploadedTimeRaw).withZone(DateTimeZone.UTC)
-    val picdarUrn = fileUserMetadata.get("identifier!picdarurn")
+    val identifiers = fileUserMetadata.filter{ case (key, _) =>
+      key.startsWith(ImageStorageProps.identifierMetadataKeyPrefix)
+    }.map{ case (key, value) =>
+      key.stripPrefix(ImageStorageProps.identifierMetadataKeyPrefix) -> value
+    }
 
-    val uploadFileNameRaw = fileUserMetadata.get("file_name")
-    // The file name is URL encoded in  S3 metadata
-    val uploadFileName = uploadFileNameRaw.map(URI.decode)
+    val uploadFileName = fileUserMetadata.get(ImageStorageProps.filenameMetadataKey)
 
     S3FileExtractedMetadata(
       uploadedBy = uploadedBy,
       uploadTime = uploadTime,
       uploadFileName = uploadFileName,
-      picdarUrn = picdarUrn,
+      identifiers = identifiers,
     )
   }
 }
@@ -96,14 +99,10 @@ class Projector(config: ImageUploadOpsCfg,
 
   def projectImage(srcFileDigest: DigestedFile, extractedS3Meta: S3FileExtractedMetadata, requestId: UUID)
                   (implicit ec: ExecutionContext, logMarker: LogMarker): Future[Image] = {
-    import extractedS3Meta._
     val DigestedFile(tempFile_, id_) = srcFileDigest
-    // TODO more identifiers_ to rehydrate
-    val identifiers_ = picdarUrn match {
-      case Some(value) => Map[String, String]("picdarURN" -> value)
-      case _ => Map[String, String]()
-    }
-    val uploadInfo_ = UploadInfo(filename = uploadFileName)
+
+    val identifiers_ = extractedS3Meta.identifiers
+    val uploadInfo_ = UploadInfo(filename = extractedS3Meta.uploadFileName)
 
     MimeTypeDetection.guessMimeType(tempFile_) match {
       case util.Left(unsupported) => Future.failed(unsupported)
@@ -113,8 +112,8 @@ class Projector(config: ImageUploadOpsCfg,
           imageId = id_,
           tempFile = tempFile_,
           mimeType = Some(mimeType),
-          uploadTime = uploadTime,
-          uploadedBy,
+          uploadTime = extractedS3Meta.uploadTime,
+          uploadedBy = extractedS3Meta.uploadedBy,
           identifiers = identifiers_,
           uploadInfo = uploadInfo_
         )

--- a/image-loader/app/model/upload/UploadRequest.scala
+++ b/image-loader/app/model/upload/UploadRequest.scala
@@ -1,12 +1,14 @@
 package model.upload
 
+import com.gu.mediaservice.lib.ImageStorageProps
+
 import java.io.File
 import java.util.UUID
-
 import com.gu.mediaservice.model.{MimeType, UploadInfo}
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
+
 import scala.collection.JavaConverters._
 
 case class UploadRequest(
@@ -20,7 +22,9 @@ case class UploadRequest(
                           uploadInfo: UploadInfo
                         ) {
 
-  val identifiersMeta: Map[String, String] = identifiers.map { case (k, v) => (s"identifier!$k", v) }
+  val identifiersMeta: Map[String, String] = identifiers.map { case (k, v) =>
+    (s"${ImageStorageProps.identifierMetadataKeyPrefix}$k", v)
+  }
 
   def toLogMarker: LogstashMarker = {
     val fallback = "none"

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -159,7 +159,7 @@ class ProjectorTest extends FunSuite with Matchers with ScalaFutures with Mockit
       uploadedBy = uploadedBy,
       uploadTime = uploadTime,
       uploadFileName = uploadFileName,
-      picdarUrn = None,
+      identifiers = Map.empty,
     )
 
     implicit val requestLoggingContext = RequestLoggingContext()

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -2,9 +2,9 @@ package model
 
 import java.io.File
 import java.net.URI
-import java.util.UUID
-
+import java.util.{Date, UUID}
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ObjectMetadata
 import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.RequestLoggingContext
@@ -15,13 +15,14 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{FreeSpec, FunSuite, Matchers}
 import play.api.libs.json.{JsArray, JsString}
 import test.lib.ResourceHelpers
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.JavaConverters._
 
-class ProjectorTest extends FunSuite with Matchers with ScalaFutures with MockitoSugar {
+class ProjectorTest extends FreeSpec with Matchers with ScalaFutures with MockitoSugar {
 
   import ResourceHelpers.fileAt
 
@@ -39,7 +40,7 @@ class ProjectorTest extends FunSuite with Matchers with ScalaFutures with Mockit
   // FIXME temporary ignored as test is not executable in CI/CD machine
   // because graphic lib files like srgb.icc, cmyk.icc are in root directory instead of resources
   // this test is passing when running on local machine
-  ignore("projectImage") {
+  "projectImage" ignore {
 
     val testFile = fileAt("resources/getty.jpg")
     val fileDigest = DigestedFile(testFile, "id123")
@@ -168,6 +169,59 @@ class ProjectorTest extends FunSuite with Matchers with ScalaFutures with Mockit
 
     whenReady(actualFuture) { actual =>
       actual shouldEqual expected
+    }
+  }
+
+  "S3FileExtractedMetadata" - {
+    "should extract URL encoded metadata" in {
+      val s3Metadata = new ObjectMetadata()
+      s3Metadata.setLastModified(new Date(1613388118000L))
+      s3Metadata.setUserMetadata(Map(
+        "file-name" -> "This%20photo%20was%20taken%20in%20%C5%81%C3%B3d%C5%BA.jpg",
+        "uploaded-by" -> "s%C3%A9b.cevey%40theguardian.co.uk",
+        "upload-time" -> "2021-02-01T12%3A52%3A34%2B09%3A00",
+        "identifier!picdarurn" -> "12*543%5E25"
+      ).asJava)
+
+      val result = S3FileExtractedMetadata(s3Metadata)
+      result.uploadFileName shouldBe Some("This photo was taken in Łódź.jpg")
+      result.uploadedBy shouldBe "séb.cevey@theguardian.co.uk"
+      result.uploadTime.toString shouldBe "2021-02-01T03:52:34.000Z"
+      result.identifiers.size shouldBe 1
+      result.identifiers.get("picdarurn") shouldBe Some("12*543^25")
+    }
+
+    "should remap headers with underscores to dashes" in {
+      val s3Metadata = new ObjectMetadata()
+      s3Metadata.setLastModified(new Date(1613388118000L))
+      s3Metadata.setUserMetadata(Map(
+        "file_name" -> "filename.jpg",
+        "uploaded_by" -> "user",
+        "upload_time" -> "2021-02-01T12%3A52%3A34%2B09%3A00",
+        "identifier!picdarurn" -> "12*543"
+      ).asJava)
+
+      val result = S3FileExtractedMetadata(s3Metadata)
+      result.uploadFileName shouldBe Some("filename.jpg")
+      result.uploadedBy shouldBe "user"
+      result.uploadTime.toString shouldBe "2021-02-01T03:52:34.000Z"
+      result.identifiers.size shouldBe 1
+      result.identifiers.get("picdarurn") shouldBe Some("12*543")
+    }
+
+    "should correctly read in non URL encoded values" in {
+      // we have plenty of values in S3 that are not URL encoded
+      // and we must be able to read them correctly
+      val s3Metadata = new ObjectMetadata()
+      s3Metadata.setLastModified(new Date(1613388118000L))
+      s3Metadata.setUserMetadata(Map(
+        "uploaded_by" -> "user",
+        "upload_time" -> "2019-12-11T01:12:10.427Z",
+      ).asJava)
+
+      val result = S3FileExtractedMetadata(s3Metadata)
+      result.uploadedBy shouldBe "user"
+      result.uploadTime.toString shouldBe "2019-12-11T01:12:10.427Z"
     }
   }
 

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/BucketMetadata.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/BucketMetadata.scala
@@ -1,0 +1,64 @@
+package com.gu.mediaservice.scripts
+
+
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+import software.amazon.awssdk.auth.credentials.{DefaultCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{HeadObjectRequest, ListObjectsV2Request}
+
+import java.io.{BufferedWriter, File, FileWriter}
+import java.time.Instant
+import scala.collection.JavaConverters.{asScalaIteratorConverter, iterableAsScalaIterableConverter, mapAsScalaMapConverter}
+
+case class ObjectMetadata(key: String, lastModified: Instant, metadata: Map[String, String])
+object ObjectMetadata {
+  implicit val format = Json.format[ObjectMetadata]
+}
+
+/**
+  * Dump selected metadata for all objects in a bucket.
+  * Given a bucket and an output file this will create a JSON line per object containing the key, lastModified time and
+  * user metadata.
+  */
+object BucketMetadata {
+  def apply(args: List[String]): Unit = {
+    args match {
+      case bucketName :: fileName :: Nil => bucketMetadata(bucketName, new File(fileName))
+      case _ => throw new IllegalArgumentException("Usage: BucketMetadata <bucket> <outputFilename.jsonl>")
+    }
+  }
+
+  def bucketMetadata(bucketName: String, outputFile: File) = {
+    val fw = new FileWriter(outputFile)
+    System.err.println(s"Output encoding: ${fw.getEncoding}")
+    val stream = new BufferedWriter(fw)
+
+    try {
+      val s3: S3Client = S3Client.builder
+        .region(Region.EU_WEST_1)
+        .credentialsProvider(DefaultCredentialsProvider.builder.profileName("media-service").build)
+        .build
+
+      val results = s3.listObjectsV2Paginator(ListObjectsV2Request.builder.bucket(bucketName).build)
+      results.iterator().asScala.flatMap { results =>
+        results.contents().asScala
+      }.map { s3Object =>
+        val headObjectResponse = s3.headObject(HeadObjectRequest.builder.bucket(bucketName).key(s3Object.key).build)
+        s3Object -> headObjectResponse
+      }.map { case (s3Object, metadata) =>
+        ObjectMetadata(s3Object.key, metadata.lastModified, metadata.metadata.asScala.toMap)
+      }.map { md =>
+        Json.stringify(Json.toJson(md))
+      }.zipWithIndex
+       .foreach { case (json, idx) =>
+        if (idx % 1000 == 0) System.err.println(s"${DateTime.now.toString}: ${idx}")
+        stream.write(json)
+        stream.newLine()
+      }
+    } finally {
+      stream.close()
+    }
+  }
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/DecodeComparator.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/DecodeComparator.scala
@@ -1,0 +1,39 @@
+package com.gu.mediaservice.scripts
+
+import com.gu.mediaservice.lib.net.URI
+import play.api.libs.json.{JsError, JsSuccess, Json}
+
+import java.io.File
+import scala.io.Source
+
+/**
+  * Given a JSON lines file output from BucketMetadata this will verify that metadata is not changed when being
+  * passed through a URI decode function. This was to check that it is safe to deploy
+  * https://github.com/guardian/grid/pull/3165
+  */
+object DecodeComparator {
+  def apply(args: List[String]): Unit = {
+    args match {
+      case fileName :: Nil => compare(new File(fileName))
+      case as => throw new IllegalArgumentException("Usage: DecodeComparator <inputFile.json>")
+    }
+  }
+
+  def compare(file: File): Unit = {
+    val source = Source.fromFile(file)
+    try {
+      source.getLines().foreach { line =>
+        Json.fromJson[ObjectMetadata](Json.parse(line)) match {
+          case JsError(errors) => System.err.println(s"Couldn't parse JSON $line")
+          case JsSuccess(metadata, _) =>
+            metadata.metadata.toList.foreach{ case (key, value) =>
+              val decodedValue = URI.decode(value)
+              if (value != decodedValue) System.out.println(s"Difference between $key '$value' and '$decodedValue'")
+            }
+        }
+      }
+    } finally {
+      source.close()
+    }
+  }
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -11,6 +11,8 @@ object Main extends App {
     case "GetSettings"      :: as => GetSettings(as)
     case "UpdateSettings"   :: as => UpdateSettings(as)
     case "ConvertConfig"    :: as => ConvertConfig(as)
+    case "BucketMetadata"   :: as => BucketMetadata(as)
+    case "DecodeComparator"   :: as => DecodeComparator(as)
     case a :: _ => sys.error(s"Unrecognised command: $a")
     case Nil    => sys.error("Usage: <Command> <args ...>")
   }


### PR DESCRIPTION
## What does this change?
This normalises and cleans up the way the user metadata on the S3 objects is created and read back in. The main changes are that we:
 - Have a set of vals for the header names and prefixes so they are not duplicated
 - Always URL encode values stored in user metadata (and URL decode on retrival)
 - Lowercase all incoming identifier keys

Having a set of vals rather than duplicating the same string in multiple places is obviously a good thing.

Only US-ASCII data can be stored in user metadata, so we should use an encoding to be sure that the data will be successfully stored and will not be corrupted. We use URL encoding for `file-name` already so we should extend that to other fields. We can now simplify the logic by doing it on everything. 

Identifiers such as picdarURN end up as picdarurn when stored in and retreived via S3 user metadata as all such metadata keys are always lowercased. Unfortunately we don't lowercase them before storing them in ElasticSearch so when we reindex the identifier keys will change. We could special case the existing examples but I suggest that we just put up with it and change any external tooling as necessary.

### What about our historical data?
When deployed, this new code will mean that fields that were not URL encoded will be URL decoded. Taking a sample of 3.5M images I've not found any values that do not decode back to themselves (other than `file-name` which was already encoded so is safe). 

I did this using a couple of little tools to do analysis of existing file metadata which I've checked in for posterity.

## Tested?
- [x] review wider corpus of identifier values in existing data
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
