### PR TITLE
Unknown text for user without Edit Metadata permission

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -235,10 +235,10 @@
                 </span>
             </dd>
 
-            <dt class="image-info__group--dl__key metadata-line__key image-info__wrap">
+            <dt ng-if="ctrl.metadata.peopleInImage || ctrl.userCanEdit" class="image-info__group--dl__key metadata-line__key image-info__wrap">
                 People
             </dt>
-            <dd class="image-info__wrap image-info__group--dl__value metadata-line__info">
+            <dd ng-if="ctrl.metadata.peopleInImage || ctrl.userCanEdit" class="image-info__wrap image-info__group--dl__value metadata-line__info">
                 <button data-cy="it-edit-people-button"
                         class="image-info__edit"
                         ng-if="ctrl.userCanEdit"


### PR DESCRIPTION
## What does this change?
Currently, when a user doesn't have Edit Metadata permission and they open an image without peopleInImage field, they can see the text "Unknown (click ✎ to add)", even when they don't have the ✎ button because of their permissions. This hides the People field for those users (only when the field is empty).

## How can success be measured?
A user without Edit Metadata permission cannot see the text "Unknown (click ✎ to add)" in the Image Metadata section, and instead doesn't see the field.

## Screenshots
Current behaviour:
![image](https://user-images.githubusercontent.com/20479781/118294729-66b0b580-b4b1-11eb-8bcc-d5d1f4320cfb.png)

Behaviour after the fix:
![image](https://user-images.githubusercontent.com/20479781/118294557-3832da80-b4b1-11eb-9191-b568911acf21.png)

## Who should look at this?
@guardian/digital-cms

## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
