### PR TITLE
Can use the tab key to navigate to quick filter buttons

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -86,6 +86,7 @@
             <li class="search__modifier-item radio-list">
                 <div class="radio-list__item">
                     <input type="radio"
+                           aria-hidden="false"
                            id="sort-direction__desc"
                            class="radio-list__circle"
                            name="sort-direction"
@@ -100,6 +101,7 @@
                 <div ng-if="!searchQuery.collectionSearch"
                      class="radio-list__item">
                     <input type="radio"
+                           aria-hidden="false"
                            id="sort-direction__asc"
                            class="radio-list__circle"
                            name="sort-direction"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2343,7 +2343,17 @@ FIXME: what to do with touch devices
 }
 
 .radio-list__circle {
-    display: none;
+    clip: rect(0 0 0 0);
+    clip-path: inset(100%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap; 
+    width: 1px;
+}
+
+.radio-list__circle:focus + .radio-list__label {
+    border: solid 3px #00adee;
 }
 
 .radio-list__selection-state {


### PR DESCRIPTION
## What does this change?

This references the proposal [3219](https://github.com/guardian/grid/issues/3219). Ensures the UI is more accessible and responsive to the assistive technology. This adds a tab index navigation on the quick filter buttons (Newest First, Oldest First) so when users use the tab key to navigate the UI, the cursor is able to land on these buttons.

## How can success be measured?

When a user clicks on the tab key, the cursor should be able to land on the quick filter buttons (Newest First, Oldest First) visibly.

## Screenshots

![Screenshot at 2021-03-22 16-17-10](https://user-images.githubusercontent.com/6728165/112460833-9cfa7000-8d5f-11eb-8df0-16c6a1a307b9.png)
<img width="159" alt="Screenshot 2021-03-24 at 11 26 07" src="https://user-images.githubusercontent.com/6728165/112460846-9ff56080-8d5f-11eb-8655-6300a0381137.png">

## Who should look at this?
@AWare , @sihil , @paperboyo and @akash1810


## Tested?
- [Y] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
