### PR TITLE
Change to triple input streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,6 +227,8 @@ lazy val thrall = playProject("thrall", 9002).settings(
     "org.codehaus.groovy" % "groovy-json" % "2.4.4",
     "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
+    "com.streetcontxt" %% "kcl-akka-stream" % "2.1.0",
+    "com.lightbend.akka" %% "akka-stream-alpakka-elasticsearch" % "2.0.2",
     "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
     "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test
   )

--- a/build.sbt
+++ b/build.sbt
@@ -227,7 +227,6 @@ lazy val thrall = playProject("thrall", 9002).settings(
     "org.codehaus.groovy" % "groovy-json" % "2.4.4",
     "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
-    "com.streetcontxt" %% "kcl-akka-stream" % "2.1.0",
     "com.lightbend.akka" %% "akka-stream-alpakka-elasticsearch" % "2.0.2",
     "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
     "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -54,7 +54,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val highPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val lowPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource()
+  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource(es)
 
   val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es), actorSystem)
   val thrallStreamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, thrallEventConsumer, actorSystem, materializer)

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -54,12 +54,26 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val highPriorityKinesisConfig: KinesisClientLibConfiguration = KinesisConfig.kinesisConfig(config.kinesisConfig)
   val lowPriorityKinesisConfig: KinesisClientLibConfiguration = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)
 
-  val highPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
-  val lowPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
+  val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
+  val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
   val reingestionSource: Source[(UpdateMessage, Instant), Future[Done]] = ReingestionSource(???)
 
-  val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, actorSystem)
-  val thrallStreamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, thrallEventConsumer, actorSystem, materializer)
+  val thrallEventConsumer = new ThrallEventConsumer(
+    es,
+    thrallMetrics,
+    store,
+    metadataEditorNotifications,
+    actorSystem
+  )
+
+  val thrallStreamProcessor = new ThrallStreamProcessor(
+    uiSource,
+    automationSource,
+    reingestionSource,
+    thrallEventConsumer,
+    actorSystem,
+    materializer
+  )
 
   val streamRunning: Future[Done] = thrallStreamProcessor.run()
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -54,9 +54,10 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val highPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val lowPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
+  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource()
 
-  val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, actorSystem)
-  val thrallStreamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, thrallEventConsumer, actorSystem, materializer)
+  val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es), actorSystem)
+  val thrallStreamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, thrallEventConsumer, actorSystem, materializer)
 
   val streamRunning: Future[Done] = thrallStreamProcessor.run()
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -56,7 +56,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource(???)
+  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource()
 
   val thrallEventConsumer = new ThrallEventConsumer(
     es,

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -58,7 +58,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val lowPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
   val reingestionSource: Source[(UpdateMessage, Instant), Future[Done]] = ReingestionSource(???)
 
-  val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es), actorSystem)
+  val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, actorSystem)
   val thrallStreamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, thrallEventConsumer, actorSystem, materializer)
 
   val streamRunning: Future[Done] = thrallStreamProcessor.run()

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -56,7 +56,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val reingestionSource: Source[(UpdateMessage, Instant), Future[Done]] = ReingestionSource(???)
+  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource(???)
 
   val thrallEventConsumer = new ThrallEventConsumer(
     es,

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -2,6 +2,7 @@ import akka.Done
 import akka.stream.scaladsl.Source
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.contxt.kinesis.{KinesisRecord, KinesisSource}
+import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
@@ -13,6 +14,7 @@ import lib.kinesis.{KinesisConfig, ThrallEventConsumer}
 import play.api.ApplicationLoader.Context
 import router.Routes
 
+import java.time.Instant
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
@@ -54,7 +56,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val highPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val lowPrioritySource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource(es)
+  val reingestionSource: Source[(UpdateMessage, Instant), Future[Done]] = ReingestionSource(???)
 
   val thrallEventConsumer = new ThrallEventConsumer(es, thrallMetrics, store, metadataEditorNotifications, new SyndicationRightsOps(es), actorSystem)
   val thrallStreamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, thrallEventConsumer, actorSystem, materializer)

--- a/thrall/app/lib/ReingestionSource.scala
+++ b/thrall/app/lib/ReingestionSource.scala
@@ -1,0 +1,19 @@
+package lib
+
+import java.time.Instant
+
+import akka.Done
+import akka.stream.scaladsl.Source
+
+import scala.concurrent.Future
+
+case class ReingestionRecord(payload: Array[Byte], approximateArrivalTimestamp: Instant)
+
+//class ReingestionSource extends Source[ReingestionRecord, Future[Done]] {
+//
+//}
+
+
+object ReingestionSource {
+  def apply(): Source[ReingestionRecord, Future[Done]] = ???
+}

--- a/thrall/app/lib/ReingestionSource.scala
+++ b/thrall/app/lib/ReingestionSource.scala
@@ -19,17 +19,21 @@ import scala.concurrent.Future
 case class ReingestionRecord(payload: UpdateMessage, approximateArrivalTimestamp: Instant)
 
 object ReingestionSource {
-  def apply(implicit es: RestClient): Source[ReingestionRecord, Future[Done]] = {
-    implicit val format: JsonFormat[Image] = ???
-    val x = ElasticsearchSource
-      .typed[Image](
-        indexName = "source",
-        typeName = "_doc",
-        query = """{"match_all": {}}"""
-      )
-    val y: Source[ReingestionRecord, NotUsed] = x.map { imageResult: ReadResult[Image] =>
-      ReingestionRecord(UpdateMessage("reproject-image", Some(imageResult.source)), java.time.Instant.now())
-    }
-    y.mapMaterializedValue(_ => Future.successful(Done))
+  def apply(/*implicit es: RestClient*/): Source[ReingestionRecord, Future[Done]] = {
+    // Justin's ideas code
+//    implicit val format: JsonFormat[Image] = ???
+//    val x = ElasticsearchSource
+//      .typed[Image](
+//        indexName = "source",
+//        typeName = "_doc",
+//        query = """{"match_all": {}}"""
+//      )
+//    val y: Source[ReingestionRecord, NotUsed] = x.map { imageResult: ReadResult[Image] =>
+//      ReingestionRecord(UpdateMessage("reproject-image", Some(imageResult.source)), java.time.Instant.now())
+//    }
+//    y.mapMaterializedValue(_ => Future.successful(Done))
+
+    // return empty Source until we implement the above properly
+    Source.empty[ReingestionRecord].mapMaterializedValue(_ => Future.successful(Done))
   }
 }

--- a/thrall/app/lib/ReingestionSource.scala
+++ b/thrall/app/lib/ReingestionSource.scala
@@ -3,17 +3,34 @@ package lib
 import java.time.Instant
 
 import akka.Done
+import akka.stream.alpakka.elasticsearch.ReadResult
+import akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSource
 import akka.stream.scaladsl.Source
+import com.gu.mediaservice.lib.aws.UpdateMessage
+import com.gu.mediaservice.model.Image
+import com.gu.mediaservice.model.Image.ImageReads
+import lib.elasticsearch.ElasticSearch
+import org.elasticsearch.client.RestClient
+import play.api.libs.json.Json
+import spray.json.DefaultJsonProtocol.jsonFormat1
+import spray.json.{JsObject, JsonFormat}
 
 import scala.concurrent.Future
 
 case class ReingestionRecord(payload: Array[Byte], approximateArrivalTimestamp: Instant)
 
-//class ReingestionSource extends Source[ReingestionRecord, Future[Done]] {
-//
-//}
-
-
 object ReingestionSource {
-  def apply(): Source[ReingestionRecord, Future[Done]] = ???
+  def apply(implicit es: RestClient): Source[ReingestionRecord, Future[Done]] = {
+    implicit val format: JsonFormat[Image] = ???
+    val x = ElasticsearchSource
+      .typed[Image](
+        indexName = "source",
+        typeName = "_doc",
+        query = """{"match_all": {}}"""
+      )
+      val y = x.map { imageResult: ReadResult[Image] =>
+        (ReingestionRecord(UpdateMessage("reproject-image", Some(imageResult.source)).toString.getBytes(), java.time.Instant.now()), Future.successful(Done))
+      }
+    y
+  }
 }

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -26,7 +26,13 @@ case object UiPriority extends Priority {
   override def toString = "high"
 }
 
-case class TaggedRecord[T](payload: T,
+/** TaggedRecord represents a message and its associated priority
+  *
+  * Type parameter P represents the type of the payload, so TaggedRecord
+  * can be used to represent both messages from Kinesis and messages
+  * originating within thrall itself
+*/
+case class TaggedRecord[P](payload: P,
                            arrivalTimestamp: Instant,
                            priority: Priority,
                            markProcessed: () => Unit) extends LogMarker {
@@ -38,7 +44,7 @@ case class TaggedRecord[T](payload: T,
     "recordArrivalTime" -> DateTimeUtils.toString (arrivalTimestamp)
   )
 
-  def map[V](f: T => V): TaggedRecord[V] = this.copy(payload = f(payload))
+  def map[V](f: P => V): TaggedRecord[V] = this.copy(payload = f(payload))
 }
 
 class ThrallStreamProcessor(

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -22,45 +22,46 @@ class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matc
   def createKinesisRecord: KinesisRecord = KinesisRecord(ByteString.empty, "", None, "", None, OffsetDateTime.now().toInstant, "")
   def createReingestionRecord: ReingestionRecord = ReingestionRecord(ByteString.empty.toArray, OffsetDateTime.now().toInstant)
 
-  val COUNT_EACH = 2000
-  val highPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
-  val lowPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
-  val reingestionSource: Source[ReingestionRecord, Future[Done.type]] = Source.repeat(createReingestionRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val COUNT_EACH = 2000 // Arbitrary number
+  val uiPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val automationPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val reingestionPrioritySource: Source[ReingestionRecord, Future[Done.type]] = Source.repeat(createReingestionRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
   val COUNT_TOTAL = 3 * COUNT_EACH
 
   lazy val mockConsumer: ThrallEventConsumer = mock[ThrallEventConsumer]
-  lazy val streamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, mockConsumer, actorSystem, materializer)
+  lazy val streamProcessor = new ThrallStreamProcessor(uiPrioritySource, automationPrioritySource, reingestionPrioritySource, mockConsumer, actorSystem, materializer)
 
   describe("Stream merging strategy") {
     it("should process high priority events first") {
       val stream = streamProcessor.createStream()
 
-      val prioritiesFromMessages = Await.result(stream.take(COUNT_TOTAL).runWith(Sink.seq), 5.minutes).map {
-        case (record, _, _) => record.priority
-      }
+      val prioritiesFromMessages =
+        Await.result(stream.take(COUNT_TOTAL).runWith(Sink.seq), 5.minutes)
+          .map {
+            case (record, _, _) => record.priority
+          }
 
       prioritiesFromMessages.length shouldBe COUNT_TOTAL
 
-      // it looks like MergedPreferred doesn't strictly process the `preferred` inlet and then the remaining inlets
-      // but rather, it appears to take some a number from all defined inlets and then the `preferred` inlet
-      // `alternatingSegment` represents this behaviour
-      val alternatingSegment = Seq(LowestPriority, LowPriority, HighPriority)
-
       val output = prioritiesFromMessages.toList
-      val mostlyHigh = output.slice(0, COUNT_EACH - 1)
-      val mostlyLow = output.slice(COUNT_EACH, 2 * COUNT_EACH - 1 )
-      val mostlyLowest = output.slice(2* COUNT_EACH,3 * COUNT_EACH - 1)
+      val mostlyUI = output.slice(0, COUNT_EACH - 1)
+      val mostlyAutomation = output.slice(COUNT_EACH, 2 * COUNT_EACH - 1 )
+      val mostlyReingestion = output.slice(2* COUNT_EACH,3 * COUNT_EACH - 1)
 
+      // This is an arbitrary value - the preference algo in MergedPreferred doesn't strictly process the
+      // `preferred` inlet and then the remaining inlets. It appears to take some a number from all defined inlets
+      // and then the `preferred` inlet until `preferred` is mostly empty.
+      //  Nonetheless the result should be that a high proportion of the highest priority turn up in the first section.
       val PERCENTAGE = 95 / 100
-
       val MINIMUM_RECORDS = COUNT_EACH * PERCENTAGE
-      mostlyHigh.count(p => p == HighPriority) should be > MINIMUM_RECORDS
-      mostlyLow.count(p => p == LowPriority) should be > MINIMUM_RECORDS
-      mostlyLowest.count(p => p == LowestPriority) should be > MINIMUM_RECORDS
 
-      output.count(p => p == HighPriority) should be (COUNT_EACH)
-      output.count(p => p == LowPriority) should be (COUNT_EACH)
-      output.count(p => p == LowestPriority) should be (COUNT_EACH)
+      mostlyUI.count(p => p == UiPriority) should be > MINIMUM_RECORDS
+      mostlyAutomation.count(p => p == AutomationPriority) should be > MINIMUM_RECORDS
+      mostlyReingestion.count(p => p == ReingestionPriority) should be > MINIMUM_RECORDS
+
+      output.count(p => p == UiPriority) should be (COUNT_EACH)
+      output.count(p => p == AutomationPriority) should be (COUNT_EACH)
+      output.count(p => p == ReingestionPriority) should be (COUNT_EACH)
     }
   }
 }

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -15,35 +15,52 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-private class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
+class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
   private implicit val actorSystem: ActorSystem = ActorSystem()
   private implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  def createRecord: KinesisRecord = KinesisRecord(ByteString.empty, "", None, "", None, OffsetDateTime.now().toInstant, "")
+  def createKinesisRecord: KinesisRecord = KinesisRecord(ByteString.empty, "", None, "", None, OffsetDateTime.now().toInstant, "")
+  def createReingestionRecord: ReingestionRecord = ReingestionRecord(ByteString.empty.toArray, OffsetDateTime.now().toInstant)
 
-  val highPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createRecord).mapMaterializedValue(_ => Future.successful(Done)).take(100)
-  val lowPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createRecord).mapMaterializedValue(_ => Future.successful(Done)).take(100)
+  val COUNT_EACH = 2000
+  val highPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val lowPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val reingestionSource: Source[ReingestionRecord, Future[Done.type]] = Source.repeat(createReingestionRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val COUNT_TOTAL = 3 * COUNT_EACH
 
   lazy val mockConsumer: ThrallEventConsumer = mock[ThrallEventConsumer]
-  lazy val streamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, mockConsumer, actorSystem, materializer)
+  lazy val streamProcessor = new ThrallStreamProcessor(highPrioritySource, lowPrioritySource, reingestionSource, mockConsumer, actorSystem, materializer)
 
   describe("Stream merging strategy") {
     it("should process high priority events first") {
       val stream = streamProcessor.createStream()
 
-      val prioritiesFromMessages = Await.result(stream.take(200).runWith(Sink.seq), 5.minutes).map {
+      val prioritiesFromMessages = Await.result(stream.take(COUNT_TOTAL).runWith(Sink.seq), 5.minutes).map {
         case (record, _, _) => record.priority
       }
 
-      prioritiesFromMessages.length shouldBe 200
+      prioritiesFromMessages.length shouldBe COUNT_TOTAL
 
       // it looks like MergedPreferred doesn't strictly process the `preferred` inlet and then the remaining inlets
       // but rather, it appears to take some a number from all defined inlets and then the `preferred` inlet
       // `alternatingSegment` represents this behaviour
-      val alternatingSegment = Seq(LowPriority, HighPriority, LowPriority)
+      val alternatingSegment = Seq(LowestPriority, LowPriority, HighPriority)
 
-      val expected: Seq[Priority] = alternatingSegment ++ (1 to 98).map(_ => HighPriority) ++ alternatingSegment ++ (1 to 96).map(_ => LowPriority)
-      prioritiesFromMessages.toList shouldBe expected.toList
+      val output = prioritiesFromMessages.toList
+      val mostlyHigh = output.slice(0, COUNT_EACH - 1)
+      val mostlyLow = output.slice(COUNT_EACH, 2 * COUNT_EACH - 1 )
+      val mostlyLowest = output.slice(2* COUNT_EACH,3 * COUNT_EACH - 1)
+
+      val PERCENTAGE = 95 / 100
+
+      val MINIMUM_RECORDS = COUNT_EACH * PERCENTAGE
+      mostlyHigh.count(p => p == HighPriority) should be > MINIMUM_RECORDS
+      mostlyLow.count(p => p == LowPriority) should be > MINIMUM_RECORDS
+      mostlyLowest.count(p => p == LowestPriority) should be > MINIMUM_RECORDS
+
+      output.count(p => p == HighPriority) should be (COUNT_EACH)
+      output.count(p => p == LowPriority) should be (COUNT_EACH)
+      output.count(p => p == LowestPriority) should be (COUNT_EACH)
     }
   }
 }

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -1,13 +1,14 @@
 package lib
 
 import java.time.OffsetDateTime
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.util.ByteString
 import com.contxt.kinesis.KinesisRecord
+import com.gu.mediaservice.lib.aws.UpdateMessage
+import com.gu.mediaservice.lib.json.JsonByteArrayUtil
 import lib.kinesis.ThrallEventConsumer
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
@@ -19,17 +20,40 @@ class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matc
   private implicit val actorSystem: ActorSystem = ActorSystem()
   private implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  def createKinesisRecord: KinesisRecord = KinesisRecord(ByteString.empty, "", None, "", None, OffsetDateTime.now().toInstant, "")
-  def createReingestionRecord: ReingestionRecord = ReingestionRecord(ByteString.empty.toArray, OffsetDateTime.now().toInstant)
+  def createKinesisRecord: KinesisRecord = KinesisRecord(
+    data = ByteString(JsonByteArrayUtil.toByteArray(UpdateMessage(subject = "example-kinesis"))),
+    partitionKey = "",
+    explicitHashKey = None,
+    sequenceNumber = "",
+    subSequenceNumber = None,
+    approximateArrivalTimestamp = OffsetDateTime.now().toInstant,
+    encryptionType = ""
+  )
+
+  def createReingestionRecord: ReingestionRecord = ReingestionRecord(
+    payload = UpdateMessage(subject = "example-reingestion"),
+    approximateArrivalTimestamp = OffsetDateTime.now().toInstant
+  )
 
   val COUNT_EACH = 2000 // Arbitrary number
-  val uiPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
-  val automationPrioritySource: Source[KinesisRecord, Future[Done.type]] = Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
-  val reingestionPrioritySource: Source[ReingestionRecord, Future[Done.type]] = Source.repeat(createReingestionRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
   val COUNT_TOTAL = 3 * COUNT_EACH
 
+  val uiPrioritySource: Source[KinesisRecord, Future[Done.type]] =
+    Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val automationPrioritySource: Source[KinesisRecord, Future[Done.type]] =
+    Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val reingestionPrioritySource: Source[ReingestionRecord, Future[Done.type]] =
+    Source.repeat(createReingestionRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+
   lazy val mockConsumer: ThrallEventConsumer = mock[ThrallEventConsumer]
-  lazy val streamProcessor = new ThrallStreamProcessor(uiPrioritySource, automationPrioritySource, reingestionPrioritySource, mockConsumer, actorSystem, materializer)
+  lazy val streamProcessor = new ThrallStreamProcessor(
+    uiPrioritySource,
+    automationPrioritySource,
+    reingestionPrioritySource,
+    mockConsumer,
+    actorSystem,
+    materializer
+  )
 
   describe("Stream merging strategy") {
     it("should process high priority events first") {
@@ -44,20 +68,20 @@ class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matc
       prioritiesFromMessages.length shouldBe COUNT_TOTAL
 
       val output = prioritiesFromMessages.toList
-      val mostlyUI = output.slice(0, COUNT_EACH - 1)
-      val mostlyAutomation = output.slice(COUNT_EACH, 2 * COUNT_EACH - 1 )
-      val mostlyReingestion = output.slice(2* COUNT_EACH,3 * COUNT_EACH - 1)
+      val firstBatch = output.slice(0, COUNT_EACH - 1)
+      val middleBatch = output.slice(COUNT_EACH, 2 * COUNT_EACH - 1 )
+      val lastBatch = output.slice(2* COUNT_EACH,3 * COUNT_EACH - 1)
 
       // This is an arbitrary value - the preference algo in MergedPreferred doesn't strictly process the
       // `preferred` inlet and then the remaining inlets. It appears to take some a number from all defined inlets
       // and then the `preferred` inlet until `preferred` is mostly empty.
       //  Nonetheless the result should be that a high proportion of the highest priority turn up in the first section.
-      val PERCENTAGE = 95 / 100
-      val MINIMUM_RECORDS = COUNT_EACH * PERCENTAGE
+      val PERCENTAGE: Double = 95.0 / 100.0
+      val MINIMUM_RECORDS: Int = (PERCENTAGE * COUNT_EACH).toInt
 
-      mostlyUI.count(p => p == UiPriority) should be > MINIMUM_RECORDS
-      mostlyAutomation.count(p => p == AutomationPriority) should be > MINIMUM_RECORDS
-      mostlyReingestion.count(p => p == ReingestionPriority) should be > MINIMUM_RECORDS
+      firstBatch.count(p => p == UiPriority) should be > MINIMUM_RECORDS
+      middleBatch.count(p => p == AutomationPriority) should be > MINIMUM_RECORDS
+      lastBatch.count(p => p == ReingestionPriority) should be > MINIMUM_RECORDS
 
       output.count(p => p == UiPriority) should be (COUNT_EACH)
       output.count(p => p == AutomationPriority) should be (COUNT_EACH)


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @tjsilver 

## What does this change?
Adds a new input stream for reingestion and changes the original two input stream names to better reflect what they do, resulting in the following in priority order (highest to lowest):

1. `uiSource` (formerly known as 'high priority') - end user actions
2. `automationSource` (formerly known as 'low priority') - e.g. usages, RCS, etc
3. `reingestionSource` (new) 

Everything should continue to process as normal, this is a no-op. There is currently no mechanism to produce messages for the new reingestion source - this will be added in future PRs.

## How can success be measured?
We take messages from the reingestion queue if the other queues are already (near) empty.

## Who should look at this?
@guardian/digital-cms


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
