### PR TITLE
Use dc-subject for keywords

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -43,8 +43,8 @@ object ImageMetadataConverter extends GridLogging {
     val fromXMP =  extractXMPArrayStrings("dc:subject", fileMetadata).toList
     val fromIPTC= fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toList) getOrElse Nil
     (fromXMP, fromIPTC) match {
-      case (xmp, _) => xmp
-      case (_, iptc) => iptc
+      case (xmp, _)  if xmp.nonEmpty  => xmp
+      case (_, iptc) if iptc.nonEmpty => iptc
       case _ => Nil
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -39,6 +39,16 @@ object ImageMetadataConverter extends GridLogging {
     (xmpIptcPeople ++ xmpGettyPeople).toSet
   }
 
+  private def extractKeywords(fileMetadata: FileMetadata): List[String] = {
+    val fromXMP =  extractXMPArrayStrings("dc:subject", fileMetadata).toList
+    val fromIPTC= fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toList) getOrElse Nil
+    (fromXMP, fromIPTC) match {
+      case (xmp, _) => xmp
+      case (Nil, iptc) => iptc
+      case _ => Nil
+    }
+  }
+
   def fromFileMetadata(fileMetadata: FileMetadata, latestAllowedDateTime: Option[DateTime] = None): ImageMetadata = {
     val xmp = fileMetadata.xmp
 
@@ -70,8 +80,7 @@ object ImageMetadataConverter extends GridLogging {
                             fileMetadata.iptc.get("Source"),
       specialInstructions = fileMetadata.readXmpHeadStringProp("photoshop:Instructions") orElse
                             fileMetadata.iptc.get("Special Instructions"),
-      // FIXME: Read XMP dc:subject array:
-      keywords            = fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toList) getOrElse Nil,
+      keywords            = extractKeywords(fileMetadata),
       // FIXME: Parse newest location schema: http://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#location-structure
       subLocation         = fileMetadata.readXmpHeadStringProp("Iptc4xmpCore:Location") orElse
                             fileMetadata.iptc.get("Sub-location"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -44,7 +44,7 @@ object ImageMetadataConverter extends GridLogging {
     val fromIPTC= fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toList) getOrElse Nil
     (fromXMP, fromIPTC) match {
       case (xmp, _) => xmp
-      case (Nil, iptc) => iptc
+      case (_, iptc) => iptc
       case _ => Nil
     }
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -312,7 +312,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
       iptc = Map(),
       exif = Map(),
       exifSub = Map(),
-      xmp = Map("dc:subjectt"-> JsArray(Seq("Foo", "Bar", "Baz"))))
+      xmp = Map("dc:subjectt"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
   }
@@ -321,7 +321,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     val fileMetadata = FileMetadata(
       iptc = Map("Keywords"->"dont,use,this"),
       exif = Map(), exifSub = Map(),
-      xmp = Map("dc:subjectt"-> JsArray(Seq("Foo", "Bar", "Baz"))))
+      xmp = Map("dc:subjectt"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -312,7 +312,7 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
       iptc = Map(),
       exif = Map(),
       exifSub = Map(),
-      xmp = Map("dc:subjectt"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
+      xmp = Map("dc:subject"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
   }
@@ -321,12 +321,10 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     val fileMetadata = FileMetadata(
       iptc = Map("Keywords"->"dont,use,this"),
       exif = Map(), exifSub = Map(),
-      xmp = Map("dc:subjectt"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
+      xmp = Map("dc:subject"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
     imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
   }
-
-
 
   it("should leave non-dates alone") {
     ImageMetadataConverter.cleanDate("banana") shouldBe "banana"

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -307,6 +307,27 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
   }
 
+  it("should populate keywords field of ImageMetadata from dc-subjects") {
+    val fileMetadata = FileMetadata(
+      iptc = Map(),
+      exif = Map(),
+      exifSub = Map(),
+      xmp = Map("dc:subjectt"-> JsArray(Seq("Foo", "Bar", "Baz"))))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
+  }
+
+  it("should populate keywords field of ImageMetadata from dc-subjectsin preference to keywords") {
+    val fileMetadata = FileMetadata(
+      iptc = Map("Keywords"->"dont,use,this"),
+      exif = Map(), exifSub = Map(),
+      xmp = Map("dc:subjectt"-> JsArray(Seq("Foo", "Bar", "Baz"))))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.keywords should be(List("Foo", "Bar", "Baz"))
+  }
+
+
+
   it("should leave non-dates alone") {
     ImageMetadataConverter.cleanDate("banana") shouldBe "banana"
   }


### PR DESCRIPTION
## What does this change?

also now uses dc-subject	

## How can success be measured?

find some images with dc-subject set and see what they look like when imported

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
