### PR TITLE
Add default local config for pinboard integration

### DIFF
--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -72,7 +72,6 @@ function getImageLoaderConfig(config) {
 function getKahunaConfig(config) {
     return stripMargin`${getCommonConfig(config)}
         |aws.region="${config.AWS_DEFAULT_REGION}"
-        |aws.region="${config.AWS_DEFAULT_REGION}"
         |origin.full="images.media.${config.DOMAIN}"
         |origin.thumb="localstack.media.${config.DOMAIN}"
         |origin.images="images.media.${config.DOMAIN}"
@@ -85,6 +84,18 @@ function getKahunaConfig(config) {
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |security.frameAncestors="https://*.${config.DOMAIN}"
         |metrics.request.enabled=false
+        |security.connectSources = [
+        |  "wss://*.iot.${config.AWS_DEFAULT_REGION}.amazonaws.com",
+        |  "https://*.appsync-api.${config.AWS_DEFAULT_REGION}.amazonaws.com"
+        |]
+        |scriptsToLoad = [
+        |  {
+        |    host: "https://pinboard.${config.DOMAIN}",
+        |    path: "pinboard.loader.js",
+        |    async: true,
+        |    permission: "pinboard"
+        |  }
+        |]
         |`;
 }
 

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -69,7 +69,23 @@ function getImageLoaderConfig(config) {
         |`;
 }
 
-function getKahunaConfig(config) {
+function getKahunaConfig(config){
+
+    // `BUILD_ORG` env variable should be set for non-Guardian orgs, e.g. bbc
+    const pinboardConfig = process.env.BUILD_ORG ? "" : stripMargin`
+        |security.connectSources = [
+        |  "wss://*.iot.${config.AWS_DEFAULT_REGION}.amazonaws.com",
+        |  "https://*.appsync-api.${config.AWS_DEFAULT_REGION}.amazonaws.com"
+        |]
+        |scriptsToLoad = [
+        |  {
+        |    host: "https://pinboard.${config.DOMAIN}",
+        |    path: "pinboard.loader.js",
+        |    async: true,
+        |    permission: "pinboard"
+        |  }
+        |]`;
+
     return stripMargin`${getCommonConfig(config)}
         |aws.region="${config.AWS_DEFAULT_REGION}"
         |origin.full="images.media.${config.DOMAIN}"
@@ -84,18 +100,7 @@ function getKahunaConfig(config) {
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |security.frameAncestors="https://*.${config.DOMAIN}"
         |metrics.request.enabled=false
-        |security.connectSources = [
-        |  "wss://*.iot.${config.AWS_DEFAULT_REGION}.amazonaws.com",
-        |  "https://*.appsync-api.${config.AWS_DEFAULT_REGION}.amazonaws.com"
-        |]
-        |scriptsToLoad = [
-        |  {
-        |    host: "https://pinboard.${config.DOMAIN}",
-        |    path: "pinboard.loader.js",
-        |    async: true,
-        |    permission: "pinboard"
-        |  }
-        |]
+        |${pinboardConfig}
         |`;
 }
 


### PR DESCRIPTION
Co-authored-by: Tom Richards <tom.richards@guardian.co.uk>

## What does this change?
Following #3179, adds default local config for Pinboard integration, ONLY if `BUILD_ORG` env variable is NOT set (to keep things simple and error free for non-Guardian orgs, e.g. BBC).

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [(N/A)] on the Guardian's TEST environment 
