### PR TITLE
Convert Crid client to Play WS

### DIFF
--- a/admin-tools/dev/app/AdminToolsComponents.scala
+++ b/admin-tools/dev/app/AdminToolsComponents.scala
@@ -20,7 +20,7 @@ object AdminToolsComponents {
 class AdminToolsComponents(context: Context) extends GridComponents(context, AdminToolsComponents.config) {
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val controller = new AdminToolsCtr(config, controllerComponents)
+  val controller = new AdminToolsCtr(config, controllerComponents)(wsClient, ec)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management)
 }

--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -6,11 +6,12 @@ import com.gu.mediaservice.model.Image._
 import com.gu.mediaservice.{FullImageProjectionFailed, FullImageProjectionSuccess, ImageDataMerger, ImageDataMergerConfig}
 import lib.AdminToolsConfig
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.ExecutionContext
 
-class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
+class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents: ControllerComponents)(implicit wsClient: WSClient, implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
   private val cfg = ImageDataMergerConfig(apiKey = config.apiKey, domainRoot = config.domainRoot, imageLoaderEndpointOpt = None)

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/BatchIndexLambdaHandler.scala
@@ -1,8 +1,17 @@
 package com.gu.mediaservice
 
 import com.gu.mediaservice.indexing.IndexInputCreation
+import play.api.libs.ws.ahc.AhcWSClient
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import play.api.libs.ws._
 
 class BatchIndexLambdaHandler {
+
+
+  implicit private val system: ActorSystem = ActorSystem()
+  implicit private val materializer: ActorMaterializer = ActorMaterializer()
+  implicit private val ws:WSClient  = AhcWSClient()
 
   private val cfg = BatchIndexHandlerConfig(
     apiKey = sys.env("API_KEY"),
@@ -24,11 +33,11 @@ class BatchIndexLambdaHandler {
   private val batchIndex = new BatchIndexHandler(cfg)
 
 
-  def handleRequest() = {
+  def handleRequest(): Unit = {
     batchIndex.processImages()
   }
 
-  def handleCheckRequest() = {
+  def handleCheckRequest(): Unit = {
     batchIndex.checkImages()
   }
 

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -13,6 +13,7 @@ import com.gu.mediaservice.model.Image
 import com.typesafe.scalalogging.LazyLogging
 import net.logstash.logback.marker.Markers
 import play.api.libs.json.{JsObject, Json}
+import play.api.libs.ws.WSClient
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -40,7 +41,7 @@ case class BatchIndexHandlerConfig(
 
 case class SuccessResult(foundImagesCount: Int, notFoundImagesCount: Int, progressHistory: String, projectionTookInSec: Long)
 
-class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers {
+class BatchIndexHandler(cfg: BatchIndexHandlerConfig)(implicit wsClient: WSClient) extends LoggingWithMarkers {
 
   import cfg._
 
@@ -53,11 +54,13 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
 
   private val GetIdsTimeout = new FiniteDuration(20, TimeUnit.SECONDS)
   private val GlobalTimeout = new FiniteDuration(MainProcessingTimeoutInSec, TimeUnit.SECONDS)
-  private val ImagesProjectionTimeout = new FiniteDuration(ProjectionTimeoutInSec, TimeUnit.MINUTES)
+  private val ImagesProjectionTimeout = new FiniteDuration(ProjectionTimeoutInSec, TimeUnit.SECONDS)
   val services = new Services(domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
-  private val gridClient = GridClient(apiKey, services, maxIdleConnections, debugHttpResponse = false)
+  private val gridClient = GridClient(services)
 
-  private val ImagesBatchProjector = new ImagesBatchProjection(apiKey, ImagesProjectionTimeout, gridClient, maxSize)
+  private val ImagesBatchProjector = new ImagesBatchProjection(apiKey, ImagesProjectionTimeout, gridClient, maxSize, projectionEndpoint)
+  ImagesBatchProjector.assertApiKeyIsValid          // fail as fast as possible if the api key is duff
+
   private val InputIdsStore = new InputIdsStore(AwsHelpers.buildDynamoTableClient(dynamoTableName), batchSize)
 
   import ImagesBatchProjector._
@@ -66,7 +69,6 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
   private implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   def checkImages(): Unit = {
-    if (!validApiKey(projectionEndpoint)) throw new IllegalStateException("invalid api key")
     val stateProgress = scala.collection.mutable.ArrayBuffer[ProduceProgress]()
     stateProgress += NotStarted
     val mediaIdsFuture = getMediaIdsBatchByState(checkerStartState)
@@ -124,7 +126,6 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
   }
 
   def processImagesOnlyIfKinesisIsNiceAndFast(): Unit = {
-    if (!validApiKey(projectionEndpoint)) throw new IllegalStateException("invalid api key")
     val stateProgress = scala.collection.mutable.ArrayBuffer[ProduceProgress]()
     stateProgress += NotStarted
     val mediaIdsFuture = getUnprocessedMediaIdsBatch(startState)
@@ -135,6 +136,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig) extends LoggingWithMarkers
         stateProgress += updateStateToItemsInProgress(mediaIds)
         logger.info(s"Indexing ${mediaIds.length} media ids. Getting image projections from: $projectionEndpoint")
         val start = System.currentTimeMillis()
+        // left is found images
         val maybeBlobsFuture: List[Either[Image, String]] = getImagesProjection(mediaIds, projectionEndpoint, InputIdsStore)
 
         val (foundImages, notFoundImagesIds) = partitionToSuccessAndNotFound(maybeBlobsFuture)

--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/ImagesBatchProjection.scala
@@ -2,55 +2,53 @@ package com.gu.mediaservice
 
 import java.net.URL
 
+import com.gu.mediaservice.GridClient.{Error, Found => GridFound, NotFound => GridNotFound, Response}
+import com.gu.mediaservice.lib.auth.provider.ApiKeyAuthentication
 import com.gu.mediaservice.model.Image
+import play.api.libs.ws.WSRequest
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
 
-class ImagesBatchProjection(apiKey: String, timeout: Duration, gridClient: GridClient, maxSize: Int) {
+class ImagesBatchProjection(apiKey: String, timeout: Duration, gridClient: GridClient, maxSize: Int, projectionEndpoint: String) extends ApiKeyAuthentication {
 
-  private implicit val ThrottledExecutionContext = ExecutionContext.fromExecutor(java.util.concurrent.Executors.newFixedThreadPool(5))
+  private implicit val ThrottledExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(java.util.concurrent.Executors.newFixedThreadPool(5))
 
-  def validApiKey(projectionEndpoint: String) = {
-    val projectionUrl = new URL(s"$projectionEndpoint/not-exists")
-    val statusCode = gridClient.makeGetRequestSync(projectionUrl, apiKey).statusCode
-    statusCode != 401 && statusCode != 403
+  private def authFunction(request: WSRequest): WSRequest = request.withHttpHeaders((apiKeyHeaderName, apiKey))
+
+  def assertApiKeyIsValid: Boolean = {
+    val f = gridClient.validateApiKey(projectionEndpoint, authFunction)
+    Await.result(f, timeout)
   }
 
   def getImagesProjection(mediaIds: List[String], projectionEndpoint: String,
-                          InputIdsStore: InputIdsStore): List[Either[Image, String]] = {
-    val apiCalls = mediaIds.map { id =>
-      val projectionUrl = new URL(s"$projectionEndpoint/$id")
-      val responseFuture: Future[ResponseWrapper] = gridClient.makeGetRequestAsync(projectionUrl, apiKey)
-      val notFoundOrImage: Future[Option[Either[Image, String]]] = responseFuture.map { response =>
-        response.statusCode match {
-          case 200 if response.bodyAsString.size > maxSize => {
-            InputIdsStore.setStateToTooBig(id, response.bodyAsString.size)
-            None
-          }
-          case 200 => {
-            val img = response.body.as[Image]
-            Some(Left(img))
-          }
-          case 404 => {
+                          InputIdsStore: InputIdsStore): List[Either[Image, String]] = Await.result(
+    Future.sequence(
+      mediaIds.map { id =>
+        val projectionUrl = new URL(s"$projectionEndpoint/$id")
+        class FailedCallException extends Exception
+        gridClient.makeGetRequestAsync(projectionUrl, authFunction) map {
+          case GridFound(json, underlying) =>
+            if (underlying.body.length > maxSize) {
+              InputIdsStore.setStateToTooBig(id, underlying.body.length)
+              Right(id)
+            } else {
+              Left(json.as[Image])
+            }
+          case GridNotFound(_, _) =>
             InputIdsStore.updateStateToNotFoundImage(id)
-            Some(Right(id))
-          }
-          case _ if (isAKnownError(response)) => {
-            InputIdsStore.setStateToKnownError(id)
-            None
-          }
-          case _ => {
-            InputIdsStore.setStateToUnknownError(id)
-            None
-          }
+            Right(id)
+          case e@Error(_, _, _) =>
+            if (isAKnownError(e)) {
+              InputIdsStore.setStateToKnownError(id)
+              throw new FailedCallException()
+            } else {
+              InputIdsStore.setStateToUnknownError(id)
+              throw new FailedCallException()
+            }
         }
       }
-      notFoundOrImage
-    }
-    val f = Future.sequence(apiCalls)
-    Await.result(f, timeout).flatten
-  }
+    ), timeout)
 
   private trait GetImageStatus
   private case object Found extends GetImageStatus
@@ -58,25 +56,20 @@ class ImagesBatchProjection(apiKey: String, timeout: Duration, gridClient: GridC
   private case object Failed extends GetImageStatus
   case class ImagesWithStatus(found: List[String], notFound: List[String], failed: List[String])
 
+  class FailureException extends Exception
   def getImages(mediaIds: List[String], imagesEndpoint: String,
                           InputIdsStore: InputIdsStore): ImagesWithStatus = {
     val apiCalls = mediaIds.map { id =>
       val imagesUrl = new URL(s"$imagesEndpoint/$id")
-      val responseFuture: Future[ResponseWrapper] = gridClient.makeGetRequestAsync(imagesUrl, apiKey)
-      val futureImageWithStatus: Future[(String, GetImageStatus)] = responseFuture.map { response =>
-        if (response.statusCode == 200) {
-           (id, Found)
-        } else if (response.statusCode == 404) {
-           (id, NotFound)
-        } else {
-          (id, Failed)
-        }
+      gridClient.makeGetRequestAsync(imagesUrl, authFunction) map {
+        case GridFound(_, _) => (id, Found)
+        case GridNotFound(_, _) => (id, NotFound)
+        case Error(_, _, _) => (id, Failed)
       }
-      futureImageWithStatus
     }
     val futureResults = Future.sequence(apiCalls)
     val futureImagesWithStatus = futureResults.map{results =>
-      val found = results.collect{case (id, Found)=> id}
+      val found = results.collect{case (id, Found) => id}
       val notFound = results.collect{case (id, NotFound) => id}
       val failed = results.collect{case (id, Failed) => id}
       ImagesWithStatus(found,notFound,failed)
@@ -89,8 +82,8 @@ class ImagesBatchProjection(apiKey: String, timeout: Duration, gridClient: GridC
     "End of data reached."
   )
 
-  private def isAKnownError(res: ResponseWrapper): Boolean =
-    res.statusCode == 500 && KnownErrors.exists(res.bodyAsString.contains(_))
+  private def isAKnownError(res: Response): Boolean =
+    res.status == 500 && KnownErrors.exists(res.underlying.body.contains(_))
 }
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.typesafe.play" %% "play-json-joda" % "2.6.9",
     "com.gu" %% "scanamo" % "1.0.0-M8",
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.7",
-    "com.squareup.okhttp3" % "okhttp" % okHttpVersion
+    ws
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 )
@@ -121,7 +121,6 @@ lazy val restLib = project("rest-lib").settings(
     "com.typesafe.play" %% "play" % "2.6.20",
     "com.typesafe.play" %% "filters-helpers" % "2.6.20",
     akkaHttpServer,
-    ws,
   ),
 
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"

--- a/image-loader/app/lib/Downloader.scala
+++ b/image-loader/app/lib/Downloader.scala
@@ -1,6 +1,6 @@
 package lib
 
-import java.io.{File, FileOutputStream}
+import java.io.{ByteArrayInputStream, File, FileOutputStream}
 import java.net.URI
 import java.nio.file.Files
 
@@ -8,7 +8,8 @@ import com.google.common.hash.HashingOutputStream
 import com.google.common.io.ByteStreams
 import com.gu.mediaservice.DeprecatedHashWrapper
 import com.gu.mediaservice.lib.logging.GridLogging
-import okhttp3.{OkHttpClient, Request}
+import play.api.http.HeaderNames
+import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -17,42 +18,40 @@ case object TruncatedDownload extends Exception
 case object InvalidDownload extends Exception
 
 //TODO Revisit this logic
-class Downloader(implicit ec: ExecutionContext) extends GridLogging {
-  private val client = new OkHttpClient()
+class Downloader(implicit ec: ExecutionContext, wsClient: WSClient) extends GridLogging {
   private val digester = DeprecatedHashWrapper.sha1()
 
-  def download(uri: URI, file: File): Future[DigestedFile] = Future {
-    val request = new Request.Builder().url(uri.toString).build()
-    val response = client.newCall(request).execute()
+  def download(uri: URI, file: File): Future[DigestedFile] = for {
+    response <- wsClient.url(uri.toString).get()
 
-    val maybeExpectedSize = Try{response.header("Content-Length").toInt}
-
-    maybeExpectedSize match {
-      case Failure(exception) => {
-        logger.error(s"Missing content-length header from $uri", exception)
-        throw InvalidDownload
-      }
-      case Success(expectedSize) => {
-        val input = response.body().byteStream()
-
-        val output = new FileOutputStream(file)
-        val hashedOutput = new HashingOutputStream(digester, output)
-
-        ByteStreams.copy(input, hashedOutput)
-
-        val hash = hashedOutput.hash().asBytes()
-
-        input.close()
-        hashedOutput.close()
-
-        val actualSize = Files.size(file.toPath)
-
-        if (actualSize != expectedSize) {
-          throw TruncatedDownload
-        }
-
-        DigestedFile(file, hash)
-      }
+    maybeExpectedSize = Try {
+      response.header(HeaderNames.CONTENT_LENGTH).map(_.toInt)
     }
+  } yield maybeExpectedSize match {
+    case Success(None) =>
+      logger.error(s"Missing content-length header from $uri")
+      throw InvalidDownload
+    case Failure(exception) =>
+      logger.error(s"Bad content-length header from $uri", exception)
+      throw InvalidDownload
+    case Success(Some(expectedSize)) =>
+      val input: java.io.InputStream = new java.io.ByteArrayInputStream(response.bodyAsBytes.toArray)
+
+      val output = new FileOutputStream(file)
+      val hashedOutput = new HashingOutputStream(digester, output)
+
+      ByteStreams.copy(input, hashedOutput)
+
+      val hash = hashedOutput.hash().asBytes()
+
+      hashedOutput.close()
+
+      val actualSize = Files.size(file.toPath)
+
+      if (actualSize != expectedSize) {
+        throw TruncatedDownload
+      }
+
+      DigestedFile(file, hash)
   }
 }

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -58,7 +58,7 @@ object FailureResponse extends ArgoHelpers with Results {
     logger.info(s"Unhandled exception", exception)
 
     Response(
-      UnsupportedMediaType,
+      InternalServerError,
       "internal-error",
       s"Unhandled error: ${exception.getMessage}"
     )

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -3,8 +3,11 @@ package model
 import java.io.File
 import java.net.URI
 import java.util.{Date, UUID}
+
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
+import com.gu.mediaservice.GridClient
+import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.cleanup.ImageProcessor
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.RequestLoggingContext
@@ -12,38 +15,42 @@ import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.LeasesByMedia
 import lib.DigestedFile
 import org.joda.time.{DateTime, DateTimeZone}
+import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{FreeSpec, FunSuite, Matchers}
+import org.scalatest.{FreeSpec, Matchers}
 import play.api.libs.json.{JsArray, JsString}
 import test.lib.ResourceHelpers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 
 class ProjectorTest extends FreeSpec with Matchers with ScalaFutures with MockitoSugar {
 
-  import ResourceHelpers.fileAt
+  import ResourceHelpers._
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(1000, Millis), interval = Span(25, Millis))
 
-  private val ctxPath = new File("image-loader/").getAbsolutePath
+  private val ctxPath = new File(".").getAbsolutePath
 
   private val imageOperations = new ImageOperations(ctxPath)
 
   private val config = ImageUploadOpsCfg(new File("/tmp"), 256, 85d, Nil, "img-bucket", "thumb-bucket")
 
   private val s3 = mock[AmazonS3]
-  private val projector = new Projector(config, s3, imageOperations, ImageProcessor.identity)
+  private val auth = mock[Authentication]
+  private val projector = new Projector(config, s3, imageOperations, ImageProcessor.identity, auth)
 
   // FIXME temporary ignored as test is not executable in CI/CD machine
   // because graphic lib files like srgb.icc, cmyk.icc are in root directory instead of resources
   // this test is passing when running on local machine
   "projectImage" ignore {
 
-    val testFile = fileAt("resources/getty.jpg")
-    val fileDigest = DigestedFile(testFile, "id123")
+    val testFile = fileAt("getty.jpg")
+    val id = "id123"
+    val fileDigest = DigestedFile(testFile, id)
     val uploadedBy = "test"
     val uploadTime = new DateTime("2020-01-24T17:36:08.456Z").withZone(DateTimeZone.UTC)
     val uploadFileName = Some("getty.jpg")
@@ -117,44 +124,69 @@ class ProjectorTest extends FreeSpec with Matchers with ScalaFutures with Mockit
     val gettyFileMetadataExpected = FileMetadata(iptc = iptc, exif = exif, xmp = xmp, getty = getty, colourModel = Some("RGB"))
 
     val expected = Image(
-      id = "id123",
+      id = id,
       uploadTime = new DateTime("2020-01-24T17:36:08.456Z").withZone(DateTimeZone.UTC),
       uploadedBy = "test",
       lastModified = Some(new DateTime("2020-01-24T17:36:08.456Z").withZone(DateTimeZone.UTC)),
       identifiers = Map(),
       uploadInfo = UploadInfo(Some("getty.jpg")),
-      source = Asset(new URI("http://img-bucket.s3.amazonaws.com/i/d/1/2/3/id123"),
+      source = Asset(new URI("http://img-bucket.s3.amazonaws.com/i/d/1/2/3/" + id),
         Some(12666),
         Some(Jpeg),
         Some(Dimensions(100, 60)), None),
-      thumbnail = Some(Asset(new URI("http://thumb-bucket.s3.amazonaws.com/i/d/1/2/3/id123"),
-        Some(6404),
+      thumbnail = Some(Asset(new URI("http://thumb-bucket.s3.amazonaws.com/i/d/1/2/3/" + id),
+        Some(6397),
         Some(Jpeg),
         Some(Dimensions(256, 154)), None)),
       optimisedPng = None,
       fileMetadata = gettyFileMetadataExpected,
       userMetadata = None,
       metadata = ImageMetadata(
-        Some(new DateTime("2015-01-22T00:00:00.000Z").withZone(DateTimeZone.UTC)),
-        Some("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
-        Some("AFP/Getty Images"),
-        None, Some("Christof Stache"), Some("Stringer"), None, Some("CHRISTOF STACHE"),
-        Some("-"), Some("AFP"), None, Nil, None, Some("Kitzbuehel"), None, Some("Austria"), List("sport")),
+        dateTaken = Some(new DateTime("2015-01-22T00:00:00.000Z").withZone(DateTimeZone.UTC)),
+        description = Some("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
+        credit = Some("AFP/Getty Images"),
+        creditUri = None,
+        byline = Some("CHRISTOF STACHE"),
+        bylineTitle = Some("Stringer"),
+        title = Some("Austria's Matthias Mayer attends the men"),
+        copyright = Some("CHRISTOF STACHE"),
+        suppliersReference = Some("-"),
+        source = Some("AFP"),
+        specialInstructions = None,
+        keywords = Nil,
+        subLocation = None,
+        city = Some("KITZBUEHEL"),
+        state = Some("-"),
+        country = Some("AUSTRIA"),
+        subjects = List("sport"),
+        ),
       originalMetadata = ImageMetadata(
-        Some(new DateTime("2015-01-22T00:00:00.000Z").withZone(DateTimeZone.UTC)),
-        Some("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
-        Some("AFP/Getty Images"), None, Some("Christof Stache"), Some("Stringer"),
-        None, Some("CHRISTOF STACHE"), Some("-"),
-        Some("AFP"), None, Nil, None, Some("Kitzbuehel"), None, Some("Austria"), List("sport")),
-      usageRights = Agency("Getty Images", Some("AFP"), None),
-      originalUsageRights = Agency("Getty Images", Some("AFP"), None),
-      exports = Nil,
-      usages = Nil,
-      leases = LeasesByMedia.empty,
-      collections = Nil,
-      syndicationRights = None,
-      userMetadataLastModified = None
-    )
+        dateTaken = Some(new DateTime("2015-01-22T00:00:00.000Z").withZone(DateTimeZone.UTC)),
+        description = Some("Austria's Matthias Mayer attends the men's downhill training of the FIS Alpine Skiing World Cup in Kitzbuehel, Austria, on January 22, 2015.       AFP PHOTO / CHRISTOF STACHECHRISTOF STACHE/AFP/Getty Images"),
+        credit = Some("AFP/Getty Images"),
+        creditUri = None,
+        byline = Some("CHRISTOF STACHE"),
+        bylineTitle = Some("Stringer"),
+        title = Some("Austria's Matthias Mayer attends the men"),
+        copyright = Some("CHRISTOF STACHE"),
+        suppliersReference = Some("-"),
+        source = Some("AFP"),
+        specialInstructions = None,
+        keywords = Nil,
+        subLocation = None,
+        city = Some("KITZBUEHEL"),
+        state = Some("-"),
+        country = Some("AUSTRIA"),
+        subjects = List("sport")),
+        usageRights = NoRights,
+        originalUsageRights = NoRights,
+        exports = Nil,
+        usages = Nil,
+        leases = LeasesByMedia.empty,
+        collections = Nil,
+        syndicationRights = None,
+        userMetadataLastModified = None
+      )
 
     val extractedS3Meta = S3FileExtractedMetadata(
       uploadedBy = uploadedBy,
@@ -163,13 +195,34 @@ class ProjectorTest extends FreeSpec with Matchers with ScalaFutures with Mockit
       identifiers = Map.empty,
     )
 
-    implicit val requestLoggingContext = RequestLoggingContext()
+    implicit val requestLoggingContext: RequestLoggingContext = RequestLoggingContext()
 
-    val actualFuture = projector.projectImage(fileDigest, extractedS3Meta, UUID.randomUUID())
+    val gridClient = mock[GridClient]
+    when(gridClient.getUsages(id, identity)).thenReturn(Future.successful(Nil))
+    when(gridClient.getCrops(id, identity)).thenReturn(Future.successful(Nil))
+    when(gridClient.getLeases(id, identity)).thenReturn(Future.successful(LeasesByMedia.empty))
+
+    val actualFuture = projector.projectImage(fileDigest, extractedS3Meta, UUID.randomUUID(), gridClient, identity)
+    actualFuture.recoverWith( {case t: Throwable => t.printStackTrace(); throw t})
 
     whenReady(actualFuture) { actual =>
+      actual.id  shouldEqual expected.id
+      actual.metadata shouldEqual expected.metadata
+      actual.originalMetadata shouldEqual expected.originalMetadata
+      actual.usageRights shouldEqual expected.usageRights
+      actual.originalUsageRights shouldEqual expected.originalUsageRights
+      actual.exports shouldEqual expected.exports
+      actual.usages shouldEqual expected.usages
+      actual.leases shouldEqual expected.leases
+      actual.collections shouldEqual expected.collections
+      actual.syndicationRights shouldEqual expected.syndicationRights
       actual shouldEqual expected
     }
+
+    verify(gridClient, times(1)).getLeases(id, identity)
+    verify(gridClient, times(1)).getUsages(id, identity)
+    verify(gridClient, times(1)).getCrops(id, identity)
+
   }
 
   "S3FileExtractedMetadata" - {


### PR DESCRIPTION
## What does this change?
Long term, we intend for Thrall to fetch content rather than blindly trust the content of the thrall message.  Similarly, we have re-projection work which requires some services to talk to other services.

The existing GridClient code is based on OK Http which adds a library (and therefore complexity) when Play's own WS library is _right there_.

This PR converts the client to WS and simplifies the interface as far as possible.

## How can success be measured?
No change to behaviour.  Tests all pass.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ X] locally by committer
- [ ] locally by Guardian reviewer
- [ X] on the Guardian's TEST environment
