### PR TITLE
Switch to new syndication

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -157,7 +157,7 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
               val maybeT = (json \ attributeKey).asOpt[T]
               logger.info(s"Obtained a T of $maybeT from json $json")
               maybeT.map(
-                (json \ IdKey).as[String] -> _
+                attributes.get(IdKey).toString -> _
               )
             })
           logger.info(s"Got $results for request")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -147,7 +147,9 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
         else {
           logger.info(s"Fetching records for $request")
           val response = client.batchGetItem(request)
-          val results = response.getResponses.get(tableName).asScala.toList
+          val responses = response.getResponses
+          logger.info(s"Got responses of $responses")
+          val results = responses.get(tableName).asScala.toList
             .flatMap(att => {
               val attributes: util.Map[String, AnyRef] = ItemUtils.toSimpleMapValue(att)
               val json = asJsObject(Item.fromMap(attributes))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -131,7 +131,7 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
              (implicit ex: ExecutionContext): Future[JsValue] =
     get(id, key).map(item => asJsObject(item))
 
-  def batchGet(ids: List[String])
+  def batchGet(ids: List[String], attributeKey: String)
               (implicit ex: ExecutionContext, rjs: Reads[T]): Future[Map[String, T]] = {
     val keyChunkList = ids
       .map(k => Map(IdKey -> new AttributeValue(k)).asJava)
@@ -153,8 +153,7 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
             .flatMap(att => {
               val attributes: util.Map[String, AnyRef] = ItemUtils.toSimpleMapValue(att)
               logger.info(s"Obtained attributes of $attributes from response $att")
-              val json = asJsObject(Item.fromMap(attributes))
-
+              val json = asJsObject(Item.fromMap(attributes)) \ attributeKey
               val maybeT = json.asOpt[T]
               logger.info(s"Obtained a T of $maybeT from json $json")
               maybeT.map(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -152,10 +152,11 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
           val results = responses.get(tableName).asScala.toList
             .flatMap(att => {
               val attributes: util.Map[String, AnyRef] = ItemUtils.toSimpleMapValue(att)
+              logger.info(s"Obtained attributes of $attributes from response $att")
               val json = asJsObject(Item.fromMap(attributes))
 
               val maybeT = json.asOpt[T]
-              logger.debug(s"Obtained a T of $maybeT from json $json")
+              logger.info(s"Obtained a T of $maybeT from json $json")
               maybeT.map(
                 (json \ IdKey).as[String] -> _
               )

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -153,8 +153,8 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
             .flatMap(att => {
               val attributes: util.Map[String, AnyRef] = ItemUtils.toSimpleMapValue(att)
               logger.info(s"Obtained attributes of $attributes from response $att")
-              val json = asJsObject(Item.fromMap(attributes)) \ attributeKey
-              val maybeT = json.asOpt[T]
+              val json = asJsObject(Item.fromMap(attributes))
+              val maybeT = (json \ attributeKey).asOpt[T]
               logger.info(s"Obtained a T of $maybeT from json $json")
               maybeT.map(
                 (json \ IdKey).as[String] -> _

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -49,7 +49,7 @@ class Kinesis(config: KinesisSenderConfig) extends GridLogging{
 
     try {
       val result = kinesisClient.putRecord(request)
-      logger.info(s"Published kinesis message: $result")
+      logger.info(markers, s"Published kinesis message: $result")
     } catch {
       case e: Exception =>
         logger.error(markers, s"kinesis putRecord failed", e)

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -33,6 +33,7 @@ trait Syndication extends Edit with MessageSubjects {
     publishChangedSyndicationRightsMessages[Unit](id, unchangedPhotoshoot = false) { () =>
       for {
         edits <- editsStore.removeKey(id, Edits.Photoshoot)
+        edits <- editsStore.removeKey(id, Edits.PhotoshootTitle)
         _ = publish(id, UpdateImagePhotoshootMetadata)(edits)
       } yield Unit
     }.map(_._1)

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -133,7 +133,7 @@ trait Syndication extends Edit with MessageSubjects with GridLogging {
   def getAllImageRightsInPhotoshoot(photoshoot: Photoshoot)
                                    (implicit ec: ExecutionContext): Future[Map[String, SyndicationRights]] = for {
     imageIds <- getImagesInPhotoshoot(photoshoot)
-    allNonInferredRights <- syndicationStore.batchGet(imageIds)
+    allNonInferredRights <- syndicationStore.batchGet(imageIds, syndicationRightsFieldName)
   } yield {
     logger.info(s"Found non-inferred rights for ${allNonInferredRights.size} of ${imageIds.size} images in photoshoot ${photoshoot.title}")
     val mostRecentInferrableRightsMaybe = getMostRecentSyndicationRights(allNonInferredRights.values.toList)

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -135,6 +135,7 @@ trait Syndication extends Edit with MessageSubjects with GridLogging {
     imageIds <- getImagesInPhotoshoot(photoshoot)
     allNonInferredRights <- syndicationStore.batchGet(imageIds)
   } yield {
+    logger.info(s"Found non-inferred rights for ${allNonInferredRights.size} of ${imageIds.size} images in photoshoot ${photoshoot.title}")
     val mostRecentInferrableRightsMaybe = getMostRecentSyndicationRights(allNonInferredRights.values.toList)
     getRightsForImages(imageIds, allNonInferredRights, mostRecentInferrableRightsMaybe)
   }

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -59,8 +59,7 @@ trait Syndication extends Edit with MessageSubjects {
     _ <- syndicationStore.jsonAdd(id, syndicationRightsFieldName, DynamoDB.caseClassToMap(syndicationRight))
     allImageRightsInPhotoshootAfter <- getAllImageRightsInPhotoshoot(photoshootMaybe)
     changedRights = getChangedRights(allImageRightsInPhotoshootBefore, allImageRightsInPhotoshootAfter)
-// TODO Uncomment to swap to new SyndicationController functionality.
-//    _ <- publish(changedRights, UpdateImageSyndicationMetadata)
+    _ <- publish(changedRights, UpdateImageSyndicationMetadata)
   } yield syndicationRight
 
   def getSyndicationForImage(id: String)

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -107,8 +107,13 @@ trait Syndication extends Edit with MessageSubjects with GridLogging {
     }
 
   private def getRightsForImages(ids: List[String], inferredRights: Option[SyndicationRights])
-                                (implicit ec: ExecutionContext, rjs: Reads[SyndicationRights]): Future[Map[String, SyndicationRights]] =
+                                (implicit ec: ExecutionContext, rjs: Reads[SyndicationRights]): Future[Map[String, SyndicationRights]] = {
       syndicationStore.batchGet(ids)
+        .map( nonInferredRights => inferredRights match {
+          case Some(rights) => nonInferredRights.withDefaultValue(rights)
+          case None => nonInferredRights
+        })
+  }
 
   def getMostRecentSyndicationRights(list: List[SyndicationRights]): Option[SyndicationRights] = list
     .filter(_.published.nonEmpty).sortBy(_.published.map(-_.getMillis)).headOption

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -28,8 +28,8 @@ trait Syndication extends Edit with MessageSubjects with GridLogging {
       newChangedRights = getChangedRights(allImageRightsInNewPhotoshootBefore, allImageRightsInNewPhotoshootAfter)
       _ <- publish(oldChangedRights ++ newChangedRights, UpdateImageSyndicationMetadata)
     } yield {
-      logger.info(s"Changed rights on old photoshoot (${oldPhotoshootMaybe}: ${oldChangedRights.size}")
-      logger.info(s"Changed rights on new photoshoot (${newPhotoshootMaybe}: ${newChangedRights.size}")
+      logger.info(s"Changed rights on old photoshoot ($oldPhotoshootMaybe): ${oldChangedRights.size}")
+      logger.info(s"Changed rights on new photoshoot ($newPhotoshootMaybe): ${newChangedRights.size}")
       result
     }
 
@@ -65,7 +65,7 @@ trait Syndication extends Edit with MessageSubjects with GridLogging {
                               (implicit ec: ExecutionContext): Future[SyndicationRights] =
     publishChangedSyndicationRightsMessages[SyndicationRights](id, unchangedPhotoshoot = true) {() =>
       syndicationStore.jsonAdd (id, syndicationRightsFieldName, DynamoDB.caseClassToMap (syndicationRight)).map(_=>syndicationRight)
-    }.map(_._1)
+    }
 
   def getSyndicationForImage(id: String)
                             (implicit ec: ExecutionContext): Future[Option[SyndicationRights]] = {

--- a/metadata-editor/app/lib/SyndicationStore.scala
+++ b/metadata-editor/app/lib/SyndicationStore.scala
@@ -1,5 +1,6 @@
 package lib
 
 import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.mediaservice.model.SyndicationRights
 
-class SyndicationStore(config: EditsConfig) extends DynamoDB(config, config.syndicationTable)
+class SyndicationStore(config: EditsConfig) extends DynamoDB[SyndicationRights](config, config.syndicationTable)

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -21,15 +21,9 @@ GET     /metadata/:id/usage-rights                      controllers.EditsControl
 PUT     /metadata/:id/usage-rights                      controllers.EditsController.setUsageRights(id: String)
 DELETE  /metadata/:id/usage-rights                      controllers.EditsController.deleteUsageRights(id: String)
 
-# TODO Comment out to swap to new SyndicationController functionality.
-GET     /metadata/:id/photoshoot                        controllers.EditsController.getPhotoshoot(id: String)
-PUT     /metadata/:id/photoshoot                        controllers.EditsController.setPhotoshoot(id: String)
-DELETE  /metadata/:id/photoshoot                        controllers.EditsController.deletePhotoshoot(id: String)
-
-# TODO Uncomment to swap to new SyndicationController functionality.
-#GET     /metadata/:id/photoshoot                        controllers.SyndicationController.getPhotoshoot(id: String)
-#PUT     /metadata/:id/photoshoot                        controllers.SyndicationController.setPhotoshoot(id: String)
-#DELETE  /metadata/:id/photoshoot                        controllers.SyndicationController.deletePhotoshoot(id: String)
+GET     /metadata/:id/photoshoot                        controllers.SyndicationController.getPhotoshoot(id: String)
+PUT     /metadata/:id/photoshoot                        controllers.SyndicationController.setPhotoshoot(id: String)
+DELETE  /metadata/:id/photoshoot                        controllers.SyndicationController.deletePhotoshoot(id: String)
 
 GET     /metadata/:id/syndication                       controllers.SyndicationController.getSyndication(id: String)
 PUT     /metadata/:id/syndication                       controllers.SyndicationController.setSyndication(id: String)

--- a/metadata-editor/test/lib/SyndicationTest.scala
+++ b/metadata-editor/test/lib/SyndicationTest.scala
@@ -1,12 +1,17 @@
 package lib
 
+import com.google.gson.JsonNull
 import com.gu.mediaservice.model._
 import org.joda.time.DateTime
+import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.{JsNull, JsObject, JsString, JsValue, Json}
 
 import scala.util.Random
 import scala.collection.Map
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 
 class SyndicationTest extends FunSpec with Matchers with Syndication with MockitoSugar {
 

--- a/metadata-editor/test/lib/SyndicationTest.scala
+++ b/metadata-editor/test/lib/SyndicationTest.scala
@@ -24,64 +24,48 @@ class SyndicationTest extends FunSpec with Matchers with Syndication with Mockit
 
     it ("should find the latest syndication rights when there is only one") {
       val right = SyndicationRights(Some(DateTime.now()), Nil, Nil)
-      val rights = List(Some(right))
+      val rights = List(right)
       getMostRecentSyndicationRights(rights) should be (Some(right))
     }
 
     it ("should find the latest syndication rights when there is more than one") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(None, Nil, Nil)
-      val rights = List(Some(right1), Some(right2))
+      val rights = List(right1, right2)
       getMostRecentSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there is more than one (swapped over)") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(None, Nil, Nil)
-      val rights = List(Some(right2), Some(right1))
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
-    }
-
-    it ("should find the latest syndication rights when there is more than one (swapped over) and a None mixed in too") {
-      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
-      val right2 = SyndicationRights(None, Nil, Nil)
-      val rights = List(Some(right2), None, Some(right1))
+      val rights = List(right2, right1)
       getMostRecentSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there is more than one with a date") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
-      val rights = List(Some(right1), Some(right2))
+      val rights = List(right1, right2)
       getMostRecentSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there is more than one with a date (swapped over)") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
-      val rights = List(Some(right2), Some(right1))
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
-    }
-
-    it ("should find the latest syndication rights when there is more than one with a date (swapped over) and a None mixed in too") {
-      val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
-      val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
-      val rights = List(Some(right2), None, Some(right1))
+      val rights = List(right2, right1)
       getMostRecentSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there are several with a date (swapped over) and a few Nones mixed in too") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val rights = List(
-        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
-        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
-        None,
-        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
-        Some(right1),
-        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
-        None,
-        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)),
-        Some(SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil))
+        SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
+        SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
+        SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
+        right1,
+        SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
+        SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
+        SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)
       )
       getMostRecentSyndicationRights(rights) should be (Some(right1))
     }
@@ -89,19 +73,19 @@ class SyndicationTest extends FunSpec with Matchers with Syndication with Mockit
 
   describe("Syndication Rights changes functions") {
     it ("Should find the added/removed rights") {
-      val before = List("1" -> Some(SyndicationRights(None, Nil, Nil, false))).toMap
-      val after = List("2" -> Some(SyndicationRights(None, Nil, Nil, false))).toMap
+      val before = List("1" -> SyndicationRights(None, Nil, Nil, false)).toMap
+      val after = List("2" -> SyndicationRights(None, Nil, Nil, false)).toMap
       val difference = Map("1" -> None, "2" -> Some(SyndicationRights(None, Nil, Nil, false)))
       getChangedRights(before, after) should be (difference)
     }
     it ("Should find the (subtly) changed rights") {
       val before = List(
-        "1" -> Some(SyndicationRights(None, Nil, Nil, true)),
-        "2" -> Some(SyndicationRights(None, Nil, Nil, false))
+        "1" -> SyndicationRights(None, Nil, Nil, true),
+        "2" -> SyndicationRights(None, Nil, Nil, false)
       ).toMap
       val after = List(
-        "1" -> Some(SyndicationRights(None, Nil, Nil, false)),
-        "2" -> Some(SyndicationRights(None, Nil, Nil, true))
+        "1" -> SyndicationRights(None, Nil, Nil, false),
+        "2" -> SyndicationRights(None, Nil, Nil, true)
       ).toMap
       val difference = Map("1" -> Some(SyndicationRights(None, Nil, Nil, false)), "2" -> Some(SyndicationRights(None, Nil, Nil, true)))
       getChangedRights(before, after) should be (difference)

--- a/metadata-editor/test/lib/SyndicationTest.scala
+++ b/metadata-editor/test/lib/SyndicationTest.scala
@@ -1,17 +1,12 @@
 package lib
 
-import com.google.gson.JsonNull
 import com.gu.mediaservice.model._
 import org.joda.time.DateTime
-import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
-import play.api.libs.json.{JsNull, JsObject, JsString, JsValue, Json}
 
 import scala.util.Random
 import scala.collection.Map
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, Future}
 
 class SyndicationTest extends FunSpec with Matchers with Syndication with MockitoSugar {
 
@@ -19,41 +14,41 @@ class SyndicationTest extends FunSpec with Matchers with Syndication with Mockit
 
     it ("should find the latest syndication rights when there are none") {
       val rights = List()
-      getMostRecentSyndicationRights(rights) should be (None)
+      getMostRecentInferrableSyndicationRights(rights) should be (None)
     }
 
     it ("should find the latest syndication rights when there is only one") {
       val right = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val rights = List(right)
-      getMostRecentSyndicationRights(rights) should be (Some(right))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right))
     }
 
     it ("should find the latest syndication rights when there is more than one") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(None, Nil, Nil)
       val rights = List(right1, right2)
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there is more than one (swapped over)") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(None, Nil, Nil)
       val rights = List(right2, right1)
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there is more than one with a date") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
-      val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
+      val right2 = SyndicationRights(Some(DateTime.now().minus(100L)), Nil, Nil)
       val rights = List(right1, right2)
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there is more than one with a date (swapped over)") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
-      val right2 = SyndicationRights(Some(DateTime.now().minus(100l)), Nil, Nil)
+      val right2 = SyndicationRights(Some(DateTime.now().minus(100L)), Nil, Nil)
       val rights = List(right2, right1)
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
     }
 
     it ("should find the latest syndication rights when there are several with a date (swapped over) and a few Nones mixed in too") {
@@ -67,27 +62,27 @@ class SyndicationTest extends FunSpec with Matchers with Syndication with Mockit
         SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
         SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)
       )
-      getMostRecentSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
     }
   }
 
   describe("Syndication Rights changes functions") {
     it ("Should find the added/removed rights") {
-      val before = List("1" -> SyndicationRights(None, Nil, Nil, false)).toMap
-      val after = List("2" -> SyndicationRights(None, Nil, Nil, false)).toMap
-      val difference = Map("1" -> None, "2" -> Some(SyndicationRights(None, Nil, Nil, false)))
+      val before = List("1" -> SyndicationRights(None, Nil, Nil)).toMap
+      val after = List("2" -> SyndicationRights(None, Nil, Nil)).toMap
+      val difference = Map("1" -> None, "2" -> Some(SyndicationRights(None, Nil, Nil)))
       getChangedRights(before, after) should be (difference)
     }
     it ("Should find the (subtly) changed rights") {
       val before = List(
-        "1" -> SyndicationRights(None, Nil, Nil, true),
-        "2" -> SyndicationRights(None, Nil, Nil, false)
+        "1" -> SyndicationRights(None, Nil, Nil, isInferred = true),
+        "2" -> SyndicationRights(None, Nil, Nil)
       ).toMap
       val after = List(
-        "1" -> SyndicationRights(None, Nil, Nil, false),
-        "2" -> SyndicationRights(None, Nil, Nil, true)
+        "1" -> SyndicationRights(None, Nil, Nil),
+        "2" -> SyndicationRights(None, Nil, Nil, isInferred = true)
       ).toMap
-      val difference = Map("1" -> Some(SyndicationRights(None, Nil, Nil, false)), "2" -> Some(SyndicationRights(None, Nil, Nil, true)))
+      val difference = Map("1" -> Some(SyndicationRights(None, Nil, Nil)), "2" -> Some(SyndicationRights(None, Nil, Nil, isInferred = true)))
       getChangedRights(before, after) should be (difference)
     }
   }

--- a/metadata-editor/test/lib/SyndicationTest.scala
+++ b/metadata-editor/test/lib/SyndicationTest.scala
@@ -20,35 +20,35 @@ class SyndicationTest extends FunSpec with Matchers with Syndication with Mockit
     it ("should find the latest syndication rights when there is only one") {
       val right = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val rights = List(right)
-      getMostRecentInferrableSyndicationRights(rights) should be (Some(right))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right.copy(isInferred = true)))
     }
 
     it ("should find the latest syndication rights when there is more than one") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(None, Nil, Nil)
       val rights = List(right1, right2)
-      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1.copy(isInferred = true)))
     }
 
     it ("should find the latest syndication rights when there is more than one (swapped over)") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(None, Nil, Nil)
       val rights = List(right2, right1)
-      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1.copy(isInferred = true)))
     }
 
     it ("should find the latest syndication rights when there is more than one with a date") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(Some(DateTime.now().minus(100L)), Nil, Nil)
       val rights = List(right1, right2)
-      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1.copy(isInferred = true)))
     }
 
     it ("should find the latest syndication rights when there is more than one with a date (swapped over)") {
       val right1 = SyndicationRights(Some(DateTime.now()), Nil, Nil)
       val right2 = SyndicationRights(Some(DateTime.now().minus(100L)), Nil, Nil)
       val rights = List(right2, right1)
-      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1.copy(isInferred = true)))
     }
 
     it ("should find the latest syndication rights when there are several with a date (swapped over) and a few Nones mixed in too") {
@@ -62,7 +62,7 @@ class SyndicationTest extends FunSpec with Matchers with Syndication with Mockit
         SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil),
         SyndicationRights(Some(DateTime.now().minus(Math.max(5, Random.nextLong() % 100))), Nil, Nil)
       )
-      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1))
+      getMostRecentInferrableSyndicationRights(rights) should be (Some(right1.copy(isInferred = true)))
     }
   }
 


### PR DESCRIPTION
## What does this change?
The old syndication ops in Thrall relied on the elastic search database as a primary source of syndication and photoshoot information.

The correct architecture is for RCS Poller Lambda to send (RESTful) updates to the (new) syndication service within metadata, which is the primary source, and for metadata to send trivial messages to Thrall, which it will simply persist in ES.

## How can success be measured?
RCS Messages from RCS Poller Lambda are ignored, but messages from Syndication are acted upon.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
