### PR TITLE
fix: fixes a failing test after the clocks have changed 😅

### DIFF
--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -89,7 +89,7 @@ trait Fixtures {
     Crop(None, None, None, cropSpec: CropSpec, None, List.empty)
   }
 
-  def usage(id: String = UUID.randomUUID().toString) = Usage(id, List.empty, DigitalUsage, "test", PublishedUsageStatus,  None, None, now)
+  def usage(id: String = UUID.randomUUID().toString, lastModified: DateTime = now) = Usage(id, List.empty, DigitalUsage, "test", PublishedUsageStatus,  None, None, lastModified)
 
   def stringLongerThan(i: Int): String = {
     var out = ""

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -28,7 +28,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           )
 
           val imageTwo = createImage("superman", StaffPhotographer("Clark Kent", "Kent Farm")).copy(
-            usages = List(usage())
+            usages = List(usage(lastModified = new DateTime(2020, 1, 1, 0, 0, DateTimeZone.UTC)))
           )
 
           val images: List[Image] = List(imageOne, imageTwo)


### PR DESCRIPTION
## What does this change?

DateTimes are the hardest thing in programming! The clocks changed yesterday and now the tests are failing as the expected and actual are an hour apart. This is causing the build of `main` to fail.

This change injects the date in rather than using `DateTime.now` to avoid this event in the future. Ultimately, this sets the [`lastModified` of a usage](https://github.com/guardian/grid/blob/5519dbb960a705f70db3ee1693333c035cf4dd69/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala#L15) within tests to be set.

Interestingly, `main` appears to only be failing within TeamCity and the GitHub Actions builds are fine.

## How can success be measured?

The build passes and CD resumes.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->

n/a

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

@guardian/digital-cms

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
