### PR TITLE
Add last modified to edits/metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,13 +243,15 @@ lazy val usage = playProject("usage", 9009).settings(
   )
 )
 
+val awsSdkV2Version = "2.15.81"
 lazy val scripts = project("scripts")
   .dependsOn(commonLib)
   .enablePlugins(JavaAppPackaging, UniversalPlugin)
   .settings(
     libraryDependencies ++= Seq(
       // V2 of the AWS SDK as it's easier to use for scripts and won't leak to the rest of the project from here
-      "software.amazon.awssdk" % "s3" % "2.15.81",
+      "software.amazon.awssdk" % "s3" % awsSdkV2Version,
+      "software.amazon.awssdk" % "dynamodb" % awsSdkV2Version,
       // bump jcommander explicitly as AWS SDK is pulling in a vulnerable version
       "com.beust" % "jcommander" % "1.75",
       "org.apache.commons" % "commons-compress" % "1.20",

--- a/collections/app/store/CollectionsStore.scala
+++ b/collections/app/store/CollectionsStore.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CollectionsStore(config: CollectionsConfig) {
-  val dynamo = new DynamoDB(config, config.collectionsTable)
+  val dynamo = new DynamoDB[Collection](config, config.collectionsTable)
 
   def getAll: Future[List[Collection]] = dynamo.scan map { jsonList =>
     jsonList.flatMap(json => (json \ "collection").asOpt[Collection])

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.dynamodbv2.document.{DynamoDB => AwsDynamoDB, _}
 import com.amazonaws.services.dynamodbv2.model.ReturnValue
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
 import com.gu.mediaservice.lib.config.CommonConfig
+import org.joda.time.DateTime
 import play.api.libs.json._
 
 import scala.collection.JavaConverters._
@@ -14,8 +15,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object NoItemFound extends Throwable("item not found")
 
-class DynamoDB(config: CommonConfig, tableName: String) {
-
+/**
+  * A lightweight wrapper around AWS dynamo SDK for undertaking various operations
+  * @param config Common grid config including AWS credentials
+  * @param tableName the table name for this instance of the dynamoDB wrapper
+  * @param lastModifiedKey if set to a string the wrapper will maintain a last modified with that name on any update
+  * @tparam T The type of this table
+  */
+class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Option[String] = None) {
   lazy val client: AmazonDynamoDBAsync = config.withAWSCredentials(AmazonDynamoDBAsyncClientBuilder.standard()).build()
   lazy val dynamo = new AwsDynamoDB(client)
   lazy val table: Table = dynamo.getTable(tableName)
@@ -137,7 +144,7 @@ class DynamoDB(config: CommonConfig, tableName: String) {
       new ValueMap().withStringSet(":value", value)
     )
 
-  def listGet[T](id: String, key: String)
+  def listGet(id: String, key: String)
                 (implicit ex: ExecutionContext, reads: Reads[T]): Future[List[T]] = {
 
     get(id, key) map { item =>
@@ -148,7 +155,7 @@ class DynamoDB(config: CommonConfig, tableName: String) {
     }
   }
 
-  def listAdd[T](id: String, key: String, value: T)
+  def listAdd(id: String, key: String, value: T)
                 (implicit ex: ExecutionContext, tjs: Writes[T], rjs: Reads[T]): Future[List[T]] = {
 
     // TODO: Deal with the case that we don't have JSON serialisers, for now we just fail.
@@ -175,13 +182,13 @@ class DynamoDB(config: CommonConfig, tableName: String) {
     }
   }
 
-  def listRemoveIndexes[T](id: String, key: String, indexes: List[Int])
+  def listRemoveIndexes(id: String, key: String, indexes: List[Int])
                           (implicit ex: ExecutionContext, rjs: Reads[T]): Future[List[T]] =
     update(
       id, s"REMOVE ${indexes.map(i => s"$key[$i]").mkString(",")}"
     ) map(j => (j \ key).as[List[T]])
 
-  def objPut[T](id: String, key: String, value: T)
+  def objPut(id: String, key: String, value: T)
                  (implicit ex: ExecutionContext, wjs: Writes[T], rjs: Reads[T]): Future[T] = Future {
 
     val item = new Item().withPrimaryKey(IdKey, id).withJSON(key, Json.toJson(value).toString)
@@ -218,9 +225,12 @@ class DynamoDB(config: CommonConfig, tableName: String) {
     val baseUpdateSpec = new UpdateItemSpec().
       withPrimaryKey(IdKey, id).
       withUpdateExpression(expression).
-      withReturnValues(ReturnValue.ALL_NEW)
+      withReturnValues(ReturnValue.ALL_NEW).
+      withValueMap(valueMap.orNull)
 
-    val updateSpec = valueMap.map(baseUpdateSpec.withValueMap(_)) getOrElse baseUpdateSpec
+    val updateSpec = lastModifiedKey.map { key =>
+      DynamoDB.addLastModifiedUpdate(baseUpdateSpec, key, DateTime.now)
+    }.getOrElse(baseUpdateSpec)
 
     table.updateItem(updateSpec)
   } map asJsObject
@@ -284,4 +294,32 @@ object DynamoDB {
   }
   def caseClassToMap[T](caseClass: T)(implicit tjs: Writes[T]): Map[String, JsValue] =
     Json.toJson[T](caseClass).as[JsObject].as[Map[String, JsValue]]
+
+  def addLastModifiedUpdate(update: UpdateItemSpec, lastModifiedKey: String, lastModifiedDate: DateTime): UpdateItemSpec = {
+    val expression = update.getUpdateExpression
+    val valueMap: ValueMap = {
+      val m = new ValueMap()
+      Option(update.getValueMap).foreach { vm =>
+        m.putAll(vm)
+      }
+      m
+    }
+
+    val newExpression = {
+      val keyUpdate: String = s"$lastModifiedKey = :$lastModifiedKey"
+      if (expression.contains("SET ")) {
+          // add to existing clause
+        expression.replace("SET ", s"SET ${keyUpdate}, ")
+      } else {
+        // add SET clause to existing expression
+        s"SET $keyUpdate ${expression}"
+      }
+    }
+
+    valueMap.put(s":$lastModifiedKey", lastModifiedDate.toString)
+
+    update
+      .withUpdateExpression(newExpression)
+      .withValueMap(valueMap)
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -96,7 +96,8 @@ object MappingTest {
       labels = List("a label", "another label"),
       metadata = testImageMetadata,
       usageRights = Some(NoRights),
-      photoshoot = Some(Photoshoot("crazy times shoot"))
+      photoshoot = Some(Photoshoot("crazy times shoot")),
+      lastModified = Some(imageModified)
     )),
     metadata = testImageMetadata,
     originalMetadata = testImageMetadata,

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -187,7 +187,8 @@ object Mappings {
     nonAnalysedList("labels").copyTo("metadata.englishAnalysedCatchAll"),
     metadataMapping("metadata"),
     usageRightsMapping("usageRights"),
-    photoshootMapping("photoshoot")
+    photoshootMapping("photoshoot"),
+    dateField("lastModified")
   )
 
   def uploadInfoMapping(name: String): ObjectField = nonDynamicObjectField(name).fields(

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Collection.scala
@@ -33,7 +33,6 @@ object Collection {
 }
 
 // Following the crop structure
-// TODO: Use this in crop too
 case class ActionData(author: String, date: DateTime)
 object ActionData {
   // TODO: Use the generic formats for DateTime

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeaseNotice.scala
@@ -13,16 +13,6 @@ case class LeaseNotice(mediaId: String, leaseByMedia: JsValue) {
 }
 
 object LeaseNotice {
-  import JodaWrites._
-
-  implicit val writer = new Writes[LeasesByMedia] {
-    def writes(leaseByMedia: LeasesByMedia) = {
-      LeasesByMedia.toJson(
-        Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.lastModified)
-      )
-    }
-  }
   def apply(mediaLease: MediaLease): LeaseNotice = LeaseNotice(
     mediaLease.mediaId,
     Json.toJson(LeasesByMedia(List(mediaLease), Some(mediaLease.createdAt)))

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/leases/LeasesByMedia.scala
@@ -15,9 +15,9 @@ object LeasesByMedia {
 
   implicit val writer = new Writes[LeasesByMedia] {
     def writes(leaseByMedia: LeasesByMedia) = {
-      LeasesByMedia.toJson(
-        Json.toJson(leaseByMedia.leases),
-        Json.toJson(leaseByMedia.lastModified)
+      Json.obj(
+        "leases" -> leaseByMedia.leases,
+        "lastModified" -> leaseByMedia.lastModified
       )
     }
   }
@@ -31,14 +31,5 @@ object LeasesByMedia {
   def build (leases: List[MediaLease]) = {
     val lastModified = leases.sortBy(_.createdAt).reverse.headOption.map(_.createdAt)
     LeasesByMedia(leases, lastModified)
-  }
-
-  def toJson(leases: JsValue, lastModified: JsValue) : JsObject = {
-    JsObject(
-      Seq(
-        "leases" -> leases,
-        "lastModified" -> lastModified
-      )
-    )
   }
 }

--- a/metadata-editor/app/lib/EditsStore.scala
+++ b/metadata-editor/app/lib/EditsStore.scala
@@ -1,5 +1,6 @@
 package lib
 
 import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.mediaservice.model.Edits
 
-class EditsStore(config: EditsConfig) extends DynamoDB(config, config.editsTable)
+class EditsStore(config: EditsConfig) extends DynamoDB[Edits](config, config.editsTable, Some(Edits.LastModified))

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/BackfillEditLastModified.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/BackfillEditLastModified.scala
@@ -1,0 +1,188 @@
+package com.gu.mediaservice.scripts
+
+import com.sksamuel.elastic4s.ElasticApi.matchQuery
+import com.sksamuel.elastic4s.ElasticDsl._
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ScanRequest, UpdateItemRequest}
+import software.amazon.awssdk.services.dynamodb.{DynamoDbClient, DynamoDbClientBuilder}
+import software.amazon.awssdk.services.s3.S3Client
+
+import java.io.{File, FileOutputStream, PrintWriter}
+import scala.collection.JavaConverters._
+import scala.io.Source
+import scala.util.Try
+
+object BackfillEditLastModified extends EsScript {
+
+  private val profile = "media-service"
+  private val region = Region.EU_WEST_1
+  private val credentials = DefaultCredentialsProvider.builder.profileName(profile).build
+  private val dynamo: DynamoDbClient = DynamoDbClient.builder
+    .region(region)
+    .credentialsProvider(credentials)
+    .build
+
+  private var total = 0
+  private var skipped = 0
+  private var updated = 0
+
+  override def run(esUrl: String, args: List[String]): Unit = {
+    def option(options: List[String], argName: String): (Option[String], List[String]) = {
+      val arg = options.find(_.startsWith(s"--$argName="))
+      val value = arg.map(_.stripPrefix(s"--$argName="))
+      value -> options.filterNot(arg.contains)
+    }
+
+    args match {
+      case dynamoTable :: fileNamePrefix :: remainder  =>
+        val (maybeRun, _) = option(remainder, "run")
+        val dryRun = !maybeRun.contains("true")
+        val esClient = new EsClient(esUrl)
+        try {
+          backfill(esClient, dynamoTable, fileNamePrefix, dryRun)
+        } finally {
+          esClient.client.close()
+        }
+      case _ => throw new IllegalArgumentException("Usage: BackfillEditLastModified <esUrl> <dynamoEditsTable> <filePrefix> [--run=true]")
+    }
+  }
+
+  def backfill(esClient: EsClient, dynamoTable: String, fileName: String, dryRun: Boolean): Unit = {
+    val lastFile = new File(s"$fileName.last")
+    val lastEvaluatedKey = if (lastFile.exists()) {
+      val source = Source.fromFile(lastFile)
+      val lastId = try {
+        source.getLines.toList match {
+          case id :: totalStr :: _ =>
+            total = totalStr.toInt
+            Some(id)
+          case _ => None
+        }
+      } finally {
+        source.close()
+      }
+      lastId.map { id =>
+        Map("id" -> AttributeValue.builder.s(id).build).asJava
+      }
+    } else None
+
+    val logWriter = new PrintWriter(new FileOutputStream(s"$fileName.$total.log"))
+    def log(msg: String) = logWriter.println(s"[${DateTime.now}/($total/U:$updated/S:$skipped]: $msg")
+
+    log(s"Starting backfill of $dynamoTable from ${esClient.url}; ${if(dryRun){"DRYRUN ONLY"}else{"RUNNING"}}")
+    log(s"Last evaluated key: $lastEvaluatedKey")
+    // scan through edits table (this is the shorter list by far)
+    val scanIterator = dynamo.scanPaginator(
+      ScanRequest.builder
+        .tableName(dynamoTable)
+        .projectionExpression("id")
+        .limit(500)
+        .exclusiveStartKey(lastEvaluatedKey.orNull)
+        .build
+    )
+    scanIterator
+      .iterator().asScala
+      .map { r =>
+
+        val lastEvaluatedKey = Some(r.lastEvaluatedKey.asScala)
+          .filter(_ => r.hasLastEvaluatedKey)
+          .flatMap(_.get("id"))
+          .map(_.s())
+
+
+        lastEvaluatedKey -> r.items.asScala
+      }
+      .map { case (lek, records) =>
+        lek -> records.flatMap(_.asScala.get("id").map(_.s))
+      }
+      .foreach { case (lek, imageIds) =>
+        imageIds.foreach { id =>
+          // for each edit entry:
+          // do a simple get on the ES cluster
+          val maybeLastModified = getUserMetadataLastModified(esClient, id)
+          // update just the last modified value on the edits table
+          maybeLastModified match {
+            case Left(reason) =>
+              skipped += 1
+              log(s"$id: Unable to get userMetadataLastModified - $reason")
+            case Right(lastModified) =>
+              updated += 1
+              val result = updateEditRecord(dynamoTable, id, lastModified, dryRun)
+              log(s"$id: $result")
+          }
+          total += 1
+          Thread.sleep(10)
+        }
+
+        lek match {
+          case Some(id) =>
+            log(s"Last evaluated key $id (batch of ${imageIds.size})")
+            val logWriter = new PrintWriter(new FileOutputStream(lastFile))
+            try {
+              logWriter.println(id)
+              logWriter.println(total)
+            } finally {
+              logWriter.close()
+            }
+          case None => // nowt
+        }
+
+      }
+    log(s"Finished. Updated: $updated; Skipped: $skipped")
+  }
+
+  def getUserMetadataLastModified(esClient: EsClient, id: String): Either[String, DateTime] = {
+    val client = esClient.client
+    val index = esClient.currentIndex
+    val queryType = matchQuery("id", id)
+    val queryResponse = client.execute({
+      search(index)
+        .query(queryType)
+        .fetchSource(false)
+        .sourceInclude(
+          "id",
+          "userMetadataLastModified"
+        )
+    }).await
+
+    queryResponse.status match {
+      case 200 => queryResponse.result.hits.hits.flatMap{ hit =>
+        (Json.parse(hit.sourceAsString) \ "userMetadataLastModified").asOpt[String]
+      }
+        .headOption
+        .toRight("Not in ES document")
+        .flatMap { lm =>
+          Try(new DateTime(lm)).toEither.left.map { t =>
+            t.toString
+          }
+        }
+      case _ =>
+        client.close()
+        throw new Exception("Failed performing search query")
+    }
+  }
+
+  def updateEditRecord(tableName: String, id: String, lastModified: DateTime, dryRun: Boolean): String = {
+    val request = UpdateItemRequest.builder
+      .tableName(tableName)
+      .key(Map("id" -> AttributeValue.builder.s(id).build).asJava)
+      .updateExpression("SET lastModified = :lastModified")
+      .expressionAttributeValues(Map(":lastModified" -> AttributeValue.builder.s(lastModified.toString).build).asJava)
+      .build
+    val msg = s"Updated with $lastModified ($request)"
+    if (dryRun) {
+      s"Would: $msg"
+    } else {
+      dynamo.updateItem(request)
+      msg
+    }
+  }
+
+  override def usageError: Nothing = {
+    System.err.println("Usage: BackfillEditLastModified <ES_URL> <EDITS_DYNAMO_TABLE_NAME> [--run=true]")
+    sys.exit(1)
+  }
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -345,7 +345,7 @@ abstract class EsScript {
   final val esShards = 5
   final val esReplicas = 0
 
-  def log(msg: String) = System.out.println(s"[Reindexer]: $msg")
+  def log(msg: String) = System.out.println(s"[${getClass.getName}]: $msg")
 
   def apply(args: List[String]) {
     // FIXME: Use Stage to get host (for some reason this isn't working)

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -16,6 +16,7 @@ object Main extends App {
     case "EnactS3Changes"   :: as => EnactS3Changes(as)
     case "EsMetadata"       :: as => EsImageMetadata(as)
     case "ProposeS3Changes" :: as => ProposeS3Changes(as)
+    case "BackfillEditLastModified" :: as => BackfillEditLastModified(as)
     case a :: _ => sys.error(s"Unrecognised command: $a")
     case Nil    => sys.error("Usage: <Command> <args ...>")
   }


### PR DESCRIPTION
## What does this change?
At the moment we don't store a last modified in the canonical data store but we do store it in elastic search. This adds that field to the canonical store and uses it to set the `userMetadataLastModified` in the elasticsearch model.

### Maintaining lastModified in the Dynamo table
The `lastModified` field is maintained as part of the `DynamoDB` abstraction so it is maintained without the need for code in the business logic of the application. The `DynamoDB` abstraction is initialised with an optional string containing the field name of the last modified field to maintain. Any operations to the table then automatically update the field to `now`.

## Applying ES migration
This changes part of the ES mapping by adding a new field. If this is not applied then you will see errors along the line of:
```
com.gu.mediaservice.lib.elasticsearch.ElasticSearchException$$anon$3: query failed because: mapping set to strict, dynamic introduction of [lastModified] within [userMetadata] is not allowed type: strict_dynamic_mapping_exception root cause ElasticError(strict_dynamic_mapping_exception,mapping set to strict, dynamic introduction of [lastModified] within [userMetadata] is not allowed,None,None,None,null,None,None,None,null)
	at com.gu.mediaservice.lib.elasticsearch.ElasticSearchException$.apply(ElasticSearchException.scala:35)
	at com.gu.mediaservice.lib.elasticsearch.ElasticSearchExecutions.$anonfun$executeAndLog$1(ElasticSearchExecutions.scala:32)
        ...
```

To apply this mapping change you need to run the `UpdateMapping` script. You can do this via sbt or you can build the scripts and use them elsewhere.

### Applying from inside SBT

Start sbt in a place that you can reach your ES instance and then run the following (replacing the URL with your ES instance URL):
```
sbt:grid> scripts/run UpdateMapping http://localhost:9200/
```

###  Applying outside of SBT

If you are unable to reach your ES URL from somewhere you can run SBT then you can use SBT to build a version of the scripts package using `sbt scripts/universal:packageBin` and then run it somewhere you have a JVM.

Start by creating a zip file of your scripts as below (on a branch containing the mapping change):
```
❯ sbt "show scripts/universal:packageBin"
<snip>
[info] /Users/sihil/code/grid/scripts/target/universal/scripts-0.1.zip
[success] Total time: 11 s, completed 20-Apr-2021 11:08:06
```

You now have a zip file that you can copy onto a host of your choice, unzip and run the script:
```
unzip <zipfile>
scripts-0.1/bin/scripts UpdateMapping http://elasticsearch:9200/
```

## Applying the backfill
Backfilling is an optional, but recommended, step to populate the new field with data currently in ElasticSearch.

A script has been written that scans through all edits in the Edit dynamo table and for each image `id` looks for the last modified in ES and then updates the new field in dynamo with that value.

As per the mapping above you can run this either inside SBT or from a zip file. In this case you will need network access to the ES service and also AWS permission on the Edit dynamo table.

As an example from the zip file:
```
unzip <zipfile>
scripts-0.1/bin/scripts BackfillEditLastModified http://elasticsearch:9200/ EditTableName backfillLogFilePrefix --run=true
```

Note that without `--run=true` it will simply output the Dynamo requests it would have made without actually running them.

## How can success be measured?
Projection no longer has any differences for the `userMetadataLastModified` field.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested?
- [X] Confirm that model change causes MappingTest sample data test failure
- [X] Confirm that fixing sample data causes ES round trip test failure
- [X] Confirm that deploying to TEST failed good to go check
- [X] locally by committer
- [x] Apply ES mapping change to TEST
- [x] Deploy to TEST
- [x] on the Guardian's TEST environment

## Rollout
 - [x] Backfill TEST
 - [x] Apply ES mapping change to PROD
 - [ ] Merge
 - [ ] Backfill PROD