### PR TITLE
feature/upload-images-permission

### DIFF
--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -3,9 +3,9 @@ package auth
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.{MachinePrincipal, UserPrincipal}
-import com.gu.mediaservice.lib.auth.Permissions.ShowPaid
+import com.gu.mediaservice.lib.auth.Permissions.{ShowPaid, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.AuthenticationProviders
-import com.gu.mediaservice.lib.auth.{Authentication, Authorisation}
+import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, Internal}
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, Result}
 
@@ -34,6 +34,7 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
 
   def session = auth { request =>
     val showPaid = authorisation.hasPermissionTo(ShowPaid)(request.user)
+    val canUpload = authorisation.hasPermissionTo(UploadImages)(request.user)
     request.user match {
       case UserPrincipal(firstName, lastName, email, _) =>
 
@@ -46,7 +47,8 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
               "email" -> email,
               "permissions" ->
                 Json.obj(
-                  "showPaid" -> showPaid
+                  "showPaid" -> showPaid,
+                  "canUpload" -> canUpload
                 )
             )
           )
@@ -58,7 +60,8 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
             "tier" -> accessor.tier.toString,
             "permissions" ->
               Json.obj(
-                "showPaid" -> showPaid
+                "showPaid" -> showPaid,
+                "canUpload" -> (accessor.tier == Internal)
               )
           )
         )

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -41,9 +41,8 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
   private val gridClient = GridClient(services)(wsClient)
 
   val controller = new ImageLoaderController(
-    auth, downloader, store, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient)
-  val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, config ,controllerComponents)
-
+    auth, downloader, store, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient, authorisation)
+  val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, config, controllerComponents, authorisation)
 
   override lazy val router = new Routes(httpErrorHandler, controller, uploadStatusController, management)
 }

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -77,7 +77,7 @@ class ImageLoaderController(auth: Authentication,
     logger.info("body parsed")
     val parsedBody = DigestBodyParser.create(tempFile)
 
-    (auth andThen authorisation.actionFilterFor(UploadImages)).async(parsedBody) { req =>
+    (auth andThen authorisation.CommonActionFilters.authorisedForUpload).async(parsedBody) { req =>
       val uploadTimeToRecord = DateTimeUtils.fromValueOrNow(uploadTime)
       val uploadedByToRecord = uploadedBy.getOrElse(Authentication.getIdentity(req.user))
 
@@ -152,7 +152,7 @@ class ImageLoaderController(auth: Authentication,
                    uploadTime: Option[String],
                    filename: Option[String]
                  ): Action[AnyContent] = {
-    (auth andThen authorisation.actionFilterFor(UploadImages)).async { request =>
+    (auth andThen authorisation.CommonActionFilters.authorisedForUpload).async { request =>
       implicit val context: RequestLoggingContext = RequestLoggingContext(
         initialMarkers = Map(
           "requestType" -> "import-image",

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -23,7 +23,6 @@ import model.upload.UploadRequest
 import java.time.Instant
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.auth.Authentication.OnBehalfOfPrincipal
-import com.gu.mediaservice.lib.auth.Permissions.UploadImages
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -44,6 +43,8 @@ class ImageLoaderController(auth: Authentication,
                            (implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
+  private val AuthenticatedAndAuthorised = auth andThen authorisation.CommonActionFilters.authorisedForUpload
+
   private lazy val indexResponse: Result = {
     val indexData = Map("description" -> "This is the Loader Service")
     val indexLinks = List(
@@ -53,7 +54,7 @@ class ImageLoaderController(auth: Authentication,
     respond(indexData, indexLinks)
   }
 
-  def index: Action[AnyContent] = auth { indexResponse }
+  def index: Action[AnyContent] = AuthenticatedAndAuthorised { indexResponse }
 
   def quarantineOrStoreImage(uploadRequest: UploadRequest)(implicit logMarker: LogMarker) = {
     quarantineUploader.map(_.quarantineFile(uploadRequest)).getOrElse(uploader.storeFile(uploadRequest))
@@ -77,7 +78,7 @@ class ImageLoaderController(auth: Authentication,
     logger.info("body parsed")
     val parsedBody = DigestBodyParser.create(tempFile)
 
-    (auth andThen authorisation.CommonActionFilters.authorisedForUpload).async(parsedBody) { req =>
+    AuthenticatedAndAuthorised.async(parsedBody) { req =>
       val uploadTimeToRecord = DateTimeUtils.fromValueOrNow(uploadTime)
       val uploadedByToRecord = uploadedBy.getOrElse(Authentication.getIdentity(req.user))
 
@@ -152,7 +153,7 @@ class ImageLoaderController(auth: Authentication,
                    uploadTime: Option[String],
                    filename: Option[String]
                  ): Action[AnyContent] = {
-    (auth andThen authorisation.CommonActionFilters.authorisedForUpload).async { request =>
+    AuthenticatedAndAuthorised.async { request =>
       implicit val context: RequestLoggingContext = RequestLoggingContext(
         initialMarkers = Map(
           "requestType" -> "import-image",

--- a/image-loader/app/controllers/UploadStatusController.scala
+++ b/image-loader/app/controllers/UploadStatusController.scala
@@ -34,7 +34,7 @@ class UploadStatusController(auth: Authentication,
       .recover{ case error => respondError(InternalServerError, "cannot-get", s"Cannot get upload status ${error}") }
   }
 
-  def updateUploadStatus(imageId: String) = (auth andThen authorisation.actionFilterFor(UploadImages)).async(parse.json[UploadStatus]) { request =>
+  def updateUploadStatus(imageId: String) = (auth andThen authorisation.CommonActionFilters.authorisedForUpload).async(parse.json[UploadStatus]) { request =>
     request.body match {
       case UploadStatus(StatusType.Failed, None) =>
         Future.successful(respondError(

--- a/image-loader/app/controllers/UploadStatusController.scala
+++ b/image-loader/app/controllers/UploadStatusController.scala
@@ -4,6 +4,7 @@ package controllers
 import java.net.URI
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth.Permissions.UploadImages
 import com.gu.mediaservice.lib.auth._
 import com.gu.scanamo.error.{ConditionNotMet, DynamoReadError, ScanamoError}
 import lib._
@@ -17,6 +18,7 @@ class UploadStatusController(auth: Authentication,
                              store: UploadStatusTable,
                              val config: ImageLoaderConfig,
                              override val controllerComponents: ControllerComponents,
+                             authorisation: Authorisation
                             )
                             (implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
@@ -32,7 +34,7 @@ class UploadStatusController(auth: Authentication,
       .recover{ case error => respondError(InternalServerError, "cannot-get", s"Cannot get upload status ${error}") }
   }
 
-  def updateUploadStatus(imageId: String) = auth.async(parse.json[UploadStatus]) { request =>
+  def updateUploadStatus(imageId: String) = (auth andThen authorisation.actionFilterFor(UploadImages)).async(parse.json[UploadStatus]) { request =>
     request.body match {
       case UploadStatus(StatusType.Failed, None) =>
         Future.successful(respondError(

--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
@@ -14,7 +14,6 @@ gr-top-bar-nav {
 
 gr-top-bar-actions {
     display: flex;
-    min-width: 100px;
     flex-direction: row;
     justify-content: flex-end;
 }

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -85,8 +85,8 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
 
             ctrl.canUpload = false;
 
-            mediaApi.getSession().then(session => {
-                ctrl.canUpload = session.user.permissions.canUpload;
+            mediaApi.canUserUpload().then(canUpload => {
+                ctrl.canUpload = canUpload;
             });
 
             cropSettings.set($stateParams);

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -77,11 +77,17 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         controllerAs: 'ctrl',
         controller: [
             '$scope', '$window', '$stateParams', 'panels', 'shortcutKeys', 'keyboardShortcut',
-            'panelService', 'cropSettings',
+            'panelService', 'cropSettings', 'mediaApi',
             function($scope, $window, $stateParams, panels, shortcutKeys, keyboardShortcut,
-                     panelService, cropSettings) {
+                     panelService, cropSettings, mediaApi) {
 
             const ctrl = this;
+
+            ctrl.canUpload = false;
+
+            mediaApi.getSession().then(session => {
+                ctrl.canUpload = session.user.permissions.canUpload;
+            });
 
             cropSettings.set($stateParams);
 

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -51,7 +51,7 @@
             </label>
             </li>
 
-            <li class="search__modifier-item">
+            <li ng-if="searchQuery.canUpload" id="my-uploads-checkbox" class="search__modifier-item">
             <label>
                 <input type="checkbox"
                     ng-model="searchQuery.filter.uploadedByMe" />

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -33,16 +33,9 @@ query.controller('SearchQueryCtrl', [
 
     ctrl.canUpload = false;
 
-    mediaApi.getSession().then(session => {
-        ctrl.user = session.user;
-        ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
-        ctrl.canUpload = session.user.permissions.canUpload;
-        if (ctrl.filter.nonFree === undefined) {
-          ctrl.filter.nonFree = session.user.permissions.showPaid ?
-            session.user.permissions.showPaid : undefined;
-        }
+    mediaApi.canUserUpload().then(canUpload => {
+        ctrl.canUpload = canUpload;
     });
-
 
     ctrl.ordering = {
         orderBy: $stateParams.orderBy
@@ -176,6 +169,15 @@ query.controller('SearchQueryCtrl', [
 
     // we can't user dynamic values in the ng:true-value see:
     // https://docs.angularjs.org/error/ngModel/constexpr
+    mediaApi.getSession().then(session => {
+        ctrl.user = session.user;
+        ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
+
+        if (ctrl.filter.nonFree === undefined) {
+          ctrl.filter.nonFree = session.user.permissions.showPaid ?
+            session.user.permissions.showPaid : undefined;
+        }
+    });
 
     function resetQuery() {
         ctrl.filter.query = undefined;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -31,6 +31,19 @@ query.controller('SearchQueryCtrl', [
 
     const ctrl = this;
 
+    ctrl.canUpload = false;
+
+    mediaApi.getSession().then(session => {
+        ctrl.user = session.user;
+        ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
+        ctrl.canUpload = session.user.permissions.canUpload;
+        if (ctrl.filter.nonFree === undefined) {
+          ctrl.filter.nonFree = session.user.permissions.showPaid ?
+            session.user.permissions.showPaid : undefined;
+        }
+    });
+
+
     ctrl.ordering = {
         orderBy: $stateParams.orderBy
     };
@@ -163,16 +176,6 @@ query.controller('SearchQueryCtrl', [
 
     // we can't user dynamic values in the ng:true-value see:
     // https://docs.angularjs.org/error/ngModel/constexpr
-    mediaApi.getSession().then(session => {
-        ctrl.user = session.user;
-        ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
-
-        if (ctrl.filter.nonFree === undefined) {
-          ctrl.filter.nonFree = session.user.permissions.showPaid ?
-            session.user.permissions.showPaid : undefined;
-        }
-    });
-
 
     function resetQuery() {
         ctrl.filter.query = undefined;

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -33,4 +33,4 @@
 </gr-panels>
 
 <ui-view name="multiDrag"></ui-view>
-<dnd-uploader></dnd-uploader>
+<dnd-uploader ng-if="ctrl.canUpload"></dnd-uploader>

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -5,14 +5,15 @@
     </gr-top-bar-nav>
 
     <gr-top-bar-actions>
-        <a ui-sref="upload"
+        <a ng-if="ctrl.canUpload"
+           ui-sref="upload"
            gr-track-click="Your recent uploads button"
            gr-track-click-data="{'Location': 'Search navigation'}"
            class="top-bar-item clickable side-padded"
            title="my recent uploads">
             <gr-icon-label gr-icon="photo_library">My recent uploads</gr-icon-label>
         </a>
-        <file-uploader class="top-bar-item side-padded"></file-uploader>
+        <file-uploader ng-if="ctrl.canUpload" class="top-bar-item side-padded"></file-uploader>
     </gr-top-bar-actions>
 </gr-top-bar>
 

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -88,6 +88,10 @@ mediaApi.factory('mediaApi',
         return image.perform('delete');
     }
 
+    function canUserUpload() {
+        return root.getLink('loader').then(() => true, () => false);
+    }
+
     return {
         root,
         search,
@@ -96,6 +100,7 @@ mediaApi.factory('mediaApi',
         metadataSearch,
         labelSearch,
         labelsSuggest,
-        delete: delete_
+        delete: delete_,
+        canUserUpload
     };
 }]);

--- a/kahuna/public/js/upload/controller.css
+++ b/kahuna/public/js/upload/controller.css
@@ -1,0 +1,5 @@
+.unauthorised-message {
+    text-align: center;
+    font-size: 3rem;
+    margin-top: 50px;
+}

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -11,8 +11,10 @@ var upload = angular.module('kahuna.upload.controller', [
 upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', function(uploadManager, mediaApi) {
     var ctrl = this;
 
-    mediaApi.canUserUpload().then(canUpload => {
-        ctrl.canUpload = canUpload;
+    ctrl.supportEmailLink = window._clientConfig.supportEmail;
+
+    mediaApi.getSession().then(session => {
+        ctrl.canUpload = session.user.permissions.canUpload;
     });
 
     // TODO: Show multiple jobs?

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import './controller.css';
 import './prompt/prompt';
 import './recent/recent-uploads';
 
@@ -7,9 +8,12 @@ var upload = angular.module('kahuna.upload.controller', [
     'kahuna.upload.recent'
 ]);
 
-upload.controller('UploadCtrl', ['uploadManager', function(uploadManager) {
+upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', function(uploadManager, mediaApi) {
     var ctrl = this;
 
+    mediaApi.getSession().then(session => {
+        ctrl.canUpload = session.user.permissions.canUpload;
+    });
     // TODO: Show multiple jobs?
     ctrl.latestJob = uploadManager.getLatestRunningJob();
 }]);

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -11,9 +11,10 @@ var upload = angular.module('kahuna.upload.controller', [
 upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', function(uploadManager, mediaApi) {
     var ctrl = this;
 
-    mediaApi.getSession().then(session => {
-        ctrl.canUpload = session.user.permissions.canUpload;
+    mediaApi.canUserUpload().then(canUpload => {
+        ctrl.canUpload = canUpload;
     });
+
     // TODO: Show multiple jobs?
     ctrl.latestJob = uploadManager.getLatestRunningJob();
 }]);

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -7,7 +7,7 @@
     <gr-top-bar-actions></gr-top-bar-actions>
 </gr-top-bar>
 
-<div class="page-wrapper">
+<div ng-if="ctrl.canUpload" class="page-wrapper">
     <file-prompt class="section"></file-prompt>
 
     <section class="section"
@@ -27,5 +27,6 @@
         <recent-uploads></recent-uploads>
     </section>
 </div>
+<div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images</div>
 
 <dnd-uploader></dnd-uploader>

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -27,6 +27,6 @@
         <recent-uploads></recent-uploads>
     </section>
 </div>
-<div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images</div>
+<div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images. <a href="{{ctrl.supportEmailLink}}" class="coloured-link">Send an email to the Grid team</a> if you think this is incorrect.</div>
 
 <dnd-uploader ng-if="ctrl.canUpload"></dnd-uploader>

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -29,4 +29,4 @@
 </div>
 <div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images</div>
 
-<dnd-uploader></dnd-uploader>
+<dnd-uploader ng-if="ctrl.canUpload"></dnd-uploader>

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.lib.auth
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.{MachinePrincipal, Principal, Request}
-import com.gu.mediaservice.lib.auth.Permissions.PrincipalFilter
+import com.gu.mediaservice.lib.auth.Permissions.{PrincipalFilter, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.AuthorisationProvider
 import play.api.mvc.{ActionFilter, Result, Results}
 
@@ -24,6 +24,10 @@ class Authorisation(provider: AuthorisationProvider, executionContext: Execution
       permission,
       respondError(Unauthorized, "permission-denied", s"You do not have permission to ${permission.name}")
     )
+
+  object CommonActionFilters {
+    lazy val authorisedForUpload = actionFilterFor(UploadImages)
+  }
 
   def hasPermissionTo(permission: SimplePermission): PrincipalFilter = {
     principal: Principal => {

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
@@ -18,4 +18,5 @@ object Permissions {
   case object DeleteCrops extends SimplePermission
   case object ShowPaid extends SimplePermission
   case object Pinboard extends SimplePermission // FIXME ideally factor this out in favour of something more generic
+  case object UploadImages extends SimplePermission
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -56,6 +56,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       case DeleteCrops => hasPermission(Permissions.DeleteCrops)
       case ShowPaid => hasPermission(Permissions.ShowPaid)
       case Pinboard => hasPermission(Permissions.Pinboard)
+      case UploadImages => true
     }
   }
 }


### PR DESCRIPTION
## What does this change?
This implements a new permission, UploadImages, that controls which users can upload images to the Grid. Users without this permission will not be able to access any loader endpoint, will be shown an error message when trying to enter /upload endpoint in Kahuna, and will have hidden all upload-related UI elements, such as:
- My Uploads checkbox
- My recent uploads button
- Upload button

## How can success be measured?
Users with UploadImages permission are able to access any loader endpoint, are not shown any error message when trying to enter /upload endpoint in Kahuna, and can see and use all upload-related UI elements, such as:
- My Uploads checkbox
- My recent uploads button
- Upload button

Users without UploadImages permission are not able to access any loader endpoint, are shown an error message when trying to enter /upload endpoint in Kahuna, and have hidden all upload-related UI elements, such as:
- My Uploads checkbox
- My recent uploads button
- Upload button

## Screenshots
Top bar for users without upload permission:
![image](https://user-images.githubusercontent.com/20479781/110522159-5fef7600-80ef-11eb-84bf-89dbe5de7401.png)

/upload frontend endpoint with authorisation error:
![image](https://user-images.githubusercontent.com/20479781/110522401-9dec9a00-80ef-11eb-9b1c-b598f71437f3.png)


## Who should look at this?
@guardian/digital-cms, @gribeiro , @wainaina 


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
