### PR TITLE
Use meta data from S3 when projecting original image

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -58,7 +58,8 @@ sealed trait StorableImage extends ImageWrapper {
     thumbBucket,
     ImageIngestOperations.fileKeyFromId(id),
     file,
-    Some(mimeType)
+    Some(mimeType),
+    meta
   )
 }
 
@@ -69,7 +70,8 @@ case class StorableOptimisedImage(id: String, file: File, mimeType: MimeType, me
     thumbBucket,
     ImageIngestOperations.optimisedPngKeyFromId(id),
     file,
-    Some(mimeType)
+    Some(mimeType),
+    meta
   )
 }
 


### PR DESCRIPTION
## What does this change?
Last PR refactor removed the metadata from the original S3 object when it is projected.  This corrects that error.

## How can success be measured?
Projections will include (for example) filename from S3.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
