### PR TITLE
Extract Staff Photographer Organisation to config

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -38,7 +38,8 @@ class KahunaController(
       config.invalidSessionHelpLink,
       config.supportEmail,
       fieldAliases,
-      config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists))
+      config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists)),
+      config.staffPhotographerOrganisation
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -28,6 +28,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)
   val invalidSessionHelpLink: Option[String]= stringOpt("links.invalidSessionHelp").filterNot(_.isEmpty)
   val supportEmail: Option[String]= stringOpt("links.supportEmail").filterNot(_.isEmpty)
+  val staffPhotographerOrganisation: String = stringOpt("branding.staffPhotographerOrganisation").filterNot(_.isEmpty).getOrElse("GNM")
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources")

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -11,7 +11,8 @@
   invalidSessionHelpLink: Option[String],
   supportEmail: Option[String],
   fieldAliases: String,
-  scriptsToLoad: List[ScriptToLoad]
+  scriptsToLoad: List[ScriptToLoad],
+  staffPhotographerOrganisation: String
 )
 <!DOCTYPE html>
 <html>
@@ -49,6 +50,7 @@
           usageRightsHelpLink: "@Html(usageRightsHelpLink.getOrElse(""))",
           invalidSessionHelpLink: "@Html(invalidSessionHelpLink.getOrElse(""))",
           supportEmail: "@Html(supportEmail.getOrElse(""))",
+          staffPhotographerOrganisation: "@Html(staffPhotographerOrganization)",
           fieldAliases: @Html(fieldAliases)
         }
     </script>

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -50,7 +50,7 @@
           usageRightsHelpLink: "@Html(usageRightsHelpLink.getOrElse(""))",
           invalidSessionHelpLink: "@Html(invalidSessionHelpLink.getOrElse(""))",
           supportEmail: "@Html(supportEmail.getOrElse(""))",
-          staffPhotographerOrganisation: "@Html(staffPhotographerOrganization)",
+          staffPhotographerOrganisation: "@Html(staffPhotographerOrganisation)",
           fieldAliases: @Html(fieldAliases)
         }
     </script>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -55,7 +55,7 @@ image.controller('uiPreviewImageCtrl', [
     ctrl.states = imageService(ctrl.image).states;
 
     ctrl.imageDescription = ctrl.states.isStaffPhotographer ?
-        `GNM-owned: ${ctrl.image.data.metadata.description}` :
+        `${window._clientConfig.staffPhotographerOrganisation}-owned: ${ctrl.image.data.metadata.description}` :
         ctrl.image.data.metadata.description;
 
     ctrl.flagState = ctrl.states.costState;

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -75,10 +75,12 @@ const fileTypes = [
     'png'
 ];
 
+const staffPhotographerOrganisation = window._clientConfig.staffPhotographerOrganisation;
+
 const isSearch = [
-  'GNM-owned-photo',
-  'GNM-owned-illustration',
-  'GNM-owned',
+    `${staffPhotographerOrganisation}-owned-photo`,
+    `${staffPhotographerOrganisation}-owned-illustration`,
+    `${staffPhotographerOrganisation}-owned`,
   'under-quota'
 ];
 

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -69,4 +69,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfig(resour
   val syndicationStartDate: Option[DateTime] = Try {
     stringOpt("syndication.start").map(d => DateTime.parse(d).withTimeAtStartOfDay())
   }.toOption.flatten
+
+  val staffPhotographerOrganisation: String = stringOpt("branding.staffPhotographerOrganisation").filterNot(_.isEmpty).getOrElse("GNM")
 }

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -54,7 +54,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies) match {
+      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies, config.staffPhotographerOrganisation) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           logger.info(s"Cannot perform IS query on ${condition.value}")

--- a/media-api/app/lib/elasticsearch/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/SyndicationFilter.scala
@@ -54,7 +54,7 @@ class SyndicationFilter(config: MediaApiConfig) extends ImageFields {
     filters.date("syndicationRights.published", None, Some(DateTime.now)).get
   )
 
-  private val syndicatableCategory: Query = IsOwnedPhotograph.query
+  private val syndicatableCategory: Query = IsOwnedPhotograph(config.staffPhotographerOrganisation).query
 
   def statusFilter(status: SyndicationStatus): Query = status match {
     case SentForSyndication => filters.and(

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -15,9 +15,9 @@ trait ConditionFixtures {
 
   val hasFieldCondition = Match(HasField, HasValue("foo"))
 
-  val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph.toString))
-  val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration.toString))
-  val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage.toString))
+  val isOwnedPhotoCondition = Match(IsField, IsValue(IsOwnedPhotograph("GNM").toString))
+  val isOwnedIllustrationCondition = Match(IsField, IsValue(IsOwnedIllustration("GNM").toString))
+  val isOwnedImageCondition = Match(IsField, IsValue(IsOwnedImage("GNM").toString))
   val isUnderQuotaCondition = Match(IsField, IsValue(IsUnderQuota(Nil).toString))
   val isInvalidCondition = Match(IsField, IsValue("a-random-string"))
 


### PR DESCRIPTION
## What does this change?
When an image is from a staff photographer, this allows to configure the alt text the image will show as "{staffOrg}-owned: ..." instead of "GNM-owned: ..."

## How can success be measured?
- The Guardian still sees the alt text as "GNM-owned: ..."
- BBC sees the alt text as "BBC-owned: ..."

## Screenshots
![image](https://user-images.githubusercontent.com/20479781/118814404-8287d300-b886-11eb-9e77-647ae86003d9.png)

## Who should look at this?
@guardian/digital-cms


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
