### PR TITLE
Implement permissions for own uploaded images

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -5,7 +5,7 @@ import com.google.common.net.HttpHeaders
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model.{Action, _}
 import com.gu.mediaservice.lib.auth.Authentication._
-import com.gu.mediaservice.lib.auth.Permissions.{DeleteCrops, DeleteImage, EditMetadata}
+import com.gu.mediaservice.lib.auth.Permissions.{DeleteCrops, DeleteImage, UploaderDeleteImage, EditMetadata, UploaderEditMetadata}
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.aws.{ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting.printDateTime
@@ -89,12 +89,13 @@ class MediaApi(
   private def isUploaderOrHasPermission(
     principal: Principal,
     image: Image,
-    permission: SimplePermission
+    permission: SimplePermission,
+    uploaderPermission: SimplePermission
   ) = {
     principal match {
       case user: UserPrincipal =>
         if (user.email.toLowerCase == image.uploadedBy.toLowerCase) {
-          true
+          authorisation.hasPermissionTo(uploaderPermission)(principal)
         } else {
           authorisation.hasPermissionTo(permission)(principal)
         }
@@ -104,10 +105,10 @@ class MediaApi(
   }
 
   def canUserWriteMetadata(principal: Principal, image: Image): Boolean =
-    isUploaderOrHasPermission(principal, image, EditMetadata)
+    isUploaderOrHasPermission(principal, image, EditMetadata, UploaderEditMetadata)
 
   def canUserDeleteImage(principal: Principal, image: Image): Boolean =
-    isUploaderOrHasPermission(principal, image, DeleteImage)
+    isUploaderOrHasPermission(principal, image, DeleteImage, UploaderDeleteImage)
 
   def canUserDeleteCropsOrUsages(principal: Principal): Boolean =
     authorisation.hasPermissionTo(DeleteCrops)(principal)

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
@@ -14,7 +14,9 @@ object Permissions {
   type PrincipalFilter = Principal => Boolean
 
   case object EditMetadata extends SimplePermission
+  case object UploaderEditMetadata extends SimplePermission
   case object DeleteImage extends SimplePermission
+  case object UploaderDeleteImage extends SimplePermission
   case object DeleteCrops extends SimplePermission
   case object ShowPaid extends SimplePermission
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -52,7 +52,9 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
     }
     permissionContext match {
       case EditMetadata => hasPermission(Permissions.EditMetadata)
+      case UploaderEditMetadata => true
       case DeleteImage => hasPermission(Permissions.DeleteImage)
+      case UploaderDeleteImage => true
       case DeleteCrops => hasPermission(Permissions.DeleteCrops)
       case ShowPaid => hasPermission(Permissions.ShowPaid)
     }


### PR DESCRIPTION
## What does this change?
Currently, if you upload an image you can delete it or edit its metadata even if you don't have general permissions to do those actions. With these changes, we add flexibility to the permissions system, by adding 2 new permissions:

- UploaderEditMetadata means the permission to edit metadata for images that were uploaded by the same user trying to edit.
- UploaderDeleteImage means the permission to delete images that were uploaded by the same user trying to delete.

These permissions will be set to true for the Guardian, while they will depend on the permission to delete or edit metadata for BBC.

## How can success be measured?
- A user without permission to edit metadata can still edit metadata from their uploaded images in Guardian Grid.
- A user without permission to delete images can still delete their uploaded images in Guardian Grid.
- A user without permission to edit metadata can no longer edit metadata from their uploaded images in BBC Grid.
- A user without permission to delete images can no longer delete their uploaded images in BBC Grid.

## Who should look at this?
@guardian/digital-cms, @sihil , @wainaina , @gribeiro 


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
