### PR TITLE
[BBC] Make additional fields visible on the UI via configuration

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -52,3 +52,5 @@ authorisation.provider {
 }
 
 uploadStatus.recordExpiry = "1 hour"
+
+field.aliases = []

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -9,7 +9,6 @@ import play.api.Configuration
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 import scala.util.Try
 
-
 abstract class CommonConfig(val configuration: Configuration) extends AwsClientBuilderUtils with StrictLogging {
   final val stackName = "media-service"
 
@@ -57,6 +56,8 @@ abstract class CommonConfig(val configuration: Configuration) extends AwsClientB
   val corsAllowedOrigins: Set[String] = getStringSet("security.cors.allowedOrigins")
 
   val services = new Services(domainRoot, serviceHosts, corsAllowedOrigins)
+
+  val fieldAliasConfigs: Seq[FieldAlias] = configuration.get[Seq[FieldAlias]]("field.aliases")
 
   private def getKinesisConfigForStream(streamName: String) = KinesisSenderConfig(awsRegion, awsCredentials, awsLocalEndpoint, isDev, streamName)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
@@ -1,0 +1,26 @@
+package com.gu.mediaservice.lib.config
+
+import play.api.ConfigLoader
+import play.api.libs.json._
+
+import scala.collection.JavaConverters._
+
+case class FieldAlias(elasticsearchPath: String,
+                      label: String,
+                      displaySearchHint: Boolean = false,
+                      alias: String)
+
+object FieldAlias {
+  implicit val FieldAliasWrites: Writes[FieldAlias] =
+    Json.writes[FieldAlias]
+
+  implicit val configLoader: ConfigLoader[Seq[FieldAlias]] =
+    ConfigLoader(_.getConfigList).map(
+      _.asScala.map(
+        config =>
+          FieldAlias(config.getString("elasticsearchPath"),
+            config.getString("label"),
+            config.getBoolean("displaySearchHint"),
+            config.getString("alias")))
+    )
+}

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -4,8 +4,9 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation}
 import lib.KahunaConfig
 import play.api.mvc.{BaseController, ControllerComponents}
-
+import play.api.libs.json._
 import scala.concurrent.ExecutionContext
+import com.gu.mediaservice.lib.config.FieldAlias._
 
 class KahunaController(
   authentication: Authentication,
@@ -23,6 +24,7 @@ class KahunaController(
     val okPath = routes.KahunaController.ok.url
     // If the auth is successful, we redirect to the kahuna domain so the iframe
     // is on the same domain and can be read by the JS
+    val fieldAliases: String = Json.toJson(config.fieldAliasConfigs).toString()
     val returnUri = config.rootUri + okPath
     Ok(views.html.main(
       config.mediaApiUri,
@@ -35,6 +37,7 @@ class KahunaController(
       config.usageRightsHelpLink,
       config.invalidSessionHelpLink,
       config.supportEmail,
+      fieldAliases,
       config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists))
     ))
   }

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -10,6 +10,7 @@
   usageRightsHelpLink: Option[String],
   invalidSessionHelpLink: Option[String],
   supportEmail: Option[String],
+  fieldAliases: String,
   scriptsToLoad: List[ScriptToLoad]
 )
 <!DOCTYPE html>
@@ -47,7 +48,8 @@
           feedbackFormLink: "@Html(feedbackFormLink.getOrElse(""))",
           usageRightsHelpLink: "@Html(usageRightsHelpLink.getOrElse(""))",
           invalidSessionHelpLink: "@Html(invalidSessionHelpLink.getOrElse(""))",
-          supportEmail: "@Html(supportEmail.getOrElse(""))"
+          supportEmail: "@Html(supportEmail.getOrElse(""))",
+          fieldAliases: @Html(fieldAliases)
         }
     </script>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -272,7 +272,7 @@
                 ng-click="metadataExpanded = !metadataExpanded">
             <span ng-hide="metadataExpanded">▸ Show</span>
             <span ng-show="metadataExpanded">▾ Hide</span>
-            full metadata
+            additional metadata
         </button>
 
         <div ng-if="metadataExpanded" class="metadata metadata-line image-info__group--dl">
@@ -280,6 +280,12 @@
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
             </dl>
+
+            <dl ng-repeat="(key, value) in ctrl.additionalMetadata" class="metadata__body image-info__group--dl">
+                <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key}}</dt>
+                <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>
+            </dl>
+
             <dl ng-repeat="(key, value) in ctrl.identifiers" class="metadata__body image-info__group--dl">
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">{{value}}</dd>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -33,8 +33,19 @@ module.controller('grImageMetadataCtrl', [
 
     let ctrl = this;
 
+    ctrl.fieldAliases = window._clientConfig.fieldAliases;
     ctrl.showUsageRights = false;
     ctrl.usageRights = imageService(ctrl.image).usageRights;
+    ctrl.additionalMetadata = Object.fromEntries(
+      Object.entries(ctrl.image.data.aliases)
+        .map(([key, val]) => {
+          let match = ctrl.fieldAliases.find(_ => _.alias === key);
+          if (match) {
+            return [match.label, val];
+          } else {
+            return [key, val];
+          }
+        }));
 
     // Alias for convenience in view
     ctrl.metadata = ctrl.image.data.metadata;

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -273,9 +273,9 @@ class MediaApi(
 
     val include = getIncludedFromParams(request)
 
-    def hitToImageEntity(elasticId: String, image: Image): EmbeddedEntity[JsValue] = {
-      val writePermission = canUserWriteMetadata(request.user, image)
-      val deletePermission = canUserDeleteImage(request.user, image)
+    def hitToImageEntity(elasticId: String, image: SourceWrapper[Image]): EmbeddedEntity[JsValue] = {
+      val writePermission = canUserWriteMetadata(request.user, image.instance)
+      val deletePermission = canUserDeleteImage(request.user, image.instance)
       val deleteCropsOrUsagePermission = canUserDeleteCropsOrUsages(request.user)
 
       val (imageData, imageLinks, imageActions) =
@@ -310,10 +310,10 @@ class MediaApi(
 
     val include = getIncludedFromParams(request)
 
-    elasticSearch.getImageById(id) map {
-      case Some(source) if hasPermission(request.user, source) =>
-        val writePermission = canUserWriteMetadata(request.user, source)
-        val deleteImagePermission = canUserDeleteImage(request.user, source)
+    elasticSearch.getImageWithSourceById(id) map {
+      case Some(source) if hasPermission(request.user, source.instance) =>
+        val writePermission = canUserWriteMetadata(request.user, source.instance)
+        val deleteImagePermission = canUserDeleteImage(request.user, source.instance)
         val deleteCropsOrUsagePermission = canUserDeleteCropsOrUsages(request.user)
 
         val (imageData, imageLinks, imageActions) = imageResponse.create(
@@ -326,7 +326,7 @@ class MediaApi(
           request.user.accessor.tier
         )
 
-        Some((source, imageData, imageLinks, imageActions))
+        Some((source.instance, imageData, imageLinks, imageActions))
 
       case _ => None
     }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -1,18 +1,16 @@
 package lib.elasticsearch
 
-import java.util.concurrent.TimeUnit
-
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.auth.Authentication.Principal
-import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, ElasticSearchConfig, ElasticSearchExecutions, Mappings}
+import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, ElasticSearchConfig}
 import com.gu.mediaservice.lib.logging.{GridLogging, MarkerMap}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
 import com.gu.mediaservice.model.{Agencies, Agency, Image}
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval, SearchHit, SearchRequest, SearchResponse}
+import com.sksamuel.elastic4s.requests.searches.aggs.Aggregation
 import com.sksamuel.elastic4s.requests.searches.queries.Query
-import lib.elasticsearch._
+import com.sksamuel.elastic4s.requests.searches._
 import lib.querysyntax.{HierarchyField, Match, Phrase}
 import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary}
 import play.api.libs.json.{JsError, JsSuccess, Json}
@@ -22,9 +20,9 @@ import play.mvc.Http.Status
 import scalaz.NonEmptyList
 import scalaz.syntax.std.list._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
-import com.sksamuel.elastic4s.requests.searches.aggs.Aggregation
 
 class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics, elasticConfig: ElasticSearchConfig, overQuotaAgencies: () => List[Agency])
   extends ElasticSearchClient with ImageFields with MatchFields with FutureSyntax with GridLogging {
@@ -51,7 +49,10 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
 
   val queryBuilder = new QueryBuilder(matchFields, overQuotaAgencies)
 
-  def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] = {
+  def getImageById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[Image]] =
+    getImageWithSourceById(id).map(_.map(_.instance))
+
+  def getImageWithSourceById(id: String)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[Option[SourceWrapper[Image]]] = {
     implicit val logMarker = MarkerMap("id" -> id)
     executeAndLog(get(imagesAlias, id), s"get image by id $id").map { r =>
       r.status match {
@@ -159,7 +160,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
     executeAndLog(searchRequest, "image search").
       toMetric(Some(mediaApiMetrics.searchQueries), List(mediaApiMetrics.searchTypeDimension("results")))(_.result.took).map { r =>
       logSearchQueryIfTimedOut(searchRequest, r.result)
-      val imageHits = r.result.hits.hits.map(resolveHit).toSeq.flatten.map(i => (i.id, i))
+      val imageHits = r.result.hits.hits.map(resolveHit).toSeq.flatten.map(i => (i.instance.id, i))
       SearchResults(hits = imageHits, total = r.result.totalHits)
     }
   }
@@ -265,8 +266,9 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
   }
 
   private def mapImageFrom(sourceAsString: String, id: String) = {
-    Json.parse(sourceAsString).validate[Image] match {
-      case i: JsSuccess[Image] => Some(i.value)
+    val source = Json.parse(sourceAsString)
+    source.validate[Image] match {
+      case i: JsSuccess[Image] => Some(SourceWrapper(source, i.value))
       case e: JsError =>
         logger.error("Failed to parse image from source string " + id + ": " + e.toString)
         None

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -15,7 +15,7 @@ import scalaz.{Validation, ValidationNel}
 
 import scala.util.Try
 
-case class SearchResults(hits: Seq[(String, Image)], total: Long)
+case class SearchResults(hits: Seq[(String, SourceWrapper[Image])], total: Long)
 
 case class AggregateSearchResults(results: Seq[BucketResult], total: Long)
 

--- a/media-api/app/lib/elasticsearch/SourceWrapper.scala
+++ b/media-api/app/lib/elasticsearch/SourceWrapper.scala
@@ -1,0 +1,6 @@
+package lib.elasticsearch
+
+import play.api.libs.json.JsValue
+
+/** A simple case class that carries the original ES source data with the deserialised instance */
+case class SourceWrapper[T](source: JsValue, instance: T)

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -1,11 +1,42 @@
 package lib
 
+import com.gu.mediaservice.lib.config.GridConfigResources
+import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.{PendingUsageStatus, PrintUsage, Usage}
-import com.gu.mediaservice.model.{Bounds, Crop, CropSpec}
+import lib.elasticsearch.{Fixtures, SourceWrapper}
 import org.joda.time.DateTime.now
 import org.scalatest.{FunSpec, Matchers}
+import play.api.Configuration
+import play.api.libs.json._
 
-class ImageResponseTest extends FunSpec with Matchers {
+class ImageResponseTest extends FunSpec with Matchers with Fixtures {
+
+  val mediaApiConfig = new MediaApiConfig(GridConfigResources(
+    Configuration.from(USED_CONFIGS_IN_TEST ++ Map(
+      "field.aliases" -> List(
+        Map(
+          "elasticsearchPath" -> "fileMetadata.xmp.org:ProgrammeMaker",
+          "alias" -> "orgProgrammeMaker",
+          "label" -> "Organization Programme Maker",
+          "displaySearchHint" -> false
+        ),
+        Map(
+          "elasticsearchPath" -> "fileMetadata.xmp.aux:Lens",
+          "alias" -> "auxLens",
+          "label" -> "Aux Lens",
+          "displaySearchHint" -> false
+        ),
+        Map(
+          "elasticsearchPath" -> "fileMetadata.iptc.Caption Writer/Editor",
+          "alias" -> "captionWriter",
+          "label" -> "Caption Writer / Editor",
+          "displaySearchHint" -> true
+        )
+      )
+    ) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap),
+    null
+  ))
+
   it("should replace \\r linebreaks with \\n") {
     val text = "Here is some text\rthat spans across\rmultiple lines\r"
     val normalisedText = ImageResponse.normaliseNewlineChars(text)
@@ -47,5 +78,52 @@ class ImageResponseTest extends FunSpec with Matchers {
     canImgBeDeleted(imgWithOnlyUsages) shouldEqual false
     val imgWithOnlyExports = img.copy(exports = List(testCrop))
     canImgBeDeleted(imgWithOnlyExports) shouldEqual false
+  }
+
+  it("should extract set of configured alias fields from sourcewrapper if fields exist in image") {
+    val image = createImage(
+      id = "test-image-with-filemetadata",
+      agency,
+      fileMetadata = Some(FileMetadata(
+        iptc = Map(
+          "Caption/Abstract" -> "the description",
+          "Caption Writer/Editor" -> "the editor"
+        ),
+        exif = Map(
+          "Copyright" -> "the copyright",
+          "Artist" -> "the artist"
+        ),
+        xmp = Map(
+          "foo" -> JsString("bar"),
+          "toolong" -> JsString(stringLongerThan(100000)),
+          "org:ProgrammeMaker" -> JsString("xmp programme maker"),
+          "aux:Lens" -> JsString("xmp aux lens")
+        )))
+    )
+    val json = Json.toJson(image)
+    val sourceWrapper = SourceWrapper[Image](json, image)
+
+    val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
+
+    extractedFields.nonEmpty shouldEqual true
+    extractedFields should have length 3
+
+    extractedFields.contains("orgProgrammeMaker" -> JsString("xmp programme maker")) shouldEqual true
+    extractedFields.contains("auxLens" -> JsString("xmp aux lens")) shouldEqual true
+    extractedFields.contains("captionWriter" -> JsString("the editor")) shouldEqual true
+  }
+
+  it("should return empty set of extract configured alias fields from sourcewrapper if fields do not exist in image") {
+    val image = createImage(
+      id = "test-image-with-no-filemetadata",
+      agency,
+      fileMetadata = Some(FileMetadata())
+    )
+    val json = Json.toJson(image)
+    val sourceWrapper = SourceWrapper[Image](json, image)
+
+    val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
+
+    extractedFields.isEmpty shouldEqual true
   }
 }

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -31,30 +31,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
 
   private val index = "images"
 
-  private val NOT_USED_IN_TEST = "not used in test"
-  private val MOCK_CONFIG_KEYS = Seq(
-    "auth.keystore.bucket",
-    "persistence.identifier",
-    "thrall.kinesis.stream.name",
-    "thrall.kinesis.lowPriorityStream.name",
-    "domain.root",
-    "s3.config.bucket",
-    "s3.usagemail.bucket",
-    "quota.store.key",
-    "es.index.aliases.read",
-    "es6.url",
-    "es6.cluster",
-    "s3.image.bucket",
-    "s3.thumb.bucket",
-    "grid.stage",
-    "grid.appName"
-  )
-
   private val mediaApiConfig = new MediaApiConfig(GridConfigResources(
-    Configuration.from(Map(
-      "es6.shards" -> 0,
-      "es6.replicas" -> 0
-    ) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap),
+    Configuration.from(USED_CONFIGS_IN_TEST ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap),
     null
   ))
 
@@ -290,8 +268,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       val search = SearchParams(tier = Internal, syndicationStatus = Some(BlockedForSyndication))
       val searchResult = ES.search(search)
       whenReady(searchResult, timeout, interval) { result =>
-        result.hits.forall(h => h._2.leases.leases.nonEmpty) shouldBe true
-        result.hits.forall(h => h._2.leases.leases.forall(l => l.access == DenySyndicationLease)) shouldBe true
+        result.hits.forall(h => h._2.instance.leases.leases.nonEmpty) shouldBe true
+        result.hits.forall(h => h._2.instance.leases.leases.forall(l => l.access == DenySyndicationLease)) shouldBe true
         result.total shouldBe 3
       }
     }
@@ -327,7 +305,7 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       val hasFileMetadataSearch = SearchParams(tier = Internal, structuredQuery = List(hasFileMetadataCondition))
       whenReady(ES.search(hasFileMetadataSearch), timeout, interval) { result =>
         result.total shouldBe 1
-        result.hits.head._2.fileMetadata.xmp.nonEmpty shouldBe true
+        result.hits.head._2.instance.fileMetadata.xmp.nonEmpty shouldBe true
       }
     }
 
@@ -336,7 +314,7 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       val hasFileMetadataSearch = SearchParams(tier = Internal, structuredQuery = List(hasFileMetadataCondition))
       whenReady(ES.search(hasFileMetadataSearch), timeout, interval) { result =>
         result.total shouldBe 1
-        result.hits.head._2.fileMetadata.xmp.get("foo") shouldBe Some(JsString("bar"))
+        result.hits.head._2.instance.fileMetadata.xmp.get("foo") shouldBe Some(JsString("bar"))
       }
     }
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -119,9 +119,20 @@ trait ElasticSearchTestBase extends FunSpec with BeforeAndAfterAll with Matchers
       rightsAcquired = true,
       Some(DateTime.parse("2018-07-03T00:00:00")),
       None,
-      fileMetadata = Some(FileMetadata(xmp = Map(
+      fileMetadata = Some(FileMetadata(
+        iptc = Map(
+          "Caption/Abstract" -> "the description",
+          "Caption Writer/Editor" -> "the editor"
+        ),
+        exif = Map(
+          "Copyright" -> "the copyright",
+          "Artist" -> "the artist"
+        ),
+        xmp = Map(
         "foo" -> JsString("bar"),
-        "toolong" -> JsString(stringLongerThan(100000))
+        "toolong" -> JsString(stringLongerThan(100000)),
+        "org:ProgrammeMaker" -> JsString("xmp programme maker"),
+        "aux:Lens" -> JsString("xmp aux lens")
       )))
     ),
 

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -14,6 +14,29 @@ trait Fixtures {
   val staffPhotographer = StaffPhotographer("Tom Jenkins", "The Guardian")
   val agency = Agency("ACME")
   val screengrab = Screengrab(None, None)
+  val USED_CONFIGS_IN_TEST = Map(
+    "es6.shards" -> 0,
+    "es6.replicas" -> 0,
+    "field.aliases" -> Seq.empty
+  )
+  val NOT_USED_IN_TEST = "not used in test"
+  val MOCK_CONFIG_KEYS = Seq(
+    "auth.keystore.bucket",
+    "persistence.identifier",
+    "thrall.kinesis.stream.name",
+    "thrall.kinesis.lowPriorityStream.name",
+    "domain.root",
+    "s3.config.bucket",
+    "s3.usagemail.bucket",
+    "quota.store.key",
+    "es.index.aliases.read",
+    "es6.url",
+    "es6.cluster",
+    "s3.image.bucket",
+    "s3.thumb.bucket",
+    "grid.stage",
+    "grid.appName"
+  )
 
   def createImage(
     id: String,


### PR DESCRIPTION
## What does this change?
It introduces a way of rendering additional fields on the UI via configuration. This is achieved by adding the following configuration to Kahuna service and Media API service configuration file i.e. 

- `$USER/.grid/kahuna.conf` or `/etc/grid/kahuna.conf` 
- `$USER/.grid/media-api.conf` or `/etc/grid/media-api.conf` 

where applicable (dev stage or prod stage respectively).

```hocon
# Field aliases configurations that are used to define which metadata field is visible, searchable and has an alias on the UI
field.aliases = [
  {
    # Sets the image metadata tag to be used when filtering FileMetadata field
    elasticsearchPath = "fileMetadata.xmp.bbc:Programme-Maker"
    # Sets an alias for use in search, shouldn't have whitespace or special characters
    alias = "BBCProgrammeMaker"
    # Sets a human readable label that will rendered on the UI
    label = "BBC Programme Maker"
    # Sets the field alias to be displayed as a search hint when you type `+`
    displaySearchHint = false
  }
  {
    elasticsearchPath = "fileMetadata.xmp.xmp:CreatorTool"
    alias = "creatorTool"
    label = "Creator Tool"
    displaySearchHint = false
  }
  {
    elasticsearchPath = "fileMetadata.exif.Artist"
    alias = "artist"
    label = "Artist"
    displaySearchHint = true
  }
  {
    elasticsearchPath = "fileMetadata.iptc.Caption Writer/Editor"
    alias = "captionWriter"
    label = "Caption Writer / Editor"
    displaySearchHint = true
  }
  {
    elasticsearchPath = "fileMetadata.xmp.Iptc4xmpExt:DigitalSourceType"
    alias = "digitalSourceType"
    label = "Digital Source Type"
    displaySearchHint = false
  }
]
```

The approach is described in the proposal: https://github.com/guardian/grid/issues/3167


## How can success be measured?

On the Image view page, the configured fields are visible on the “Show additional metadata” section when expanded.


## Screenshots

![Screenshot at 2021-03-02 20-44-10](https://user-images.githubusercontent.com/12212239/109691299-59657980-7b98-11eb-8b1f-ad909b478eb7.png)

![Screenshot at 2021-03-02 20-45-57](https://user-images.githubusercontent.com/12212239/109691428-7b5efc00-7b98-11eb-80dd-fc1d99287764.png)


## Who should look at this?

@AWare , @sihil , @paperboyo and @akash1810 

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
