### PR TITLE
'add to pinboard' button for crop thumbnails

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -193,6 +193,9 @@ image.controller('ImageCtrl', [
       $state.go('image', {imageId: ctrl.image.data.id, crop: undefined}, {reload: true});
     };
 
+    ctrl.getEmbeddableUrl = (maybeCropId) =>
+      $state.href($state.current.name, { crop: maybeCropId || null }, { absolute: true });
+
     // TODO: move this to a more sensible place.
     function getCropDimensions() {
       return {

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -15,4 +15,10 @@
     <span class="flex-spacer"></span>
     <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
   </div>
+  <pinboard-add-button
+    data-type="grid-crop"
+    data-grid-crop-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
+    data-grid-image-id="{{ctrl.image.data.id}}"
+    data-grid-crop-id="{{crop.id}}"
+  ></pinboard-add-button>
 </div>

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -19,7 +19,6 @@
     data-source="grid"
     data-source-type="crop"
     data-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
-    data-primary-id="{{ctrl.image.data.id}}"
-    data-secondary-id="{{crop.id}}"
+    data-embeddable-url="{{ctrl.getEmbeddableUrl(crop.id)}}"
   ></asset-handle>
 </div>

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -15,10 +15,11 @@
     <span class="flex-spacer"></span>
     <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
   </div>
-  <pinboard-add-button
-    data-type="grid-crop"
-    data-grid-crop-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
-    data-grid-image-id="{{ctrl.image.data.id}}"
-    data-grid-crop-id="{{crop.id}}"
-  ></pinboard-add-button>
+  <asset-handle
+    data-source="grid"
+    data-source-type="crop"
+    data-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
+    data-primary-id="{{ctrl.image.data.id}}"
+    data-secondary-id="{{crop.id}}"
+  ></asset-handle>
 </div>


### PR DESCRIPTION
Co-authored-by: @tjsilver 

https://trello.com/c/TIeyuEff/511-1st-pinboard-integration-grid-phase-1

Following https://github.com/guardian/grid/pull/3179 we can now load the pinboard script via config, this PR benefits from the pinboard improvements in https://github.com/guardian/editorial-tools-pinboard/pull/36 which actually does something with the data-attributes on `<pinboard-add-button` HTML tags (i.e. puts them in the `payload` of the `item`s it stores).


## What does this change?
This PR simply adds the `<pinboard-add-button` HTML tag with the following data attributes...
- `data-type="grid-crop"` this is needed to distinguish from other types of item (such as `message-only` or `mam-video`)
- `data-grid-crop-thumbnail="{{:: extremeAssets.smallest | assetFile}}"` the URL pointing directly to the smallest thumbnail for the crop
- `data-grid-image-id="{{ctrl.image.data.id}}"` the main image identifier
- `data-grid-crop-id="{{crop.id}}"` the identifier for the specific crop

... as per the philosophy of pinboard this HTML tag means nothing to the host platform (in this case grid) but is picked up dynamically by pinboard and a button is rendered using React Portals. [TODO add link to pinboard ADR once written].

This is just phase 1 of the grid integration, in future we hope to support 'pinning' the base image and collections as well as drag&drop support (see https://trello.com/c/5WaJkX3Q/587-pinboard-grid-integration-phase-2-base-images-and-collections).

## How to test
With this branch deployed to Grid TEST and `tr-ts-grid-image-support` branch deployed to Pinboard CODE:
- Create a crop of an image
- Click on the `add to 📌` button
- Observe as pinboard opens (if not open already) and a selector popout appears allowing you to choose a pinboard to add the image to
- Select a suitable pinboard e.g. 'test draggable'
- Notice the image preview in the text box
- Observe that you can also discard the image in the selector or text box
- Add optional message and hit send
- Notice the image in the discussion thread above

To test how to use this image, see details in the [Pinboard PR](https://github.com/guardian/editorial-tools-pinboard/pull/36).

## How can success be measured?
Different editorial teams can share grid assets for a piece with accompanying discussion.

## Screenshots
![grid_drop](https://user-images.githubusercontent.com/19289579/109323352-475ba200-784b-11eb-8ec0-e433f0baa0e5.gif)


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
