### PR TITLE
add GET upload status API poll

### DIFF
--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -42,7 +42,8 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
 
   val controller = new ImageLoaderController(
     auth, downloader, store, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient)
-  val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, controllerComponents)
+  val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, config ,controllerComponents)
+
 
   override lazy val router = new Routes(httpErrorHandler, controller, uploadStatusController, management)
 }

--- a/image-loader/app/model/QuarantineUploader.scala
+++ b/image-loader/app/model/QuarantineUploader.scala
@@ -36,7 +36,7 @@ class QuarantineUploader(val store: QuarantineStore,
       meta
     )
   }
-  
+
   def quarantineFile(uploadRequest: UploadRequest)(
     implicit ec: ExecutionContext,
     logMarker: LogMarker): Future[JsObject] = {
@@ -45,7 +45,7 @@ class QuarantineUploader(val store: QuarantineStore,
 
     for {
       _ <- storeQuarantineFile(uploadRequest)
-      uri = s"${config.apiUri}/images/${uploadRequest.imageId}"
+      uri = s"${config.rootUri}/uploadStatus/${uploadRequest.imageId}"
     } yield {
       Json.obj("uri" -> uri)
     }

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -343,7 +343,7 @@ class Uploader(val store: ImageLoaderStore,
       updateMessage = UpdateMessage(subject = "image", image = Some(imageUpload.image))
       _ <- Future { notifications.publish(updateMessage) }
       // TODO: centralise where all these URLs are constructed
-      uri = s"${config.apiUri}/images/${uploadRequest.imageId}"
+      uri = s"${config.rootUri}/uploadStatus/${uploadRequest.imageId}"
     } yield {
       Json.obj("uri" -> uri)
     }


### PR DESCRIPTION
## What does this change?
This Introduce new API Polling for `GET /image-loader/UploadStatus` to get image upload status 
and show it in the UI

## How can success be measured?
In case of quarantine enabled and quarantine processor failed to process an image 
the quarantine status should show up below the image 

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![Screenshot from 2021-03-03 12-53-42](https://user-images.githubusercontent.com/33189781/109795508-ae989e00-7c1f-11eb-8a62-ebe80c87f361.png)



## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
