### PR TITLE
Elasticseach mapping test and good to go check

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -51,7 +51,7 @@ object MappingTest {
     secureUrl = Some(new URL("http://host/filename.jpg"))
   )
 
-  val testUploader = "grid-internal-mapping-test-image"
+  val testUploader = "grid-internal-mapping-test-image" // Do not change this, we use it to clean up old test images
 
   val testImage: Image = Image(
     id = "abcdef1234567890",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -1,0 +1,227 @@
+package com.gu.mediaservice.lib.elasticsearch
+
+import com.gu.mediaservice.model.leases.{AllowUseLease, LeasesByMedia, MediaLease}
+import com.gu.mediaservice.model.usage._
+import com.gu.mediaservice.model._
+import org.joda.time.{DateTime, Period}
+import play.api.libs.json.{JsArray, JsNumber, JsString}
+
+import java.net.{URI, URL}
+
+/**
+  * This object contains a test image that is fully populated (i.e. all fields of a collection
+  * type including options have a value rather than None, Nil or other empty alternative).
+  * This is used to test that the elasticsearch mapping is still correct when changes are
+  * made to the model.
+  */
+object MappingTest {
+  // various dates for use below - these are deliberately a long time ago in case we accidentally leave anything lying
+  // around
+  private val imageTaken: DateTime = new DateTime(2010, 3, 26, 12, 0)
+  private val imageImported: DateTime = imageTaken.plus(Period.days(1).plusHours(1))
+  private val imageModified: DateTime = imageImported.plus(Period.hours(2))
+
+  private val testImageMetadata: ImageMetadata = ImageMetadata(
+    dateTaken = Some(imageTaken),
+    description = Some("a very lovely photograph"),
+    credit = Some("Bill Withers"),
+    creditUri = Some("https://bill.example.com"),
+    byline = Some("Bill and Friends"),
+    bylineTitle = Some("Bill"),
+    title = Some("Lovely day"),
+    copyright = Some("Bill 1999"),
+    suppliersReference = Some("ASDFFF"),
+    source = Some("bill-withers"),
+    specialInstructions = Some("This is really important."),
+    keywords = List("sunset", "loveliness", "distance"),
+    subLocation = Some("Downtown"),
+    city = Some("LA"),
+    state = Some("California"),
+    country = Some("USA"),
+    subjects = List("Bill", "Friends"),
+    peopleInImage = Set("Bill", "Friends", "Other friends")
+  )
+
+  private val testAsset: Asset = Asset(
+    file = new URI("file://filename.jpg"),
+    size = Some(12345L),
+    mimeType = Some(Jpeg),
+    dimensions = Some(Dimensions(1000, 2000)),
+    secureUrl = Some(new URL("http://host/filename.jpg"))
+  )
+
+  val testImage: Image = Image(
+    id = "abcdef1234567890",
+    uploadTime = imageImported,
+    uploadedBy = "Monkey",
+    lastModified = Some(imageModified),
+    identifiers = Map("id1" -> "value1"),
+    uploadInfo = UploadInfo(
+      filename = Some("filename.jpg")
+    ),
+    source = testAsset,
+    thumbnail = Some(Asset(
+      file = new URI("file://thumb.jpg"),
+      size = Some(1234L),
+      mimeType = Some(Jpeg),
+      dimensions = Some(Dimensions(500, 1000)),
+      secureUrl = Some(new URL("http://host/thumb.jpg"))
+    )),
+    optimisedPng = Some(Asset(
+      file = new URI("file://filename.png"),
+      size = Some(1245L),
+      mimeType = Some(Png),
+      dimensions = Some(Dimensions(1000, 2000)),
+      secureUrl = Some(new URL("http://host/filename.jpg"))
+    )),
+    fileMetadata = FileMetadata(
+      iptc = Map("iptc1" -> "value1"),
+      exif = Map("exif1" -> "value1"),
+      exifSub = Map("exifSub1" -> "value1"),
+      xmp = Map(
+        "xmp1" -> JsString("value1"),
+        "xmp2" -> JsNumber(12345),
+        "xmp3" -> JsArray(List(JsString("value2"), JsString("value3")))
+      ),
+      icc = Map("icc1" -> "value1"),
+      getty = Map("getty1" -> "value1"),
+      colourModel = Some("my-model"),
+      colourModelInformation = Map("colourModel1" -> "value1")
+    ),
+    userMetadata = Some(Edits(
+      archived = true,
+      labels = List("a label", "another label"),
+      metadata = testImageMetadata,
+      usageRights = Some(NoRights),
+      photoshoot = Some(Photoshoot("crazy times shoot"))
+    )),
+    metadata = testImageMetadata,
+    originalMetadata = testImageMetadata,
+    usageRights = Agency(
+      supplier = "Karpow Images Inc",
+      suppliersCollection = Some("All The Metadata™"),
+      restrictions = Some("All the time")
+    ),
+    originalUsageRights = StaffPhotographer(
+      photographer = "Barton",
+      publication = "Bricking It (The Lego Times)",
+      restrictions = Some("Not before June")
+    ),
+    exports = List(
+      Crop(
+        id = Some("1234567890987654321"),
+        author = Some("me"),
+        date = Some(imageModified),
+        specification = CropSpec(
+          uri = "http://host/file",
+          bounds = Bounds(
+            x = 100, y = 100, width = 500, height = 300
+          ),
+          aspectRatio = Some("5:3"),
+          `type` = CropExport
+        ),
+        master = Some(testAsset),
+        assets = List(testAsset)
+      )
+    ),
+    usages = List(Usage(
+      id = "usage1",
+      references = List(
+        UsageReference(
+          `type` = FrontendUsageReference,
+          uri = Some(new URI("something:fancy")),
+          name = Some("frontend-use")
+        )
+      ),
+      platform = DigitalUsage,
+      media = "some-media",
+      status = PublishedUsageStatus,
+      dateAdded = Some(imageTaken),
+      dateRemoved = Some(imageModified),
+      lastModified = imageModified,
+      printUsageMetadata = Some(
+        PrintUsageMetadata(
+          sectionName = "g1",
+          issueDate = imageModified,
+          pageNumber = 1,
+          storyName = "front-page-story",
+          publicationCode = "G1M",
+          publicationName = "G1 main",
+          layoutId = Some(1234L),
+          edition = Some(1),
+          size = Some(PrintImageSize(500, 300)),
+          orderedBy = Some("Bob"),
+          sectionCode = "NEWS",
+          notes = Some("a boss story"),
+          source = Some("source information")
+        )
+      ),
+      digitalUsageMetadata = Some(DigitalUsageMetadata(
+        webUrl = new URI("https://gu.com/12345"),
+        webTitle = "Article title",
+        sectionId = "uk/news",
+        composerUrl = Some(new URI("https://composer/api/2345678987654321345678"))
+      )),
+      syndicationUsageMetadata = Some(SyndicationUsageMetadata(
+        partnerName = "friends of ours"
+      )),
+      frontUsageMetadata = Some(FrontUsageMetadata(
+        addedBy = "me",
+        front = "uk/news"
+      )),
+      downloadUsageMetadata = Some(DownloadUsageMetadata(
+        downloadedBy = "me"
+      ))
+    )),
+    leases = LeasesByMedia.build(List(
+      MediaLease(
+        id = Some("leaseA"),
+        leasedBy = Some("you"),
+        startDate = Some(imageTaken),
+        endDate = Some(imageModified),
+        access = AllowUseLease,
+        notes = Some("use it for this"),
+        mediaId = "an id for leaseA",
+        createdAt = imageTaken
+      )
+    )),
+    collections = List(
+      Collection(
+        path = List(
+          "a/path",
+          "another/path"
+        ),
+        actionData = ActionData(
+          author = "me",
+          date = imageModified
+        ),
+        description = "useful collection"
+      )
+    ),
+    syndicationRights = Some(SyndicationRights(
+      published = Some(imageTaken),
+      suppliers = List(
+        Supplier(
+          supplierName = Some("I sell photographs"),
+          supplierId = Some("i-sell-photos"),
+          prAgreement = Some(true)
+        )
+      ),
+      rights = List(
+        Right(
+          rightCode = "myCode",
+          acquired = Some(true),
+          properties = List(
+            Property(
+              propertyCode = "propCode",
+              expiresOn = Some(imageModified),
+              value = Some("aValue")
+            )
+          )
+        )
+      ),
+      isInferred = true
+    )),
+    userMetadataLastModified = Some(imageModified)
+  )
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -1,8 +1,8 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-import com.gu.mediaservice.model.leases.{AllowUseLease, LeasesByMedia, MediaLease}
-import com.gu.mediaservice.model.usage._
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.{DenyUseLease, LeasesByMedia, MediaLease}
+import com.gu.mediaservice.model.usage._
 import org.joda.time.{DateTime, Period}
 import play.api.libs.json.{JsArray, JsNumber, JsString}
 
@@ -20,6 +20,7 @@ object MappingTest {
   private val imageTaken: DateTime = new DateTime(2010, 3, 26, 12, 0)
   private val imageImported: DateTime = imageTaken.plus(Period.days(1).plusHours(1))
   private val imageModified: DateTime = imageImported.plus(Period.hours(2))
+  private val imageDenyLeaseExpiry: DateTime = new DateTime(2030, 3, 26, 12, 0)
 
   private val testImageMetadata: ImageMetadata = ImageMetadata(
     dateTaken = Some(imageTaken),
@@ -50,10 +51,12 @@ object MappingTest {
     secureUrl = Some(new URL("http://host/filename.jpg"))
   )
 
+  val testUploader = "grid-internal-mapping-test-image"
+
   val testImage: Image = Image(
     id = "abcdef1234567890",
     uploadTime = imageImported,
-    uploadedBy = "Monkey",
+    uploadedBy = testUploader, // Do not change this, we use it to clean up old test images
     lastModified = Some(imageModified),
     identifiers = Map("id1" -> "value1"),
     uploadInfo = UploadInfo(
@@ -176,11 +179,11 @@ object MappingTest {
     leases = LeasesByMedia.build(List(
       MediaLease(
         id = Some("leaseA"),
-        leasedBy = Some("you"),
+        leasedBy = Some(testUploader),
         startDate = Some(imageTaken),
-        endDate = Some(imageModified),
-        access = AllowUseLease,
-        notes = Some("use it for this"),
+        endDate = Some(imageDenyLeaseExpiry),
+        access = DenyUseLease,
+        notes = Some("this prevents use of this test image and should hide it from the default view"),
         mediaId = "an id for leaseA",
         createdAt = imageTaken
       )

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibC
 import com.contxt.kinesis.{KinesisRecord, KinesisSource}
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
 import com.gu.mediaservice.lib.play.GridComponents
+import com.typesafe.scalalogging.StrictLogging
 import controllers.{HealthCheck, ThrallController}
 import lib._
 import lib.elasticsearch._
@@ -11,9 +12,12 @@ import lib.kinesis.{KinesisConfig, ThrallEventConsumer}
 import play.api.ApplicationLoader.Context
 import router.Routes
 
-import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.language.postfixOps
+import scala.util.{Failure, Success}
 
-class ThrallComponents(context: Context) extends GridComponents(context, new ThrallConfig(_)) {
+class ThrallComponents(context: Context) extends GridComponents(context, new ThrallConfig(_)) with StrictLogging {
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   val store = new ThrallStore(config)
@@ -30,6 +34,19 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val es = new ElasticSearch(esConfig, Some(thrallMetrics))
   es.ensureAliasAssigned()
+
+  // before firing up anything to consume streams or say we are OK let's do the critical good to go check
+  private val goodToGoCheckResult = Await.ready(GoodToGoCheck.run(es), 30 seconds)
+  goodToGoCheckResult.value match {
+    case Some(Success(_)) => // all good
+      logger.info("Passed good to go")
+    case Some(Failure(exception)) =>
+      logger.error("Failed good to go, aborting startup", exception)
+      throw exception
+    case other =>
+      logger.warn(s"Result of good to go was $other, aborting as this result doesn't make sense")
+      throw new IllegalStateException("Good to go test didn't pass or throw exception")
+  }
 
   val highPriorityKinesisConfig: KinesisClientLibConfiguration = KinesisConfig.kinesisConfig(config.kinesisConfig)
   val lowPriorityKinesisConfig: KinesisClientLibConfiguration = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)

--- a/thrall/app/lib/elasticsearch/GoodToGoCheck.scala
+++ b/thrall/app/lib/elasticsearch/GoodToGoCheck.scala
@@ -1,0 +1,63 @@
+package lib.elasticsearch
+
+import com.amazonaws.util.EC2MetadataUtils
+import com.gu.mediaservice.lib.elasticsearch.MappingTest
+import com.gu.mediaservice.lib.logging.LogMarker
+import com.sksamuel.elastic4s.Response
+import com.sksamuel.elastic4s.requests.delete.DeleteResponse
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * This implements a good to go check that validates when Thrall starts up that it can successfully write and read
+  * and image into the elasticsearch node.
+  */
+object GoodToGoCheck extends StrictLogging {
+  def run(es: ElasticSearch)(implicit ex: ExecutionContext): Future[Unit] = {
+    // make a test image with an ID that is unique to the node so that multiple nodes can run the check at once
+    val uniqueId = Option(EC2MetadataUtils.getInstanceId).map(_.stripPrefix("i-")).getOrElse("abcdef")
+    val image = MappingTest.testImage.copy(id = s"${MappingTest.testImage.id}$uniqueId")
+    val lastModified = image.lastModified.get
+    implicit val marker: LogMarker = image ++ Map("goToGo" -> true)
+
+    val indexResult: Future[Unit] =
+      for {
+        // perhaps a test image wasn't previously cleaned up, let's err on the side of caution and check and deal with it
+        _ <- Future.successful(logger.info(s"Ensuring test image ${image.id} doesn't exist"))
+        checkAbsent <- es.getImage(image.id)
+        _ <- Future.successful(if (checkAbsent.nonEmpty) logger.info("Deleting prior test image"))
+        _ <- if (checkAbsent.nonEmpty) deleteTestImage(es, image.id) else Future.successful(())
+        // now index and retrieve the test image
+        _ <- Future.successful(logger.info(s"Indexing test image ${image.id}"))
+        indexResult <- Future.sequence(es.indexImage(image.id, image, lastModified))
+        _ <- Future.successful(logger.info(s"Retrieving test image ${image.id}"))
+        maybeRetrieveResult <- es.getImage(image.id)
+        _ <- Future.successful(logger.info(s"Validating test image"))
+        validation <- {
+          // check that we indexed one object
+          val indexedOneItem = indexResult.size == 1
+          // and retrieving it is the same object - note: we use a string check here as the DateTimes don't compare usefully
+          val retrievedImageSameAsIndexed = maybeRetrieveResult.toString == Some(image).toString
+
+          if (indexedOneItem && retrievedImageSameAsIndexed) {
+            Future.successful(())
+          } else {
+            Future.failed(new IllegalStateException(s"Failed to validate insertion [Indexed ${indexResult.size} (one item check: $indexedOneItem); retrieved image matches indexed image: $retrievedImageSameAsIndexed]"))
+          }
+        }
+        // once that's all done, let's delete the image again so it's not lying around
+        _ <- Future.successful(logger.info(s"Deleting test image"))
+        _ <- deleteTestImage(es, image.id)
+      } yield validation
+
+    // return the future for the healthcheck
+    indexResult
+  }
+
+  def deleteTestImage(es: ElasticSearch, imageId: String)(implicit ex: ExecutionContext, lm: LogMarker): Future[Response[DeleteResponse]] = {
+    import com.sksamuel.elastic4s.ElasticDsl._
+    // this manipulates the underlying ES API as the built in delete API guards against deleting images that are in use
+    es.executeAndLog(deleteById(es.imagesAlias, imageId), s"Deleting good to go test image $imageId")
+  }
+}

--- a/thrall/test/lib/elasticsearch/GoodToGoCheckTest.scala
+++ b/thrall/test/lib/elasticsearch/GoodToGoCheckTest.scala
@@ -1,0 +1,106 @@
+package lib.elasticsearch
+
+import com.gu.mediaservice.lib.elasticsearch.MappingTest
+import com.gu.mediaservice.lib.logging.LogMarker
+import com.sksamuel.elastic4s.requests.count.CountResponse
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.Response
+import org.joda.time.{DateTime, Period}
+
+import scala.concurrent.Future
+
+class GoodToGoCheckTest extends ElasticSearchTestBase {
+  implicit val lm: LogMarker = new LogMarker{
+    override def markerContents: Map[String, Any] = Map.empty
+  }
+
+  "GoodToGoCheck" - {
+    "the good to go check passes when run against docker" in {
+      GoodToGoCheck.run(ES).futureValue
+    }
+    "deleteOldTestImages" - {
+      val now = new DateTime(2021, 3, 3, 3, 0)
+      val old = now.minus(Period.minutes(15))
+      val testIds = List("first", "second", "third")
+      "should delete old test images" in {
+        // insert a few 'old' test images
+        Future.sequence(testIds.flatMap { id =>
+          ES.indexImage(id, MappingTest.testImage.copy(id = id), old)
+        }).futureValue
+
+        // wait for them to appear in ES
+        testIds.foreach { id =>
+          eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(id))
+        }
+
+        eventually {
+          ES.client.execute(count(ES.initialImagesIndex))
+            .futureValue.result.count shouldBe 3
+        }
+
+        // now delete them
+        GoodToGoCheck.deleteOldTestImages(ES, now).futureValue shouldBe 3
+
+        // wait for them to disappear from ES
+        testIds.foreach { id =>
+          eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe None)
+        }
+      }
+
+      "should not delete recent test images" in {
+        val notVeryOld = now.minus(Period.minutes(5))
+        // insert one normal and a few others with an alternative uploader
+        val eventualInserts: List[Future[ElasticSearchUpdateResponse]] =
+          ES.indexImage("test", MappingTest.testImage.copy(id = "test"), old) :::
+          testIds.flatMap { id =>
+            ES.indexImage(id, MappingTest.testImage.copy(id = id), notVeryOld)
+          }
+        Future.sequence(eventualInserts).futureValue
+        // ensure they are all in ES
+        eventually(reloadedImage("test").map(_.id) shouldBe Some("test"))
+        testIds.foreach { id =>
+          eventually(reloadedImage(id).map(_.id) shouldBe Some(id))
+        }
+        eventually {
+          ES.client.execute(count(ES.initialImagesIndex))
+            .futureValue.result.count shouldBe 4
+        }
+
+        // now run a delete old test images to show that our images remain
+        GoodToGoCheck.deleteOldTestImages(ES, now).futureValue shouldBe 1
+        // ensure the test image is gone
+        eventually(reloadedImage("test").map(_.id) shouldBe None)
+        // ensure the other images still exist
+        testIds.foreach { id =>
+          reloadedImage(id).map(_.id) shouldBe Some(id)
+        }
+      }
+
+      "should not delete images without the defined test uploader" in {
+        val eventualInserts: List[Future[ElasticSearchUpdateResponse]] =
+          ES.indexImage("old", MappingTest.testImage.copy(id = "old"), old) :::
+            testIds.flatMap { id =>
+              ES.indexImage(id, MappingTest.testImage.copy(id = id, uploadedBy = "joe-bloggs"), old)
+            }
+        val eventualResponses = Future.sequence(eventualInserts).futureValue
+        eventually(reloadedImage("old").map(_.id) shouldBe Some("old"))
+        testIds.foreach { id =>
+          eventually(reloadedImage(id).map(_.id) shouldBe Some(id))
+        }
+        eventually {
+          ES.client.execute(count(ES.initialImagesIndex))
+            .futureValue.result.count shouldBe 4
+        }
+
+        // now run a delete old test images to show that our normal images remain
+        GoodToGoCheck.deleteOldTestImages(ES, now).futureValue shouldBe 1
+        // now check that the test image has gone
+        eventually(reloadedImage("old").map(_.id) shouldBe None)
+        // confirm that our other images are still present
+        testIds.foreach { id =>
+          reloadedImage(id).map(_.id) shouldBe Some(id)
+        }
+      }
+    }
+  }
+}

--- a/thrall/test/lib/elasticsearch/ImageModelTest.scala
+++ b/thrall/test/lib/elasticsearch/ImageModelTest.scala
@@ -1,0 +1,65 @@
+package lib.elasticsearch
+
+import com.gu.mediaservice.lib.elasticsearch.MappingTest
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
+
+import scala.collection.TraversableLike
+import scala.concurrent.{Await, Future}
+
+class ImageModelTest extends ElasticSearchTestBase {
+  implicit val logMarker: LogMarker = MarkerMap()
+  "the image model matches the mapping" - {
+    "the testImage is fully populated (doesn't have any fields that are empty)" in {
+      /* This test is an important prelude to the serialisation check. Here we ensure that the
+       * test Image is fully populated with no None values or empty collections. This is to
+       * ensure that we test all corners of the data model when we serialise into elasticsearch.
+       * If this fails then it indicates that a field in the Image model does not contain a value.
+       * This should be fixed by adding appropriate values in MappingTest.scala
+       */
+
+      /* recurse through a typical scala structure */
+      def check(maybeProduct: Any): List[Either[String, Any]] = {
+        maybeProduct match {
+          case None =>
+            List(Left("Empty Option"))
+          case collection: TraversableLike[_, _] if collection.isEmpty =>
+            // this should pick up most collections including List, Map, Set, Seq etc.
+            List(Left(s"Empty ${collection.getClass.getName}"))
+          case string: String =>
+            List(scala.util.Right(string))
+          case list: TraversableLike[_, _] =>
+            list.toList.flatMap(check)
+          case product: Product => product.productIterator.flatMap(check).toList
+          case other =>
+            List(scala.util.Right(other))
+        }
+      }
+
+      val results = check(MappingTest.testImage)
+      if (results.exists(_.isLeft)) {
+        results.foreach{
+          case Left(msg) => System.err.println(s"❌ $msg")
+          case scala.util.Right(value) => System.err.println(s"✅ $value")
+        }
+      }
+
+      results.count(_.isLeft) shouldBe 0
+    }
+    "can insert a fully populated image into elasticsearch" in {
+      /* This test ensures that a fully populated image can be successfully inserted into
+       * ElasticSearch with the mappings in Mappings.scala. If this fails then it indicates
+       * that the currently defined mappings are wrong and should be corrected.
+       */
+      val image = MappingTest.testImage
+
+      Await.result(Future.sequence(ES.indexImage(image.id, image, image.lastModified.get)), fiveSeconds)
+      eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(image.id).map(_.id) shouldBe Some(image.id))
+
+      val retrievedImage = reloadedImage(image.id).get
+      /* note that we compare the toString method here as the Joda serialisation/deserialisation ends up with
+       * equivalent but not equal/== dates due to different ways of internally expressing the chronology
+       * see https://stackoverflow.com/questions/21002385/datetime-does-not-equal-itself-after-unserialization */
+      retrievedImage.toString shouldBe image.toString
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?
Previously it was fairly easy to make a change to the Grid's model that made it impossible to serialise to the existing ElasticSearch mappings (an additional field for example). This can be fixed by adapting the mapping in the codebase accordingly BUT this is only applied when there is no index so established installations will still fail.

This PR makes evolving the model lower risk by:
 - Adding some unit tests to test serialising and deserialising the Image model into ES using the mappings in the code base
 - Adding a good to go check to Thrall's startup that tries to serialise and deserialise into the configured ES database

These help a developer to catch evolutions when they are made prior to spinning it up or deploying it. They also ensure that operational errors are quickly detected, such as deploying a build with a model that is incompatible with the current index mappings in ES. Previously we would only have a failure when an edit to the altered part of the model was made, now thrall will fail fast.

## How can success be measured?
An upcoming change will add a new `lastModified` field to the Edits model. This change should be picked up immediately by these tests and good to go check to ensure that appropriate mapping changes are made locally and to the deployed databases.

## Tested?
- [X] locally by committer
- [x] on the Guardian's TEST environment
