### PR TITLE
Let's think about reingestion / multi indexing

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchConfig.scala
@@ -1,3 +1,3 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-case class ElasticSearchConfig(alias: String, url: String, cluster: String, shards: Int, replicas: Int)
+case class ElasticSearchConfig(alias: String, accretorAlias: String, url: String, cluster: String, shards: Int, replicas: Int)

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -17,7 +17,7 @@ trait MessageSubjects {
   val DeleteUsages = "delete-usages"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"
   val UpdateImagePhotoshootMetadata = "update-image-photoshoot-metadata"
-
+  val ReingestNewIndex = "reindex-image"
 }
 
 object MessageSubjects extends MessageSubjects

--- a/dev/script/generate-config/package-lock.json
+++ b/dev/script/generate-config/package-lock.json
@@ -1,8 +1,159 @@
 {
   "name": "generate-config",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "aws-sdk": "^2.874.0",
+        "dotenv": "^9.0.2",
+        "json5": "^2.2.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.907.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.907.0.tgz",
+      "integrity": "sha512-P1gth8sVqXCIjKN78kyD3OosEzqUSYxDG04Cpp2wVGx/djsd5OSv4NkayOhKZ5OMXwk6IdA82oXV/HQR8EjbwQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "aws-sdk": {
       "version": "2.907.0",

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -21,6 +21,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
 
   val es6Config: ElasticSearchConfig = ElasticSearchConfig(
     alias = config.imagesAlias,
+    accretorAlias = config.imageAccretorIndex,
     url = config.elasticsearch6Url,
     cluster = config.elasticsearch6Cluster,
     shards = config.elasticsearch6Shards,

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -23,6 +23,7 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfig(resour
   val recordDownloadAsUsage: Boolean = boolean("image.record.download")
 
   val imagesAlias: String = string("es.index.aliases.read")
+  val imageAccretorIndex: String = string ("es.index.aliases.accretor") //nb spelt correctly
 
   val elasticsearch6Url: String =  string("es6.url")
   val elasticsearch6Cluster: String = string("es6.cluster")

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -24,6 +24,7 @@ class MessageProcessor(es: ElasticSearch,
     updateMessage.subject match {
       case Image => indexImage(updateMessage, logMarker)
       case ReingestImage => indexImage(updateMessage, logMarker)
+      case ReingestNewIndex => reingestImage(updateMessage, logMarker)
       case DeleteImage => deleteImage(updateMessage, logMarker)
       case UpdateImage => indexImage(updateMessage, logMarker)
       case DeleteImageExports => deleteImageExports(updateMessage, logMarker)
@@ -54,9 +55,9 @@ class MessageProcessor(es: ElasticSearch,
     }
   }
 
-  private def reindexImage(message: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) = {
-    logger.info(logMarker, s"Reindexing image: ${message.image.map(_.id).getOrElse("image not found")}")
-    indexImage(message, logMarker)
+  private def reingestImage(message: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) = {
+    logger.info(logMarker, s"Reingesting image: ${message.image.map(_.id).getOrElse("image not found")}")
+    indexImage(message, logMarker, true)
   }
 
   private def indexImage(message: UpdateMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =


### PR DESCRIPTION
## 🖋 Whither index/alias

So, to reingest an image, we'll need some kind of multi-index support. Just enough to be able to manually write to a second index. 

This really needs a sensible name. 

## 👻 Ghost of reindex past

In this work, we've been a little lax about whether to call it _reindex_ or _reinest_, and we were similarly lax when we did the past (different) reindexing work. We'll need to either rip out that logic, or keep both sets but be strict.

## 🧵 Thrall

I don't think that the current way that thrall passes messages is great for this work. Discussing with @sihil, we thought about moving from a giant optional fieldy json with a string tag to some kind of `trait`/`case class` combo- where each message type has its own object. 

Right now, I'm just using the `image` field on the multi-purpose object to start the reingest for now.

## 🤷‍♂️ What I'm looking for?

I'd like to get some opinions on this all so I can start carding out parts. I'm thinking:

1) Typesafe messages in thrall
	a) Delete past reindexer from thrall
1) Spare alias configured and available for multi-index running.
1) Reindex an image into the spare.