### PR TITLE
Introduce syndication service

### DIFF
--- a/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
+++ b/admin-tools/lib/src/main/scala/com/gu/mediaservice/BatchIndexHandler.scala
@@ -10,6 +10,7 @@ import com.gu.mediaservice.indexing.ProduceProgress
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
 import com.gu.mediaservice.model.Image
+import com.gu.mediaservice.syntax.MessageSubjects
 import com.typesafe.scalalogging.LazyLogging
 import net.logstash.logback.marker.Markers
 import play.api.libs.json.{JsObject, Json}
@@ -41,7 +42,7 @@ case class BatchIndexHandlerConfig(
 
 case class SuccessResult(foundImagesCount: Int, notFoundImagesCount: Int, progressHistory: String, projectionTookInSec: Long)
 
-class BatchIndexHandler(cfg: BatchIndexHandlerConfig)(implicit wsClient: WSClient) extends LoggingWithMarkers {
+class BatchIndexHandler(cfg: BatchIndexHandlerConfig)(implicit wsClient: WSClient) extends MessageSubjects with LoggingWithMarkers {
 
   import cfg._
 
@@ -151,7 +152,7 @@ class BatchIndexHandler(cfg: BatchIndexHandlerConfig)(implicit wsClient: WSClien
           val kinesisClient = AwsHelpers.buildKinesisClient(kinesisEndpoint)
           foundImages.foreach { image =>
             val message = UpdateMessage(
-              subject = "reingest-image",
+              subject = ReingestImage,
               image = Some(image)
             )
             AwsHelpers.putToKinesis(message, kinesisStreamName, kinesisClient)

--- a/collections/app/controllers/ImageCollectionsController.scala
+++ b/collections/app/controllers/ImageCollectionsController.scala
@@ -7,6 +7,7 @@ import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound, UpdateMessage}
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.lib.net.{URI => UriOps}
 import com.gu.mediaservice.model.{ActionData, Collection}
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib.{CollectionsConfig, Notifications}
 import org.joda.time.DateTime
 import play.api.libs.json.Json
@@ -18,7 +19,7 @@ import scala.concurrent.Future
 
 class ImageCollectionsController(authenticated: Authentication, config: CollectionsConfig, notifications: Notifications,
                                  override val controllerComponents: ControllerComponents)
-  extends BaseController with ArgoHelpers {
+  extends BaseController with MessageSubjects with ArgoHelpers {
 
   import CollectionsManager.onlyLatest
 
@@ -63,7 +64,7 @@ class ImageCollectionsController(authenticated: Authentication, config: Collecti
 
   def publish(id: String)(collections: List[Collection]): List[Collection] = {
     val onlyLatestCollections = onlyLatest(collections)
-    val updateMessage = UpdateMessage(subject = "set-image-collections", id = Some(id), collections = Some(onlyLatestCollections))
+    val updateMessage = UpdateMessage(subject = SetImageCollections, id = Some(id), collections = Some(onlyLatestCollections))
     notifications.publish(updateMessage)
     onlyLatestCollections
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Edits.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Edits.scala
@@ -18,20 +18,27 @@ case class Edits(
 object Edits {
   val emptyMetadata = ImageMetadata()
 
+  val Photoshoot = "photoshoot"
+  val PhotoshootTitle = "photoshootTitle"
+  val Labels = "labels"
+  val Archived = "archived"
+  val Metadata = "metadata"
+  val UsageRights = "usageRights"
+
   implicit val EditsReads: Reads[Edits] = (
-    (__ \ "archived").readNullable[Boolean].map(_ getOrElse false) ~
-    (__ \ "labels").readNullable[List[String]].map(_ getOrElse Nil) ~
-    (__ \ "metadata").readNullable[ImageMetadata].map(_ getOrElse emptyMetadata) ~
-    (__ \ "usageRights").readNullable[UsageRights] ~
-    (__ \ "photoshoot").readNullable[Photoshoot]
+    (__ \ Archived).readNullable[Boolean].map(_ getOrElse false) ~
+    (__ \ Labels).readNullable[List[String]].map(_ getOrElse Nil) ~
+    (__ \ Metadata).readNullable[ImageMetadata].map(_ getOrElse emptyMetadata) ~
+    (__ \ UsageRights).readNullable[UsageRights] ~
+    (__ \ Photoshoot).readNullable[Photoshoot]
   )(Edits.apply _)
 
   implicit val EditsWrites: Writes[Edits] = (
-    (__ \ "archived").write[Boolean] ~
-    (__ \ "labels").write[List[String]] ~
-    (__ \ "metadata").writeNullable[ImageMetadata].contramap(noneIfEmptyMetadata) ~
-    (__ \ "usageRights").writeNullable[UsageRights] ~
-    (__ \ "photoshoot").writeNullable[Photoshoot]
+    (__ \ Archived).write[Boolean] ~
+    (__ \ Labels).write[List[String]] ~
+    (__ \ Metadata).writeNullable[ImageMetadata].contramap(noneIfEmptyMetadata) ~
+    (__ \ UsageRights).writeNullable[UsageRights] ~
+    (__ \ Photoshoot).writeNullable[Photoshoot]
   )(unlift(Edits.unapply))
 
   def getEmpty = Edits(metadata = emptyMetadata)

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -1,0 +1,27 @@
+package com.gu.mediaservice.syntax
+
+trait MessageSubjects {
+
+  val Image = "image"
+  val ReingestImage = "reingest-image"
+  val DeleteImage = "delete-image"
+  val UpdateImage = "update-image"
+  val DeleteImageExports = "delete-image-exports"
+  val UpdateImageExports = "update-image-exports"
+  val UpdateImageUserMetadata = "update-image-user-metadata"
+  val UpdateImageUsages = "update-image-usages"
+  val ReplaceImageLeases = "replace-image-leases"
+  val AddImageLease = "add-image-lease"
+  val RemoveImageLease = "remove-image-lease"
+  val SetImageCollections = "set-image-collections"
+  val DeleteUsages = "delete-usages"
+  // TODO This will be removed once RCS poller lambda talks to Edits subsystem.
+  val UpsertRcsRights = "upsert-rcs-rights"
+  val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"
+  // TODO This will be removed once RCS poller lambda talks to Edits subsystem.
+  val UpdateImagePhotoshoot = "update-image-photoshoot"
+  val UpdateImagePhotoshootMetadata = "update-image-photoshoot-metadata"
+
+}
+
+object MessageSubjects extends MessageSubjects

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -83,7 +83,7 @@ Resources:
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
-        - AttributeName: photoshoot
+        - AttributeName: photoshootTitle
           AttributeType: S
       KeySchema:
         - AttributeName: id
@@ -94,7 +94,7 @@ Resources:
       GlobalSecondaryIndexes:
         - IndexName: Photoshoots
           KeySchema:
-            - AttributeName: photoshoot
+            - AttributeName: photoshootTitle
               KeyType: HASH
           Projection:
             ProjectionType: KEYS_ONLY
@@ -260,6 +260,8 @@ Outputs:
     Value: !Ref 'S3WatcherFailBucket'
   UsageMailBucket:
     Value: !Ref 'UsageMailBucket'
+  SyndicationDynamoTable:
+    Value: !Ref 'SyndicationDynamoTable'
   EditsDynamoTable:
     Value: !Ref 'EditsDynamoTable'
   CollectionsDynamoTable:

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -62,19 +62,45 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  SyndicationDynamoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: SyndicationTable
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
+
   EditsDynamoTable:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: EditsTable
       AttributeDefinitions:
-      - AttributeName: id
-        AttributeType: S
+        - AttributeName: id
+          AttributeType: S
+        - AttributeName: photoshoot
+          AttributeType: S
       KeySchema:
-      - AttributeName: id
-        KeyType: HASH
+        - AttributeName: id
+          KeyType: HASH
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1
+      GlobalSecondaryIndexes:
+        - IndexName: Photoshoots
+          KeySchema:
+            - AttributeName: photoshoot
+              KeyType: HASH
+          Projection:
+            ProjectionType: KEYS_ONLY
+          ProvisionedThroughput:
+            ReadCapacityUnits: '4'
+            WriteCapacityUnits: '2'
 
   CollectionsDynamoTable:
     Type: AWS::DynamoDB::Table

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -138,6 +138,8 @@ function getMetadataEditorConfig(config) {
         |aws.region="${config.AWS_DEFAULT_REGION}"
         |s3.collections.bucket="${config.coreStackProps.CollectionsBucket}"
         |dynamo.table.edits="EditsTable"
+        |dynamo.globalsecondaryindex.edits.photoshoots="Photoshoots"
+        |dynamo.table.syndication="SyndicationTable"
         |indexed.images.sqs.queue.url="${config.coreStackProps.IndexedImageMetadataQueue.replace("http://localhost:4576", `https://localstack.media.${config.DOMAIN}`)}"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -18,6 +18,7 @@ import com.gu.mediaservice.lib.logging._
 import com.gu.mediaservice.lib.metadata.{FileMetadataHelper, ImageMetadataConverter}
 import com.gu.mediaservice.lib.net.URI
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib.{DigestedFile, ImageLoaderConfig, Notifications}
 import lib.imaging.{FileMetadataReader, MimeTypeDetection}
 import lib.storage.ImageLoaderStore
@@ -280,7 +281,7 @@ class Uploader(val store: ImageLoaderStore,
                val imageOps: ImageOperations,
                val notifications: Notifications,
                imageProcessor: ImageProcessor)
-              (implicit val ec: ExecutionContext) extends ArgoHelpers {
+              (implicit val ec: ExecutionContext) extends MessageSubjects with ArgoHelpers {
 
 
 
@@ -345,7 +346,7 @@ class Uploader(val store: ImageLoaderStore,
 
     for {
       imageUpload <- fromUploadRequest(uploadRequest)
-      updateMessage = UpdateMessage(subject = "image", image = Some(imageUpload.image))
+      updateMessage = UpdateMessage(subject = Image, image = Some(imageUpload.image))
       _ <- Future { notifications.publish(updateMessage) }
       // TODO: centralise where all these URLs are constructed
       uri = s"${config.rootUri}/uploadStatus/${uploadRequest.imageId}"

--- a/leases/app/lib/LeaseNotifier.scala
+++ b/leases/app/lib/LeaseNotifier.scala
@@ -2,34 +2,28 @@ package lib
 
 import com.gu.mediaservice.lib.aws.{ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.model.leases.MediaLease
+import com.gu.mediaservice.syntax.MessageSubjects
 import org.joda.time.DateTime
 
-class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends ThrallMessageSender(config.thrallKinesisStreamConfig) {
+class LeaseNotifier(config: LeasesConfig, store: LeaseStore) extends ThrallMessageSender(config.thrallKinesisStreamConfig) with MessageSubjects {
   def sendReindexLeases(mediaId: String) = {
-    val replaceImageLeases = "replace-image-leases"
     val leases = store.getForMedia(mediaId)
-    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(leases), id = Some(mediaId) )
+    val updateMessage = UpdateMessage(subject = ReplaceImageLeases, leases = Some(leases), id = Some(mediaId) )
     publish(updateMessage)
   }
 
   def sendAddLease(mediaLease: MediaLease) = {
-    val addImageLease = "add-image-lease"
-    val updateMessage = UpdateMessage(subject = addImageLease, mediaLease = Some(mediaLease), id = Some(mediaLease.mediaId))
+    val updateMessage = UpdateMessage(subject = AddImageLease, mediaLease = Some(mediaLease), id = Some(mediaLease.mediaId))
     publish(updateMessage)
   }
 
   def sendAddLeases(mediaLeases: List[MediaLease], mediaId: String) = {
-    val replaceImageLeases = "replace-image-leases"
-    val updateMessage = UpdateMessage(subject = replaceImageLeases, leases = Some(mediaLeases), id = Some(mediaId))
+    val updateMessage = UpdateMessage(subject = ReplaceImageLeases, leases = Some(mediaLeases), id = Some(mediaId))
     publish(updateMessage)
   }
 
   def sendRemoveLease(mediaId: String, leaseId: String) = {
-    val removeImageLease = "remove-image-lease"
-
-    val updateMessage = UpdateMessage(subject = removeImageLease, id = Some(mediaId),
-      leaseId = Some(leaseId)
-    )
+    val updateMessage = UpdateMessage(subject = RemoveImageLease, id = Some(mediaId), leaseId = Some(leaseId))
     publish(updateMessage)
   }
 }

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -5,7 +5,7 @@ import com.google.common.net.HttpHeaders
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model.{Action, _}
 import com.gu.mediaservice.lib.auth.Authentication._
-import com.gu.mediaservice.lib.auth.Permissions.{DeleteCrops, DeleteImage, EditMetadata, UploadImages}
+import com.gu.mediaservice.lib.auth.Permissions.{DeleteCrops, DeleteImage => DeleteImagePermission, EditMetadata, UploadImages}
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.aws.{S3Metadata, ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting.printDateTime
@@ -60,7 +60,7 @@ class MediaApi(
 
   private def getUploader(imageId: String, user: Principal): Future[Option[String]] = elasticSearch.getImageUploaderById(imageId)
 
-  private def authorisedForDeleteImageOrUploader(imageId: String) = authorisation.actionFilterForUploaderOr(imageId, DeleteImage, getUploader)
+  private def authorisedForDeleteImageOrUploader(imageId: String) = authorisation.actionFilterForUploaderOr(imageId, DeleteImagePermission, getUploader)
 
   private def indexResponse(user: Principal) = {
     val indexData = Json.obj(
@@ -207,7 +207,7 @@ class MediaApi(
         val imageCanBeDeleted = imageResponse.canBeDeleted(image)
 
         if (imageCanBeDeleted) {
-          val canDelete = authorisation.isUploaderOrHasPermission(request.user, image.uploadedBy, DeleteImage)
+          val canDelete = authorisation.isUploaderOrHasPermission(request.user, image.uploadedBy, DeleteImagePermission)
 
           if (canDelete) {
             val updateMessage = UpdateMessage(subject = DeleteImage, id = Some(id))
@@ -297,7 +297,7 @@ class MediaApi(
 
     def hitToImageEntity(elasticId: String, image: SourceWrapper[Image]): EmbeddedEntity[JsValue] = {
       val writePermission = authorisation.isUploaderOrHasPermission(request.user, image.instance.uploadedBy, EditMetadata)
-      val deletePermission = authorisation.isUploaderOrHasPermission(request.user, image.instance.uploadedBy, DeleteImage)
+      val deletePermission = authorisation.isUploaderOrHasPermission(request.user, image.instance.uploadedBy, DeleteImagePermission)
       val deleteCropsOrUsagePermission = canUserDeleteCropsOrUsages(request.user)
 
       val (imageData, imageLinks, imageActions) =
@@ -335,7 +335,7 @@ class MediaApi(
     elasticSearch.getImageWithSourceById(id) map {
       case Some(source) if hasPermission(request.user, source.instance) =>
         val writePermission = authorisation.isUploaderOrHasPermission(request.user, source.instance.uploadedBy, EditMetadata)
-        val deleteImagePermission = authorisation.isUploaderOrHasPermission(request.user, source.instance.uploadedBy, DeleteImage)
+        val deleteImagePermission = authorisation.isUploaderOrHasPermission(request.user, source.instance.uploadedBy, DeleteImagePermission)
         val deleteCropsOrUsagePermission = canUserDeleteCropsOrUsages(request.user)
 
         val (imageData, imageLinks, imageActions) = imageResponse.create(

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.JsonDiff
 import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
+import com.gu.mediaservice.syntax.MessageSubjects
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -41,7 +42,7 @@ class MediaApi(
                 mediaApiMetrics: MediaApiMetrics,
                 ws: WSClient,
                 authorisation: Authorisation
-)(implicit val ec: ExecutionContext) extends BaseController with ArgoHelpers {
+)(implicit val ec: ExecutionContext) extends BaseController with MessageSubjects with ArgoHelpers {
 
   val services: Services = new Services(config.domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
   val gridClient: GridClient = GridClient(services)(ws)
@@ -209,8 +210,7 @@ class MediaApi(
           val canDelete = authorisation.isUploaderOrHasPermission(request.user, image.uploadedBy, DeleteImage)
 
           if (canDelete) {
-            val deleteImage = "delete-image"
-            val updateMessage = UpdateMessage(subject = deleteImage, id = Some(id))
+            val updateMessage = UpdateMessage(subject = DeleteImage, id = Some(id))
             messageSender.publish(updateMessage)
             Accepted
           } else {

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -8,19 +8,21 @@ import router.Routes
 class MetadataEditorComponents(context: Context) extends GridComponents(context, new EditsConfig(_)) {
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val store = new EditsStore(config)
+  val editsStore = new EditsStore(config)
+  val syndicationStore = new SyndicationStore(config)
   val notifications = new Notifications(config)
   val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val metrics = new MetadataEditorMetrics(config)
-  val messageConsumer = new MetadataSqsMessageConsumer(config, metrics, store)
+  val messageConsumer = new MetadataSqsMessageConsumer(config, metrics, editsStore)
 
   messageConsumer.startSchedule()
   context.lifecycle.addStopHook {
     () => messageConsumer.actorSystem.terminate()
   }
 
-  val editsController = new EditsController(auth, store, notifications, config, wsClient, authorisation, controllerComponents)
+  val editsController = new EditsController(auth, editsStore, notifications, config, controllerComponents)
+  val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
 
   override val router = new Routes(httpErrorHandler, controller, editsController, management)

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -25,6 +25,6 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
   val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
 
-  override val router = new Routes(httpErrorHandler, controller, editsController, management)
+  override val router = new Routes(httpErrorHandler, controller, editsController, syndicationController, management)
 }
 

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,6 +1,6 @@
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.play.GridComponents
-import controllers.{EditsApi, EditsController}
+import controllers.{EditsApi, EditsController, SyndicationController}
 import lib._
 import play.api.ApplicationLoader.Context
 import router.Routes
@@ -21,9 +21,10 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
     () => messageConsumer.actorSystem.terminate()
   }
 
-  val editsController = new EditsController(auth, editsStore, notifications, config, controllerComponents)
+  val editsController = new EditsController(auth, editsStore, notifications, config, wsClient, authorisation, controllerComponents)
   val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
 
   override val router = new Routes(httpErrorHandler, controller, editsController, management)
 }
+

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -7,6 +7,8 @@ import com.amazonaws.AmazonServiceException
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model._
+import com.gu.mediaservice.lib.aws.DynamoDB.caseClassToMap
+import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound, UpdateMessage}
 import com.gu.mediaservice.lib.auth.Authentication.{Principal, Request}
 import com.gu.mediaservice.lib.auth.Permissions.EditMetadata
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, SimplePermission}
@@ -14,10 +16,9 @@ import com.gu.mediaservice.lib.aws.{NoItemFound, UpdateMessage}
 import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
 import com.gu.mediaservice.lib.formatting._
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
-import org.joda.time.DateTime
-import play.api.data.Forms._
-import play.api.data._
+import lib.Edit
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{ActionFilter, BaseController, ControllerComponents, Result}
@@ -45,14 +46,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class EditsController(
                        auth: Authentication,
-                       store: EditsStore,
-                       notifications: Notifications,
-                       config: EditsConfig,
+                       val editsStore: EditsStore,
+                       val notifications: Notifications,
+                       val config: EditsConfig,
                        ws: WSClient,
                        authorisation: Authorisation,
                        override val controllerComponents: ControllerComponents
                      )(implicit val ec: ExecutionContext)
-  extends BaseController with ArgoHelpers with EditsResponse {
+  extends BaseController with ArgoHelpers with EditsResponse with MessageSubjects with Edit {
 
   import UsageRightsMetadataMapper.usageRightsToMetadata
 
@@ -70,7 +71,7 @@ class EditsController(
   // TODO: Think about calling this `overrides` or something that isn't metadata
   def getAllMetadata(id: String) = auth.async {
     val emptyResponse = respond(Edits.getEmpty)(editsEntity(id))
-    store.get(id) map { dynamoEntry =>
+    editsStore.get(id) map { dynamoEntry =>
       dynamoEntry.asOpt[Edits]
         .map(respond(_)(editsEntity(id)))
         .getOrElse(emptyResponse)
@@ -78,14 +79,14 @@ class EditsController(
   }
 
   def getEdits(id: String) = auth.async {
-    store.get(id) map { dynamoEntry =>
+    editsStore.get(id) map { dynamoEntry =>
       val edits = dynamoEntry.asOpt[Edits]
       respond(data = edits)
     } recover { case NoItemFound => NotFound }
   }
 
   def getArchived(id: String) = auth.async {
-    store.booleanGet(id, "archived") map { archived =>
+    editsStore.booleanGet(id, Edits.Archived) map { archived =>
       respond(archived.getOrElse(false))
     } recover {
       case NoItemFound => respond(false)
@@ -97,21 +98,21 @@ class EditsController(
       errors =>
         Future.successful(BadRequest(errors.toString())),
       archived =>
-        store.booleanSetOrRemove(id, "archived", archived)
-          .map(publish(id))
+        editsStore.booleanSetOrRemove(id, "archived", archived)
+          .map(publish(id, UpdateImageUserMetadata))
           .map(edits => respond(edits.archived))
     )
   }
 
   def unsetArchived(id: String) = auth.async {
-    store.removeKey(id, "archived")
-      .map(publish(id))
+    editsStore.removeKey(id, Edits.Archived)
+      .map(publish(id, UpdateImageUserMetadata))
       .map(_ => respond(false))
   }
 
 
   def getLabels(id: String) = auth.async {
-    store.setGet(id, "labels")
+    editsStore.setGet(id, Edits.Labels)
       .map(labelsCollection(id, _))
       .map {case (uri, labels) => respondCollection(labels)} recover {
       case NoItemFound => respond(Array[String]())
@@ -119,8 +120,8 @@ class EditsController(
   }
 
   def getPhotoshoot(id: String) = auth.async {
-    store.jsonGet(id, "photoshoot").map(dynamoEntry => {
-      (dynamoEntry \ "photoshoot").toOption match {
+    editsStore.jsonGet(id, Edits.Photoshoot).map(dynamoEntry => {
+      (dynamoEntry \ Edits.Photoshoot).toOption match {
         case Some(photoshoot) => respond(photoshoot.as[Photoshoot])
         case None => respondNotFound("No photoshoot found")
       }
@@ -131,8 +132,8 @@ class EditsController(
 
   def setPhotoshoot(id: String) = auth.async(parse.json) { req => {
     (req.body \ "data").asOpt[Photoshoot].map(photoshoot => {
-      store.jsonAdd(id, "photoshoot", caseClassToMap(photoshoot))
-        .map(publish(id, "update-image-photoshoot"))
+      editsStore.jsonAdd(id, Edits.Photoshoot, caseClassToMap(photoshoot))
+        .map(publish(id, UpdateImagePhotoshoot))
         .map(_ => respond(photoshoot))
     }).getOrElse(
       Future.successful(respondError(BadRequest, "invalid-form-data", "Invalid form data"))
@@ -140,8 +141,8 @@ class EditsController(
   }}
 
   def deletePhotoshoot(id: String) = auth.async {
-    store.removeKey(id, "photoshoot")
-      .map(publish(id, "update-image-photoshoot"))
+    editsStore.removeKey(id, Edits.Photoshoot)
+      .map(publish(id, UpdateImagePhotoshoot))
       .map(_ => Accepted)
   }
 
@@ -150,9 +151,9 @@ class EditsController(
       errors =>
         Future.successful(BadRequest(errors.toString())),
       labels =>
-        store
-          .setAdd(id, "labels", labels)
-          .map(publish(id))
+        editsStore
+          .setAdd(id, Edits.Labels, labels)
+          .map(publish(id, UpdateImageUserMetadata))
           .map(edits => labelsCollection(id, edits.labels.toSet))
           .map { case (uri, l) => respondCollection(l) } recover {
             case _: AmazonServiceException => BadRequest
@@ -161,16 +162,16 @@ class EditsController(
   }
 
   def removeLabel(id: String, label: String) = auth.async {
-    store.setDelete(id, "labels", decodeUriParam(label))
-      .map(publish(id))
+    editsStore.setDelete(id, Edits.Labels, decodeUriParam(label))
+      .map(publish(id, UpdateImageUserMetadata))
       .map(edits => labelsCollection(id, edits.labels.toSet))
       .map {case (uri, labels) => respondCollection(labels, uri=Some(uri))}
   }
 
 
   def getMetadata(id: String) = auth.async {
-    store.jsonGet(id, "metadata").map { dynamoEntry =>
-      val metadata = (dynamoEntry \ "metadata").as[ImageMetadata]
+    editsStore.jsonGet(id, Edits.Metadata).map { dynamoEntry =>
+      val metadata = (dynamoEntry \ Edits.Metadata).as[ImageMetadata]
       respond(metadata)
     } recover {
       case NoItemFound => respond(Json.toJson(JsObject(Nil)))
@@ -181,14 +182,14 @@ class EditsController(
     (req.body \ "data").validate[ImageMetadata].fold(
       errors => Future.successful(BadRequest(errors.toString())),
       metadata =>
-        store.jsonAdd(id, "metadata", metadataAsMap(metadata))
-          .map(publish(id))
+        editsStore.jsonAdd(id, Edits.Metadata, metadataAsMap(metadata))
+          .map(publish(id, UpdateImageUserMetadata))
           .map(edits => respond(edits.metadata))
     )
   }
 
   def setMetadataFromUsageRights(id: String) = (auth andThen authorisedForEditMetadataOrUploader(id)).async { req =>
-    store.get(id) flatMap { dynamoEntry =>
+    editsStore.get(id) flatMap { dynamoEntry =>
       val edits = dynamoEntry.as[Edits]
       val originalMetadata = edits.metadata
       val metadataOpt = edits.usageRights.flatMap(usageRightsToMetadata)
@@ -199,8 +200,8 @@ class EditsController(
           credit = metadata.credit orElse originalMetadata.credit
         )
 
-        store.jsonAdd(id, "metadata", metadataAsMap(mergedMetadata))
-          .map(publish(id))
+        editsStore.jsonAdd(id, Edits.Metadata, metadataAsMap(mergedMetadata))
+          .map(publish(id, UpdateImageUserMetadata))
           .map(edits => respond(edits.metadata, uri = Some(metadataUri(id))))
       } getOrElse {
         // just return the unmodified
@@ -212,8 +213,8 @@ class EditsController(
   }
 
   def getUsageRights(id: String) = auth.async {
-    store.jsonGet(id, "usageRights").map { dynamoEntry =>
-      val usageRights = (dynamoEntry \ "usageRights").as[UsageRights]
+    editsStore.jsonGet(id, Edits.UsageRights).map { dynamoEntry =>
+      val usageRights = (dynamoEntry \ Edits.UsageRights).as[UsageRights]
       respond(usageRights)
     } recover {
       case NoItemFound => respondNotFound("No usage rights overrides found")
@@ -222,29 +223,18 @@ class EditsController(
 
   def setUsageRights(id: String) = auth.async(parse.json) { req =>
     (req.body \ "data").asOpt[UsageRights].map(usageRight => {
-      store.jsonAdd(id, "usageRights", caseClassToMap(usageRight))
-        .map(publish(id))
-        .map(edits => respond(usageRight))
+      editsStore.jsonAdd(id, Edits.UsageRights, DynamoDB.caseClassToMap(usageRight))
+        .map(publish(id, UpdateImageUserMetadata))
+        .map(_ => respond(usageRight))
     }).getOrElse(Future.successful(respondError(BadRequest, "invalid-form-data", "Invalid form data")))
   }
 
   def deleteUsageRights(id: String) = auth.async { req =>
-    store.removeKey(id, "usageRights").map(publish(id)).map(edits => Accepted)
+    editsStore.removeKey(id, Edits.UsageRights).map(publish(id, UpdateImageUserMetadata)).map(edits => Accepted)
   }
-
-  // TODO: Move this to the dynamo lib
-  def caseClassToMap[T](caseClass: T)(implicit tjs: Writes[T]): Map[String, JsValue] =
-    Json.toJson[T](caseClass).as[JsObject].as[Map[String, JsValue]]
 
   def labelsCollection(id: String, labels: Set[String]): (URI, Seq[EmbeddedEntity[String]]) =
-    (labelsUri(id), labels.map(setUnitEntity(id, "labels", _)).toSeq)
-
-  def publish(id: String, subject: String = "update-image-user-metadata")(metadata: JsObject): Edits = {
-    val edits = metadata.as[Edits]
-    val updateMessage = UpdateMessage(subject = subject, id = Some(id), edits = Some(edits))
-    notifications.publish(updateMessage)
-    edits
-  }
+    (labelsUri(id), labels.map(setUnitEntity(id, Edits.Labels, _)).toSeq)
 
   def metadataAsMap(metadata: ImageMetadata) = {
     (Json.toJson(metadata).as[JsObject]).as[Map[String, JsValue]]

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -3,6 +3,7 @@ package controllers
 
 import java.net.URI
 import java.net.URLDecoder.decode
+
 import com.amazonaws.AmazonServiceException
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.argo.ArgoHelpers
@@ -119,6 +120,7 @@ class EditsController(
     }
   }
 
+  // TODO remove when SyndicationController takes over.
   def getPhotoshoot(id: String) = auth.async {
     editsStore.jsonGet(id, Edits.Photoshoot).map(dynamoEntry => {
       (dynamoEntry \ Edits.Photoshoot).toOption match {
@@ -130,6 +132,7 @@ class EditsController(
     }
   }
 
+  // TODO remove when SyndicationController takes over.
   def setPhotoshoot(id: String) = auth.async(parse.json) { req => {
     (req.body \ "data").asOpt[Photoshoot].map(photoshoot => {
       editsStore.jsonAdd(id, Edits.Photoshoot, caseClassToMap(photoshoot))
@@ -140,6 +143,7 @@ class EditsController(
     )
   }}
 
+  // TODO remove when SyndicationController takes over.
   def deletePhotoshoot(id: String) = auth.async {
     editsStore.removeKey(id, Edits.Photoshoot)
       .map(publish(id, UpdateImagePhotoshoot))

--- a/metadata-editor/app/controllers/SyndicationController.scala
+++ b/metadata-editor/app/controllers/SyndicationController.scala
@@ -1,0 +1,72 @@
+package controllers
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound}
+import play.api.mvc.{Action, AnyContent}
+import com.gu.mediaservice.model._
+import com.gu.mediaservice.syntax.MessageSubjects
+import lib._
+import play.api.libs.json._
+import play.api.mvc.{BaseController, ControllerComponents}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class SyndicationController(auth: Authentication,
+                            val editsStore: EditsStore,
+                            val syndicationStore: SyndicationStore,
+                            val notifications: Notifications,
+                            val config: EditsConfig,
+                            override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
+  extends BaseController with Syndication with MessageSubjects with ArgoHelpers with EditsResponse {
+
+  override val metadataBaseUri: String = config.services.metadataBaseUri
+
+  def getPhotoshoot(id: String) = auth.async {
+    editsStore.jsonGet(id, Edits.Photoshoot).map(dynamoEntry => {
+      (dynamoEntry \ Edits.Photoshoot).toOption match {
+        case Some(photoshoot) => respond(photoshoot.as[Photoshoot])
+        case None => respondNotFound("No photoshoot found")
+      }
+    }) recover {
+      case NoItemFound => respondNotFound("No photoshoot found")
+    }
+  }
+
+  def setPhotoshoot(id: String) = auth.async(parse.json) { req => {
+    (req.body \ "data").asOpt[Photoshoot].map(photoshoot =>
+      setPhotoshootAndPublish(id, photoshoot)
+        .map(photoshoot => respond(photoshoot))
+    )
+    .getOrElse(
+      Future.successful(respondError(BadRequest, "invalid-form-data", "Invalid form data"))
+    )
+  }}
+
+  def deletePhotoshoot(id: String) = auth.async {
+    deletePhotoshootAndPublish(id).map(_ => Accepted)
+  }
+
+  def getSyndication(id: String): Action[AnyContent] = auth.async {
+    getSyndicationForImage(id)
+    .map {
+      case Some(rights) => respond(rights)
+      // If no rights, send a 404 - no syndication rights for this id.  Either id is duff, or it really has none.
+      case None => NotFound
+    }
+  }
+
+  def setSyndication(id: String): Action[JsValue] = auth.async(parse.json) { req => {
+    (req.body \ "data").asOpt[SyndicationRights].map(syndicationRight => {
+      setSyndicationAndPublish(id, syndicationRight)
+        .map(syndicationRight => respond(syndicationRight))
+    }).getOrElse(Future.successful(respondError(BadRequest, "invalid-form-data", "Invalid form data")))
+  }}
+
+  def deleteSyndication(id: String): Action[AnyContent] = auth.async {
+    deleteSyndicationAndPublish(id).map(_ => Accepted)
+  }
+
+}
+

--- a/metadata-editor/app/lib/Edit.scala
+++ b/metadata-editor/app/lib/Edit.scala
@@ -1,0 +1,22 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.UpdateMessage
+import com.gu.mediaservice.model.Edits
+import com.gu.mediaservice.syntax.MessageSubjects
+import play.api.libs.json.JsObject
+
+trait Edit extends MessageSubjects {
+
+  def config: EditsConfig
+  def editsStore: EditsStore
+  def notifications: Notifications
+
+  def publish(id: String, subject: String)(metadata: JsObject): Edits = {
+    val edits = metadata.as[Edits]
+    val updateMessage = UpdateMessage(subject = subject, id = Some(id), edits = Some(edits))
+    notifications.publish(updateMessage)
+    edits
+  }
+
+}
+

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -10,6 +10,8 @@ class EditsConfig(resources: GridConfigResources) extends CommonConfig(resources
   val collectionsBucket: String = string("s3.collections.bucket")
 
   val editsTable = string("dynamo.table.edits")
+  val editsTablePhotoshootIndex = string("dynamo.globalsecondaryindex.edits.photoshoots")
+  val syndicationTable = string("dynamo.table.syndication")
 
   val queueUrl = string("indexed.images.sqs.queue.url")
 

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -1,0 +1,171 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound, UpdateMessage}
+import com.gu.mediaservice.model.{Edits, Image, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.syntax.MessageSubjects
+import play.api.libs.json.{JsNull, JsString}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait Syndication extends Edit with MessageSubjects {
+
+  def syndicationStore: SyndicationStore
+
+  private val syndicationRightsFieldName = "syndicationRights"
+
+  def deletePhotoshootAndPublish(id: String)
+                                (implicit ec: ExecutionContext): Future[Unit.type] = {
+    for {
+      photoshootMaybe <- getPhotoshootForImage(id)
+      // Get the list of rights potentially affected BEFORE doing the delete!
+      allImageRightsInPhotoshootBefore <- getAllImageRightsInPhotoshoot(photoshootMaybe)
+      // Do the delete
+      edits <- editsStore.removeKey(id, Edits.Photoshoot)
+      allImageRightsInPhotoshootAfter <- getAllImageRightsInPhotoshoot(photoshootMaybe)
+      changedRights = getChangedRights(allImageRightsInPhotoshootBefore, allImageRightsInPhotoshootAfter)
+      _ = publish(id, UpdateImagePhotoshootMetadata)(edits)
+      _ <- publish(changedRights, UpdateImageSyndicationMetadata)
+    } yield Unit
+  }
+
+  def deleteSyndicationAndPublish(id: String)
+                                 (implicit ec: ExecutionContext): Future[Unit] = {
+    for {
+      photoshootMaybe <- getPhotoshootForImage(id)
+      // Get the list of rights potentially affected BEFORE doing the delete!
+      allImageRightsInPhotoshootBefore <- getAllImageRightsInPhotoshoot(photoshootMaybe)
+      // Do the delete
+      _ <- syndicationStore.deleteItem(id)
+      allImageRightsInPhotoshootAfter <- getAllImageRightsInPhotoshoot(photoshootMaybe)
+      changedRights = getChangedRights(allImageRightsInPhotoshootBefore, allImageRightsInPhotoshootAfter)
+      _ <- publish(changedRights, UpdateImageSyndicationMetadata)
+    } yield Unit
+  }
+
+  def setPhotoshootAndPublish(id: String, photoshoot: Photoshoot)
+                             (implicit ec: ExecutionContext): Future[Photoshoot] = for {
+    editsAsJsonResponse <- editsStore.jsonAdd(id, Edits.Photoshoot, DynamoDB.caseClassToMap(photoshoot))
+    _ <- editsStore.stringSet(id, Edits.PhotoshootTitle, JsString(photoshoot.title)) // store - don't care about return
+    allImageRightsInPhotoshootAfter <- getAllImageRightsInPhotoshoot(photoshoot)
+    _ = publish(id, UpdateImagePhotoshootMetadata)(editsAsJsonResponse)
+    _ <- publish(allImageRightsInPhotoshootAfter, UpdateImageSyndicationMetadata) // update all images in photoshoot
+  } yield photoshoot
+
+  def setSyndicationAndPublish(id: String, syndicationRight: SyndicationRights)
+                              (implicit ec: ExecutionContext): Future[SyndicationRights] = for {
+    photoshootMaybe <- getPhotoshootForImage(id)
+    // Get the list of rights potentially affected BEFORE doing the delete!
+    allImageRightsInPhotoshootBefore <- getAllImageRightsInPhotoshoot(photoshootMaybe)
+    _ <- syndicationStore.jsonAdd(id, syndicationRightsFieldName, DynamoDB.caseClassToMap(syndicationRight))
+    allImageRightsInPhotoshootAfter <- getAllImageRightsInPhotoshoot(photoshootMaybe)
+    changedRights = getChangedRights(allImageRightsInPhotoshootBefore, allImageRightsInPhotoshootAfter)
+    _ <- publish(changedRights, UpdateImageSyndicationMetadata)
+  } yield syndicationRight
+
+  def getSyndicationForImage(id: String)
+                            (implicit ec: ExecutionContext): Future[Option[SyndicationRights]] = {
+    syndicationStore.jsonGet(id, syndicationRightsFieldName)
+      // It's OK for the image to _not_ exist in the syndication store, so this needs to be recovered
+      .recover { case NoItemFound => JsNull }
+      .flatMap(dynamoEntry => (dynamoEntry \ syndicationRightsFieldName).toOption match {
+        // If image has its own rights, return those rights, with isInferred false
+        case Some(rights) => Future.successful(Some(rights.as[SyndicationRights].copy(isInferred = false)))
+        // If the image does not have it's own rights, get rights for the photoshoot
+        case None => getRightsByPhotoshoot(id)
+      })
+  }
+
+  def getRightsByPhotoshoot(id: String)
+                           (implicit ec: ExecutionContext): Future[Option[SyndicationRights]] =
+    getPhotoshootForImage(id)
+      // It's ok for the image to _not_ exist in the edits store - it may have no photoshoot (or any other edit)
+      .recover { case NoItemFound => None }
+      .flatMap { photoshootMaybe: Option[Photoshoot] =>
+        photoshootMaybe match {
+          //  If image is not in a photoshoot, return no rights
+          case None => Future.successful(None)
+          //  If image is in a photo shoot, find the most recently published image and return those rights, with isInferred true
+          case Some(photoshoot) => getMostRecentInferredSyndicationRights(photoshoot)
+        }
+      }
+
+  private def getMostRecentInferredSyndicationRights(ids: List[String])
+                                                    (implicit ec: ExecutionContext): Future[Option[SyndicationRights]] =
+    getRightsForImages(ids, None)
+      .map(list => getMostRecentSyndicationRights(list.values.toList))
+      .map(rightsMaybe => rightsMaybe.map(rights => rights.copy(isInferred = true)))
+
+  private def getMostRecentInferredSyndicationRights(photoshoot: Photoshoot)
+                                                    (implicit ec: ExecutionContext): Future[Option[SyndicationRights]] =
+    getImagesInPhotoshoot(photoshoot) flatMap {
+      ids => getMostRecentInferredSyndicationRights(ids)
+    }
+
+  private def getRightsForImages(ids: List[String], inferredRights: Option[SyndicationRights])
+                                (implicit ec: ExecutionContext): Future[Map[String, Option[SyndicationRights]]] = {
+    Future.traverse(ids)(id => {
+      syndicationStore.jsonGet(id, syndicationRightsFieldName)
+        // Any/all of the images in this photoshoot may have no rights, so recover
+        .recover { case NoItemFound => JsNull }
+        .map(dynamoEntry => {
+          (dynamoEntry \ syndicationRightsFieldName).toOption map (x => x.as[SyndicationRights].copy(isInferred = false))
+        })
+        .map(rightMaybe => id -> rightMaybe.orElse(inferredRights))
+    }).map(list => list.toMap)
+  }
+
+  def getMostRecentSyndicationRights(list: List[Option[SyndicationRights]]): Option[SyndicationRights] = list
+    .collect {case Some(sr) => sr}.filter(_.published.nonEmpty).sortBy(_.published.map(-_.getMillis)).headOption
+
+  def filterImagesByInference(ids: List[String], inferred: Boolean)
+                             (implicit ec: ExecutionContext): Future[List[String]] = {
+    Future.traverse(ids)(id => syndicationStore.jsonGet(id, syndicationRightsFieldName)
+      // It's OK for the image to _not_ exist in the syndication store, so this needs to be recovered
+      .recover { case NoItemFound => JsNull }
+      // Filter depending on if we want inferred or not-inferred.
+      .filter( rights => inferred && rights == JsNull || !inferred && rights != JsNull )
+      .map(_ => id)
+    )
+  }
+
+  def getAllImageRightsInPhotoshoot(photoshootMaybe: Option[Photoshoot])
+                                   (implicit ec: ExecutionContext): Future[Map[String, Option[SyndicationRights]]] =
+    photoshootMaybe.map(photoshoot => getAllImageRightsInPhotoshoot(photoshoot))
+      .getOrElse(Future.successful(Map.empty[String, Option[SyndicationRights]]))
+
+  def getAllImageRightsInPhotoshoot(photoshoot: Photoshoot)
+                                   (implicit ec: ExecutionContext): Future[Map[String, Option[SyndicationRights]]] = for {
+    imageIds <- getImagesInPhotoshoot(photoshoot)
+    mostRecentInferredRightsMaybe <- getMostRecentInferredSyndicationRights(imageIds)
+    rights <- getRightsForImages(imageIds, mostRecentInferredRightsMaybe)
+  } yield rights
+
+  def getImagesInPhotoshoot(photoshoot: Photoshoot)
+                           (implicit ec: ExecutionContext): Future[List[String]] =
+      editsStore.scanForId(config.editsTablePhotoshootIndex, Edits.PhotoshootTitle, photoshoot.title)
+        .recover { case NoItemFound => Nil }
+
+  def getChangedRights(before: Map[String, Option[SyndicationRights]], after: Map[String, Option[SyndicationRights]]): Map[String, Option[SyndicationRights]] = {
+    // Rights in 'after' which do not have an exact equal in 'before'
+    // Rights in 'before' which are not present at all in 'after', so have no inferred rights now
+    (after.toSet -- before.toSet).toMap ++
+      (before.keySet -- after.keySet).map(id => id -> None)
+  }
+
+  def getPhotoshootForImage(id: String)
+                           (implicit ec: ExecutionContext): Future[Option[Photoshoot]] =
+    editsStore.jsonGet(id, Edits.Photoshoot)
+      .map(dynamoEntry => (dynamoEntry \ Edits.Photoshoot).toOption map {
+        photoshootJson => photoshootJson.as[Photoshoot]
+      })
+
+  def publish(imagesInPhotoshoot: Map[String, Option[SyndicationRights]], subject: String)
+             (implicit ec: ExecutionContext): Future[Unit] = Future {
+    for (kv <- imagesInPhotoshoot) {
+      val (k, v) = kv
+      val updateMessage = UpdateMessage(subject = subject, id = Some(k), syndicationRights = v)
+      notifications.publish(updateMessage)
+    }
+  }
+
+}

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -59,7 +59,8 @@ trait Syndication extends Edit with MessageSubjects {
     _ <- syndicationStore.jsonAdd(id, syndicationRightsFieldName, DynamoDB.caseClassToMap(syndicationRight))
     allImageRightsInPhotoshootAfter <- getAllImageRightsInPhotoshoot(photoshootMaybe)
     changedRights = getChangedRights(allImageRightsInPhotoshootBefore, allImageRightsInPhotoshootAfter)
-    _ <- publish(changedRights, UpdateImageSyndicationMetadata)
+// TODO Uncomment to swap to new SyndicationController functionality.
+//    _ <- publish(changedRights, UpdateImageSyndicationMetadata)
   } yield syndicationRight
 
   def getSyndicationForImage(id: String)

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -1,7 +1,7 @@
 package lib
 
 import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound, UpdateMessage}
-import com.gu.mediaservice.model.{Edits, Image, Photoshoot, SyndicationRights}
+import com.gu.mediaservice.model.{Edits, Photoshoot, SyndicationRights}
 import com.gu.mediaservice.syntax.MessageSubjects
 import play.api.libs.json.{JsNull, JsString}
 
@@ -117,17 +117,6 @@ trait Syndication extends Edit with MessageSubjects {
 
   def getMostRecentSyndicationRights(list: List[Option[SyndicationRights]]): Option[SyndicationRights] = list
     .collect {case Some(sr) => sr}.filter(_.published.nonEmpty).sortBy(_.published.map(-_.getMillis)).headOption
-
-  def filterImagesByInference(ids: List[String], inferred: Boolean)
-                             (implicit ec: ExecutionContext): Future[List[String]] = {
-    Future.traverse(ids)(id => syndicationStore.jsonGet(id, syndicationRightsFieldName)
-      // It's OK for the image to _not_ exist in the syndication store, so this needs to be recovered
-      .recover { case NoItemFound => JsNull }
-      // Filter depending on if we want inferred or not-inferred.
-      .filter( rights => inferred && rights == JsNull || !inferred && rights != JsNull )
-      .map(_ => id)
-    )
-  }
 
   def getAllImageRightsInPhotoshoot(photoshootMaybe: Option[Photoshoot])
                                    (implicit ec: ExecutionContext): Future[Map[String, Option[SyndicationRights]]] =

--- a/metadata-editor/app/lib/SyndicationStore.scala
+++ b/metadata-editor/app/lib/SyndicationStore.scala
@@ -1,0 +1,5 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.DynamoDB
+
+class SyndicationStore(config: EditsConfig) extends DynamoDB(config, config.syndicationTable)

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -21,6 +21,7 @@ GET     /metadata/:id/usage-rights                      controllers.EditsControl
 PUT     /metadata/:id/usage-rights                      controllers.EditsController.setUsageRights(id: String)
 DELETE  /metadata/:id/usage-rights                      controllers.EditsController.deleteUsageRights(id: String)
 
+# TODO Comment out to swap to new SyndicationController functionality.
 GET     /metadata/:id/photoshoot                        controllers.EditsController.getPhotoshoot(id: String)
 PUT     /metadata/:id/photoshoot                        controllers.EditsController.setPhotoshoot(id: String)
 DELETE  /metadata/:id/photoshoot                        controllers.EditsController.deletePhotoshoot(id: String)

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -25,6 +25,15 @@ GET     /metadata/:id/photoshoot                        controllers.EditsControl
 PUT     /metadata/:id/photoshoot                        controllers.EditsController.setPhotoshoot(id: String)
 DELETE  /metadata/:id/photoshoot                        controllers.EditsController.deletePhotoshoot(id: String)
 
+# TODO Uncomment to swap to new SyndicationController functionality.
+#GET     /metadata/:id/photoshoot                        controllers.SyndicationController.getPhotoshoot(id: String)
+#PUT     /metadata/:id/photoshoot                        controllers.SyndicationController.setPhotoshoot(id: String)
+#DELETE  /metadata/:id/photoshoot                        controllers.SyndicationController.deletePhotoshoot(id: String)
+
+GET     /metadata/:id/syndication                       controllers.SyndicationController.getSyndication(id: String)
+PUT     /metadata/:id/syndication                       controllers.SyndicationController.setSyndication(id: String)
+DELETE  /metadata/:id/syndication                       controllers.SyndicationController.deleteSyndication(id: String)
+
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest

--- a/metadata-editor/test/lib/SyndicationTest.scala
+++ b/metadata-editor/test/lib/SyndicationTest.scala
@@ -1,0 +1,110 @@
+package lib
+
+import com.gu.mediaservice.model._
+import org.joda.time.DateTime
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.util.Random
+import scala.collection.Map
+
+class SyndicationTest extends FunSpec with Matchers with Syndication with MockitoSugar {
+
+  describe("Syndication Rights date functions") {
+
+    it ("should find the latest syndication rights when there are none") {
+      val rights = List()
+      getMostRecentSyndicationRights(rights) should be (None)
+    }
+
+    it ("should find the latest syndication rights when there is only one") {
+      val right = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val rights = List(Some(right))
+      getMostRecentSyndicationRights(rights) should be (Some(right))
+    }
+
+    it ("should find the latest syndication rights when there is more than one") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val right2 = SyndicationRights(None, Nil, Nil)
+      val rights = List(Some(right1), Some(right2))
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+
+    it ("should find the latest syndication rights when there is more than one (swapped over)") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val right2 = SyndicationRights(None, Nil, Nil)
+      val rights = List(Some(right2), Some(right1))
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+
+    it ("should find the latest syndication rights when there is more than one (swapped over) and a None mixed in too") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val right2 = SyndicationRights(None, Nil, Nil)
+      val rights = List(Some(right2), None, Some(right1))
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+
+    it ("should find the latest syndication rights when there is more than one with a date") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
+      val rights = List(Some(right1), Some(right2))
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+
+    it ("should find the latest syndication rights when there is more than one with a date (swapped over)") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
+      val rights = List(Some(right2), Some(right1))
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+
+    it ("should find the latest syndication rights when there is more than one with a date (swapped over) and a None mixed in too") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
+      val rights = List(Some(right2), None, Some(right1))
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+
+    it ("should find the latest syndication rights when there are several with a date (swapped over) and a few Nones mixed in too") {
+      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
+      val rights = List(
+        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
+        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
+        None,
+        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
+        Some(right1),
+        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
+        None,
+        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
+        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil))
+      )
+      getMostRecentSyndicationRights(rights) should be (Some(right1))
+    }
+  }
+
+  describe("Syndication Rights changes functions") {
+    it ("Should find the added/removed rights") {
+      val before = List("1" -> Some(SyndicationRights(None, Nil, Nil, false))).toMap
+      val after = List("2" -> Some(SyndicationRights(None, Nil, Nil, false))).toMap
+      val difference = Map("1" -> None, "2" -> Some(SyndicationRights(None, Nil, Nil, false)))
+      getChangedRights(before, after) should be (difference)
+    }
+    it ("Should find the (subtly) changed rights") {
+      val before = List(
+        "1" -> Some(SyndicationRights(None, Nil, Nil, true)),
+        "2" -> Some(SyndicationRights(None, Nil, Nil, false))
+      ).toMap
+      val after = List(
+        "1" -> Some(SyndicationRights(None, Nil, Nil, false)),
+        "2" -> Some(SyndicationRights(None, Nil, Nil, true))
+      ).toMap
+      val difference = Map("1" -> Some(SyndicationRights(None, Nil, Nil, false)), "2" -> Some(SyndicationRights(None, Nil, Nil, true)))
+      getChangedRights(before, after) should be (difference)
+    }
+  }
+
+  override val syndicationStore:SyndicationStore = mock[SyndicationStore]
+  override def config: EditsConfig = mock[EditsConfig]
+  override def editsStore: EditsStore = mock[EditsStore]
+  override def notifications: Notifications = mock[Notifications]
+}

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -6,6 +6,7 @@ import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.{Usage, UsageNotice}
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
 import lib.elasticsearch._
 import org.joda.time.{DateTime, DateTimeZone}
@@ -18,7 +19,7 @@ class MessageProcessor(es: ElasticSearch,
                        store: ThrallStore,
                        metadataEditorNotifications: MetadataEditorNotifications,
                        syndicationRightsOps: SyndicationRightsOps
-                      ) extends GridLogging {
+                      ) extends GridLogging with MessageSubjects {
 
   def process(updateMessage: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     updateMessage.subject match {

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -23,21 +23,36 @@ class MessageProcessor(es: ElasticSearch,
 
   def process(updateMessage: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     updateMessage.subject match {
-      case "image" => indexImage(updateMessage, logMarker)
-      case "reingest-image" => indexImage(updateMessage, logMarker)
-      case "delete-image" => deleteImage(updateMessage, logMarker)
-      case "update-image" => indexImage(updateMessage, logMarker)
-      case "delete-image-exports" => deleteImageExports(updateMessage, logMarker)
-      case "update-image-exports" => updateImageExports(updateMessage, logMarker)
-      case "update-image-user-metadata" => updateImageUserMetadata(updateMessage, logMarker)
-      case "update-image-usages" => updateImageUsages(updateMessage, logMarker)
-      case "replace-image-leases" => replaceImageLeases(updateMessage, logMarker)
-      case "add-image-lease" => addImageLease(updateMessage, logMarker)
-      case "remove-image-lease" => removeImageLease(updateMessage, logMarker)
-      case "set-image-collections" => setImageCollections(updateMessage, logMarker)
-      case "delete-usages" => deleteAllUsages(updateMessage, logMarker)
-      case "upsert-rcs-rights" => upsertSyndicationRights(updateMessage, logMarker)
-      case "update-image-photoshoot" => updateImagePhotoshoot(updateMessage, logMarker)
+      case Image => indexImage(updateMessage, logMarker)
+      case ReingestImage => indexImage(updateMessage, logMarker)
+      case DeleteImage => deleteImage(updateMessage, logMarker)
+      case UpdateImage => indexImage(updateMessage, logMarker)
+      case DeleteImageExports => deleteImageExports(updateMessage, logMarker)
+      case UpdateImageExports => updateImageExports(updateMessage, logMarker)
+      case UpdateImageUserMetadata => updateImageUserMetadata(updateMessage, logMarker)
+      case UpdateImageUsages => updateImageUsages(updateMessage, logMarker)
+      case ReplaceImageLeases => replaceImageLeases(updateMessage, logMarker)
+      case AddImageLease => addImageLease(updateMessage, logMarker)
+      case RemoveImageLease => removeImageLease(updateMessage, logMarker)
+      case SetImageCollections => setImageCollections(updateMessage, logMarker)
+      case DeleteUsages => deleteAllUsages(updateMessage, logMarker)
+
+      // Notes on upsertSyndicationRights[Only]
+      // The first message type comes from the RCS poller lambda.
+      // The second comes from metadata editor
+      // Poller lambda must update metadata editor
+      // See https://trello.com/c/tyarJEax/2241-grid-add-syndication-to-metadata-service
+      case UpsertRcsRights => upsertSyndicationRights(updateMessage, logMarker)
+      case UpdateImageSyndicationMetadata => upsertSyndicationRightsOnly(updateMessage, logMarker)
+
+      // Notes on updateImagePhotoshoot
+      // This message type comes from metadata editor.
+      // It currently works out the syndication rights and upserts ElasticSearch
+      // via syndicationRightsOps.upsertOrRefreshRights.  See note in method
+      // The new code does not upsert syndication rights - these are handled by the
+      // UpdateImageSyndicationMetadata message (see above)
+      case UpdateImagePhotoshoot => updateImagePhotoshoot(updateMessage, logMarker, updateSyndicationRights = true)
+      case UpdateImagePhotoshootMetadata => updateImagePhotoshoot(updateMessage, logMarker, updateSyndicationRights = false)
       case unknownSubject => Future.failed(ProcessorNotFoundException(unknownSubject))
      }
   }
@@ -132,6 +147,18 @@ class MessageProcessor(es: ElasticSearch,
     withId(message)(id =>
       Future.sequence(es.deleteAllImageUsages(id, message.lastModified)(ec, logMarker)))
 
+  def upsertSyndicationRightsOnly(message: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] =
+    withId(message){ id =>
+      implicit val marker: LogMarker = logMarker ++ logger.imageIdMarker(ImageId(id))
+        es.getImage(id) map {
+          case Some(image) =>
+            val photoshoot = image.userMetadata.flatMap(_.photoshoot)
+            logger.info(marker, s"Upserting syndication rights for image $id in photoshoot $photoshoot with rights ${Json.toJson(message.syndicationRights)}")
+            es.updateImageSyndicationRights(id, message.syndicationRights, message.lastModified)
+          case _ => logger.info(marker, s"Image $id not found")
+        }
+    }
+
   def upsertSyndicationRights(message: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] =
     withId(message){ id =>
       implicit val marker: LogMarker = logMarker ++ logger.imageIdMarker(ImageId(id))
@@ -151,7 +178,8 @@ class MessageProcessor(es: ElasticSearch,
       )
     }
 
-  def updateImagePhotoshoot(message: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Unit] = {
+
+  def updateImagePhotoshoot(message: UpdateMessage, logMarker: LogMarker, updateSyndicationRights: Boolean)(implicit ec: ExecutionContext): Future[Unit] = {
     withId(message) { id =>
       implicit val marker: LogMarker = logMarker ++ logger.imageIdMarker(ImageId(id))
       withEdits(message) { upcomingEdits =>
@@ -159,14 +187,21 @@ class MessageProcessor(es: ElasticSearch,
           imageOpt <- es.getImage(id)
           prevPhotoshootOpt = imageOpt.flatMap(_.userMetadata.flatMap(_.photoshoot))
           _ <- updateImageUserMetadata(message, logMarker)
+          // Once the new UpdateImageSyndication messages are being acted upon, this
+          // section should be dropped.
           _ <- {
-            logger.info(marker, s"Upserting syndication rights for image $id. Moving from photoshoot $prevPhotoshootOpt to ${upcomingEdits.photoshoot}.")
-            syndicationRightsOps.upsertOrRefreshRights(
-              image = imageOpt.get,
-              currentPhotoshootOpt = upcomingEdits.photoshoot,
-              previousPhotoshootOpt = prevPhotoshootOpt,
-              message.lastModified
-            )
+            if (updateSyndicationRights) {
+              logger.info(marker, s"Upserting syndication rights for image $id. Moving from photoshoot $prevPhotoshootOpt to ${upcomingEdits.photoshoot}.")
+              syndicationRightsOps.upsertOrRefreshRights(
+                image = imageOpt.get,
+                currentPhotoshootOpt = upcomingEdits.photoshoot,
+                previousPhotoshootOpt = prevPhotoshootOpt,
+                message.lastModified
+              )
+            } else {
+              logger.info(marker, s"NOT upserting syndication rights for image $id.")
+              Future.successful(Unit)
+            }
           }
         } yield logger.info(marker, s"Moved image $id from $prevPhotoshootOpt to ${upcomingEdits.photoshoot}")
       }

--- a/thrall/test/lib/kinesis/MessageProcessorTest.scala
+++ b/thrall/test/lib/kinesis/MessageProcessorTest.scala
@@ -6,6 +6,7 @@ import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging.MarkerMap
 import com.gu.mediaservice.model.usage.UsageNotice
 import com.gu.mediaservice.model.{Edits, ImageMetadata}
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib.{MetadataEditorNotifications, ThrallStore}
 import lib.elasticsearch.{ElasticSearchTestBase, ElasticSearchUpdateResponse, SyndicationRightsOps}
 import org.joda.time.{DateTime, DateTimeZone}
@@ -16,7 +17,7 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Success, Try}
 
 
-class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
+class MessageProcessorTest extends ElasticSearchTestBase with MessageSubjects with MockitoSugar {
   implicit val logMarker: MarkerMap = MarkerMap()
   "MessageProcessor" - {
     val messageProcessor = new MessageProcessor(
@@ -48,7 +49,7 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(image.id))
 
           val message = UpdateMessage(
-            "update-image-usages",
+            UpdateImageUsages,
             image = None,
             id = Some(id),
             usageNotice = Some(UsageNotice(id, JsArray())),
@@ -68,7 +69,7 @@ class MessageProcessorTest extends ElasticSearchTestBase with MockitoSugar {
           val id = UUID.randomUUID().toString
 
           val message = UpdateMessage(
-            "update-image-usages",
+            UpdateImageUsages,
             image = None,
             id = Some(id),
             usageNotice = Some(UsageNotice(id, JsArray())),

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -9,6 +9,7 @@ import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.usage.UsageBuilder
 import com.gu.mediaservice.model.usage.{MediaUsage, Usage}
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
 import model._
 import play.api.libs.json.{JsError, JsValue, Json}
@@ -20,7 +21,7 @@ import scala.util.Try
 
 class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGroupOps, notifications: Notifications, config: UsageConfig, usageRecorder: UsageRecorder, liveContentApi: LiveContentApi,
   override val controllerComponents: ControllerComponents, playBodyParsers: PlayBodyParsers)(implicit val ec: ExecutionContext)
-  extends BaseController with ArgoHelpers {
+  extends BaseController with MessageSubjects with ArgoHelpers {
 
   private def wrapUsage(usage: Usage): EntityResponse[Usage] = {
     EntityResponse(
@@ -215,7 +216,7 @@ class UsageApi(auth: Authentication, usageTable: UsageTable, usageGroup: UsageGr
         respondError(InternalServerError, "image-usage-delete-failed", error.getMessage)
     }
 
-    val updateMessage = UpdateMessage(subject = "delete-usages", id = Some(mediaId))
+    val updateMessage = UpdateMessage(subject = DeleteUsages, id = Some(mediaId))
     notifications.publish(updateMessage)
     Future.successful(Ok)
   }

--- a/usage/app/lib/UsageNotifier.scala
+++ b/usage/app/lib/UsageNotifier.scala
@@ -4,6 +4,7 @@ import com.gu.mediaservice.lib.aws.{ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.lib.usage.UsageBuilder
 import com.gu.mediaservice.model.usage.{MediaUsage, UsageNotice}
+import com.gu.mediaservice.syntax.MessageSubjects
 import model.UsageTable
 import org.joda.time.DateTime
 import play.api.libs.json._
@@ -12,7 +13,7 @@ import rx.lang.scala.Observable
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class UsageNotifier(config: UsageConfig, usageTable: UsageTable)
-  extends ThrallMessageSender(config.thrallKinesisLowPriorityStreamConfig) with GridLogging {
+  extends ThrallMessageSender(config.thrallKinesisLowPriorityStreamConfig) with GridLogging with MessageSubjects {
 
   def build(mediaId: String) = Observable.from(
     usageTable.queryByImageId(mediaId).map((usages: Set[MediaUsage]) => {
@@ -22,7 +23,7 @@ class UsageNotifier(config: UsageConfig, usageTable: UsageTable)
 
   def send(usageNotice: UsageNotice) = {
     logger.info(s"Sending usage notice for ${usageNotice.mediaId}")
-    val updateMessage = UpdateMessage(subject = "update-image-usages", id = Some(usageNotice.mediaId), usageNotice = Some(usageNotice))
+    val updateMessage = UpdateMessage(subject = UpdateImageUsages, id = Some(usageNotice.mediaId), usageNotice = Some(usageNotice))
     publish(updateMessage)
   }
 }


### PR DESCRIPTION
## What does this change?
Syndication rights are currently received from RCS and stored in ElasticSearch.  This PR provides a primary store for them.

1) Syndication rights and photoshoots are now updated by a dedicated Controller within the metadata service
2) Rights are stored in their own dynamo table; photoshoots continue to be stored with edits.
3) Calculation of affected images takes place within the metadata service, Thrall messages are sent for each affected image
4) Thrall no longer calculates affected images, but _only_ updates ElasticSearch with the provided rights.

A LATER PR will address
1) the issue of Thrall fetching all kinds of data from the primary store (requires more consideration of authentication)
2) removing data from messages

## How can success be measured?
Syndication rights can be reprojected via the syndication store.

## Deployment
See https://trello.com/c/tyarJEax/2241-grid-add-syndication-to-metadata-service

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
