### PR TITLE
Fix BBC test dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ val okHttpVersion = "3.12.1"
 val bbcBuildProcess: Boolean = System.getenv().asScala.get("BUILD_ORG").contains("bbc")
 
 //BBC specific project, it only gets compiled when bbcBuildProcess is true
-lazy val bbcProject = project("bbc").dependsOn(restLib)
+lazy val bbcProject = project("bbc").dependsOn(restLib % "compile->compile;test->test")
 
 val maybeBBCLib: Option[sbt.ProjectReference] = if(bbcBuildProcess) Some(bbcProject) else None
 
@@ -124,7 +124,7 @@ lazy val restLib = project("rest-lib").settings(
   ),
 
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
-).dependsOn(commonLib)
+).dependsOn(commonLib % "compile->compile;test->test")
 
 lazy val auth = playProject("auth", 9011)
 


### PR DESCRIPTION
## What does this change?
Currently there is a compilation failure on BBC's tests caused by an inability to access common-lib's traits in the test folder. This change allows BBC (and other external projects depending on rest-lib) to access common-lib's and rest-lib's test folders.

See https://stackoverflow.com/questions/8193904/sbt-test-dependencies-in-multiprojects-make-the-test-code-available-to-dependen and https://www.scala-sbt.org/release/docs/Multi-Project.html#Per-configuration+classpath+dependencies for more info on the problem and solution

## How can success be measured?
sbt test:compile runs successfully on BBC and Guardian

## Who should look at this?
@guardian/digital-cms


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
