### PR TITLE
Faster fades on load and progressive display of images

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -117,6 +117,7 @@ class ImageOperations(playPath: String) extends GridLogging {
   val thumbUnsharpRadius = 0.5d
   val thumbUnsharpSigma = 0.5d
   val thumbUnsharpAmount = 0.8d
+  val interlacedHow = "Line"
 
   /**
     * Given a source file containing a png (the 'browser viewable' file),
@@ -146,7 +147,8 @@ class ImageOperations(playPath: String) extends GridLogging {
     val profiled    = applyOutputProfile(stripped, optimised = true)
     val unsharpened = unsharp(profiled)(thumbUnsharpRadius, thumbUnsharpSigma, thumbUnsharpAmount)
     val qualified   = quality(unsharpened)(qual)
-    val addOutput   = {file:File => addDestImage(qualified)(file)}
+    val interlaced  = interlace(qualified)(interlacedHow)
+    val addOutput   = {file:File => addDestImage(interlaced)(file)}
     for {
       outputFile <- createTempFile(s"thumb-", thumbMimeType.fileExtension, tempDir)
       _          <- runConvertCmd(addOutput(outputFile), useImageMagick = sourceMimeType.contains(Tiff))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -28,6 +28,7 @@ object ImageMagick extends GridLogging {
   def scale(op: IMOperation)(dimensions: Dimensions): IMOperation = op <| (_.scale(dimensions.width, dimensions.height))
   def format(op: IMOperation)(definition: String): IMOperation = op <| (_.format(definition))
   def depth(op: IMOperation)(depth: Int): IMOperation = op <| (_.depth(depth))
+  def interlace(op: IMOperation)(interlacedHow: String): IMOperation = op <| (_.interlace(interlacedHow))
 
   def runConvertCmd(op: IMOperation, useImageMagick: Boolean): Future[Unit] = {
     logger.info(s"Using ${if(useImageMagick) { "imagemagick" } else { "graphicsmagick" }} for imaging operation $op")

--- a/kahuna/public/js/directives/gr-image-fade-on-load.js
+++ b/kahuna/public/js/directives/gr-image-fade-on-load.js
@@ -7,21 +7,25 @@ imageFade.directive('grImageFadeOnLoad',
                      function ($q, $timeout) {
 
     // TODO: customise duration, transition
-    const animationThreshold = 50; // ms
-    const animationDuration = 200; // ms
+                         const animationDuration = 200; // ms
+                         const revealAfter = 200; // ms
 
     return {
         restrict: 'A',
         link: function (scope, element) {
-            // If not loaded after animationThreshold, hide and wait
+            // If not loaded, hide and wait
             // until loaded to fade in
-            $timeout(() => {
                 if (! isLoaded()) {
                     hide();
-                    whenLoaded().finally(reveal);
+                    whenLoaded();
                 }
-            }, animationThreshold);
 
+            // If not loaded after revealAfter
+            // show the image, it's progressive so we should
+            // have something to show for our time
+            $timeout(() => {
+                reveal();
+            }, revealAfter);
 
             function isLoaded() {
                 return element[0].complete;
@@ -29,19 +33,26 @@ imageFade.directive('grImageFadeOnLoad',
 
             function whenLoaded() {
                 const defer = $q.defer();
-
+                const revealAndResolve = () => {
+                    reveal();
+                    defer.resolve();
+                };
+                const revealAndReject = () => {
+                    reveal();
+                    defer.reject();
+                };
                 // already loaded
                 if (isLoaded()) {
-                    defer.resolve();
+                    revealAndResolve();
                 } else {
                     // wait until loaded/error
-                    element.on('load', defer.resolve);
-                    element.on('error', defer.reject);
+                    element.on('load', revealAndResolve);
+                    element.on('error', revealAndReject);
 
                     // free listeners once observed
                     defer.promise.finally(() => {
-                        element.off('load', defer.resolve);
-                        element.off('error', defer.reject);
+                        element.off('load', revealAndResolve);
+                        element.off('error', revealAndReject);
                     });
                 }
 

--- a/kahuna/public/js/directives/gr-image-fade-on-load.js
+++ b/kahuna/public/js/directives/gr-image-fade-on-load.js
@@ -8,7 +8,7 @@ imageFade.directive('grImageFadeOnLoad',
 
     // TODO: customise duration, transition
                          const animationDuration = 200; // ms
-                         const revealAfter = 200; // ms
+                         const revealAfter = 1500; // ms
 
     return {
         restrict: 'A',

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -150,8 +150,7 @@
                ng-src="{{:: ctrl.optimisedImageUri}}"
                grid:track-image="ctrl.image"
                grid:track-image-location="original"
-               grid:track-image-loadtime
-               gr-image-fade-on-load/>
+               grid:track-image-loadtime/>
         </div>
 
         <!-- TODO: As this loads async, add a loader -->

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -35,8 +35,7 @@
        <img class="preview__image"
             ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
             alt="{{::ctrl.imageDescription}}"
-            ng-src="{{::ctrl.image.data.thumbnail | assetFile}}"
-            gr-image-fade-on-load />
+            ng-src="{{::ctrl.image.data.thumbnail | assetFile}}"/>
     </a>
 
     <span ng-if="ctrl.selectionMode" class="preview__no-link">
@@ -45,8 +44,7 @@
              ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"
              alt="{{::ctrl.image.data.metadata.description}}"
              ng-src="{{::ctrl.image.data.thumbnail | assetFile}}"
-             ui-drag-data="ctrl.image | asImageDragData"
-             gr-image-fade-on-load />
+             ui-drag-data="ctrl.image | asImageDragData"/>
     </span>
 
     <div class="preview__info" ng-if="! ctrl.hideInfo">


### PR DESCRIPTION
## What does this change?

We are using a very nice fading of thumbnails and main preview. Sadly, it depends on them being loaded in full. We have [imgOps configured](https://github.com/guardian/grid/blob/9588b1c2b5074866ffd11a3dd8176592271cb432/dev/imgops/nginx.conf#L30) to provide progressive JPEGs.

This PR:
- changes the fading so that it doesn’t depend on an image being fully loaded
- changes the thumbnail generation, so that they are also progressive JPEGs

Currently, the image fade in on load applies an element style using the
angular digest loop. As this style stuff is done on the element directly
there's no state here for angular to track. I've reorganised things to:
- make the reveal happen before we do any $q promisey stuff, so no more waiting on the digest loop
- set a timeout (which ironically will fire in the digest loop) so that after a while we just show the image


## How can success be measured?

I think this would work better with #3166 from @paperboyo than just dropping the fade. The app should feel more snappy.

## Screenshots
(bottom: current situation)
### Viewer:
![both](https://user-images.githubusercontent.com/6032869/107898699-52056580-6f34-11eb-964e-cb3557141810.gif)
### Browser  (played at 25% speed for effect):
![both_thumb5](https://user-images.githubusercontent.com/6032869/107898723-65183580-6f34-11eb-9fb5-7eb2eaaf20cd.gif)

## Who should look at this?
@guardian/digital-cms 


## Tested?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
