### PR TITLE
fix: use explicit read/writes for Usage

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
@@ -3,8 +3,7 @@ package com.gu.mediaservice.lib
 import scala.concurrent.duration.Duration
 import scala.util.Try
 import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.format.DateTimeFormatterBuilder
+import org.joda.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ISODateTimeFormat}
 
 package object formatting {
 
@@ -20,7 +19,7 @@ package object formatting {
       withZoneUTC
   }
 
-  val dateTimeFormat = parseDateTimeFormat.withZoneUTC
+  val dateTimeFormat: DateTimeFormatter = parseDateTimeFormat.withZoneUTC
 
   def printDateTime(date: DateTime): String = date.toString()
   def printOptDateTime(date: Option[DateTime]): Option[String] = date.map(printDateTime)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/Usage.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.model.usage
 
 import play.api.libs.json._
 import org.joda.time.DateTime
-
+import play.api.libs.functional.syntax._
 
 case class Usage(
   id: String,
@@ -22,9 +22,37 @@ case class Usage(
   downloadUsageMetadata: Option[DownloadUsageMetadata] = None
 )
 object Usage {
-  import JodaWrites._
-  import JodaReads._
+  import com.gu.mediaservice.lib.formatting._
 
-  implicit val writes: Writes[Usage] = Json.writes[Usage]
-  implicit val reads: Reads[Usage] = Json.reads[Usage]
+  implicit val writes: Writes[Usage] = (
+    (__ \ "id").write[String] ~
+      (__ \ "references").write[List[UsageReference]] ~
+      (__ \ "platform").write[UsageType] ~
+      (__ \ "media").write[String] ~
+      (__ \ "status").write[UsageStatus] ~
+      (__ \ "dateAdded").writeNullable[String].contramap(printOptDateTime) ~
+      (__ \ "dateRemoved").writeNullable[String].contramap(printOptDateTime) ~
+      (__ \ "lastModified").write[String].contramap(printDateTime) ~
+      (__ \ "printUsageMetadata").writeNullable[PrintUsageMetadata] ~
+      (__ \ "digitalUsageMetadata").writeNullable[DigitalUsageMetadata] ~
+      (__ \ "syndicationUsageMetadata").writeNullable[SyndicationUsageMetadata] ~
+      (__ \ "frontUsageMetadata").writeNullable[FrontUsageMetadata] ~
+      (__ \ "downloadUsageMetadata").writeNullable[DownloadUsageMetadata]
+    )(unlift(Usage.unapply))
+
+  implicit val reads: Reads[Usage] = (
+    (__ \ "id").read[String] ~
+      (__ \ "references").read[List[UsageReference]] ~
+      (__ \ "platform").read[UsageType] ~
+      (__ \ "media").read[String] ~
+      (__ \ "status").read[UsageStatus] ~
+      (__ \ "dateAdded").readNullable[String].map(parseOptDateTime) ~
+      (__ \ "dateRemoved").readNullable[String].map(parseOptDateTime) ~
+      (__ \ "lastModified").read[String].map(unsafeParseDateTime) ~
+      (__ \ "printUsageMetadata").readNullable[PrintUsageMetadata] ~
+      (__ \ "digitalUsageMetadata").readNullable[DigitalUsageMetadata] ~
+      (__ \ "syndicationUsageMetadata").readNullable[SyndicationUsageMetadata] ~
+      (__ \ "frontUsageMetadata").readNullable[FrontUsageMetadata] ~
+      (__ \ "downloadUsageMetadata").readNullable[DownloadUsageMetadata]
+    )(Usage.apply _)
 }


### PR DESCRIPTION
## What does this change?

We're seeing tests on `main` fail after the clocks have changed. In this change, we use an explicit read/writes for Usage to ensure dates are always in UTC to avoid this... quirk... in the future.

This is an better version of https://github.com/guardian/grid/pull/3235.

## How can success be measured?

The build passes and CD resumes.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->

n/a

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

@guardian/digital-cms

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
