### PR TITLE
feature/bbc-pluggable-project: Implement pluggable bbc project mechanism

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,11 @@ val commonSettings = Seq(
   publishArtifact in (Compile, packageDoc) := false
 )
 
+//Common projects to all organizations
+lazy val commonProjects: Seq[sbt.ProjectReference] = Seq(commonLib, restLib, auth, collections, cropper, imageLoader, leases, thrall, kahuna, metadataEditor, usage, mediaApi, adminToolsLambda, adminToolsScripts, adminToolsDev)
+
 lazy val root = project("grid", path = Some("."))
-  .aggregate(commonLib, restLib, auth, collections, cropper, imageLoader, leases, thrall, kahuna, metadataEditor, usage, mediaApi, adminToolsLambda, adminToolsScripts, adminToolsDev)
+  .aggregate((maybeBBCLib.toList ++ commonProjects):_*)
   .enablePlugins(RiffRaffArtifact)
   .settings(
     riffRaffManifestProjectName := s"media-service::grid::all",
@@ -67,20 +70,16 @@ val okHttpVersion = "3.12.1"
 
 val bbcBuildProcess: Boolean = System.getenv().asScala.get("BUILD_ORG").contains("bbc")
 
-val bbcCommonLibSettings: SettingsDefinition = if (bbcBuildProcess) {
-  Seq(
-    libraryDependencies ++= Seq("com.gu" %% "pan-domain-auth-play_2-6" % "0.9.2-SNAPSHOT")
-  )
-} else {
-  Seq(
-    libraryDependencies ++= Seq("com.gu" %% "pan-domain-auth-play_2-6" % "0.8.2")
-  )
-}
+//BBC specific project, it only gets compiled when bbcBuildProcess is true
+lazy val bbcProject = project("bbc").dependsOn(restLib)
+
+val maybeBBCLib: Option[sbt.ProjectReference] = if(bbcBuildProcess) Some(bbcProject) else None
 
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
     "com.gu" %% "editorial-permissions-client" % "2.0",
+    "com.gu" %% "pan-domain-auth-play_2-6" % "0.8.2",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
@@ -114,7 +113,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.squareup.okhttp3" % "okhttp" % okHttpVersion
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
-).settings(bbcCommonLibSettings)
+)
 
 lazy val restLib = project("rest-lib").settings(
   libraryDependencies ++= Seq(
@@ -289,8 +288,8 @@ val buildInfo = Seq(
   )
 )
 
-def playProject(projectName: String, port: Int, path: Option[String] = None): Project =
-  project(projectName, path)
+def playProject(projectName: String, port: Int, path: Option[String] = None): Project = {
+  val commonProject = project(projectName, path)
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
     .dependsOn(restLib)
     .settings(commonSettings ++ buildInfo ++ Seq(
@@ -317,3 +316,6 @@ def playProject(projectName: String, port: Int, path: Option[String] = None): Pr
         "-J-XX:GCLogFileSize=2M"
       )
     ))
+  //Add the BBC library dependency if defined
+  maybeBBCLib.fold(commonProject){commonProject.dependsOn(_)}
+}


### PR DESCRIPTION
## What does this change?
These changes provide BBC a way to have their own specific project, allowing them to use different versions of other libraries or have code that wouldn't otherwise compile on the Guardian version. The bbcLib project is only compiled if the BUILD_ORG environment variable is set to "bbc".

## How can success be measured?
BBC grid works successfully in BBC environments, while not affecting Guardian's Grid behaviour or compilation in any way.

## Who should look at this?
@sihil , @wainaina , @gribeiro

## Tested?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
