### PR TITLE
Permissions on Metadata service

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -172,6 +172,16 @@ class GridClient(services: Services)(implicit wsClient: WSClient) extends LazyLo
     }
   }
 
+  def getUploadedBy(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[Option[String]] = {
+    logger.info("attempt to get uploadedBy")
+    val url = new URL(s"${services.apiBaseUri}/images/$mediaId/uploadedBy")
+    makeGetRequestAsync(url, authFn) map {
+      case Found(json, _) => Some((json \ "data").as[String])
+      case NotFound(_, _) => None
+      case e@Error(_, _, _) => e.logErrorAndThrowException()
+    }
+  }
+
   def getCrops(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[List[Crop]] = {
     logger.info("attempt to get crops")
     val url = new URL(s"${services.cropperBaseUri}/crops/$mediaId")

--- a/kahuna/public/js/edits/image-editor.css
+++ b/kahuna/public/js/edits/image-editor.css
@@ -1,0 +1,8 @@
+.section__disabled {
+    opacity: 0.4;
+}
+
+.edit_metadata__warning {
+    color: orange;
+    font-size: 13px;
+}

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -143,7 +143,8 @@
         </section>
 
         <section>
-            <h1>Image Metadata</h1>
+            <span class="edit_metadata__warning" ng-if="!ctrl.userCanEdit">WARNING: This image is already in The Grid. Since you're not the original uploader, you are not allowed to edit its metadata.</span>
+            <h1 ng-class="{'section__disabled': !ctrl.userCanEdit}">Image Metadata</h1>
             <ui-required-metadata-editor
                 class="result-editor__metadata-editor"
                 resource="ctrl.image.data.userMetadata.data.metadata"

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import template from './image-editor.html';
+import './image-editor.css';
 
 import {service} from './service';
 import {imageService} from '../image/service';
@@ -39,6 +40,9 @@ imageEditor.controller('ImageEditorCtrl', [
 
     var ctrl = this;
 
+    editsService.canUserEdit(ctrl.image).then(editable => {
+        ctrl.userCanEdit = editable;
+    });
     ctrl.batchApplyUsageRights = batchApplyUsageRights;
     editsApi.getUsageRightsCategories()
         .then(cats => ctrl.categories = cats)

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -13,8 +13,8 @@ upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', function(uploadMan
 
     ctrl.supportEmailLink = window._clientConfig.supportEmail;
 
-    mediaApi.getSession().then(session => {
-        ctrl.canUpload = session.user.permissions.canUpload;
+    mediaApi.canUserUpload().then(canUpload => {
+        ctrl.canUpload = canUpload;
     });
 
     // TODO: Show multiple jobs?

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -1,0 +1,3 @@
+.job-editor__disabled {
+    opacity: 0.4;
+}

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -1,4 +1,4 @@
-<form class="job-editor" name="jobEditor" ng-submit="ctrl.save()" novalidate>
+<form class="job-editor" name="jobEditor" ng-submit="ctrl.save()" novalidate ng-class="{'job-editor__disabled': !ctrl.userCanEdit}">
     <div class="job-editor__inputs">
         <label class="job-info--editor__field flex-center">
             <div class="job-info--editor__label job-info--editor__label flex-center text-small">Description</div>
@@ -13,13 +13,14 @@
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-disabled="!ctrl.userCanEdit"
             ></textarea>
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this description to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit"
                 ng-click="ctrl.batchApplyMetadata('description')"
             >⇔</button>
         </label>
@@ -38,13 +39,14 @@
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-disabled="!ctrl.userCanEdit"
             />
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this byline to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit"
                 ng-click="ctrl.batchApplyMetadata('byline')"
             >⇔</button>
 
@@ -65,6 +67,7 @@
                     gr-datalist-input
                     ng-model="ctrl.metadata.credit"
                     ng-change="ctrl.save()"
+                    ng-disabled="!ctrl.userCanEdit"
                     ng-model-options="{ updateOn: 'gr-datalist:update blur' }" />
             </gr-datalist>
 
@@ -72,7 +75,7 @@
                 class="job-editor__apply-to-all"
                 title="Apply this credit to all"
                 type="button"
-                ng-if="ctrl.withBatch"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit"
                 ng-click="ctrl.batchApplyMetadata('credit')"
             >⇔</button>
         </div>
@@ -86,13 +89,14 @@
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-disabled="!ctrl.userCanEdit"
             />
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply this copyright to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit"
                 ng-click="ctrl.batchApplyMetadata('copyright')"
             >⇔</button>
         </label>
@@ -107,13 +111,14 @@
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-disabled="!ctrl.userCanEdit"
             />
 
             <button
                 class="job-editor__apply-to-all"
                 title="Apply these instructions to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit"
                 ng-click="ctrl.batchApplyMetadata('specialInstructions')"
             >⇔</button>
         </label>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import './required-metadata-editor.css';
 import 'angular-elastic';
 import template from './required-metadata-editor.html';
 
@@ -20,6 +21,9 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     var ctrl = this;
 
+    editsService.canUserEdit(ctrl.image).then(editable => {
+        ctrl.userCanEdit = editable;
+    });
     ctrl.saving = false;
     ctrl.disabled = () => Boolean(ctrl.saving || ctrl.externallyDisabled);
     ctrl.saveOnTime = 750; // ms
@@ -62,8 +66,10 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     if (Boolean(ctrl.withBatch)) {
         $scope.$on(batchApplyMetadataEvent, (e, { field, data }) => {
-            ctrl.metadata[field] = data;
-            ctrl.save();
+            if (ctrl.canEditMetadata()) {
+                ctrl.metadata[field] = data;
+                ctrl.save();
+            }
         });
 
         ctrl.batchApplyMetadata = field =>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -66,7 +66,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     if (Boolean(ctrl.withBatch)) {
         $scope.$on(batchApplyMetadataEvent, (e, { field, data }) => {
-            if (ctrl.canEditMetadata()) {
+            if (ctrl.userCanEdit) {
                 ctrl.metadata[field] = data;
                 ctrl.save();
             }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -62,6 +62,18 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
     }
   }
 
+  def getImageUploaderById(id: String)(implicit ex: ExecutionContext): Future[Option[String]] = {
+    implicit val logMarker = MarkerMap("id" -> id)
+    val request = get(imagesAlias, id).fetchSourceInclude("uploadedBy")
+    executeAndLog(request, s"get image uploader by id $id").map { r =>
+
+      r.status match {
+        case Status.OK => r.result.sourceFieldOpt("uploadedBy").collect{case s: String => s}
+        case _ => None
+      }
+    }
+  }
+
   def search(params: SearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[SearchResults] = {
     implicit val logMarker = MarkerMap()
     def resolveHit(hit: SearchHit) = mapImageFrom(hit.sourceAsString, hit.id)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -16,6 +16,7 @@ GET     /images/:id                                   controllers.MediaApi.getIm
 GET     /images/:id/_elasticsearch                    controllers.MediaApi.getImageFromElasticSearch(id: String)
 GET     /images/:id/projection/diff                   controllers.MediaApi.diffProjection(id: String)
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
+GET     /images/:imageId/uploadedBy                   controllers.MediaApi.uploadedBy(imageId: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -20,7 +20,7 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
     () => messageConsumer.actorSystem.terminate()
   }
 
-  val editsController = new EditsController(auth, store, notifications, config, controllerComponents)
+  val editsController = new EditsController(auth, store, notifications, config, wsClient, authorisation, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
 
   override val router = new Routes(httpErrorHandler, controller, editsController, management)


### PR DESCRIPTION
## What does this change?
This implements permission checks on the following metadata-editor service endpoints for editing metadata:
```

PUT     /metadata/:id/metadata                          controllers.EditsController.setMetadata(id: String)
POST    /metadata/:id/metadata/set-from-usage-rights    controllers.EditsController.setMetadataFromUsageRights(id: String)

```
With this change, if a request to one of those endpoints is sent by a user who is not the uploader of the image AND does not have EditMetadata permission, the request will be denied.

To get the information about the uploader of the image, a new endpoint was implemented in media-api service:
`
GET     /images/:imageId/uploadedBy                   controllers.MediaApi.uploadedBy(imageId: String)
`
This endpoint returns the uploadedBy field of the image as a string. The metadata-editor service will make use of this endpoint to check if the user trying to edit metadata is the original uploader of the image.

Also, this implements some changes in the UI. In the case of uploading an image already in the system with a diffent uploader, and no EditMetadata permissions, the /upload page reflects this by showing a warning on the Image Metadata section of the conflicting image, and by disallowing edits to the metadata of that image. Batch metadata copying should work without any errors, since the batch process has been updated to avoid copying data into images without permissions.

## How can success be measured?
- As a user with EditMetadata permissions, I'm able to edit the metadata of any image.
- As a user without EditMetadata permissions, I'm only able to edit the metadata of the images I uploaded.
- When an image without EditMetadata permissions is uploaded, the user cannot edit the metadata of it, and an appropriate warning is shown in the UI.

## Screenshots
Batch upload of images, one of which is an image with a different uploader, and with no EditMetadata permissions:
![image](https://user-images.githubusercontent.com/20479781/113930702-00f14f80-97c8-11eb-93c6-757655be782b.png)


## Who should look at this?
@guardian/digital-cms @sihil @ochiengolanga 

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
