### PR TITLE
Create merged metadata on reprojection

### DIFF
--- a/admin-tools/dev/app/controllers/AdminToolsCtr.scala
+++ b/admin-tools/dev/app/controllers/AdminToolsCtr.scala
@@ -16,7 +16,7 @@ class AdminToolsCtr(config: AdminToolsConfig, override val controllerComponents:
 
   private val cfg = ImageDataMergerConfig(apiKey = config.apiKey, domainRoot = config.domainRoot, imageLoaderEndpointOpt = None)
 
-  private val merger = new ImageDataMerger(cfg)
+  private val merger = ImageDataMerger(cfg)
 
   private val indexResponse = {
     val indexData = Json.obj(

--- a/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
+++ b/admin-tools/lambda/src/main/scala/com/gu/mediaservice/ImageProjectionLambdaHandler.scala
@@ -46,7 +46,7 @@ class ImageProjectionLambdaHandler extends ApiKeyAuthentication with LazyLogging
     apiKey match {
       case Some(key) =>
         val cfg: ImageDataMergerConfig = ImageDataMergerConfig(apiKey = key, domainRoot = domainRoot, imageLoaderEndpointOpt = imageLoaderEndpoint)
-        val merger = new ImageDataMerger(cfg)
+        val merger = ImageDataMerger(cfg)
 
         val ok = Await.result(merger.isValidApiKey, apiCheckTimeout)
         if (!ok) {

--- a/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -122,8 +122,11 @@ class ImageDataMerger(gridClient: GridClient, services: Services, authFunction: 
     image <- getFullMergedImageData(maybeStubImage)
   } yield image
 
-  private def blah(maybeImage: Option[Image])(implicit ec: ExecutionContext): Future[Option[Image]] = maybeImage match {
-    case Some(image) => ImageDataMerger.aggregate(image, gridClient, authFunction) map (i => Some(i))
+  private def getFullMergedImageData(maybeImage: Option[Image])(implicit ec: ExecutionContext): Future[Option[Image]] = maybeImage match {
+    case Some(image) =>
+      // TODO I'm suspicious that we don't invoke the cleaners on this pass...
+      val imageWithMetadata = image.copy(originalMetadata = ImageMetadataConverter.fromFileMetadata(image.fileMetadata))
+      ImageDataMerger.aggregate(imageWithMetadata, gridClient, authFunction) map (i => Some(i))
     case None => Future.successful(None)
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -120,7 +120,7 @@ class ImageDataMerger(gridClient: GridClient, services: Services, authFunction: 
 
   private def getMergedImageDataInternal(mediaId: String)(implicit ec: ExecutionContext): Future[Option[Image]] = for {
     maybeStubImage <- gridClient.getImageLoaderProjection(mediaId, imageLoaderEndpoint, authFunction)
-    image <- blah(maybeStubImage)
+    image <- getFullMergedImageData(maybeStubImage)
   } yield image
 
   private def blah(maybeImage: Option[Image])(implicit ec: ExecutionContext): Future[Option[Image]] = maybeImage match {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -26,7 +26,29 @@ case class ImageMetadata(
   country:             Option[String]   = None,
   subjects:            List[String]     = Nil,
   peopleInImage:       Set[String]      = Set(),
-)
+) {
+  def merge(that: ImageMetadata) = this.copy(
+    dateTaken = (that.dateTaken ++ this.dateTaken).headOption,
+    description = (that.description ++ this.description).headOption,
+    credit = (that.credit ++ this.credit).headOption,
+    creditUri = (that.creditUri ++ this.creditUri).headOption,
+    byline = (that.byline ++ this.byline).headOption,
+    bylineTitle = (that.bylineTitle ++ this.bylineTitle).headOption,
+    title = (that.title ++ this.title).headOption,
+    copyright = (that.copyright ++ this.copyright).headOption,
+    suppliersReference = (that.suppliersReference ++ this.suppliersReference).headOption,
+    source = (that.source ++ this.source).headOption,
+    specialInstructions = (that.specialInstructions ++ this.specialInstructions).headOption,
+    keywords = that.keywords ++ this.keywords,
+    subLocation = (that.subLocation ++ this.subLocation).headOption,
+    city = (that.city ++ this.city).headOption,
+    state = (that.state ++ this.state).headOption,
+    country = (that.country ++ this.country).headOption,
+    subjects = that.subjects ++ this.subjects,
+    peopleInImage = that.peopleInImage ++ this.peopleInImage
+  )
+
+}
 
 object ImageMetadata {
   val empty = ImageMetadata()

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -125,7 +125,7 @@ class ImageLoaderController(auth: Authentication,
     val tempFile = createTempFile(s"projection-$imageId")
     auth.async { req =>
       val onBehalfOfFn: OnBehalfOfPrincipal = auth.getOnBehalfOfPrincipal(req.user)
-      val result= projector.projectS3ImageById(projector, imageId, tempFile, context.requestId, gridClient, onBehalfOfFn)
+      val result= projector.projectS3ImageById(imageId, tempFile, context.requestId, gridClient, onBehalfOfFn)
 
       result.onComplete( _ => Try { deleteTempFile(tempFile) } )
 

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -141,7 +141,7 @@ class Projector(config: ImageUploadOpsCfg,
         )
 
         imageUploadProjectionOps.projectImageFromUploadRequest(uploadRequest) flatMap (
-          futureImage => ImageDataMerger.aggregate(futureImage, gridClient, onBehalfOfFn)
+          image => ImageDataMerger.aggregate(image, gridClient, onBehalfOfFn)
         )
     }
   }

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -140,10 +140,9 @@ class Projector(config: ImageUploadOpsCfg,
           uploadInfo = uploadInfo_
         )
 
-        for {
-          futureImage <- imageUploadProjectionOps.projectImageFromUploadRequest(uploadRequest)
-          aggregatedImage <- ImageDataMerger.aggregate(futureImage, gridClient, onBehalfOfFn)
-        } yield aggregatedImage
+        imageUploadProjectionOps.projectImageFromUploadRequest(uploadRequest) flatMap (
+          futureImage => ImageDataMerger.aggregate(futureImage, gridClient, onBehalfOfFn)
+        )
     }
   }
 }

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -89,7 +89,7 @@ class Projector(config: ImageUploadOpsCfg,
 
   private val imageUploadProjectionOps = new ImageUploadProjectionOps(config, imageOps, processor)
 
-  def projectS3ImageById(imageUploadProjector: Projector, imageId: String, tempFile: File, requestId: UUID, gridClient: GridClient, onBehalfOfFn: WSRequest => WSRequest)
+  def projectS3ImageById(imageId: String, tempFile: File, requestId: UUID, gridClient: GridClient, onBehalfOfFn: WSRequest => WSRequest)
                         (implicit ec: ExecutionContext, logMarker: LogMarker): Future[Option[Image]] = {
     Future {
       import ImageIngestOperations.fileKeyFromId
@@ -104,7 +104,7 @@ class Projector(config: ImageUploadOpsCfg,
       val digestedFile = getSrcFileDigestForProjection(s3Source, imageId, tempFile)
       val extractedS3Meta = S3FileExtractedMetadata(s3Source.getObjectMetadata)
 
-      val finalImageFuture = imageUploadProjector.projectImage(digestedFile, extractedS3Meta, requestId, gridClient, onBehalfOfFn)
+      val finalImageFuture = projectImage(digestedFile, extractedS3Meta, requestId, gridClient, onBehalfOfFn)
       val finalImage = Await.result(finalImageFuture, Duration.Inf)
       Some(finalImage)
     }


### PR DESCRIPTION
## What does this change?
Currently, on re-projection (recreation of image data) the metadata is not populated _at all_.

It should be populated by taking the original file metadata, creating image metadata, and then merging down any user metadata changes.  It was missed originally because the re-projection tool was first created for images which were orphaned in S3 and so could not have _any_ user edits.

This missing action has come to light via diff'ing of projections.

## How can success be measured?
Smaller diffs, with correct information.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
