### PR TITLE
Make the PR branch script more forceful

### DIFF
--- a/dev/script/push-pr.sh
+++ b/dev/script/push-pr.sh
@@ -11,6 +11,6 @@ fi
 
 PR=$1
 
-echo "Pushing PR $PR to origin"
-git fetch origin pull/${PR}/merge:pr${PR}
-git push origin pr${PR}:pr${PR}
+echo "Pushing PR merge commit for ${PR} to remote pr${PR} branch"
+git fetch -f origin pull/${PR}/merge:pr${PR}
+git push -f origin pr${PR}:pr${PR}


### PR DESCRIPTION
## What does this change?
Previously this script wouldn't work if the PR committer had already force pushed. This tweak forces the fetch and push so that it will never fail.

This seems safe since we are only ever touching specifically named branches.
