### PR TITLE
Revert "Only process user/provided metadata if image has not previously been uploaded"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -29,18 +29,15 @@ class ImageIngestOperations(imageBucket: String, thumbnailBucket: String, config
 
   private def storeOriginalImage(storableImage: StorableOriginalImage)
                         (implicit logMarker: LogMarker): Future[S3Object] =
-    storeImage(imageBucket, fileKeyFromId(storableImage.id), storableImage.file, Some(storableImage.mimeType),
-      storableImage.meta, overwrite = false)
+    storeImage(imageBucket, fileKeyFromId(storableImage.id), storableImage.file, Some(storableImage.mimeType), storableImage.meta)
 
   private def storeThumbnailImage(storableImage: StorableThumbImage)
                          (implicit logMarker: LogMarker): Future[S3Object] =
-    storeImage(thumbnailBucket, fileKeyFromId(storableImage.id), storableImage.file, Some(storableImage.mimeType),
-      overwrite = true)
+    storeImage(thumbnailBucket, fileKeyFromId(storableImage.id), storableImage.file, Some(storableImage.mimeType))
 
   private def storeOptimisedImage(storableImage: StorableOptimisedImage)
                        (implicit logMarker: LogMarker): Future[S3Object] =
-    storeImage(imageBucket, optimisedPngKeyFromId(storableImage.id), storableImage.file, Some(storableImage.mimeType),
-      overwrite = true)
+    storeImage(imageBucket, optimisedPngKeyFromId(storableImage.id), storableImage.file, Some(storableImage.mimeType))
 
   def deleteOriginal(id: String): Future[Unit] = if(isVersionedS3) deleteVersionedImage(imageBucket, fileKeyFromId(id)) else deleteImage(imageBucket, fileKeyFromId(id))
   def deleteThumbnail(id: String): Future[Unit] = deleteImage(thumbnailBucket, fileKeyFromId(id))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageQuarantineOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageQuarantineOperations.scala
@@ -14,7 +14,7 @@ class ImageQuarantineOperations(quarantineBucket: String, config: CommonConfig, 
 
   def storeQuarantineImage(id: String, file: File, mimeType: Option[MimeType], meta: Map[String, String] = Map.empty)
                        (implicit logMarker: LogMarker): Future[S3Object] =
-    storeImage(quarantineBucket, ImageIngestOperations.fileKeyFromId(id), file, mimeType, meta, overwrite = true)
+    storeImage(quarantineBucket, ImageIngestOperations.fileKeyFromId(id), file, mimeType, meta)
 }
 
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageStorage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageStorage.scala
@@ -34,8 +34,7 @@ trait ImageStorage {
   /** Store a copy of the given file and return the URI of that copy.
     * The file can safely be deleted afterwards.
     */
-  def storeImage(bucket: String, id: String, file: File, mimeType: Option[MimeType],
-                 meta: Map[String, String] = Map.empty, overwrite: Boolean)
+  def storeImage(bucket: String, id: String, file: File, mimeType: Option[MimeType], meta: Map[String, String] = Map.empty)
                 (implicit logMarker: LogMarker): Future[S3Object]
 
   def deleteImage(bucket: String, id: String): Future[Unit]

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -3,6 +3,7 @@ package com.gu.mediaservice.lib.aws
 import java.io.File
 import java.net.{URI, URLEncoder}
 import java.nio.charset.{Charset, StandardCharsets}
+
 import com.amazonaws.{AmazonServiceException, ClientConfiguration}
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, model}
@@ -18,46 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class S3Object(uri: URI, size: Long, metadata: S3Metadata)
 
-object S3Object {
-  def objectUrl(bucket: String, key: String): URI = {
-    val bucketUrl = s"$bucket.${S3Ops.s3Endpoint}"
-    new URI("http", bucketUrl, s"/$key", null)
-  }
-
-  def apply(bucket: String, key: String, size: Long, metadata: S3Metadata): S3Object =
-    apply(objectUrl(bucket, key), size, metadata)
-
-  def apply(bucket: String, key: String, file: File, mimeType: Option[MimeType],
-            meta: Map[String, String] = Map.empty, cacheControl: Option[String] = None): S3Object = {
-    S3Object(
-      bucket,
-      key,
-      file.length,
-      S3Metadata(
-        meta,
-        S3ObjectMetadata(
-          mimeType,
-          cacheControl
-        )
-      )
-    )
-  }
-}
-
 case class S3Metadata(userMetadata: Map[String, String], objectMetadata: S3ObjectMetadata)
-
-object S3Metadata {
-  def apply(meta: ObjectMetadata): S3Metadata = {
-    S3Metadata(
-      meta.getUserMetadata.asScala.toMap,
-      S3ObjectMetadata(
-        contentType = Option(meta.getContentType).map(MimeType.apply),
-        cacheControl = Option(meta.getCacheControl),
-        lastModified = Option(meta.getLastModified).map(new DateTime(_))
-      )
-    )
-  }
-}
 
 case class S3ObjectMetadata(contentType: Option[MimeType], cacheControl: Option[String], lastModified: Option[DateTime] = None)
 
@@ -65,6 +27,8 @@ class S3(config: CommonConfig) extends GridLogging {
   type Bucket = String
   type Key = String
   type UserMetadata = Map[String, String]
+
+  import S3Ops.objectUrl
 
   lazy val client: AmazonS3 = S3Ops.buildS3Client(config)
   // also create a legacy client that uses v2 signatures for URL signing
@@ -152,7 +116,7 @@ class S3(config: CommonConfig) extends GridLogging {
   }
 
   def store(bucket: Bucket, id: Key, file: File, mimeType: Option[MimeType], meta: UserMetadata = Map.empty, cacheControl: Option[String] = None)
-           (implicit ex: ExecutionContext, logMarker: LogMarker): Future[S3Object] =
+           (implicit ex: ExecutionContext, logMarker: LogMarker): Future[Unit] =
     Future {
       val metadata = new ObjectMetadata
       mimeType.foreach(m => metadata.setContentType(m.name))
@@ -168,26 +132,9 @@ class S3(config: CommonConfig) extends GridLogging {
 
       val req = new PutObjectRequest(bucket, id, file).withMetadata(metadata)
       Stopwatch(s"S3 client.putObject ($req)"){
-        val res = client.putObject(req)
-        S3Object(bucket, id, res.getMetadata.getContentLength, S3Metadata(res.getMetadata))
+        client.putObject(req)
       }(markers)
     }
-
-  def storeIfNotPresent(bucket: Bucket, id: Key, file: File, mimeType: Option[MimeType], meta: UserMetadata = Map.empty, cacheControl: Option[String] = None)
-                       (implicit ex: ExecutionContext, logMarker: LogMarker): Future[S3Object] = {
-    Future{
-      Some(client.getObjectMetadata(bucket, id))
-    }.recover {
-      // translate this exception into the object not existing
-      case as3e:AmazonS3Exception if as3e.getStatusCode == 404 => None
-    }.flatMap {
-      case Some(objectMetadata) =>
-        log.info(s"Skipping storing of S3 file $id as key is already present in bucket $bucket")
-        Future.successful(S3Object(bucket, id, objectMetadata.getContentLength, S3Metadata(objectMetadata)))
-      case None =>
-        store(bucket, id, file, mimeType, meta, cacheControl)
-    }
-  }
 
   def list(bucket: Bucket, prefixDir: String)
           (implicit ex: ExecutionContext): Future[List[S3Object]] =
@@ -197,13 +144,21 @@ class S3(config: CommonConfig) extends GridLogging {
       val summaries = listing.getObjectSummaries.asScala
       summaries.map(summary => (summary.getKey, summary)).foldLeft(List[S3Object]()) {
         case (memo: List[S3Object], (key: String, summary: S3ObjectSummary)) =>
-          S3Object(bucket, key, summary.getSize, getMetadata(bucket, key)) :: memo
+          S3Object(objectUrl(bucket, key), summary.getSize, getMetadata(bucket, key)) :: memo
       }
     }
 
   def getMetadata(bucket: Bucket, key: Key): S3Metadata = {
     val meta = client.getObjectMetadata(bucket, key)
-    S3Metadata(meta)
+
+    S3Metadata(
+      meta.getUserMetadata.asScala.toMap,
+      S3ObjectMetadata(
+        contentType = Option(MimeType(meta.getContentType)),
+        cacheControl = Option(meta.getCacheControl),
+        lastModified = Option(meta.getLastModified).map(new DateTime(_))
+      )
+    )
   }
 
   def getUserMetadata(bucket: Bucket, key: Key): Map[Bucket, Bucket] =
@@ -221,7 +176,7 @@ class S3(config: CommonConfig) extends GridLogging {
 object S3Ops {
   // TODO make this localstack friendly
   // TODO: Make this region aware - i.e. RegionUtils.getRegion(region).getServiceEndpoint(AmazonS3.ENDPOINT_PREFIX)
-  val s3Endpoint = "s3.amazonaws.com"
+  private val s3Endpoint = "s3.amazonaws.com"
 
   def buildS3Client(config: CommonConfig, forceV2Sigs: Boolean = false, localstackAware: Boolean = true): AmazonS3 = {
 
@@ -242,5 +197,28 @@ object S3Ops {
     }
 
     config.withAWSCredentials(builder, localstackAware).build()
+  }
+
+  def objectUrl(bucket: String, key: String): URI = {
+    val bucketUrl = s"$bucket.$s3Endpoint"
+    new URI("http", bucketUrl, s"/$key", null)
+  }
+
+  def projectFileAsS3Object(url: URI, file: File, mimeType: Option[MimeType], meta: Map[String, String], cacheControl: Option[String]): S3Object = {
+    S3Object(
+      url,
+      file.length,
+      S3Metadata(
+        meta,
+        S3ObjectMetadata(
+          mimeType,
+          cacheControl
+        )
+      )
+    )
+  }
+
+  def projectFileAsS3Object(bucket: String, key: String, file: File, mimeType: Option[MimeType], meta: Map[String, String] = Map.empty, cacheControl: Option[String] = None): S3Object = {
+    projectFileAsS3Object(objectUrl(bucket, key), file, mimeType, meta, cacheControl)
   }
 }

--- a/cropper/app/lib/CropStore.scala
+++ b/cropper/app/lib/CropStore.scala
@@ -35,7 +35,7 @@ class CropStore(config: CropperConfig) extends S3ImageStorage(config) {
       case (key, value)       => key -> value
     }.mapValues(_.toString)
 
-    storeImage(config.imgPublishingBucket, filename, file, Some(mimeType), filteredMetadata, overwrite = true) map { s3Object =>
+    storeImage(config.imgPublishingBucket, filename, file, Some(mimeType), filteredMetadata) map { s3Object =>
       Asset(
         translateImgHost(s3Object.uri),
         Some(s3Object.size),

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -3,10 +3,9 @@ package model
 import java.io.{File, FileOutputStream}
 import java.util.UUID
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object => AwsS3Object}
+import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
 import com.gu.mediaservice.lib.{ImageIngestOperations, ImageStorageProps, StorableOptimisedImage, StorableOriginalImage, StorableThumbImage}
 import com.gu.mediaservice.lib.aws.S3Ops
-import com.gu.mediaservice.lib.aws.S3Object
 import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.LogMarker
@@ -40,26 +39,22 @@ case class S3FileExtractedMetadata(
 
 object S3FileExtractedMetadata {
   def apply(s3ObjectMetadata: ObjectMetadata): S3FileExtractedMetadata = {
-    val lastModified = new DateTime(s3ObjectMetadata.getLastModified)
-    val userMetadata = s3ObjectMetadata.getUserMetadata.asScala.toMap
-    apply(lastModified, userMetadata)
-  }
-
-  def apply(lastModified: DateTime, userMetadata: Map[String, String]): S3FileExtractedMetadata = {
-    val fileUserMetadata = userMetadata.map { case (key, value) =>
-      // Fix up the contents of the metadata.
-      (
-        // The keys used to be named with underscores instead of dashes but due to localstack being written in Python
-        // this didn't work locally (see https://github.com/localstack/localstack/issues/459)
-        key.replaceAll("_", "-"),
-        // The values are now all URL encoded and it is assumed safe to decode historical values too (based on the tested corpus)
-        URI.decode(value)
-      )
-    }
+    val lastModified = s3ObjectMetadata.getLastModified.toInstant.toString
+    val fileUserMetadata = s3ObjectMetadata.getUserMetadata.asScala.toMap
+      .map { case (key, value) =>
+        // Fix up the contents of the metadata.
+        (
+          // The keys used to be named with underscores instead of dashes but due to localstack being written in Python
+          // this didn't work locally (see https://github.com/localstack/localstack/issues/459)
+          key.replaceAll("_", "-"),
+          // The values are now all URL encoded and it is assumed safe to decode historical values too (based on the tested corpus)
+          URI.decode(value)
+        )
+      }
 
     val uploadedBy = fileUserMetadata.getOrElse(ImageStorageProps.uploadedByMetadataKey, "re-ingester")
-    val uploadedTimeRaw = fileUserMetadata.get(ImageStorageProps.uploadTimeMetadataKey).map(new DateTime(_).withZone(DateTimeZone.UTC))
-    val uploadTime = uploadedTimeRaw.getOrElse(lastModified)
+    val uploadedTimeRaw = fileUserMetadata.getOrElse(ImageStorageProps.uploadTimeMetadataKey, lastModified)
+    val uploadTime = new DateTime(uploadedTimeRaw).withZone(DateTimeZone.UTC)
     val identifiers = fileUserMetadata.filter{ case (key, _) =>
       key.startsWith(ImageStorageProps.identifierMetadataKeyPrefix)
     }.map{ case (key, value) =>
@@ -105,7 +100,7 @@ class Projector(config: ImageUploadOpsCfg,
     }
   }
 
-  private def getSrcFileDigestForProjection(s3Src: AwsS3Object, imageId: String, tempFile: File) = {
+  private def getSrcFileDigestForProjection(s3Src: S3Object, imageId: String, tempFile: File) = {
     IOUtils.copy(s3Src.getObjectContent, new FileOutputStream(tempFile))
     DigestedFile(tempFile, imageId)
   }
@@ -152,7 +147,7 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
   private def projectOriginalFileAsS3Model(storableOriginalImage: StorableOriginalImage)
                                           (implicit ec: ExecutionContext)= Future {
     val key = ImageIngestOperations.fileKeyFromId(storableOriginalImage.id)
-    S3Object(
+    S3Ops.projectFileAsS3Object(
       config.originalFileBucket,
       key,
       storableOriginalImage.file,
@@ -164,7 +159,7 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
   private def projectThumbnailFileAsS3Model(storableThumbImage: StorableThumbImage)(implicit ec: ExecutionContext) = Future {
     val key = ImageIngestOperations.fileKeyFromId(storableThumbImage.id)
     val thumbMimeType = Some(ImageOperations.thumbMimeType)
-    S3Object(
+    S3Ops.projectFileAsS3Object(
       config.thumbBucket,
       key,
       storableThumbImage.file,
@@ -175,7 +170,7 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
   private def projectOptimisedPNGFileAsS3Model(storableOptimisedImage: StorableOptimisedImage)(implicit ec: ExecutionContext) = Future {
     val key = ImageIngestOperations.optimisedPngKeyFromId(storableOptimisedImage.id)
     val optimisedPngMimeType = Some(ImageOperations.thumbMimeType) // this IS what we will generate.
-    S3Object(
+    S3Ops.projectFileAsS3Object(
       config.originalFileBucket,
       key,
       storableOptimisedImage.file,

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -146,7 +146,6 @@ object Uploader extends GridLogging {
     val eventualImage = for {
       browserViewableImage <- eventualBrowserViewableImage
       s3Source <- sourceStoreFuture
-      mergedUploadRequest = patchUploadRequestWithS3Metadata(uploadRequest, s3Source)
       optimisedFileMetadata <- FileMetadataReader.fromIPTCHeadersWithColorInfo(browserViewableImage)
       thumbViewableImage <- createThumbFuture(optimisedFileMetadata, colourModelFuture, browserViewableImage, deps)
       s3Thumb <- storeOrProjectThumbFile(thumbViewableImage)
@@ -166,7 +165,7 @@ object Uploader extends GridLogging {
       val thumbAsset = Asset.fromS3Object(s3Thumb, thumbDimensions)
 
       val pngAsset = s3PngOption.map(Asset.fromS3Object(_, sourceDimensions))
-      val baseImage = ImageUpload.createImage(mergedUploadRequest, sourceAsset, thumbAsset, pngAsset, fullFileMetadata, metadata)
+      val baseImage = ImageUpload.createImage(uploadRequest, sourceAsset, thumbAsset, pngAsset, fullFileMetadata, metadata)
 
       val processedImage = processor(baseImage)
 
@@ -257,16 +256,6 @@ object Uploader extends GridLogging {
         )
       case None => Future.failed(new Exception("This file is not an image with an identifiable mime type"))
     }
-  }
-
-  def patchUploadRequestWithS3Metadata(request: UploadRequest, s3Object: S3Object): UploadRequest = {
-    val metadata = S3FileExtractedMetadata(s3Object.metadata.objectMetadata.lastModified.getOrElse(new DateTime), s3Object.metadata.userMetadata)
-    request.copy(
-      uploadTime = metadata.uploadTime,
-      uploadedBy = metadata.uploadedBy,
-      uploadInfo = request.uploadInfo.copy(filename = metadata.uploadFileName),
-      identifiers = metadata.identifiers
-    )
   }
 }
 

--- a/image-loader/test/scala/model/ImageUploadTest.scala
+++ b/image-loader/test/scala/model/ImageUploadTest.scala
@@ -53,7 +53,7 @@ class ImageUploadTest extends AsyncFunSuite with Matchers with MockitoSugar {
 
     def mockStore = (a: StorableImage) =>
       Future.successful(
-        S3Object("madeupname", "madeupkey", a.file, Some(a.mimeType), a.meta, None)
+        S3Ops.projectFileAsS3Object(new URI("http://madeupname/"), a.file, Some(a.mimeType), a.meta, None)
       )
 
     def storeOrProjectOriginalFile: StorableOriginalImage => Future[S3Object] = mockStore


### PR DESCRIPTION
Reverts guardian/grid#3178 as it caused issues with missing `uploadedBy` data (defaulting to re-ingester) and possibly also problems with cropping.