### PR TITLE
Moved Xenial AMI to Bionic as it is no longer supported

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -95,7 +95,7 @@ deployments:
         ImgOpsAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-imgops
+          Recipe: grid-imgops-bionic
 
   elasticsearch-ami-update:
     type: ami-cloudformation-parameter
@@ -108,7 +108,7 @@ deployments:
         ElasticSearchAMI:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-elasticsearch
+          Recipe: grid-elasticsearch-bionic
 
   s3watcher:
     type: aws-lambda

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -87,7 +87,7 @@ deployments:
         AmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: editorial-tools-xenial-java8
+          Recipe: editorial-tools-bionic-java8
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

**Update:** `grid-imgops` and `grid-elasticsearch` recipes have now also been replaced with newly baked recipes.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## Has it been successfully deployed?

Yes, [here](**url**). All seems to be working well.
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to [TEST](https://media.test.dev-gutools.co.uk/search) via RiffRaff (it's under `media-service::grid::all`), and ensure it deploys and runs correctly.