### PR TITLE
fix/setup-script: Use correct name for guardian local auth stack

### DIFF
--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -330,7 +330,7 @@ main() {
       setupLocalAuthenticationProviderConfiguration
       setupLocalAuthorisationProviderConfiguration
     else
-      createLocalAuthStack
+      createGuardianLocalAuthStack
       setupPanDomainConfiguration
       setupGuardianPermissionConfiguration
     fi


### PR DESCRIPTION
## What does this change?
This fixes a renaming of a function that was incomplete, thus failing when setting up locally without LOCAL_SIMPLE_AUTH_PROVIDER variable.

## How can success be measured?
Local setup for The Guardian works correctly

## Who should look at this?
@guardian/digital-cms

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
