### PR TITLE
Update CollectionsManager.scala so label colours are accessible

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/collections/CollectionsManager.scala
@@ -41,15 +41,16 @@ object CollectionsManager {
   // We could use `ValidationNel`s here, but that's overkill
   def isValidPathBit(s: String) = if (s.contains(delimiter) || s.contains(doublequotes)) false else true
 
+  // These use Source swatches
   val collectionColours = Map(
-    "australia"    -> "#ffb93e",
-    "culture"      -> "#d1008b",
-    "film & music" -> "#b1532f",
-    "g2"           -> "#000000",
-    "guide"        -> "#8F1AB6",
-    "observer"     -> "#006f94",
-    "sport"        -> "#008000",
-    "travel"       -> "#65C5FB"
+    "australia"    -> "#185E36",
+    "culture"      -> "#BB3B80",
+    "film & music" -> "#6B5840",
+    "g2"           -> "#121212",
+    "guide"        -> "#7D0068",
+    "observer"     -> "#052962",
+    "sport"        -> "#22874D",
+    "travel"       -> "#041F4A"
   )
 
   def getCollectionColour(s: String) = collectionColours.get(s)


### PR DESCRIPTION
## What does this change?
Updated the collectionColours to match Source and make Australia and Travel accessible for all users.

## Screenshots
<img width="597" alt="Screenshot 2021-05-04 at 12 48 44" src="https://user-images.githubusercontent.com/45033520/117115080-85fa6500-ad84-11eb-92d8-9a285a024cd5.png">


## Tested?
- [x] checked on figma, not tested
