### PR TITLE
Correct MIME type for projections

### DIFF
--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -11,13 +11,13 @@ import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.LogMarker
 import com.gu.mediaservice.lib.net.URI
-import com.gu.mediaservice.model.{Image, Jpeg, Png, UploadInfo}
+import com.gu.mediaservice.model.{Image, UploadInfo}
 import lib.imaging.{MimeTypeDetection, NoSuchImageExistsInS3}
 import lib.{DigestedFile, ImageLoaderConfig}
-import model.upload.{OptimiseWithPngQuant, UploadRequest}
+import model.upload.UploadRequest
 import org.apache.tika.io.IOUtils
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.{Logger, MarkerContext}
+import play.api.Logger
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
@@ -151,7 +151,7 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
 
   private def projectThumbnailFileAsS3Model(storableThumbImage: StorableThumbImage)(implicit ec: ExecutionContext) = Future {
     val key = ImageIngestOperations.fileKeyFromId(storableThumbImage.id)
-    val thumbMimeType = Some(OptimiseWithPngQuant.optimiseMimeType) // this IS what we will generate.
+    val thumbMimeType = Some(ImageOperations.thumbMimeType)
     S3Ops.projectFileAsS3Object(
       config.thumbBucket,
       key,


### PR DESCRIPTION
## What does this change?

Currently the projection services 'spoofs' the metadata content for optimised images and thumbnail images, rather than go to the effort of converting.

The thumbnail process is wrongly reading the optimised mime type; it should be using the thumb mime type.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
