### PR TITLE
Ensure that permission check is exhaustive

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -99,6 +99,7 @@ class MediaApi(
           authorisation.hasPermissionTo(permission)(principal)
         }
       case service: MachinePrincipal if service.accessor.tier == Internal => true
+      case _ => false
     }
   }
 


### PR DESCRIPTION
## What does this change?
In #3131 a case was missed where a machine principal is in a tier other than Internal. This fixes that by adding a catch all that defaults to denying permission.

## How can success be measured?
No internal errors in logs.

## Tested?
Not planning to test due to current issue and simplicity of change.