### PR TITLE
Add classes to dropdown menu options

### DIFF
--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -5,8 +5,8 @@
         <gr-icon>more_vert</gr-icon>
     </button>
     <ul class="drop-menu__items drop-menu__items--right" ng-if="showUserActions">
-        <li><a href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
-        <li><a href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
-        <li><a href="{{ctrl.logoutUri}}" target="_self">Logout</a></li>
+        <li><a class="drop-menu__items__quotas" href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
+        <li><a class="drop-menu__items__feedback" href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
+        <li><a class="drop-menu__items__logout" href="{{ctrl.logoutUri}}" target="_self">Logout</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
## What does this change?
Add classes to dropdown menu options. The BBC would like to hide the Quotas button for the moment, and it will do so by targeting the specific class for that button and hiding it with specific BBC css.

## How can success be measured?
The Guardian can see the Quotas button, while BBC cannot.

## Screenshots
![image](https://user-images.githubusercontent.com/20479781/119184987-79486300-ba4c-11eb-9f3b-e91897df633a.png)


## Who should look at this?
@guardian/digital-cms


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
