### PR TITLE
Do not error for syndication rights on images without photoshoots

### DIFF
--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -148,6 +148,7 @@ trait Syndication extends Edit with MessageSubjects {
       .map(dynamoEntry => (dynamoEntry \ Edits.Photoshoot).toOption map {
         photoshootJson => photoshootJson.as[Photoshoot]
       })
+      .recover { case NoItemFound => None }
 
   def publish(imagesInPhotoshoot: Map[String, Option[SyndicationRights]], subject: String)
              (implicit ec: ExecutionContext): Future[Unit] = Future {


### PR DESCRIPTION
## What does this change?
Do not error for syndication rights on images without photoshoots.

## How can success be measured?
Set syndication rights messages (from RCS) do not error if the image has no photoshoot.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
