### PR TITLE
Experiment with S3 vs ES metadata

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -22,10 +22,7 @@ import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 import java.net.URI
 
-import scala.collection.JavaConverters.mapAsScalaMapConverter
-
-//import play.api.libs.json.Format.GenericFormat
-//import play.api.libs.json.OFormat.GenericOFormat
+import com.gu.mediaservice.lib.ImageIngestOperations
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -162,12 +159,7 @@ class MediaApi(
 
     elasticSearch.getImageById(id) map {
       case Some(image) if hasPermission(request.user, image) =>
-        val s3Metadata:Map[String,String] = s3Client
-          .getObject(config.imageBucket, image.source.file)
-          .getObjectMetadata
-          .getUserMetadata()
-          .asScala
-          .toMap
+        val s3Metadata:Map[String,String] = s3Client.getUserMetadata(config.imageBucket, ImageIngestOperations.fileKeyFromId(id))
           .filter(p => p._1.startsWith(AWSMetadataPrefix))
           .map(p => (p._1.substring(AWSMetadataPrefix.length), p._2))
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -15,6 +15,7 @@ GET     /images/aggregations/date/:field              controllers.AggregationCon
 GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
 GET     /images/:id/_elasticsearch                    controllers.MediaApi.getImageFromElasticSearch(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
+GET     /images/:id/s3Metadata                        controllers.MediaApi.getImageS3Metadata(id: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)


### PR DESCRIPTION
## What does this change?
Beginnings of creating a mechanism for backfilling S3 user metadata from ElasticSearch.

Definitely draft!

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
