### PR TITLE
Implement local providers for authentication and authorisation

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/LocalAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/LocalAuthenticationProvider.scala
@@ -1,0 +1,41 @@
+package com.gu.mediaservice.lib.auth.provider
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.Authentication.UserPrincipal
+import com.gu.mediaservice.lib.auth.provider.AuthenticationProvider.RedirectUri
+import com.typesafe.scalalogging.StrictLogging
+import play.api.http.HeaderNames
+import play.api.libs.ws.WSRequest
+import play.api.mvc.{RequestHeader, Result}
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class LocalAuthenticationProvider (resources: AuthenticationProviderResources)
+  extends UserAuthenticationProvider with StrictLogging with ArgoHelpers with HeaderNames {
+  logger.warn("Authentication set to local, every user will be authenticated")
+
+  implicit val ec: ExecutionContext = resources.controllerComponents.executionContext
+  private val kahunaBaseURI: String = resources.commonConfig.services.kahunaBaseUri
+
+  override def authenticateRequest(request: RequestHeader): AuthenticationStatus = {
+    Authenticated(UserPrincipal("John", "Doe", "johndoe@example.com"))
+  }
+
+  override def sendForAuthentication: Option[RequestHeader => Future[Result]] = Some({requestHeader: RequestHeader =>
+    Future(redirectToSource(requestHeader))
+  })
+
+  override def sendForAuthenticationCallback: Option[(RequestHeader, Option[RedirectUri]) => Future[Result]] = None
+
+  override def flushToken: Option[(RequestHeader, Result) => Result] = None
+
+  override def onBehalfOf(request: Authentication.Principal): Either[String, WSRequest => WSRequest] = {
+    Right { identity }
+  }
+
+  private def redirectToSource(request: RequestHeader): Result = {
+    request.getQueryString("redirectUri").map(redirectURL => Redirect(redirectURL)).getOrElse(Redirect(kahunaBaseURI))
+  }
+}
+

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/LocalAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/LocalAuthorisationProvider.scala
@@ -1,0 +1,10 @@
+package com.gu.mediaservice.lib.auth.provider
+
+import com.gu.mediaservice.lib.auth.Authentication.Principal
+import com.gu.mediaservice.lib.auth.SimplePermission
+import com.typesafe.scalalogging.StrictLogging
+
+class LocalAuthorisationProvider extends AuthorisationProvider with StrictLogging {
+  logger.warn("Authorisation set to local, every user will have permission for everything")
+  override def hasPermissionTo(permission: SimplePermission, principal: Principal): Boolean = true
+}


### PR DESCRIPTION
## What does this change?
This PR implements a LocalAuthenticationProvider and a LocalAuthorisationProvider which lets everyone through anything with a generic user, for simplicity in local development. It also changes the setup script so that the application.conf file has the correct local providers when running locally.

## How can success be measured?
As a developer, when I'm running the grid locally I don't need to authenticate, and I have permissions for everything.

## Who should look at this?
@guardian/digital-cms @sihil @gribeiro @wainaina 

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
