### PR TITLE
[Accessibility] Add "new image" alert to tab in browser

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -461,7 +461,16 @@ kahuna.directive('uiTitle', ['$rootScope', function($rootScope) {
                   var title = (titleFunc ? titleFunc(toParams) : toState.name) +
                           ' | ' + attrs.uiTitleSuffix;
 
+                  attrs.uiTitle = title;
+
                   element.text(title);
+            });
+
+            $rootScope.$on('events:new-images',
+                function(event, data) {
+                    var title = (data.count ? `(${data.count} new)  ${attrs.uiTitle}` : attrs.uiTitle);
+
+                    element.text(title);
             });
         }
     };

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -233,6 +233,11 @@ results.controller('SearchResultsCtrl', [
                     // FIXME: minor assumption that only the latest
                     // displayed image is matching the uploadTime
                     ctrl.newImagesCount = resp.total;
+
+                    if (ctrl.newImagesCount > 0) {
+                        $rootScope.$emit('events:new-images', { count: ctrl.newImagesCount});
+                    }
+
                     ctrl.lastestTimeMoment = moment(latestTime).from(moment());
 
                     if (! scopeGone) {


### PR DESCRIPTION
## What does this change?

Adds a "(X new)"  text to the page title when new images arrive after polling.

Proposal - https://github.com/guardian/grid/issues/3218

## How can success be measured?

When the UI (Kahuna) polls for new images:
- and X new images arrive, then the page title should be updated to "(X new) `page_title`"
- using a user defined search term and X new images arrive, then the page title should be updated to "(X new) `page_title`"

## Screenshots

Tab with new image alert

![Screenshot at 2021-03-23 17-14-30](https://user-images.githubusercontent.com/12212239/112446117-e9927b00-8d60-11eb-99eb-0e83db08a387.png)

![Screenshot at 2021-03-23 17-43-51](https://user-images.githubusercontent.com/12212239/112446140-f020f280-8d60-11eb-863f-38c84b757f9b.png)

## Who should look at this?
@guardian/digital-cms @AWare @paperboyo 


## Tested?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
