### PR TITLE
Enact S3 metadata changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,7 +252,8 @@ lazy val scripts = project("scripts")
       "software.amazon.awssdk" % "s3" % "2.15.81",
       // bump jcommander explicitly as AWS SDK is pulling in a vulnerable version
       "com.beust" % "jcommander" % "1.75",
-      "org.apache.commons" % "commons-compress" % "1.20"
+      "org.apache.commons" % "commons-compress" % "1.20",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.6.4"
     )
   )
 

--- a/scripts/src/main/scala/com/gu/mediaservice/lib/JsonValueCodecJsValue.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/lib/JsonValueCodecJsValue.scala
@@ -1,0 +1,103 @@
+package com.gu.mediaservice.lib
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter}
+import _root_.play.api.libs.json.{JsArray, JsBoolean, JsFalse, JsNull, JsNumber, JsObject, JsString, JsTrue, JsValue}
+
+import scala.collection.IndexedSeq
+
+object JsonValueCodecJsValue {
+
+  implicit def jsValueCodec: JsonValueCodec[JsValue] = {
+    new JsonValueCodec[JsValue] {
+
+      /**
+        * The implementation was borrowed from: https://github.com/plokhotnyuk/jsoniter-scala/blob/e80d51019b39efacff9e695de97dce0c23ae9135/jsoniter-scala-benchmark/src/main/scala/io/circe/CirceJsoniter.scala
+        * and adapted to meet PlayJson criteria.
+        */
+      def decodeValue(in: JsonReader, default: JsValue): JsValue = {
+        val b = in.nextToken()
+        if (b == 'n') in.readNullOrError(default, "expected `null` value")
+        else if (b == '"') {
+          in.rollbackToken()
+          JsString(in.readString(null))
+        } else if (b == 'f' || b == 't') {
+          in.rollbackToken()
+          if (in.readBoolean()) JsTrue else JsFalse
+        } else if ((b >= '0' && b <= '9') || b == '-') {
+          in.rollbackToken()
+          val bigDecimal = in.readBigDecimal(null)
+          JsNumber(bigDecimal)
+        } else if (b == '[') {
+          val array: IndexedSeq[JsValue] =
+            if (in.isNextToken(']')) new Array[JsValue](0)
+            else {
+              in.rollbackToken()
+              var i = 0
+              var arr = new Array[JsValue](4)
+              do {
+                if (i == arr.length) arr = java.util.Arrays.copyOf(arr, i << 1)
+                arr(i) = decodeValue(in, default)
+                i += 1
+              } while (in.isNextToken(','))
+
+              if (in.isCurrentToken(']'))
+                if (i == arr.length) arr else java.util.Arrays.copyOf(arr, i)
+              else in.arrayEndOrCommaError()
+            }
+          JsArray(array)
+        } else if (b == '{') {
+          /*
+           * Because of DoS vulnerability in Scala 2.12 HashMap https://github.com/scala/bug/issues/11203
+           * we use a Java LinkedHashMap because it better handles hash code collisions for Comparable keys.
+           */
+          val kvs =
+            if (in.isNextToken('}')) new java.util.LinkedHashMap[String, JsValue]()
+            else {
+              val underlying = new java.util.LinkedHashMap[String, JsValue]()
+              in.rollbackToken()
+              do {
+                underlying.put(in.readKeyAsString(), decodeValue(in, default))
+              } while (in.isNextToken(','))
+
+              if (!in.isCurrentToken('}'))
+                in.objectEndOrCommaError()
+
+              underlying
+            }
+          import scala.collection.JavaConverters._
+          JsObject(kvs.asScala)
+        } else {
+          in.decodeError("expected JSON value")
+        }
+      }
+
+      def encodeValue(jsValue: JsValue, out: JsonWriter): Unit = {
+        jsValue match {
+          case JsBoolean(b) =>
+            out.writeVal(b)
+          case JsString(value) =>
+            out.writeVal(value)
+          case JsNumber(value) =>
+            out.writeVal(value)
+          case JsArray(items) =>
+            out.writeArrayStart()
+            items.foreach(encodeValue(_, out))
+            out.writeArrayEnd()
+          case JsObject(kvs) =>
+            out.writeObjectStart()
+            kvs.foreach {
+              case (k, v) =>
+                out.writeKey(k)
+                encodeValue(v, out)
+            }
+            out.writeObjectEnd()
+          case JsNull =>
+            out.writeNull()
+        }
+      }
+
+      val nullValue: JsValue = JsNull
+    }
+  }
+
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
@@ -25,7 +25,7 @@ object EnactS3Changes {
         bucketName,
         new File(inputFileName)
       )
-      case _ => throw new IllegalArgumentException("Usage: ProposeS3Changes <bucketMetadataFile> <esMetadataFile> <outputFilePrefix>")
+      case _ => throw new IllegalArgumentException("Usage: EnactS3Changes <bucketName> <inputFile>")
     }
   }
 

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
@@ -1,0 +1,68 @@
+package com.gu.mediaservice.scripts
+
+import java.io._
+
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import org.apache.commons.compress.compressors.bzip2.{BZip2CompressorInputStream, BZip2CompressorOutputStream}
+import play.api.libs.json.Json
+
+import scala.io.Source
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+
+
+object EnactS3Changes {
+
+  private val profile = "media-service"
+  private val credentials = new ProfileCredentialsProvider(profile)
+  private val s3: AmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(credentials).withRegion(Regions.DEFAULT_REGION).build
+
+  def apply(args: List[String]): Unit = {
+    args match {
+      case bucketName :: inputFileName :: Nil => enactS3Changes(
+        bucketName,
+        new File(inputFileName)
+      )
+      case _ => throw new IllegalArgumentException("Usage: ProposeS3Changes <bucketMetadataFile> <esMetadataFile> <outputFilePrefix>")
+    }
+  }
+
+  def getBzipWriter(outputFile: File) = {
+    val fileOutputStream = new FileOutputStream(outputFile)
+    val compressOutputStream = new BZip2CompressorOutputStream(fileOutputStream)
+    val sw = new OutputStreamWriter(compressOutputStream)
+    new BufferedWriter(sw)
+  }
+
+  def enactS3Changes(
+                        bucketName: String,
+                        inputFile: File) = {
+    withSourceFromBzipFile(inputFile) {source =>
+      source
+        .getLines()
+        .take(4)
+        .flatMap(line => (Json.parse(line) \ "proposed").asOpt[ObjectMetadata])
+        .zipWithIndex
+        .foreach { case (metadata, i) =>
+          if (i % 10000 == 0) System.err.println(s"Processing object metadata line $i")
+          val key = metadata.key
+          println(key)
+          println(s3.getObjectMetadata(bucketName, key).getUserMetadata)
+          println(metadata)
+        }
+    }
+  }
+
+  private def withSourceFromBzipFile[T](file: File)(f: Source => T) = {
+    val fileInputStream = new FileInputStream(file)
+    val compressInputStream = new BZip2CompressorInputStream(fileInputStream)
+    val source = Source.fromInputStream(compressInputStream)
+    try {
+      f(source)
+    } finally {
+      source.close()
+    }
+  }
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
@@ -1,19 +1,20 @@
 package com.gu.mediaservice.scripts
 
 import java.io._
-
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import org.apache.commons.compress.compressors.bzip2.{BZip2CompressorInputStream, BZip2CompressorOutputStream}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, JsValue, Json, OWrites}
 
 import scala.io.Source
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.s3.model.CopyObjectRequest
+import com.amazonaws.services.s3.model.{AmazonS3Exception, CopyObjectRequest}
+import org.joda.time.{DateTime, Duration}
+import com.gu.mediaservice.lib.JsonValueCodecJsValue.jsValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core._
 
 import collection.JavaConverters._
-import scala.util.control.Exception
-import scala.util.control.Exception.noCatch.either
+import scala.util.{Failure, Success, Try}
 
 object EnactS3Changes {
 
@@ -22,58 +23,156 @@ object EnactS3Changes {
   private val credentials = new ProfileCredentialsProvider(profile)
   private val s3: AmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(credentials).withRegion(region).build
 
+  def option(options: List[String], argName: String): (Option[String], List[String]) = {
+    val arg = options.find(_.startsWith(s"$argName="))
+    val value = arg.map(_.stripPrefix(s"$argName="))
+    value -> options.filterNot(arg.contains)
+  }
+
   def apply(args: List[String]): Unit = {
     args match {
-      case bucketName :: inputFileName :: Nil => enactS3Changes(
-        bucketName,
-        new File(inputFileName)
-      )
-      case _ => throw new IllegalArgumentException("Usage: EnactS3Changes <bucketName> <inputFile>")
+      case bucketName :: inputFileName :: auditFileName :: options =>
+        val (maybeDrop, optionsAfterDrop) = option(options, "drop")
+        val (maybeTake, optionsAfterTake) = option(optionsAfterDrop, "take")
+        val (maybePrefixFilter, unknownOptions) = option(optionsAfterTake, "prefixFilter")
+        if (unknownOptions.nonEmpty) throw new IllegalArgumentException(s"Didn't recognise options $unknownOptions")
+        enactS3Changes(
+          bucketName,
+          new File(inputFileName),
+          new File(auditFileName),
+          maybeDrop.map(_.toInt),
+          maybeTake.map(_.toInt),
+          maybePrefixFilter
+        )
+      case _ => throw new IllegalArgumentException("Usage: EnactS3Changes <bucketName> <inputFile> <auditFile> [drop=<n>] [take=<n>] [prefixFilter=<s>]")
     }
   }
 
-  def getBzipWriter(outputFile: File) = {
-    val fileOutputStream = new FileOutputStream(outputFile)
+  def getBzipWriter(outputFile: File, append: Boolean = false) = {
+    val fileOutputStream = new FileOutputStream(outputFile, append)
     val compressOutputStream = new BZip2CompressorOutputStream(fileOutputStream)
     val sw = new OutputStreamWriter(compressOutputStream)
     new BufferedWriter(sw)
   }
 
+  case class AuditEntry(status: String, key: String, message: Option[String] = None, details: Option[JsObject] = None)
+
+  object AuditEntry {
+    def apply(status: String, key: String, message: String): AuditEntry = AuditEntry(status, key, Some(message))
+    def apply(status: String, key: String, message: String, details: JsObject): AuditEntry = AuditEntry(status, key, Some(message), Some(details))
+
+    implicit val writes: OWrites[AuditEntry] = Json.writes[AuditEntry]
+    def audit(writer: BufferedWriter, entry: AuditEntry): Unit = {
+      val value = Json.toJsObject(entry)
+      val json = writeToString[JsValue](value)
+      writer.append(s"$json\n")
+    }
+    val OK = "OK"
+    val SKIPPED = "SKIPPED"
+    val ERROR = "ERROR"
+  }
+
+  def getAuditFileName(auditFile: File, id: Int = 0): File = {
+    val file = new File(s"${auditFile.getPath}${if (id > 0) s".$id" else ""}")
+    if (file.exists()) getAuditFileName(auditFile, id+1) else file
+  }
+
   def enactS3Changes(
                         bucketName: String,
-                        inputFile: File) = {
-    withSourceFromBzipFile(inputFile) {source =>
-      source
-        .getLines()
-        .take(1)
-        .map(line => (
-          (Json.parse(line) \ "proposed").asOpt[ObjectMetadata],
-          (Json.parse(line) \ "original").asOpt[ObjectMetadata]
-        ))
-        .zipWithIndex
-        .foreach {
-          case ((Some(proposed), Some(original)), i) =>
-            if (i % 10000 == 0) System.err.println(s"Processing object metadata line $i")
-            val key = proposed.key
-            either {s3.getObjectMetadata(bucketName, key)} match {
-              case Right(awsObjectMetadata) =>
-                val check = awsObjectMetadata.getUserMetadata.asScala
-                if (check!=original.metadata) {
-                  System.err.println(s"Unable to update - AWS entry for key ${original.key} has changed")
-                  System.err.println(check)
-                  System.err.println(original.metadata)
-                } else {
-                  awsObjectMetadata.setUserMetadata(proposed.metadata.asJava)
-                  val request = new CopyObjectRequest(bucketName, key, bucketName, key).withNewObjectMetadata(awsObjectMetadata)
-                  either {s3.copyObject(request)} match {
-                    case Left(e) => System.err.println(s"Unable to update s3 record - has it been deleted? (${e.getMessage}")
-                    case _ => System.out.println(s"Successfully updated $key")
+                        inputFile: File,
+                        auditFile: File,
+                        maybeDrop: Option[Int],
+                        maybeTake: Option[Int],
+                        prefixFilter: Option[String]) = {
+    import AuditEntry._
+
+    // do this to ensure creds work before starting
+    s3.listObjectsV2(bucketName)
+
+    // reporting
+    val batchSize = 1000
+    val startTime = DateTime.now
+    var startBatchTime = DateTime.now
+    var total = 0L
+
+    // auditing
+    val auditWriter = getBzipWriter(getAuditFileName(auditFile))
+    auditWriter.append(s"Enacting changes in $bucketName from $inputFile (dropping: $maybeDrop, taking: $maybeTake, prefixFilter: $prefixFilter)\n")
+    System.err.println(s"Enacting changes in $bucketName from $inputFile (dropping: $maybeDrop, taking: $maybeTake, prefixFilter: $prefixFilter)")
+    try {
+      withSourceFromBzipFile(inputFile) {source =>
+        val lines = source
+          .getLines()
+          .map(line => {
+            val maybeJsValue = Try(readFromString[JsValue](line)).toOption
+            (
+              maybeJsValue.map(_ \ "proposed").flatMap(_.asOpt[ObjectMetadata]),
+              maybeJsValue.map(_ \ "original").flatMap(_.asOpt[ObjectMetadata])
+            )
+          })
+        val filteredLines = prefixFilter
+          .map(pf => lines.filter{
+            case (Some(proposed), _) => proposed.key.startsWith(pf)
+            case _ => false
+          })
+          .getOrElse(lines)
+        val droppedLines = maybeDrop.map(filteredLines.drop).getOrElse(filteredLines)
+        val linesToProcess = maybeTake.map(droppedLines.take).getOrElse(droppedLines)
+
+        val auditEntries: Iterator[AuditEntry] = linesToProcess
+          .map {
+            case (Some(proposed), Some(original)) =>
+              val key = proposed.key
+              Try {Some(s3.getObjectMetadata(bucketName, key))}.recover{
+                case as3e:AmazonS3Exception if as3e.getStatusCode == 404 => None
+              } match {
+                case Success(Some(awsObjectMetadata)) =>
+                  val check = awsObjectMetadata.getUserMetadata.asScala
+                  if (check!=original.metadata) {
+                    if (check==proposed.metadata) {
+                      AuditEntry(SKIPPED, key, s"Already updated")
+                    } else {
+                      AuditEntry(ERROR, key, s"Metadata doesn't match that expected", Json.obj(
+                        "actual" -> check,
+                        "expected" -> original.metadata
+                      ))
+                    }
+                  } else {
+                    awsObjectMetadata.setUserMetadata(proposed.metadata.asJava)
+                    val request = new CopyObjectRequest(bucketName, key, bucketName, key).withNewObjectMetadata(awsObjectMetadata)
+                    Try {s3.copyObject(request)} match {
+                      case Success(_) => AuditEntry(OK, key)
+                      case Failure(e) => AuditEntry(ERROR, key, s"Error whilst copying object ($e)")
+                    }
                   }
-                }
-              case Left(e) => System.err.println(s"Unable to get s3 record - has it been deleted? (${e.getMessage}")
-            }
-          case (_, i) => System.err.println(s"Unable to parse record $i")
-        }
+                case Success(None) =>
+                  AuditEntry(SKIPPED, key, "Object no longer exists")
+                case Failure(e) =>
+                  AuditEntry(ERROR, key, s"Error whilst getting object metadata ($e)")
+              }
+            case other => AuditEntry(ERROR, "n/a", s"Unable to parse record", Json.obj("record" -> other.toString))
+          }
+        auditEntries
+          .map{ entry =>
+            audit(auditWriter, entry)
+            entry
+          }
+          .grouped(batchSize)
+          .foreach{ auditEntryBatch =>
+            val auditEntries = auditEntryBatch.toList
+            total = total + auditEntries.size
+            val now = DateTime.now
+            val elapsed = new Duration(startTime, now)
+            val elapsedBatch = new Duration(startBatchTime, now).getMillis
+            System.err.println(s"${DateTime.now.toString} Processed $total lines")
+            System.err.println(s"Batch: Processed ${auditEntries.size} in ${elapsedBatch}ms (mean: ${elapsedBatch/auditEntries.size}ms per line)")
+            System.err.println(s"       OK: ${auditEntries.count(_.status==OK)} SKIPPED: ${auditEntries.count(_.status==SKIPPED)} ERROR: ${auditEntries.count(_.status==ERROR)}")
+            System.err.println(s"Total: Processed $total in ${elapsed.getStandardSeconds}s (mean: ${elapsed.getMillis/total}ms per line)")
+            startBatchTime = now
+          }
+      }
+    } finally {
+      auditWriter.close()
     }
   }
 

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -12,7 +12,8 @@ object Main extends App {
     case "UpdateSettings"   :: as => UpdateSettings(as)
     case "ConvertConfig"    :: as => ConvertConfig(as)
     case "BucketMetadata"   :: as => BucketMetadata(as)
-    case "DecodeComparator"   :: as => DecodeComparator(as)
+    case "DecodeComparator" :: as => DecodeComparator(as)
+    case "EnactS3Changes"   :: as => EnactS3Changes(as)
     case a :: _ => sys.error(s"Unrecognised command: $a")
     case Nil    => sys.error("Usage: <Command> <args ...>")
   }


### PR DESCRIPTION
## What does this change?
Once we have found all the metadata which needs updating in S3, we need a tool to enact those changes.

This is that tool.

## How can success be measured?
Given a file (output from Propose S3 Changes tool https://github.com/guardian/grid/pull/3213), we can update S3 user metadata appropriately.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
