### PR TITLE
free now means under quota

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -95,7 +95,7 @@ class ElasticSearch(val config: MediaApiConfig, mediaApiMetrics: MediaApiMetrics
     val hasIdentifier = params.hasIdentifier.map(idName => filters.exists(NonEmptyList(identifierField(idName))))
     val missingIdentifier = params.missingIdentifier.map(idName => filters.missing(NonEmptyList(identifierField(idName))))
     val uploadedByFilter = params.uploadedBy.map(uploadedBy => filters.terms("uploadedBy", NonEmptyList(uploadedBy)))
-    val simpleCostFilter = params.free.flatMap(free => if (free) searchFilters.freeFilter else searchFilters.nonFreeFilter)
+    val simpleCostFilter = params.free.flatMap(free => if (free) searchFilters.veryFreeFilter(overQuotaAgencies) else searchFilters.nonFreeFilter)
     val costFilter = params.payType match {
       case Some(PayType.Free) => searchFilters.freeFilter
       case Some(PayType.MaybeFree) => searchFilters.maybeFreeFilter

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -43,6 +43,7 @@ class SearchFilters(config: MediaApiConfig)  extends ImageFields {
   val hasRightsCategoryFilter: Query = filters.existsOrMissing(usageRightsField("category"), exists = true)
 
   val freeFilter: Option[Query] = filterOrFilter(freeSupplierFilter, freeUsageRightsFilter)
+  def veryFreeFilter(overQuotaAgencies: ()=> List[Agency]): Option[Query] = filterAndFilter(freeFilter, Some(IsUnderQuota(overQuotaAgencies())))
   val nonFreeFilter: Option[Query] = freeFilter.map(filters.not)
 
   val maybeFreeFilter: Option[Query] = filterOrFilter(freeFilter, Some(filters.not(hasRightsCategoryFilter)))


### PR DESCRIPTION
## What does this change?
spike to let us explore making free mean under quota. 
also, any UI should probably look at combining the CostFilter with quotas lest we make too much extra complexity here. 

also might be worth adding payType to the UI for chips
## How can success be measured?
this took 3 minutes to implement

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
