### PR TITLE
add config options to support loading arbitrary scripts (with permission support)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -1,12 +1,12 @@
 package com.gu.mediaservice.lib.config
 
 import java.util.UUID
-
 import com.gu.mediaservice.lib.aws.{AwsClientBuilderUtils, KinesisSenderConfig}
-import com.typesafe.config.ConfigException
+import com.typesafe.config.{Config, ConfigException}
 import com.typesafe.scalalogging.StrictLogging
 import play.api.Configuration
 
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 import scala.util.Try
 
 
@@ -66,6 +66,10 @@ abstract class CommonConfig(val configuration: Configuration) extends AwsClientB
     case _:ConfigException.WrongType => configuration.get[String](key).split(",").toSeq.map(_.trim)
   }.map(_.toSet)
    .getOrElse(Set.empty)
+
+  def getConfigList(key:String): List[_ <: Config] =
+    if (configuration.has(key)) configuration.underlying.getConfigList(key).asScala.toList
+    else List.empty
 
   final def apply(key: String): String =
     string(key)

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -34,29 +34,43 @@ object KahunaSecurityConfig {
       config.services.guardianWitnessBaseUri
     )
 
+    val gaHost = "www.google-analytics.com"
+
     val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com"
     val frameAncestors = s"frame-ancestors ${config.frameAncestors.mkString(" ")}"
-    val connectSources = s"connect-src ${(services :+ config.imageOrigin).mkString(" ")} 'self' www.google-analytics.com"
+    val connectSources = s"connect-src 'self' ${(services :+ config.imageOrigin).mkString(" ")} $gaHost ${config.connectSources.mkString(" ")}"
 
-    val imageSources: List[String] = List(
+    val imageSources = s"img-src ${List(
       "data:",
       "blob:",
       URI.ensureSecure(config.services.imgopsBaseUri).toString,
       URI.ensureSecure(config.fullOrigin).toString,
       URI.ensureSecure(config.thumbOrigin).toString,
       URI.ensureSecure(config.cropOrigin).toString,
-      URI.ensureSecure("www.google-analytics.com").toString,
+      URI.ensureSecure(gaHost).toString,
       URI.ensureSecure("app.getsentry.com").toString,
       "'self'"
-    )
+    ).mkString(" ")}"
 
     val fontSources = s"font-src data: 'self'"
+
+    val scriptSources = s"script-src 'self' 'unsafe-inline' $gaHost ${config.scriptsToLoad.map(_.host).mkString(" ")}"
 
     base.copy(
       // covered by frame-ancestors in contentSecurityPolicy
       frameOptions = None,
       // We use inline styles and script tags <sad face>
-      contentSecurityPolicy = Some(s"$frameSources; $frameAncestors; $connectSources; $fontSources; img-src ${imageSources.mkString(" ")}; default-src 'unsafe-inline' 'self'; script-src 'self' 'unsafe-inline' www.google-analytics.com;")
+      contentSecurityPolicy = Some(
+        List(
+          frameSources,
+          frameAncestors,
+          connectSources,
+          fontSources,
+          imageSources,
+          "default-src 'unsafe-inline' 'self'",
+          scriptSources
+        ).mkString("; ")
+      )
     )
   }
 }

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -12,7 +12,7 @@ class KahunaComponents(context: Context) extends GridComponents(context, new Kah
 
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val controller = new KahunaController(auth, config, controllerComponents)
+  val controller = new KahunaController(auth, config, controllerComponents, authorisation)
   final override val router = new Routes(httpErrorHandler, controller, assets, management)
 
 }

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -1,16 +1,19 @@
 package controllers
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
-import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.{Authentication, PermissionsHandler}
 import lib.KahunaConfig
 import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.ExecutionContext
 
-class KahunaController(auth: Authentication, config: KahunaConfig, override val controllerComponents: ControllerComponents)
-                      (implicit val ec: ExecutionContext) extends BaseController with ArgoHelpers {
+class KahunaController(auth: Authentication, val config: KahunaConfig, override val controllerComponents: ControllerComponents)
+                      (implicit val ec: ExecutionContext) extends BaseController with ArgoHelpers with PermissionsHandler {
 
   def index(ignored: String) = Action { req =>
+
+    val maybeUser = auth.authenticationStatus(req).toOption
+
     val okPath = routes.KahunaController.ok.url
     // If the auth is successful, we redirect to the kahuna domain so the iframe
     // is on the same domain and can be read by the JS
@@ -25,7 +28,8 @@ class KahunaController(auth: Authentication, config: KahunaConfig, override val 
       config.feedbackFormLink,
       config.usageRightsHelpLink,
       config.invalidSessionHelpLink,
-      config.supportEmail
+      config.supportEmail,
+      config.scriptsToLoad.filter(_.permission.exists(permission => maybeUser.exists(hasPermission(_, permission))))
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -1,6 +1,14 @@
 package lib
 
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
+import com.gu.permissions.PermissionDefinition
+
+case class ScriptToLoad(
+  host: String,
+  path: String,
+  async: Option[Boolean],
+  permission: Option[PermissionDefinition]
+)
 
 class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
   val rootUri: String = services.kahunaBaseUri
@@ -21,4 +29,21 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val supportEmail: Option[String]= stringOpt("links.supportEmail").filterNot(_.isEmpty)
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
+  val connectSources: Set[String] = getStringSet("security.connectSources")
+
+  val scriptsToLoad: List[ScriptToLoad] = getConfigList("scriptsToLoad").map(entry => ScriptToLoad(
+    host = entry.getString("host"),
+    path = entry.getString("path"),
+    async = if (entry.hasPath("async")) Some(entry.getBoolean("async")) else None,
+    permission =
+      if (entry.hasPath("permission")) Some(
+        PermissionDefinition(
+          name = entry.getString("permission.name"),
+          app = entry.getString("permission.app")
+        )
+      )
+      else None
+  ))
+
 }
+

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -1,13 +1,14 @@
 package lib
 
+import com.gu.mediaservice.lib.auth.Permissions.Pinboard
+import com.gu.mediaservice.lib.auth.SimplePermission
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
-import com.gu.permissions.PermissionDefinition
 
 case class ScriptToLoad(
   host: String,
   path: String,
   async: Option[Boolean],
-  permission: Option[PermissionDefinition]
+  permission: Option[SimplePermission]
 )
 
 class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resources.configuration) {
@@ -35,14 +36,8 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     host = entry.getString("host"),
     path = entry.getString("path"),
     async = if (entry.hasPath("async")) Some(entry.getBoolean("async")) else None,
-    permission =
-      if (entry.hasPath("permission")) Some(
-        PermissionDefinition(
-          name = entry.getString("permission.name"),
-          app = entry.getString("permission.app")
-        )
-      )
-      else None
+    // FIXME ideally the below would not hardcode reference to pinboard - hopefully future iterations of the pluggable authorisation will support evaluating permissions without a corresponding case object
+    permission = if (entry.hasPath("permission") && entry.getString("permission") == "pinboard") Some(Pinboard) else None
   ))
 
 }

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -1,3 +1,5 @@
+@import lib.ScriptToLoad
+
 @(mediaApiUri: String,
   authApiUri: String,
   reauthUri: String,
@@ -7,7 +9,9 @@
   feedbackFormLink: Option[String],
   usageRightsHelpLink: Option[String],
   invalidSessionHelpLink: Option[String],
-  supportEmail: Option[String])
+  supportEmail: Option[String],
+  scriptsToLoad: List[ScriptToLoad]
+)
 <!DOCTYPE html>
 <html>
   <head>
@@ -63,6 +67,10 @@
     }
 
     <script src="@routes.Assets.versioned("dist/build.js")"></script>
+
+    @scriptsToLoad.map { scriptDetail =>
+      <script async="@scriptDetail.async" src="@scriptDetail.host/@scriptDetail.path"></script>
+    }
 
   </body>
 </html>

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
@@ -17,4 +17,5 @@ object Permissions {
   case object DeleteImage extends SimplePermission
   case object DeleteCrops extends SimplePermission
   case object ShowPaid extends SimplePermission
+  case object Pinboard extends SimplePermission // FIXME ideally factor this out in favour of something more generic
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/Permissions.scala
@@ -9,4 +9,7 @@ object Permissions {
   val DeleteImage: PermissionDefinition = PermissionDefinition("delete_image", app)
   val DeleteCrops: PermissionDefinition = PermissionDefinition("delete_crops", app)
   val ShowPaid: PermissionDefinition = PermissionDefinition("show_paid", app)
+
+  // FIXME ideally factor this out in favour of a permission definition that can be defined at runtime (e.g. loaded from config)
+  val Pinboard: PermissionDefinition = PermissionDefinition("pinboard", "pinboard")
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -55,6 +55,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       case DeleteImage => hasPermission(Permissions.DeleteImage)
       case DeleteCrops => hasPermission(Permissions.DeleteCrops)
       case ShowPaid => hasPermission(Permissions.ShowPaid)
+      case Pinboard => hasPermission(Permissions.Pinboard)
     }
   }
 }


### PR DESCRIPTION
Co-authored-by: @tjsilver 

https://trello.com/c/TIeyuEff/511-1st-pinboard-integration-grid

## What does this change?
- New config option in `KahunaConfig`(i.e. `kahuna.conf`) entitled `scriptsToLoad` (list of objects) which allows the loading of arbitrary scripts (immediate use case is https://github.com/guardian/editorial-tools-pinboard) which optionally have a permission requirement on them, for example...
![image](https://user-images.githubusercontent.com/19289579/108713630-663afb00-7510-11eb-8918-6c9f09c6e9c5.png)

- Refactors to make the `Content-Security-Policy` more configurable by...
   - adding new config option `security.connectSources` (list of string) to control the `connect-src` portion of the CSP
   - re-using the 'hosts' from the new `scriptsToLoad` config option in the `script-src` portion of the CSP

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
