### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,40 +9,6 @@ updates:
     commit-message:
       prefix: "chore(deps): "
 
-  # the frontend site
-  - package-ecosystem: 'npm'
-    directory: '/kahuna'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: "chore(deps): "
-
-  # things that run in an AWS Lambda environment
-  - package-ecosystem: 'npm'
-    directory: '/reaper'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: "chore(deps): "
-  - package-ecosystem: 'npm'
-    directory: '/image-counter-lambda'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: "chore(deps): "
-  - package-ecosystem: 'npm'
-    directory: '/s3watcher/lambda'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: "chore(deps): "
-  - package-ecosystem: 'npm'
-    directory: '/s3watcher/scripts'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: "chore(deps): "
-
   # things that only get run locally
   - package-ecosystem: 'npm'
     directory: '/dev/oidc-provider'
@@ -68,3 +34,39 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: "chore(deps): "
+
+
+# Not scanning these projects for now as I'm not sure how noisy/annoying dependabot will be for the team.
+#  # the frontend site
+#  - package-ecosystem: 'npm'
+#    directory: '/kahuna'
+#    schedule:
+#      interval: 'weekly'
+#    commit-message:
+#      prefix: "chore(deps): "
+#
+#  # things that run in an AWS Lambda environment
+#  - package-ecosystem: 'npm'
+#    directory: '/reaper'
+#    schedule:
+#      interval: 'weekly'
+#    commit-message:
+#      prefix: "chore(deps): "
+#  - package-ecosystem: 'npm'
+#    directory: '/image-counter-lambda'
+#    schedule:
+#      interval: 'weekly'
+#    commit-message:
+#      prefix: "chore(deps): "
+#  - package-ecosystem: 'npm'
+#    directory: '/s3watcher/lambda'
+#    schedule:
+#      interval: 'weekly'
+#    commit-message:
+#      prefix: "chore(deps): "
+#  - package-ecosystem: 'npm'
+#    directory: '/s3watcher/scripts'
+#    schedule:
+#      interval: 'weekly'
+#    commit-message:
+#      prefix: "chore(deps): "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,70 @@
+# See the documentation for all configuration options https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+
+  # the frontend site
+  - package-ecosystem: 'npm'
+    directory: '/kahuna'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+
+  # things that run in an AWS Lambda environment
+  - package-ecosystem: 'npm'
+    directory: '/reaper'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/image-counter-lambda'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/s3watcher/lambda'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/s3watcher/scripts'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+
+  # things that only get run locally
+  - package-ecosystem: 'npm'
+    directory: '/dev/oidc-provider'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/dev/script/generate-config'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/scripts/sample-images'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/scripts/reindex-images'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "


### PR DESCRIPTION
## What does this change?

Dependabot is a little nicer than Snyk:
- It has a simpler API, driven by comments on GitHub
- It authors under a consistent username

The downside of this is Dependabot doesn't (yet) support SBT and Snyk does, however I can only see PRs against NPM dependencies so maybe this is OK?

We may want to consider [throttling](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit) the number of PRs at the start as it might be overwhelming with so many sub-projects.

See https://github.com/guardian/grid/pulls?q=is%3Apr+%5BSnyk%5D+.

## How can success be measured?

Dependency updates are attributed to a consistent user and all `package.json` files are inspected.

(There are a lot in this repo, which might suggest a need for workspaces which [recently landed in NPM v7](https://docs.npmjs.com/cli/v7/using-npm/workspaces) or [Yarn](https://classic.yarnpkg.com/en/docs/workspaces/))

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->

n/a

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

@guardian/digital-cms

## Tested?
n/a