### PR TITLE
Add Google user photos host to content security policy

### DIFF
--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -49,6 +49,7 @@ object KahunaSecurityConfig {
       URI.ensureSecure(config.cropOrigin).toString,
       URI.ensureSecure(gaHost).toString,
       URI.ensureSecure("app.getsentry.com").toString,
+      "https://*.googleusercontent.com",
       "'self'"
     ).mkString(" ")}"
 


### PR DESCRIPTION
Co-authored-by: @twrichards 

## What does this change?
Adds `https://*.googleusercontent.com` to the `img-src` portion of the Content Security Policy to allow Google user photos to display correctly when using the ['mentions' feature in Pinboard](https://github.com/guardian/editorial-tools-pinboard/pull/45).

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
