### PR TITLE
someBODY once told me to fix the all star cleaner

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -114,6 +114,10 @@ trait CanonicalisingImageProcessor extends ImageProcessor {
   def getCanonicalName(): String
   lazy val canonicalName = getCanonicalName
 
+  private def matches(image: Image):Boolean = {
+    List(image.metadata.byline, image.metadata.credit).flatten.mkString.contains(canonicalName)
+  }
+
   def getPrefixAndSuffix(s:Option[String]): Option[RegexResult]
 
   lazy val agencyName = getAgencyName
@@ -121,7 +125,8 @@ trait CanonicalisingImageProcessor extends ImageProcessor {
   def getAgencyName(): String
 
   // Rules for slash delimited strings: byline, credit and supplier collection.
-  def apply(image: Image): Image = (
+  def apply(image: Image): Image = image match {
+    case _ if matches(image) => (
       dedupeAndCanonicaliseName _ andThen
       moveCanonicalNameFromBylineToCredit andThen
       removeBylineElementsInCredit andThen
@@ -129,6 +134,8 @@ trait CanonicalisingImageProcessor extends ImageProcessor {
       setSupplierCollection andThen
       stripDuplicateByline
     )(image)
+    case _ => image
+  }
 
   // There should only be one instance of the name
   private def dedupeAndCanonicaliseName(image: Image): Image = {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromBylineTest.scala
@@ -12,7 +12,7 @@ class AttributeCreditFromBylineTest extends FunSpec with Matchers with MetadataH
     testCleaner.clean(metadata).credit should be (Some("Some Credit"))
   }
 
-  it("should not set the credit if the byline doesn't matche the configured list") {
+  it("should not set the credit if the byline doesn't match the configured list") {
     val metadata = createImageMetadata("byline" -> "Someone else")
     testCleaner.clean(metadata).credit should be (None)
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromBylineTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/AttributeCreditFromBylineTest.scala
@@ -12,9 +12,14 @@ class AttributeCreditFromBylineTest extends FunSpec with Matchers with MetadataH
     testCleaner.clean(metadata).credit should be (Some("Some Credit"))
   }
 
-  it("should not set the credit if the byline doesn't matches the configured list") {
+  it("should not set the credit if the byline doesn't matche the configured list") {
     val metadata = createImageMetadata("byline" -> "Someone else")
     testCleaner.clean(metadata).credit should be (None)
   }
 
+  it("should not alter the byline if the byline doesn't matche the configured list") {
+    val metadata = createImageMetadata("byline" -> "Someone else","credit"->"Something witless")
+    testCleaner.clean(metadata).credit should be (Some("Something witless"))
+    testCleaner.clean(metadata).byline should be (Some("Someone else"))
+  }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -20,6 +20,13 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
     processedImage.metadata.credit should be (Some("Unknown Party"))
   }
 
+  it("should absolutely not delete the byline when it's the same as the credit"){
+    val image = createImageFromMetadata("credit" -> "Lorem Ipsum", "byline" -> "Lorem Ipsum")
+    val processedImage = applyProcessors(image)
+    processedImage.metadata.byline should be(Some("Lorem Ipsum"))
+    processedImage.metadata.credit should be(Some("Lorem Ipsum"))
+  }
+
   describe("Photographer") {
     it("should match StaffPhotographer byline") {
       val image = createImageFromMetadata("byline" -> "Graham Turner")


### PR DESCRIPTION
## What does this change?

It has been noticed that Allstar supplierProcessor is deduplicating byline whne it equals to credit for all images. This change applies the deduping only to images with Allstar [CanonicalName](https://github.com/guardian/grid/blob/6f0eb2228253b546f6c365da185b47f74511acc6/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala#L80).

A supplier processor is deleting byline when it is equal to credit.
![May-13-2021 17-23-24](https://user-images.githubusercontent.com/2670496/118155345-0d447a00-b410-11eb-8062-89bc0c8388f6.gif)


## How can success be measured?
When the tests pass!

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment

(ps its the allstar processor) 