### PR TITLE
Debug projection

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -79,12 +79,16 @@ object ImageDataMerger extends LazyLogging {
     val collectionsDates = image.collections.map(_.actionData.date)
     val usagesDates = image.usages.map(_.lastModified)
 
-    val lmDatesCandidates: List[DateTime] = List(
-      image.lastModified,
-      image.leases.lastModified
-    ).flatten ++ exportsDates ++ collectionsDates ++ usagesDates
+    // TODO this should actually be stored in the Edit object.
+    // Failing that, we will guess that edits come along at once, and hope that the other edits are close.
+    val allDatesForUserEditableFields = image.leases.lastModified ++
+      exportsDates ++
+      collectionsDates
 
-    Option(lmDatesCandidates).collect { case dates if dates.nonEmpty => dates.max(dtOrdering) }
+    allDatesForUserEditableFields match {
+      case Nil => None
+      case dates => Some(dates.max(dtOrdering))
+    }
   }
 
   private def mergeMetadata(edits: Option[Edits], originalMetadata: ImageMetadata) = edits match {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -53,11 +53,28 @@ sealed trait ImageWrapper {
   val mimeType: MimeType
   val meta: Map[String, String]
 }
-sealed trait StorableImage extends ImageWrapper
+sealed trait StorableImage extends ImageWrapper {
+  def toProjectedS3Object(thumbBucket: String): S3Object = S3Object(
+    thumbBucket,
+    ImageIngestOperations.fileKeyFromId(id),
+    file,
+    Some(mimeType)
+  )
+}
 
 case class StorableThumbImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage
 case class StorableOriginalImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage
-case class StorableOptimisedImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage
+case class StorableOptimisedImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage {
+  override def toProjectedS3Object(thumbBucket: String): S3Object = S3Object(
+    thumbBucket,
+    ImageIngestOperations.optimisedPngKeyFromId(id),
+    file,
+    Some(mimeType)
+  )
+}
+
+
+
 case class BrowserViewableImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty, mustUpload: Boolean = false) extends ImageWrapper {
   def asStorableOptimisedImage = StorableOptimisedImage(id, file, mimeType, meta)
   def asStorableThumbImage = StorableThumbImage(id, file, mimeType, meta)

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -161,38 +161,13 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
     fromUploadRequestShared(uploadRequest, dependenciesWithProjectionsOnly, processor)
   }
 
-  private def projectOriginalFileAsS3Model(storableOriginalImage: StorableOriginalImage)
-                                          (implicit ec: ExecutionContext)= Future {
-    val key = ImageIngestOperations.fileKeyFromId(storableOriginalImage.id)
-    S3Object(
-      config.originalFileBucket,
-      key,
-      storableOriginalImage.file,
-      Some(storableOriginalImage.mimeType),
-      storableOriginalImage.meta
-    )
-  }
+  private def projectOriginalFileAsS3Model(storableOriginalImage: StorableOriginalImage) =
+    Future.successful(storableOriginalImage.toProjectedS3Object(config.originalFileBucket))
 
-  private def projectThumbnailFileAsS3Model(storableThumbImage: StorableThumbImage)(implicit ec: ExecutionContext) = Future {
-    val key = ImageIngestOperations.fileKeyFromId(storableThumbImage.id)
-    val thumbMimeType = Some(ImageOperations.thumbMimeType)
-    S3Object(
-      config.thumbBucket,
-      key,
-      storableThumbImage.file,
-      thumbMimeType
-    )
-  }
+  private def projectThumbnailFileAsS3Model(storableThumbImage: StorableThumbImage) =
+    Future.successful(storableThumbImage.toProjectedS3Object(config.thumbBucket))
 
-  private def projectOptimisedPNGFileAsS3Model(storableOptimisedImage: StorableOptimisedImage)(implicit ec: ExecutionContext) = Future {
-    val key = ImageIngestOperations.optimisedPngKeyFromId(storableOptimisedImage.id)
-    val optimisedPngMimeType = Some(ImageOperations.thumbMimeType) // this IS what we will generate.
-    S3Object(
-      config.originalFileBucket,
-      key,
-      storableOptimisedImage.file,
-      optimisedPngMimeType
-    )
-  }
+  private def projectOptimisedPNGFileAsS3Model(storableOptimisedImage: StorableOptimisedImage) =
+    Future.successful(storableOptimisedImage.toProjectedS3Object(config.originalFileBucket))
 
 }

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -193,7 +193,12 @@ object Uploader extends GridLogging {
     if (optimiseOps.shouldOptimise(Some(browserViewableImage.mimeType), optimisedFileMetadata)) {
       for {
         (optimisedFile: File, optimisedMimeType: MimeType) <- optimiseOps.toOptimisedFile(browserViewableImage.file, browserViewableImage, tempDir)
-      } yield Some(browserViewableImage.copy(file = optimisedFile).copy(mimeType = optimisedMimeType).asStorableOptimisedImage)
+      } yield Some(
+        browserViewableImage.copy(
+          file = optimisedFile,
+          mimeType = optimisedMimeType
+        ).asStorableOptimisedImage
+      )
     } else if (browserViewableImage.mustUpload) {
       Future.successful(Some(browserViewableImage.asStorableOptimisedImage))
     } else

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -156,7 +156,7 @@ object Uploader extends GridLogging {
         case None => Future.successful(None)
       }
       sourceDimensions <- sourceDimensionsFuture
-      thumbDimensions <- FileMetadataReader.dimensions(thumbViewableImage.file, Some(Jpeg))
+      thumbDimensions <- FileMetadataReader.dimensions(thumbViewableImage.file, Some(thumbViewableImage.mimeType))
       colourModel <- colourModelFuture
     } yield {
       val fullFileMetadata = fileMetadata.copy(colourModel = colourModel)

--- a/image-loader/app/model/upload/OptimiseOps.scala
+++ b/image-loader/app/model/upload/OptimiseOps.scala
@@ -33,7 +33,7 @@ object OptimiseWithPngQuant extends OptimiseOps {
 
     val optimisedFile = new File(optimisedFilePath)
     if (optimisedFile.exists()) {
-      (optimisedFile, Png)
+      (optimisedFile, optimiseMimeType)
     } else {
       throw new Exception(s"Attempted to optimise PNG file ${optimisedFile.getPath}")
     }

--- a/image-loader/app/model/upload/OptimiseOps.scala
+++ b/image-loader/app/model/upload/OptimiseOps.scala
@@ -49,7 +49,7 @@ object OptimiseWithPngQuant extends OptimiseOps {
           case Some("True Color with Alpha") => true
           case _ => false
         }
-      case Some(Tiff) => true
+      case Some(Tiff) => true // TODO This should be done better, it could be better optimised into a jpeg.
       case _ => false
     }
 }

--- a/image-loader/app/model/upload/OptimiseOps.scala
+++ b/image-loader/app/model/upload/OptimiseOps.scala
@@ -49,8 +49,7 @@ object OptimiseWithPngQuant extends OptimiseOps {
           case Some("True Color with Alpha") => true
           case _ => false
         }
-      case Some(Tiff) => true // TODO This should be done better, it could be better optimised into a jpeg.
+      case Some(Tiff) => true // TODO This should be done better, it could be better optimised into a jpeg if there is no transparency.
       case _ => false
     }
 }
-


### PR DESCRIPTION
## What does this change?
Several small bugs/improvements in the projection code:
 - user metadata last modified date is closer to current value
 - thumbnails and optimised mime types derive from their parent objects rather than hard coded.

## How can success be measured?
Mostly mime type for optimised files is correct, see diff endpoint.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
