### PR TITLE
feature/archive-images-permission

### DIFF
--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
@@ -17,7 +17,7 @@
         <gr-library-added-icon class="gr-archiver-status__icon"></gr-library-added-icon>
         <gr-library-remove-icon class="gr-archiver-status__icon"></gr-library-remove-icon>
     </button>
-    <button ng-switch-when="unarchived"
+    <button ng-if="ctrl.canArchive" ng-switch-when="unarchived"
             type="button"
             class="gr-archiver-status__button inner-clickable"
             title="Add to Library"

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
@@ -14,15 +14,20 @@ export const archiver = angular.module('gr.archiverStatus', [
 
 archiver.controller('ArchiverCtrl',
                     ['$scope', '$window', 'archiveService',
-                     'imageLogic', 'humanJoin',
+                     'imageLogic', 'humanJoin', 'mediaApi',
                      function($scope, $window, archiveService,
-                              imageLogic, humanJoin) {
+                              imageLogic, humanJoin, mediaApi) {
 
     const ctrl = this;
 
     ctrl.archive = archive;
     ctrl.unarchive = unarchive;
     ctrl.archiving = false;
+    ctrl.canArchive = false;
+
+    mediaApi.canUserArchive().then(canArchive => {
+        ctrl.canArchive = canArchive;
+    });
 
     $scope.$watch(() => ctrl.image, image => {
         ctrl.archivedState = imageLogic.getArchivedState(image);

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -18,7 +18,7 @@
         <span ng-if="ctrl.archiving">Removing from Library…</span>
     </button>
 
-    <button ng-switch-when="unarchived"
+    <button ng-if="ctrl.canArchive" ng-switch-when="unarchived"
             type="button"
             class="clickable side-padded batch-archive__button"
             ng-click="ctrl.archive()"

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -23,17 +23,24 @@ module.controller('grArchiverCtrl', [
     'imageAccessor',
     'imageLogic',
     'humanJoin',
+    'mediaApi',
     function ($scope,
               $window,
               archiveService,
               imageAccessor,
               imageLogic,
-              humanJoin) {
+              humanJoin,
+              mediaApi) {
 
         const ctrl = this;
 
         ctrl.archivedState = 'unarchived';
         ctrl.archiving = false;
+        ctrl.canArchive = false;
+
+        mediaApi.canUserArchive().then(canArchive => {
+            ctrl.canArchive = canArchive;
+        });
 
         $scope.$watchCollection(getImageArray, (images) => {
             const noneCanBeArchived = ! images.some(imageLogic.canBeArchived);

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -92,6 +92,10 @@ mediaApi.factory('mediaApi',
         return root.getLink('loader').then(() => true, () => false);
     }
 
+    function canUserArchive() {
+        return root.getLink('archive').then(() => true, () => false);
+    }
+
     return {
         root,
         search,
@@ -101,6 +105,7 @@ mediaApi.factory('mediaApi',
         labelSearch,
         labelsSuggest,
         delete: delete_,
-        canUserUpload
+        canUserUpload,
+        canUserArchive
     };
 }]);

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -5,7 +5,7 @@ import com.google.common.net.HttpHeaders
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model.{Action, _}
 import com.gu.mediaservice.lib.auth.Authentication._
-import com.gu.mediaservice.lib.auth.Permissions.{DeleteCrops, DeleteImage => DeleteImagePermission, EditMetadata, UploadImages}
+import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCrops, DeleteImage => DeleteImagePermission, EditMetadata, UploadImages}
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.aws.{S3Metadata, ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting.printDateTime
@@ -69,8 +69,10 @@ class MediaApi(
     )
 
     val userCanUpload: Boolean = authorisation.hasPermissionTo(UploadImages)(user)
+    val userCanArchive: Boolean = authorisation.hasPermissionTo(ArchiveImages)(user)
 
     val maybeLoaderLink: Option[Link] = Some(Link("loader", config.loaderUri)).filter(_ => userCanUpload)
+    val maybeArchiveLink: Option[Link] = Some(Link("archive", s"${config.metadataUri}/metadata/{id}/archived")).filter(_ => userCanArchive)
 
     val indexLinks = List(
       searchLink,
@@ -87,7 +89,7 @@ class MediaApi(
       Link("permissions",     s"${config.rootUri}/permissions"),
       Link("leases",          config.leasesUri),
       Link("admin-tools",     config.adminToolsUri)
-    ) ++ maybeLoaderLink.toList
+    ) ++ maybeLoaderLink.toList ++ maybeArchiveLink.toList
     respond(indexData, indexLinks)
   }
 

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -62,7 +62,7 @@ class EditsController(
   val gridClient: GridClient = GridClient(services)(ws)
 
   val metadataBaseUri = config.services.metadataBaseUri
-
+  private val AuthenticatedAndAuthorised = auth andThen authorisation.CommonActionFilters.authorisedForArchive
   private def getUploader(imageId: String, user: Principal): Future[Option[String]] = gridClient.getUploadedBy(imageId, auth.getOnBehalfOfPrincipal(user))
 
   private def authorisedForEditMetadataOrUploader(imageId: String) = authorisation.actionFilterForUploaderOr(imageId, EditMetadata, getUploader)
@@ -94,7 +94,7 @@ class EditsController(
     }
   }
 
-  def setArchived(id: String) = auth.async(parse.json) { implicit req =>
+  def setArchived(id: String) = AuthenticatedAndAuthorised.async(parse.json) { implicit req =>
     (req.body \ "data").validate[Boolean].fold(
       errors =>
         Future.successful(BadRequest(errors.toString())),

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -3,7 +3,7 @@ package com.gu.mediaservice.lib.auth
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.{MachinePrincipal, Principal, Request, UserPrincipal}
-import com.gu.mediaservice.lib.auth.Permissions.{DeleteImage, EditMetadata, PrincipalFilter, UploadImages}
+import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteImage, EditMetadata, PrincipalFilter, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.AuthorisationProvider
 import play.api.mvc.{ActionFilter, Result, Results}
 
@@ -56,6 +56,7 @@ class Authorisation(provider: AuthorisationProvider, executionContext: Execution
 
   object CommonActionFilters {
     lazy val authorisedForUpload = actionFilterFor(UploadImages)
+    lazy val authorisedForArchive = actionFilterFor(ArchiveImages)
   }
 
   def isUploaderOrHasPermission(

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
@@ -19,4 +19,5 @@ object Permissions {
   case object ShowPaid extends SimplePermission
   case object Pinboard extends SimplePermission // FIXME ideally factor this out in favour of something more generic
   case object UploadImages extends SimplePermission
+  case object ArchiveImages extends SimplePermission
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -57,6 +57,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       case ShowPaid => hasPermission(Permissions.ShowPaid)
       case Pinboard => hasPermission(Permissions.Pinboard)
       case UploadImages => true
+      case ArchiveImages => true
     }
   }
 }


### PR DESCRIPTION
## What does this change?
This implements new permission, _ArchiveImages_, that controls which users can archive images on the Grid. Users without this permission will not be able to see the _Add To Library_ button or access the Archive image endpoint `PUT     metadata-editor-service/metadata/:id/archived`, however, they can see the _Kept in library_ label in the menu bar at the top of the screen in Kahuna in case image is archived 


## How can success be measured?
Given a user has _ArchiveImages_ permission
Then the user should see the "Add to Library" in the menu bar at the top of the screen 

Given a user doesn't have  _ArchiveImages_  permission
Then the user should NOT see the 'Add to Library' button in the menu bar
and cant access The Archive image endpoint `PUT     metadata-editor-service/metadata/:id/archived`
and can see  the _Kept in library_ label in archived images
## Screenshots
- user has _ArchiveImages_  permission
>  unarchived image
![Screenshot from 2021-05-14 10-08-36](https://user-images.githubusercontent.com/33189781/118243566-dc5f5600-b49e-11eb-8a2f-955c45765a66.png)

> archived image
![Screenshot from 2021-05-14 10-09-18](https://user-images.githubusercontent.com/33189781/118243730-0c0e5e00-b49f-11eb-9967-8bbe2af0beb7.png)

- user doesn't have _ArchiveImages_  permission
> unarchived image
![Screenshot from 2021-05-14 10-10-33](https://user-images.githubusercontent.com/33189781/118243899-411ab080-b49f-11eb-98ca-3b87bcb148a9.png)
> archived image
![Screenshot from 2021-05-14 10-09-45](https://user-images.githubusercontent.com/33189781/118243949-51329000-b49f-11eb-83b5-de7ae4b3bc1d.png)





<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
