### PR TITLE
ES extraction and ES/S3 metadata proposal tools

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/S3ImageStorage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/S3ImageStorage.scala
@@ -18,11 +18,14 @@ class S3ImageStorage(config: CommonConfig) extends S3(config) with ImageStorage 
   def storeImage(bucket: String, id: String, file: File, mimeType: Option[MimeType],
                  meta: Map[String, String] = Map.empty, overwrite: Boolean)
                 (implicit logMarker: LogMarker) = {
-    if (overwrite) {
+    logger.info(s"bucket: $bucket, id: $id, meta: $meta")
+    val eventualObject = if (overwrite) {
       store(bucket, id, file, mimeType, meta, cacheSetting)
     } else {
       storeIfNotPresent(bucket, id, file, mimeType, meta, cacheSetting)
     }
+    eventualObject.onComplete(o => logger.info(s"storeImage completed $o"))
+    eventualObject
   }
 
   def deleteImage(bucket: String, id: String) = Future {

--- a/scripts/src/main/resources/logback.xml
+++ b/scripts/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5relative %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+<!--  <logger name="com.sksamuel.elastic4s" level="DEBUG" />-->
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsImageMetadata.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsImageMetadata.scala
@@ -1,0 +1,169 @@
+package com.gu.mediaservice.scripts
+
+import ch.qos.logback.classic.{Level, Logger}
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.{ElasticClient, Response}
+import com.sksamuel.elastic4s.requests.indexes.GetIndexResponse
+import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
+import org.slf4j.LoggerFactory
+import play.api.libs.json._
+import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter, Writer}
+import java.util.concurrent.TimeUnit
+
+import scala.annotation.tailrec
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+object EsImageMetadata extends EsScript {
+  override def run(esUrl: String, args: List[String]): Unit = {
+    val outputFile: File = args match {
+      case fileName :: Nil =>
+        val file = new File(fileName)
+        //if (file.exists()) throw new IllegalStateException("This would overwrite a file so bailing now in case that would be bad")
+        file
+      case _ => throw new IllegalArgumentException("Usage: BucketMetadata <bucket> <outputFilename.jsonl.bz2>")
+    }
+
+    object Client extends EsClient(esUrl) {
+    }
+
+    val scrollTime = new FiniteDuration(5, TimeUnit.MINUTES)
+    val scrollSize = 500
+    val currentIndex = Client.currentIndex
+
+    System.err.println(s"Using index $currentIndex")
+
+    val fileOutputStream = new FileOutputStream(outputFile)
+    val compressOutputStream = new BZip2CompressorOutputStream(fileOutputStream)
+    val sw = new OutputStreamWriter(compressOutputStream)
+    System.err.println(s"Output encoding: ${sw.getEncoding}")
+    val writer = new BufferedWriter(sw)
+
+    try {
+      val initialResults = initialQuery(Client.client, currentIndex, scrollTime, scrollSize)
+      Await.ready(recurse(initialResults, writer, 0L, 0L), Duration.Inf)
+    } finally {
+      Client.client.close()
+      writer.close()
+    }
+
+    @tailrec
+    def recurse(lastResponse: SearchResponse, outputWriter: BufferedWriter, done: Long, warnings: Long): Future[Unit] = {
+      val newDone = done + scrollSize
+      val hits = lastResponse.hits.hits
+      if(hits.nonEmpty) {
+        val newWarnings = writeMetadata(outputWriter, hits) + warnings
+        System.err.println(scrollPercentage(lastResponse, newDone, newWarnings))
+        val scrollResponse = performScroll(Client.client, lastResponse.scrollId.get, scrollTime)
+        Thread.sleep(500)
+        //if (done < 100000)
+        recurse(scrollResponse, outputWriter, newDone, newWarnings)
+        //else Future.successful(())
+      } else {
+        System.err.println("No more results found")
+        Future.successful(())
+      }
+    }
+
+  }
+
+  override def usageError: Nothing = {
+    System.err.println("Usage: UpdateSettings <ES_URL>")
+    sys.exit(1)
+  }
+
+  def scrollPercentage(scroll: SearchResponse, done: Long, warnings: Long): String = {
+    val total = scroll.hits.total.value
+    val percentage = (Math.min(done,total).toFloat / total) * 100
+    s"Extracted ${Math.min(done,total)} of $total ($percentage%) with $warnings warnings"
+  }
+
+  def initialQuery(client: ElasticClient, index: String, scrollTime: FiniteDuration, scrollSize: Int) : SearchResponse = {
+    val queryType = matchAllQuery()
+    //val queryType = matchQuery("id", "cbaa4f052b1d4ae996e63ee1d07ada0092b4b581")
+
+    val queryResponse = client.execute({
+      search(index)
+        .scroll(scrollTime)
+        .size(scrollSize)
+        .query(queryType)
+        .fetchSource(false)
+        .sourceInclude(
+        //.docValues(
+          "id",
+          "uploadedBy",
+          "uploadTime",
+          "uploadInfo.filename",
+          "identifiers.*",
+          "lastModified"
+        )
+    }).await
+
+    queryResponse.status match {
+      case 200 => queryResponse.result
+      case _ =>
+        client.close()
+        throw new Exception("Failed performing search query")
+    }
+  }
+
+  def performScroll(client: ElasticClient, scrollId: String, scrollTime: FiniteDuration): SearchResponse = {
+    val scrollResponse = client.execute({
+      searchScroll(scrollId)
+        .keepAlive(scrollTime)
+    }).await
+
+    scrollResponse.status match {
+      case 200 => scrollResponse.result
+      case _ =>
+        client.close()
+        throw new Exception("Failed performing bulk index")
+    }
+  }
+
+  def writeMetadata(writer: BufferedWriter, hits: Array[SearchHit]): Long = {
+    def jsObjectToStringMap(obj: JsObject): Map[String, String] = {
+      obj.fields.collect {
+        case (key, JsString(value)) => key -> value
+      }.toMap
+    }
+
+    val jsonLines = hits.flatMap { hit =>
+      val source = Json.parse(hit.sourceAsString)
+      (source \ "id").asOpt[String] map { id =>
+        val doc = EsDocumentWithMetadata(
+          id = id,
+          lastModified = (source \ "lastModified").asOpt[String],
+          uploadedBy = (source \ "uploadedBy").asOpt[String],
+          uploadTime = (source \ "uploadTime").asOpt[String],
+          fileName = (source \ "uploadInfo" \ "filename").asOpt[String],
+          identifiers = (source \ "identifiers").asOpt[JsObject].map(jsObjectToStringMap).getOrElse(Map.empty)
+        )
+        Json.stringify(Json.toJson(doc))
+      }
+    }
+
+    jsonLines.foreach{ json =>
+      writer.write(json)
+      writer.newLine()
+    }
+    writer.flush()
+
+    hits.length - jsonLines.length
+  }
+}
+
+case class EsDocumentWithMetadata(
+                                   id: String,
+                                   lastModified: Option[String],
+                                   uploadedBy: Option[String],
+                                   uploadTime: Option[String],
+                                   fileName: Option[String],
+                                   identifiers: scala.collection.immutable.Map[String, String] = Map.empty
+                                 )
+
+object EsDocumentWithMetadata {
+  implicit val formats: Format[EsDocumentWithMetadata] = Json.using[Json.WithDefaultValues].format[EsDocumentWithMetadata]
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -12,6 +12,8 @@ object Main extends App {
     case "UpdateSettings"   :: as => UpdateSettings(as)
     case "ConvertConfig"    :: as => ConvertConfig(as)
     case "BucketMetadata"   :: as => BucketMetadata(as)
+    case "EsMetadata"       :: as => EsImageMetadata(as)
+    case "ProposeS3Changes" :: as => ProposeS3Changes(as)
     case "DecodeComparator"   :: as => DecodeComparator(as)
     case a :: _ => sys.error(s"Unrecognised command: $a")
     case Nil    => sys.error("Usage: <Command> <args ...>")

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/ProposeS3Changes.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/ProposeS3Changes.scala
@@ -1,0 +1,254 @@
+package com.gu.mediaservice.scripts
+
+import com.gu.mediaservice.JsonDiff
+import com.gu.mediaservice.lib.ImageStorageProps
+import com.gu.mediaservice.lib.net.URI
+import org.apache.commons.compress.compressors.bzip2.{BZip2CompressorInputStream, BZip2CompressorOutputStream}
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+
+import java.io._
+import scala.collection.mutable
+import scala.io.Source
+import scala.language.postfixOps
+
+object ProposeS3Changes {
+  def apply(args: List[String]): Unit = {
+    args match {
+      case bucketMetadata :: esMetadata :: picdarCsv :: outputFile :: Nil => proposeS3Changes(
+        new File(bucketMetadata),
+        new File(esMetadata),
+        new File(picdarCsv),
+        new File(s"$outputFile.update.jsonl.bz2"),
+        new File(s"$outputFile.correct.jsonl.bz2"),
+        new File(s"$outputFile.esonlykeys.txt"),
+        new File(s"$outputFile.s3onlykeys.txt"),
+        new File(s"$outputFile.s3badkeys.txt"),
+      )
+      case _ => throw new IllegalArgumentException("Usage: ProposeS3Changes <bucketMetadataFile> <esMetadataFile> <picdarCsv> <outputFilePrefix>")
+    }
+  }
+
+  def getBzipWriter(outputFile: File) = {
+    val fileOutputStream = new FileOutputStream(outputFile)
+    val compressOutputStream = new BZip2CompressorOutputStream(fileOutputStream)
+    val sw = new OutputStreamWriter(compressOutputStream)
+    new BufferedWriter(sw)
+  }
+
+  def proposeS3Changes(
+                        bucketMetadata: File,
+                        esMetadata: File,
+                        picdarCsv: File,
+                        outputFileForJsonUpdate: File,
+                        outputFileForJsonCorrect: File,
+                        outputFileForESKeys: File,
+                        outputFileForS3Keys: File,
+                        outputFileForBadS3Keys: File) = {
+    val picdarData = readPicdarCsv(picdarCsv)
+    System.err.println(s"Completed reading ${picdarData.gridToPicdar.size} Picdar mappings")
+
+    val s3Metadata = {
+      val (md, badKeys) = readS3Metadata(bucketMetadata)
+      System.err.println(s"Completed reading S3 metadata. ${md.size} records, ${badKeys.size} bad keys")
+      // write out the bad keys in this scope so they can then be GCd
+      val outputWriterForBadS3Keys = new FileWriter(outputFileForBadS3Keys)
+      try {
+        badKeys.foreach(k => outputWriterForBadS3Keys.append(s"$k\n"))
+      } finally {
+        outputWriterForBadS3Keys.close()
+      }
+      md
+    }
+
+    var s3KeysNotYetSeenInEs = s3Metadata.keySet
+    var esKeysNotInS3 = Set.empty[String]
+
+    System.err.println(s"Starting change proposals...")
+    val outputWriterForJsonUpdate = getBzipWriter(outputFileForJsonUpdate)
+    val outputWriterForJsonCorrect = getBzipWriter(outputFileForJsonCorrect)
+    val outputWriterForESKeys = new FileWriter(outputFileForESKeys)
+    val outputWriterForS3Keys = new FileWriter(outputFileForS3Keys)
+    try {
+      withSourceFromBzipFile(esMetadata){ source =>
+        source
+          .getLines()
+          .flatMap(line => Json.fromJson[EsDocumentWithMetadata](Json.parse(line)).asOpt)
+          .zipWithIndex
+          .foreach { case (metadata, i) =>
+            if (i % 10000 == 0) System.err.println(s"Processing ES metadata line $i")
+            val id = metadata.id
+            val maybeS3 = s3Metadata.get(id)
+            maybeS3 match {
+              case Some(s3Metadata) =>
+                s3KeysNotYetSeenInEs -= id
+                val mergedMetadata = mergeMetadata(metadata, s3Metadata, picdarData)
+                if (mergedMetadata != mergeMetadata(metadata, mergedMetadata, picdarData)) {
+                  System.err.println(s"Merged metadata for $id not idempotent")
+                }
+                if (mergedMetadata != s3Metadata) {
+                  val jsS3 = Json.toJson(s3Metadata)
+                  val jsMerged = Json.toJson(mergedMetadata)
+                  val diff = JsonDiff.diff(jsS3, jsMerged)
+                  outputWriterForJsonUpdate
+                    .append(s"${Json.toJson(Json.obj(
+                      "original" -> jsS3,
+                      "proposed" -> jsMerged,
+                      "diff" -> diff
+                  )).toString()}\n")
+                } else {
+                  outputWriterForJsonCorrect
+                    .append(s"${Json.toJson(mergedMetadata).toString()}\n")
+                }
+              case None =>
+                esKeysNotInS3 += id
+            }
+          }
+      }
+
+      esKeysNotInS3.foreach(k => outputWriterForESKeys.append(s"$k\n"))
+      s3KeysNotYetSeenInEs.foreach(k => outputWriterForS3Keys.append(s"$k\n"))
+    } finally {
+      outputWriterForJsonUpdate.close()
+      outputWriterForJsonCorrect.close()
+      outputWriterForESKeys.close()
+      outputWriterForS3Keys.close()
+    }
+  }
+
+
+  def mergeMetadata(esMetadata: EsDocumentWithMetadata, s3Metadata: ObjectMetadata, picdarData: PicdarData): ObjectMetadata = {
+    /* If we can we should retain the legacy keys with _ in so that we don't have to touch the object */
+    def bestKeyNameFor(dashVariant: String): String = {
+      val hasDashVariant = s3Metadata.metadata.contains(dashVariant)
+      // does this have underscore version of key?
+      val underscoreVariant = dashVariant.replace("-", "_")
+      val hasUnderscoreVariant = s3Metadata.metadata.contains(underscoreVariant)
+      if (hasDashVariant && hasUnderscoreVariant) {
+        System.err.println(s"Warning: both dash and underscore keys on ${s3Metadata.key}")
+      }
+      if (hasUnderscoreVariant)
+        underscoreVariant
+      else
+        dashVariant
+    }
+
+    /* Find the "best" value, trying hard to detect values that haven't really changed despite encoding or format changes */
+    def bestValue(maybeEsValue: Option[String], maybeS3Value: Option[String], isDate: Boolean = false): Option[String] = {
+      def isSame(esValue: String, s3Value: String): Boolean = {
+        val decodedS3 = URI.decode(s3Value)
+        if (!isDate) {
+          decodedS3 == esValue
+        } else {
+          val s3Date = DateTime.parse(decodedS3)
+          val esDate = DateTime.parse(esValue)
+          s3Date.equals(esDate)
+        }
+      }
+      (maybeEsValue, maybeS3Value) match {
+        case (None, s3Value) => s3Value
+        case (Some(esValue), Some(s3Value)) if isSame(esValue, s3Value) => Some(s3Value)
+        case (Some(esValue), _) => Some(URI.encode(esValue))
+      }
+    }
+
+    val filenameKey = bestKeyNameFor(ImageStorageProps.filenameMetadataKey)
+    val uploadedByKey = bestKeyNameFor(ImageStorageProps.uploadedByMetadataKey)
+    val uploadTimeKey = bestKeyNameFor(ImageStorageProps.uploadTimeMetadataKey)
+
+    if (metadataEquivalent(esMetadata, s3Metadata)) {
+      s3Metadata
+    } else {
+      // filename: taken from ES if it exists, then from S3, otherwise empty
+      val fileName = bestValue(esMetadata.fileName, s3Metadata.metadata.get(filenameKey))
+        .map(s => s.replaceAll(s" (${esMetadata.id})", ""))
+      // uploaded by: taken from ES if it exists, then from S3, otherwise empty
+      val uploadedBy = bestValue(esMetadata.uploadedBy, s3Metadata.metadata.get(uploadedByKey))
+      // uploaded time: taken from ES if it exists, then from S3, otherwise empty
+      val uploadTime = bestValue(esMetadata.uploadTime, s3Metadata.metadata.get(uploadTimeKey), isDate = true)
+
+      // Find ALL identifiers in elasticsearch (put "identifier!" on the front and make lowercase)
+      val esIdentifiers = esMetadata.identifiers
+        .map{ case (key, value ) => s"${ImageStorageProps.identifierMetadataKeyPrefix}$key".toLowerCase -> URI.encode(value)}
+
+      // Find all OUR identifiers in S3 (must have "identifier!" on the front)
+      val s3Identifiers = s3Metadata.metadata
+        .filter{case (key, _) => key.startsWith(ImageStorageProps.identifierMetadataKeyPrefix)}
+
+      val picdarIdEntry = picdarData.gridToPicdar.get(esMetadata.id).map(s"${ImageStorageProps.identifierMetadataKeyPrefix}picdarurn" ->)
+
+      // Merge the two maps together with any picdar entry
+      val allIdentifierKeys = s3Identifiers.keySet ++ esIdentifiers.keySet
+      val identifiers = allIdentifierKeys.foldLeft(Map.empty[String, String]) { case (acc, key) =>
+        acc ++ bestValue(esIdentifiers.get(key), s3Identifiers.get(key)).map(key ->)
+      } ++ picdarIdEntry
+
+      ObjectMetadata(
+        key = s3Metadata.key,
+        lastModified = s3Metadata.lastModified,
+        metadata = identifiers
+          ++ fileName.map(fn => filenameKey -> fn)
+          ++ uploadedBy.map(ub => uploadedByKey -> ub)
+          ++ uploadTime.map(ut => uploadTimeKey -> ut)
+      )
+    }
+  }
+
+  def metadataEquivalent(metadata: EsDocumentWithMetadata, s3Metadata: ObjectMetadata): Boolean = {
+    metadata.uploadTime == s3Metadata.metadata.get(ImageStorageProps.uploadTimeMetadataKey) &&
+      metadata.uploadedBy == s3Metadata.metadata.get(ImageStorageProps.uploadedByMetadataKey) &&
+      metadata.fileName == s3Metadata.metadata.get(ImageStorageProps.filenameMetadataKey) &&
+      metadata.identifiers.map{case (key, value) =>
+        ImageStorageProps.identifierMetadataKeyPrefix + key.toLowerCase -> value
+      } == s3Metadata.metadata.filter{ case (key, _) => key.startsWith(ImageStorageProps.identifierMetadataKeyPrefix)}
+  }
+
+  private val hex = """[0-9a-f]"""
+  private val GoodKey = s"""^($hex)/($hex)/($hex)/($hex)/($hex)/($hex)/(\\1\\2\\3\\4\\5\\6$hex{34})$$""".r
+  def readS3Metadata(bucketMetadata: File): (Map[String, ObjectMetadata], List[String]) = {
+    val (goodEntries, badValues) = withSourceFromBzipFile(bucketMetadata){ source =>
+      source.getLines().zipWithIndex.foldLeft[(mutable.Builder[(String, ObjectMetadata), Map[String, ObjectMetadata]], List[String])] (Map.newBuilder[String, ObjectMetadata], Nil) { case ((goodEntries, badKeys), (line, i)) =>
+        if (i % 10000 == 0) System.err.println(s"Loading index $i")
+        Json.fromJson[ObjectMetadata](Json.parse(line)).asOpt match {
+          case Some(objMd@ObjectMetadata(GoodKey(_, _, _, _, _, _, id), _, _)) => (goodEntries += (id -> objMd), badKeys)
+          case Some(ObjectMetadata(badKey, _, _)) => (goodEntries, badKey :: badKeys)
+          case None => (goodEntries, badKeys)
+        }
+      }
+    }
+    (goodEntries.result(), badValues)
+  }
+
+  case class PicdarData(gridToPicdar: Map[String, String])
+
+  def readPicdarCsv(picdarCsvFile: File): PicdarData = {
+    val source = Source.fromFile(picdarCsvFile)
+    try {
+      val gridIdAndPicdarId = source.getLines().collect {
+        case line if line.contains(",") =>
+          line.takeWhile(_ != ',') -> line.dropWhile(_ != ',').drop(1)
+      }.toList
+      val gridIds = gridIdAndPicdarId.map{ case (gridId, _) => gridId }
+      val picdarIds = gridIdAndPicdarId.map{ case (_, picdarId) => picdarId }
+      if (gridIds.length != gridIds.toSet.size) {
+        throw new IllegalArgumentException(s"Picdar CSV file contains duplicate IDs: ${gridIds.length} / ${gridIds.toSet.size} uniques")
+      }
+      val gridToPicdar = gridIdAndPicdarId.toMap
+      //val picdarToGrid = gridIdAndPicdarId.map(_.swap).toMap
+      PicdarData(gridToPicdar)
+    } finally {
+      source.close()
+    }
+  }
+
+  private def withSourceFromBzipFile[T](file: File)(f: Source => T) = {
+    val fileInputStream = new FileInputStream(file)
+    val compressInputStream = new BZip2CompressorInputStream(fileInputStream)
+    val source = Source.fromInputStream(compressInputStream)
+    try {
+      f(source)
+    } finally {
+      source.close()
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?
We have drift between S3 and ES user metadata.

This PR contains:
 - A tool to extract metadata from ES
 - A tool to compare S3 metadata to ES metadata

EsImageMetadata
------------------
This script tool connects to an ES instance and attempts to locate an images index via a know alias. Once discovered it scrolls through the entire index and extracts the fields which are connected to the data in the S3 metadata and writes it to a compressed JSON lines output file.

ProposeS3Changes
--------------------
This script tool takes an extract file from S3 containing the object metadata, and an extract from ElasticSearch (from above), and attempts to create a correct version of the user metadata.  It then checks that this metadata would not be changed if the process was repeated, thus ensuring a canonically correct, idempotent result.

Output of the original, proposed, and diff user metadata is written to an output file, as are the keys found in S3 but not ES and vice versa.

The data can then be used as an input for the "Enact S3 Metadata Changes" tool:
https://github.com/guardian/grid/pull/3212


## How can success be measured?
Ultimately that S3 has all of the metadata that we stored in ES and could have been lost.