### PR TITLE
Disable the compiling of scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,10 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
     "org.mockito" % "mockito-core" % "2.18.0" % Test
-  )
+  ),
+
+  sources in (Compile,doc) := Seq.empty,
+  publishArtifact in (Compile, packageDoc) := false
 )
 
 lazy val root = project("grid", path = Some("."))


### PR DESCRIPTION
## What does this change?
This disables the creation of scaladoc from the source files. 

We don't publish it anywhere, it slows down the build and in fact the scripts project was actually broken if you ever ran a dist on it.

## How can success be measured?
Faster builds but mainly that you can packageBin scripts successfully.
