### PR TITLE
Filter for unprocessable (bad) entities

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -28,6 +28,9 @@ case class MediaUsage(
       // remove events from CAPI that represent images previous to Grid existing
       logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
       false
+    } else if (mediaId.trim.isEmpty) {
+      logger.warn("Unprocessable MediaUsage", this)
+      false
     } else {
       true
     }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -29,7 +29,7 @@ case class MediaUsage(
       logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
       false
     } else if (mediaId.trim.isEmpty) {
-      logger.warn("Unprocessable MediaUsage", this)
+      logger.warn("Unprocessable MediaUsage, mediaId is empty", this)
       false
     } else {
       true
@@ -51,4 +51,3 @@ case class MediaUsage(
     case _ => false
   }
 }
-


### PR DESCRIPTION
## What does this change?
We log at ERROR (and thus set off alarms) when we receive MediaUsage notifications which have an empty mediaId.

This is not helpful, as we can't do anything about them, and the exception propagation means the entire set of updates is abandoned rather than just the bad messages.

```
lib.BadInputException: Empty string received for image id at model.UsageTable.$anonfun$queryByImageId$1(UsageTable.scala:40) 
```

This PR filters out those messages and logs a warning instead.

## How can success be measured?
No more errors, warnings in logs.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
