### PR TITLE
Improve json diff

### DIFF
--- a/common-lib/src/test/scala/com/gu/mediaservice/JsonDiffTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/JsonDiffTest.scala
@@ -18,26 +18,6 @@ class JsonDiffTest extends FunSpec with Matchers {
     JsonDiff.diff(jsonA, jsonB) should be (jsonC)
   }
 
-  it ("should detect changes") {
-
-    val jsonA = load(""" {"a": 1} """)
-
-    val jsonB = load(""" {"a": 2} """)
-
-    val jsonC = load("""
-      |{
-      |  "a": {
-      |    "≠≠≠": {
-      |      "---": 1,
-      |      "+++": 2
-      |    }
-      |  }
-      |}
-      """)
-
-    JsonDiff.diff(jsonA, jsonB) should be (jsonC)
-  }
-
   it ("should detect additions") {
 
     val jsonA = load(""" {} """)
@@ -68,6 +48,26 @@ class JsonDiffTest extends FunSpec with Matchers {
       |  }
       |}
     """)
+
+    JsonDiff.diff(jsonA, jsonB) should be (jsonC)
+  }
+
+  it ("should detect changes") {
+
+    val jsonA = load(""" {"a": 1} """)
+
+    val jsonB = load(""" {"a": 2} """)
+
+    val jsonC = load("""
+      |{
+      |  "a": {
+      |    "≠≠≠": {
+      |      "---": 1,
+      |      "+++": 2
+      |    }
+      |  }
+      |}
+      """)
 
     JsonDiff.diff(jsonA, jsonB) should be (jsonC)
   }
@@ -166,6 +166,7 @@ class JsonDiffTest extends FunSpec with Matchers {
     JsonDiff.diff(jsonA, jsonB) should be (jsonC)
   }
 
+
   it ("should handle and find completely different elements in arrays") {
 
     val jsonA = load("""
@@ -184,14 +185,151 @@ class JsonDiffTest extends FunSpec with Matchers {
                        |{
                        |  "a": {
                        |    "≠≠≠": {
-                       |      "+++": ["a", 2, "c"],
-                       |      "---": [1, "b", 3]
+                       |      "---": [1, "b", 3],
+                       |      "+++": ["a", 2, "c"]
                        |    }
                        |  }
                        |}
       """)
 
     JsonDiff.diff(jsonA, jsonB) should be (jsonC)
+  }
+
+  it ("should handle disordered lists which are still equal") {
+    val jsonA = load("""
+                       |{
+                       |  "a": [1, 2]
+                       |}
+    """)
+    val jsonB = load("""
+                       |{
+                       |  "a": [2, 1]
+                       |}
+    """)
+    val jsonC = load("{}")
+    JsonDiff.diff(jsonA, jsonB) should be (jsonC)
+
+  }
+
+  it ("should handle disordered lists of lists which are still really equal") {
+    val jsonA = load("""
+                       |{
+                       |  "a": [
+                       |    {
+                       |      "b": [1, 2]
+                       |    },
+                       |    {
+                       |      "b": [3, 4]
+                       |    }
+                       |  ]
+                       |}
+    """)
+    val jsonB = load("""
+                       |{
+                       |  "a": [
+                       |    {
+                       |      "b": [4, 3]
+                       |    },
+                       |    {
+                       |      "b": [2, 1]
+                       |    }
+                       |  ]
+                       |}
+    """)
+    val jsonC = load("{}")
+    JsonDiff.diff(jsonA, jsonB) should be (jsonC)
+
+  }
+
+  it ("should handle disordered lists of lists which are not really equal") {
+    val jsonA = load("""
+                       |{
+                       |  "a": [
+                       |    {
+                       |      "b": [1, 2]
+                       |    },
+                       |    {
+                       |      "b": [3, 4, 5]
+                       |    }
+                       |  ]
+                       |}
+    """)
+    val jsonB = load("""
+                       |{
+                       |  "a": [
+                       |    {
+                       |      "b": [4, 3]
+                       |    },
+                       |    {
+                       |      "b": [2, 1]
+                       |    }
+                       |  ]
+                       |}
+    """)
+    val jsonC = load("""
+                       |{
+                       |  "a": {
+                       |    "≠≠≠": {
+                       |      "---": [
+                       |        {
+                       |          "b": [3,4,5]
+                       |        }
+                       |      ],
+                       |      "+++": [
+                       |        {
+                       |          "b": [4,3]
+                       |        }
+                       |      ]
+                       |    }
+                       |  }
+                       |}
+      """)
+
+
+    JsonDiff.diff(jsonA, jsonB) should be (jsonC)
+
+  }
+
+  it ("should handle recursive disordered lists which are still really equal") {
+    val jsonA = load("""
+                       |{
+                       |  "a": [
+                       |    {
+                       |      "b": [
+                       |        {"c": 1},
+                       |        {"c": 2}
+                       |      ]
+                       |    },
+                       |    {
+                       |      "b": [
+                       |        {"c": 3},
+                       |        {"c": 4}
+                       |      ]
+                       |    }
+                       |  ]
+                       |}
+    """)
+    val jsonB = load("""
+                       |{
+                       |  "a": [
+                       |    {
+                       |      "b": [
+                       |        {"c": 4},
+                       |        {"c": 3}
+                       |      ]
+                       |    },
+                       |    {
+                       |      "b": [
+                       |        {"c": 2},
+                       |        {"c": 1}
+                       |      ]
+                       |    }
+                       |  ]
+                       |}
+    """)
+    val jsonC = load("{}")
+    JsonDiff.diff(jsonA, jsonB) should be (jsonC)
+
   }
 
 }


### PR DESCRIPTION
## What does this change?
The simple json diff implemented for comparing ES and projection json did not handle disordered arrays well enough.

This PR compares every object in an array with every object in the matching array and removes any which have a perfect match, thus generating a better list of additions and removals.

## How can success be measured?
Disordered arrays are treated as identical.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

NB this is a deliberate choice to treat all arrays as sets.  This may not be correct under all circumstances, ie where ordering matters.  However that cannot be inferred from raw json.  We may add another element to mark 'changed order'.

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
