### PR TITLE
Make Grid HTTP services common

### DIFF
--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
@@ -17,7 +17,8 @@ class BatchIndexLambdaHandler {
     threshold = sys.env.get("LATENCY_THRESHOLD").map(t => Integer.parseInt(t)),
     maxSize = sys.env("MAX_SIZE").toInt,
     startState = IndexInputCreation.get(sys.env("START_STATE").toInt),
-    checkerStartState = IndexInputCreation.get(sys.env("CHECKER_START_STATE").toInt)
+    checkerStartState = IndexInputCreation.get(sys.env("CHECKER_START_STATE").toInt),
+    domainRoot = sys.env("DOMAIN_ROOT"),
   )
 
   private val batchIndex = new BatchIndexHandler(cfg)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -7,7 +7,7 @@ import com.gu.mediaservice.model.Image
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class ImagesBatchProjection(apiKey: String, domainRoot: String, timeout: Duration, gridClient: GridClient, maxSize: Int) {
+class ImagesBatchProjection(apiKey: String, timeout: Duration, gridClient: GridClient, maxSize: Int) {
 
   private implicit val ThrottledExecutionContext = ExecutionContext.fromExecutor(java.util.concurrent.Executors.newFixedThreadPool(5))
 

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val commonLib = project("common-lib").settings(
     "org.codehaus.janino" % "janino" % "3.0.6",
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
     "com.gu" %% "scanamo" % "1.0.0-M8",
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.7"
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.7",
+    "com.squareup.okhttp3" % "okhttp" % okHttpVersion
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 ).settings(bbcCommonLibSettings)
@@ -134,7 +135,6 @@ lazy val cropper = playProject("cropper", 9006)
 
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
-    "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
     "org.apache.tika" % "tika-core" % "1.20",
     "com.drewnoakes" % "metadata-extractor" % "2.15.0"
   )
@@ -180,7 +180,6 @@ lazy val adminToolsLib = project("admin-tools-lib", Some("admin-tools/lib"))
       ExclusionRule("com.gu", "kinesis-logback-appender")
     ),
     libraryDependencies ++= Seq(
-      "com.squareup.okhttp3" % "okhttp" % okHttpVersion,
       "com.typesafe.play" %% "play-json" % "2.6.9",
       "com.typesafe.play" %% "play-json-joda" % "2.6.9",
       "com.typesafe.play" %% "play-functional" % "2.6.9",

--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -2,13 +2,18 @@ package com.gu.mediaservice
 
 import java.io.IOException
 import java.net.URL
-import com.gu.mediaservice.lib.auth.provider.ApiKeyAuthentication
-import com.typesafe.scalalogging.LazyLogging
-import okhttp3._
-import play.api.libs.json.{JsValue, Json}
 
-import scala.util.{Failure, Success, Try}
+import com.gu.mediaservice.lib.auth.provider.ApiKeyAuthentication
+import com.gu.mediaservice.lib.config.Services
+import com.gu.mediaservice.model.{Crop, Edits, Image}
+import com.gu.mediaservice.model.leases.LeasesByMedia
+import com.gu.mediaservice.model.usage.Usage
+import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
+import okhttp3._
+
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
 
 object ClientResponse {
   case class Message(errorMessage: String, downstreamErrorMessage: String)
@@ -35,10 +40,11 @@ case class ClientErrorMessages(errorMessage: String, downstreamErrorMessage: Str
 case class ResponseWrapper(body: JsValue, statusCode: Int, bodyAsString: String)
 
 object GridClient {
-  def apply(maxIdleConnections: Int, debugHttpResponse: Boolean = true): GridClient = new GridClient(maxIdleConnections, debugHttpResponse)
+  def apply(apiKey: String, services: Services, maxIdleConnections: Int, debugHttpResponse: Boolean = true): GridClient =
+    new GridClient(apiKey, services, maxIdleConnections, debugHttpResponse)
 }
 
-class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends ApiKeyAuthentication with LazyLogging {
+class GridClient(apiKey: String, services: Services, maxIdleConnections: Int, debugHttpResponse: Boolean) extends ApiKeyAuthentication with LazyLogging {
 
   import java.util.concurrent.TimeUnit
 
@@ -136,5 +142,82 @@ class GridClient(maxIdleConnections: Int, debugHttpResponse: Boolean) extends Ap
     })
     promise.future
   }
+
+  private def validateResponse(res: ResponseWrapper, url: URL): Unit = {
+    import res._
+    if (statusCode != 200 && statusCode != 404) {
+      val errorMessage = s"breaking the circuit of full image projection, downstream API: $url is in a bad state, code: $statusCode"
+      val downstreamErrorMessage = res.bodyAsString
+
+      val errorJson = Json.obj(
+        "level" -> "ERROR",
+        "errorStatusCode" -> statusCode,
+        "message" -> Json.obj(
+          "errorMessage" -> errorMessage,
+          "downstreamErrorMessage" -> downstreamErrorMessage
+        )
+      )
+      logger.error(errorJson.toString())
+      throw new DownstreamApiInBadStateException(errorMessage, downstreamErrorMessage)
+    }
+  }
+
+  def getImageLoaderProjection(mediaId: String, imageLoaderEndpoint: String): Option[Image] = {
+    logger.info("attempt to get image projection from image-loader")
+    val url = new URL(s"${imageLoaderEndpoint}/images/project/$mediaId")
+    val res = makeGetRequestSync(url, apiKey)
+    validateResponse(res, url)
+    logger.info(s"got image projection from image-loader for $mediaId with status code $res.statusCode")
+    if (res.statusCode == 200) Some(res.body.as[Image]) else None
+  }
+
+  def getLeases(mediaId: String)(implicit ec: ExecutionContext): Future[LeasesByMedia] = {
+    logger.info("attempt to get leases")
+    val url = new URL(s"${services.leasesBaseUri}/leases/media/$mediaId")
+    makeGetRequestAsync(url, apiKey).map { res =>
+      validateResponse(res, url)
+      if (res.statusCode == 200) (res.body \ "data").as[LeasesByMedia] else LeasesByMedia.empty
+    }
+  }
+
+  def getEdits(mediaId: String)(implicit ec: ExecutionContext): Future[Option[Edits]] = {
+    logger.info("attempt to get edits")
+    val url = new URL(s"${services.metadataBaseUri}/edits/$mediaId")
+    makeGetRequestAsync(url, apiKey).map { res =>
+      validateResponse(res, url)
+      if (res.statusCode == 200) Some((res.body \ "data").as[Edits]) else None
+    }
+  }
+
+  def getCrops(mediaId: String)(implicit ec: ExecutionContext): Future[List[Crop]] = {
+    logger.info("attempt to get crops")
+    val url = new URL(s"${services.cropperBaseUri}/crops/$mediaId")
+    makeGetRequestAsync(url, apiKey).map { res =>
+      validateResponse(res, url)
+      if (res.statusCode == 200) (res.body \ "data").as[List[Crop]] else Nil
+    }
+  }
+
+  def getUsages(mediaId: String)(implicit ec: ExecutionContext): Future[List[Usage]] = {
+    logger.info("attempt to get usages")
+
+    def unpackUsagesFromEntityResponse(resBody: JsValue): List[JsValue] = {
+      (resBody \ "data").as[JsArray].value
+        .map(entity => (entity.as[JsObject] \ "data").as[JsValue]).toList
+    }
+
+    val url = new URL(s"${services.usageBaseUri}/usages/media/$mediaId")
+    makeGetRequestAsync(url, apiKey).map { res =>
+      validateResponse(res, url)
+      if (res.statusCode == 200) unpackUsagesFromEntityResponse(res.body).map(_.as[Usage])
+      else Nil
+    }
+  }
+
+
+
 }
 
+class DownstreamApiInBadStateException(message: String, downstreamMessage: String) extends IllegalStateException(message) {
+  def getDownstreamMessage = downstreamMessage
+}


### PR DESCRIPTION
## What does this change?
Currently the Grid offers various microservices which are all presented as HTTPS/REST interfaces.

We have code to simplify cross-service calls, but it is only present in the admin microservice.  We have intentions that Thrall and Projection code will no longer trust message content and ElasticSearch results respectively, but will fetch up-to-date data from the microservice (and thus from the source of truth, Dynamo).

This means that those services need access to the GridClient class, which entails moving it into the common library.

_NB The lambda now needs to have the domain root for the stage as an environment variable_
See https://github.com/guardian/editorial-tools-platform/pull/483

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
