### PR TITLE
Remove conversion to UTC in DateTime parsers

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
@@ -15,11 +15,10 @@ package object formatting {
     ).map(_.getParser)
     new DateTimeFormatterBuilder().
       append(null, parsers).
-      toFormatter.
-      withZoneUTC
+      toFormatter
   }
 
-  val dateTimeFormat: DateTimeFormatter = parseDateTimeFormat.withZoneUTC
+  val dateTimeFormat: DateTimeFormatter = parseDateTimeFormat
 
   def printDateTime(date: DateTime): String = date.toString()
   def printOptDateTime(date: Option[DateTime]): Option[String] = date.map(printDateTime)


### PR DESCRIPTION
## What does this change?
Currently there's an automatic conversion to UTC DateTimes when parsing them. This causes GoodToGoCheck to fail on thrall when the server time is in a different timezone than UTC, since the created objects have a local DateTimeZone, but when written into elasticSearch and then read back, the time is converted to UTC, causing the objects to be different.

This fixes it by removing the conversion on parsing.

## How can success be measured?
Thrall service doesn't fail when the server uses a different timezone than UTC.

## Who should look at this?
@sihil 

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
