### PR TITLE
Introduce an edit field to Date Picker in quick filters and leases

### DIFF
--- a/kahuna/public/js/components/gu-date-range/gu-date-range.css
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.css
@@ -58,3 +58,8 @@
 .gu-date-range__overlay__preset__button:last-child {
     margin-right: 0px;
 }
+
+.date-edit-field {
+  margin-bottom: 10px;
+  width: 240px;
+}

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -56,6 +56,7 @@
         <div class="gu-date-range__overlay__pikaday">
             <span class="gu-date-range__overlay__pikaday__wrapper">
                 <h2 class="gu-date-range__overlay__title search__overlay__title">From</h2>
+                <input type="text" class="gu-date-range__input__start--hidden date-edit-field" placeholder="DD-MM-YYYY" ng-model="pikaStartValue">
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--start"/>
                 <button type="button"
                         class="gu-date-range__overlay__pikaday__clear button-shy"
@@ -66,6 +67,7 @@
 
             <span class="gu-date-range__overlay__pikaday__wrapper">
                 <h2 class="gu-date-range__overlay__title search__overlay__title">To</h2>
+                <input type="text" class="gu-date-range__input__end--hidden date-edit-field" placeholder="DD-MM-YYYY"  ng-model="pikaEndValue">
                 <div class="gu-date-range__overlay__pikaday__container gu-date-range__overlay__pikaday--end"/>
                 <button type="button"
                         class="gu-date-range__overlay__pikaday__clear button-shy"
@@ -90,7 +92,4 @@
             </button>
         </div>
     </div>
-
-    <input hidden type="text" class="gu-date-range__input__start--hidden" ng-model="pikaStartValue">
-    <input hidden type="text" class="gu-date-range__input__end--hidden" ng-model="pikaEndValue">
 </div>

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.js
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.js
@@ -83,7 +83,6 @@ guDateRange.directive('guDateRange', [function () {
             .querySelectorAll('.gu-date-range__overlay__pikaday--end')[0];
 
 
-          var iso8601Format = 'YYYY-MM-DDTHH:mm:ssZ';
           const tenYearsInMilliseconds = (10 * 365 * 24 * 60 * 60 * 1000);
           const tenYearsFromNow =  new Date(Date.now() + tenYearsInMilliseconds);
 
@@ -94,7 +93,7 @@ guDateRange.directive('guDateRange', [function () {
               maxDate: tenYearsFromNow,
               yearRange: 100,
               firstDay: parseInt(ctrl.guFirstDay),
-              format: iso8601Format,
+              format: ctrl.guDateFormat,
               keyboardInput: false
           });
 
@@ -104,7 +103,7 @@ guDateRange.directive('guDateRange', [function () {
               bound: false,
               maxDate: tenYearsFromNow,
               firstDay: parseInt(ctrl.guFirstDay),
-              format: iso8601Format,
+              format: ctrl.guDateFormat,
               yearRange: 100,
               keyboardInput: false
           });

--- a/kahuna/public/js/components/gu-date/gu-date.html
+++ b/kahuna/public/js/components/gu-date/gu-date.html
@@ -17,6 +17,6 @@
 
     <div ng-show="showingOverlay" class="gu-date__container"></div>
 
-    <input hidden type="text" class="gu-date__value--hidden" ng-model="pikaValue">
+    <input type="text" class="gu-date__value--hidden" placeholder="DD-MM-YYYY" ng-model="pikaValue">
 </div>
 

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -7,7 +7,6 @@ import template from './gu-date.html';
 import rangeTemplate from './gu-date-range-x.html';
 import './gu-date.css';
 
-const ISO8601_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 const DISPLAY_FORMAT = 'DD MMM YYYY';
 const TEN_YEARS_MILLIS = (10 * 365 * 24 * 60 * 60 * 1000);
 const START_OF_WEEK = 1; // Monday
@@ -54,7 +53,7 @@ guDate.directive('guDate', [function () {
                 maxDate: tenYearsFromNow,
                 yearRange: 100,
                 firstDay: START_OF_WEEK,
-                format: ISO8601_FORMAT,
+                format: DISPLAY_FORMAT,
                 keyboardInput: false
             });
 


### PR DESCRIPTION
## What does this change?
this makes the Datepicker's edit field visible so it allows the user to easily enter the dates

## How can success be measured?
User can type the date in the Datepicker's text input and the calendar should sync with the text input

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![Screenshot from 2021-03-26 03-50-21](https://user-images.githubusercontent.com/33189781/112566087-01acdd80-8de7-11eb-8275-d94ad6914762.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
