### PR TITLE
rename reindex/reingest to 'migration' and introduce new message type for starting a migration

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ExternalThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ExternalThrallMessage.scala
@@ -1,0 +1,92 @@
+package com.gu.mediaservice.model
+
+import com.gu.mediaservice.model.leases.MediaLease
+import com.gu.mediaservice.model.usage.UsageNotice
+import org.joda.time.{DateTime, DateTimeZone}
+import play.api.libs.json
+import play.api.libs.json.{JodaReads, JodaWrites, JsValue, Json, Reads}
+
+
+sealed trait ExternalThrallMessage extends ThrallMessage {
+  implicit val yourJodaDateReads: Reads[DateTime] = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
+  implicit val yourJodaDateWrites: json.JodaWrites.JodaDateTimeWrites.type = JodaWrites.JodaDateTimeWrites
+  val id: String
+  val lastModified: DateTime
+  def toJson: JsValue = Json.toJson(this)(ExternalThrallMessage.writes)
+
+  override def markerContents: Map[String, Any] = {
+    val message = Json.stringify(toJson)
+    super.markerContents ++ Map (
+      "id" -> id,
+      "size" -> message.getBytes.length,
+      "length" -> message.length
+    )
+  }
+}
+
+object ExternalThrallMessage{
+  implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
+  implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
+
+  implicit val usageNoticeFormat = Json.format[UsageNotice]
+
+  implicit val replaceImageLeasesMessageFormat = Json.format[ReplaceImageLeasesMessage]
+  implicit val deleteImageMessageFormat = Json.format[DeleteImageMessage]
+  implicit val updateImageSyndicationMetadataMessageFormat = Json.format[UpdateImageSyndicationMetadataMessage]
+  implicit val setImageCollectionsMessageFormat = Json.format[SetImageCollectionsMessage]
+  implicit val updateImageUserMetadataMessageFormat = Json.format[UpdateImageUserMetadataMessage]
+  implicit val deleteImageExportsMessageFormat = Json.format[DeleteImageExportsMessage]
+  implicit val softDeleteImageMessageFormat = Json.format[SoftDeleteImageMessage]
+  implicit val imageMessageFormat = Json.format[ImageMessage]
+  implicit val updateImagePhotoshootMetadataMessage = Json.format[UpdateImagePhotoshootMetadataMessage]
+  implicit val deleteUsagesMessage = Json.format[DeleteUsagesMessage]
+  implicit val updateImageUsagesMessage = Json.format[UpdateImageUsagesMessage]
+  implicit val addImageLeaseMessage = Json.format[AddImageLeaseMessage]
+  implicit val removeImageLeaseMessage = Json.format[RemoveImageLeaseMessage]
+  implicit val updateImageExportsMessage = Json.format[UpdateImageExportsMessage]
+  implicit val writes = Json.writes[ExternalThrallMessage]
+
+}
+
+
+
+case class ImageMessage(lastModified: DateTime, image: Image) extends ExternalThrallMessage {
+  override def additionalMarkers: () => Map[String, Any] = ()=>
+    Map("fileName" -> image.source.file.toString)
+
+  override val id: String = image.id
+}
+
+case class DeleteImageMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
+
+case class SoftDeleteImageMessage(id: String, lastModified: DateTime, softDeletedMetadata: SoftDeletedMetadata) extends ExternalThrallMessage
+
+case class DeleteImageExportsMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
+
+case class UpdateImageExportsMessage(id: String, lastModified: DateTime, crops: Seq[Crop]) extends ExternalThrallMessage
+
+case class UpdateImageUserMetadataMessage(id: String, lastModified: DateTime, edits: Edits) extends ExternalThrallMessage
+
+case class UpdateImageUsagesMessage(id: String, lastModified: DateTime, usageNotice: UsageNotice) extends ExternalThrallMessage
+
+case class ReplaceImageLeasesMessage(id: String, lastModified: DateTime, leases: Seq[MediaLease]) extends ExternalThrallMessage
+
+case class AddImageLeaseMessage(id: String, lastModified: DateTime, lease: MediaLease) extends ExternalThrallMessage
+
+case class RemoveImageLeaseMessage(id: String, lastModified: DateTime, leaseId: String) extends ExternalThrallMessage
+
+case class SetImageCollectionsMessage(id: String, lastModified: DateTime, collections: Seq[Collection]) extends ExternalThrallMessage
+
+case class DeleteUsagesMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
+
+object DeleteUsagesMessage {
+  implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
+  implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites
+  implicit val what = Json.format[DeleteUsagesMessage]
+}
+
+case class UpdateImageSyndicationMetadataMessage(id: String, lastModified: DateTime, maybeSyndicationRights: Option[SyndicationRights]) extends ExternalThrallMessage
+
+case class UpdateImagePhotoshootMetadataMessage(id: String, lastModified: DateTime, edits: Edits) extends ExternalThrallMessage
+
+

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/InternalThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/InternalThrallMessage.scala
@@ -1,0 +1,17 @@
+package com.gu.mediaservice.model
+
+import org.joda.time.DateTime
+
+sealed trait InternalThrallMessage extends ThrallMessage {
+
+}
+
+/**
+  * Message to start a new 'migration' (for re-index, re-ingestion etc.)
+  * @param migrationStart timestamp representing when a migration commenced
+  * @param gitHash the git commit hash (of the grid repo) at the point the migration commenced
+  */
+case class CreateMigrationIndexMessage(
+  migrationStart: DateTime,
+  gitHash: String
+) extends InternalThrallMessage

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -1,85 +1,16 @@
 package com.gu.mediaservice.model
 
- import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
- import com.gu.mediaservice.model.leases.MediaLease
- import com.gu.mediaservice.model.usage.UsageNotice
- import org.joda.time.{DateTime, DateTimeZone}
- import play.api.libs.json
- import play.api.libs.json.{JodaReads, JodaWrites, Json, OFormat, OWrites, Reads, __}
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 
-sealed trait ThrallMessage extends GridLogging with LogMarker {
-  val subject: String = this.getClass.getSimpleName()
-  val id: String
-  val lastModified: DateTime
-  val additionalMarkers: Map[String, Any] = Map()
-  def toJson = Json.toJson(this)
+trait ThrallMessage extends GridLogging with LogMarker {
+  val subject: String = this.getClass.getSimpleName
+  def additionalMarkers: () => Map[String, Any] = () => Map()
 
-  override def markerContents = {
-    val message = Json.stringify(Json.toJson(this)(ThrallMessage.formats))
+  override def markerContents: Map[String, Any] = {
     Map (
-      "subject" -> subject,
-      "id" -> id,
-      "size" -> message.getBytes.length,
-      "length" -> message.length
+      "subject" -> subject
     )
   }
 }
-object ThrallMessage{
-  implicit val yourJodaDateReads: Reads[DateTime] = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
-  implicit val yourJodaDateWrites: json.JodaWrites.JodaDateTimeWrites.type = JodaWrites.JodaDateTimeWrites
-
-  implicit val usageNoticeFormat: OFormat[UsageNotice] = Json.format[UsageNotice]
-  implicit val replaceImageLeasesMessageFormat: OFormat[ReplaceImageLeasesMessage] = Json.format[ReplaceImageLeasesMessage]
-  implicit val deleteImageMessageFormat: OFormat[DeleteImageMessage] = Json.format[DeleteImageMessage]
-  implicit val softDeleteImageMessageFormat: OFormat[SoftDeleteImageMessage] = Json.format[SoftDeleteImageMessage]
-  implicit val updateImageSyndicationMetadataMessageFormat: OFormat[UpdateImageSyndicationMetadataMessage] = Json.format[UpdateImageSyndicationMetadataMessage]
-  implicit val setImageCollectionsMessageFormat: OFormat[SetImageCollectionsMessage] = Json.format[SetImageCollectionsMessage]
-  implicit val updateImageUserMetadataMessageFormat: OFormat[UpdateImageUserMetadataMessage] = Json.format[UpdateImageUserMetadataMessage]
-  implicit val deleteImageExportsMessageFormat: OFormat[DeleteImageExportsMessage] = Json.format[DeleteImageExportsMessage]
-  implicit val imageMessageFormat: OFormat[ImageMessage] = Json.format[ImageMessage]
-  implicit val updateImagePhotoshootMetadataMessage: OFormat[UpdateImagePhotoshootMetadataMessage] = Json.format[UpdateImagePhotoshootMetadataMessage]
-  implicit val deleteUsagesMessage: OFormat[DeleteUsagesMessage] = Json.format[DeleteUsagesMessage]
-  implicit val updateImageUsagesMessage: OFormat[UpdateImageUsagesMessage] = Json.format[UpdateImageUsagesMessage]
-  implicit val addImageLeaseMessage: OFormat[AddImageLeaseMessage] = Json.format[AddImageLeaseMessage]
-  implicit val removeImageLeaseMessage: OFormat[RemoveImageLeaseMessage] = Json.format[RemoveImageLeaseMessage]
-  implicit val updateImageExportsMessage: OFormat[UpdateImageExportsMessage] = Json.format[UpdateImageExportsMessage]
-  implicit val formats: OFormat[ThrallMessage] = Json.format[ThrallMessage]
-}
-
-
-
-case class ImageMessage(lastModified: DateTime, image: Image) extends ThrallMessage {
-  override val additionalMarkers = {
-    Map("fileName" -> image.source.file.toString)
-  }
-  override val id = image.id
-}
-
-case class DeleteImageMessage(id: String, lastModified: DateTime) extends ThrallMessage
-
-case class SoftDeleteImageMessage(id: String, lastModified: DateTime, softDeletedMetadata: SoftDeletedMetadata) extends ThrallMessage
-
-case class DeleteImageExportsMessage(id: String, lastModified: DateTime) extends ThrallMessage
-
-case class UpdateImageExportsMessage(id: String, lastModified: DateTime, crops: Seq[Crop]) extends ThrallMessage
-
-case class UpdateImageUserMetadataMessage(id: String, lastModified: DateTime, edits: Edits) extends ThrallMessage
-
-case class UpdateImageUsagesMessage(id: String, lastModified: DateTime, usageNotice: UsageNotice) extends ThrallMessage
-
-case class ReplaceImageLeasesMessage(id: String, lastModified: DateTime, leases: Seq[MediaLease]) extends ThrallMessage
-
-case class AddImageLeaseMessage(id: String, lastModified: DateTime, lease: MediaLease) extends ThrallMessage
-
-case class RemoveImageLeaseMessage(id: String, lastModified: DateTime, leaseId: String) extends ThrallMessage
-
-case class SetImageCollectionsMessage(id: String, lastModified: DateTime, collections: Seq[Collection]) extends ThrallMessage
-
-case class DeleteUsagesMessage(id: String, lastModified: DateTime) extends ThrallMessage
-
-case class UpdateImageSyndicationMetadataMessage(id: String, lastModified: DateTime, maybeSyndicationRights: Option[SyndicationRights]) extends ThrallMessage
-
-case class UpdateImagePhotoshootMetadataMessage(id: String, lastModified: DateTime, edits: Edits) extends ThrallMessage
-
 
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -3,7 +3,7 @@ package com.gu.mediaservice.syntax
 trait MessageSubjects {
 
   val Image = "image"
-  val ReingestImage = "reingest-image" // FIXME: this will conflict with reingest, suggest remove
+  val ReingestImage = "reingest-image" // FIXME: the new migration process will replace the legacy reingest lambda etc
   val DeleteImage = "delete-image"
   val SoftDeleteImage = "soft-delete-image"
   val UpdateImage = "update-image" // TODO: this appears unused https://logs.gutools.co.uk/s/editorial-tools/goto/f0a03ca3c37261985b2e6292adb8de0f

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/ExternalThrallMessageTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/ExternalThrallMessageTest.scala
@@ -7,16 +7,16 @@ import org.scalatest.prop.{Checkers, PropertyChecks}
 import org.scalatest.{FreeSpec, Matchers}
 import play.api.libs.json.{JsArray, JsSuccess, Json}
 
-class ThrallMessageTest extends FreeSpec with Matchers with Checkers with PropertyChecks {
-  //This doesn't test any messsage contents as we assume they have their own checks.
+class ExternalThrallMessageTest extends FreeSpec with Matchers with Checkers with PropertyChecks {
+  //This doesn't test any message contents as we assume they have their own checks.
   val now = DateTime.now(DateTimeZone.forOffsetHours(9))
   val nowUtc = new DateTime(now.getMillis()).toDateTime(DateTimeZone.UTC)
 
-  def roundTrip(m: ThrallMessage) = {
+  def roundTrip(m: ExternalThrallMessage) = {
     val json = m.toJson
     val string = Json.stringify(json)
     val parsed = Json.parse(string)
-    val reformed = parsed.validate[ThrallMessage]
+    val reformed = parsed.validate[ExternalThrallMessage](Json.reads[ExternalThrallMessage])
     reformed should equal(JsSuccess(m))
   }
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -48,7 +48,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val reingestionSource: Source[ReingestionRecord, Future[Done]] = ReingestionSource()
+  val migrationSource: Source[MigrationRecord, Future[Done]] = MigrationSource()
 
   val thrallEventConsumer = new ThrallEventConsumer(
     es,
@@ -61,7 +61,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val thrallStreamProcessor = new ThrallStreamProcessor(
     uiSource,
     automationSource,
-    reingestionSource,
+    migrationSource,
     thrallEventConsumer,
     actorSystem,
     materializer

--- a/thrall/app/lib/MigrationSource.scala
+++ b/thrall/app/lib/MigrationSource.scala
@@ -16,10 +16,10 @@ import spray.json.{JsObject, JsonFormat}
 
 import scala.concurrent.Future
 
-case class ReingestionRecord(payload: UpdateMessage, approximateArrivalTimestamp: Instant)
+case class MigrationRecord(payload: UpdateMessage, approximateArrivalTimestamp: Instant)
 
-object ReingestionSource {
-  def apply(/*implicit es: RestClient*/): Source[ReingestionRecord, Future[Done]] = {
+object MigrationSource {
+  def apply(/*implicit es: RestClient*/): Source[MigrationRecord, Future[Done]] = {
     // Justin's ideas code
 //    implicit val format: JsonFormat[Image] = ???
 //    val x = ElasticsearchSource
@@ -28,12 +28,12 @@ object ReingestionSource {
 //        typeName = "_doc",
 //        query = """{"match_all": {}}"""
 //      )
-//    val y: Source[ReingestionRecord, NotUsed] = x.map { imageResult: ReadResult[Image] =>
-//      ReingestionRecord(UpdateMessage("reproject-image", Some(imageResult.source)), java.time.Instant.now())
+//    val y: Source[MigrationRecord, NotUsed] = x.map { imageResult: ReadResult[Image] =>
+//      MigrationRecord(UpdateMessage("migrate-image", Some(imageResult.source)), java.time.Instant.now())
 //    }
 //    y.mapMaterializedValue(_ => Future.successful(Done))
 
     // return empty Source until we implement the above properly
-    Source.empty[ReingestionRecord].mapMaterializedValue(_ => Future.successful(Done))
+    Source.empty[MigrationRecord].mapMaterializedValue(_ => Future.successful(Done))
   }
 }

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -10,7 +10,7 @@ import com.contxt.kinesis.KinesisRecord
 import com.gu.mediaservice.lib.DateTimeUtils
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging._
-import com.gu.mediaservice.model.ThrallMessage
+import com.gu.mediaservice.model.ExternalThrallMessage
 import lib.kinesis.{MessageTranslator,ThrallEventConsumer}
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -99,7 +99,7 @@ class ThrallStreamProcessor(
     SourceShape(mergePreferred.out)
   })
 
-  def createStream(): Source[(TaggedRecord[UpdateMessage], Stopwatch, Either[Throwable, ThrallMessage]), NotUsed] = {
+  def createStream(): Source[(TaggedRecord[UpdateMessage], Stopwatch, Either[Throwable, ExternalThrallMessage]), NotUsed] = {
     mergedKinesisSource.map{ taggedRecord =>
       taggedRecord -> MessageTranslator.translate(taggedRecord.payload)
     }.mapAsync(1) { result =>

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -20,7 +20,7 @@ class MessageProcessor(es: ElasticSearch,
                        metadataEditorNotifications: MetadataEditorNotifications,
                       ) extends GridLogging with MessageSubjects {
 
-  def process(updateMessage: ThrallMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
+  def process(updateMessage: ExternalThrallMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     updateMessage match {
       case message: ImageMessage => indexImage(message, logMarker)
       case message: DeleteImageMessage => deleteImage(message, logMarker)

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -2,11 +2,11 @@ package lib.kinesis
 
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging.GridLogging
-import com.gu.mediaservice.model.{AddImageLeaseMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, ThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
+import com.gu.mediaservice.model.{AddImageLeaseMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, ExternalThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
 import com.gu.mediaservice.syntax.MessageSubjects._
 
 object MessageTranslator extends GridLogging {
-  def translate(updateMessage: UpdateMessage): Either[Throwable, ThrallMessage] = {
+  def translate(updateMessage: UpdateMessage): Either[Throwable, ExternalThrallMessage] = {
     updateMessage.subject match {
       case Image | ReingestImage | UpdateImage =>
         updateMessage.image match {
@@ -18,7 +18,7 @@ object MessageTranslator extends GridLogging {
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
       case SoftDeleteImage => (updateMessage.id, updateMessage.softDeletedMetadata) match {
-        case (Some(id) , Some(deletedMetadata)) => Right(SoftDeleteImageMessage(id, updateMessage.lastModified ,deletedMetadata))
+        case (Some(id) , Some(deletedMetadata)) => Right(SoftDeleteImageMessage(id, updateMessage.lastModified, deletedMetadata))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
       case DeleteImageExports => (updateMessage.id) match {

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.json.{JsonByteArrayUtil, PlayJsonHelpers}
 import com.gu.mediaservice.lib.logging._
-import com.gu.mediaservice.model.ThrallMessage
+import com.gu.mediaservice.model.ExternalThrallMessage
 import com.gu.mediaservice.model.usage.UsageNotice
 import lib._
 import lib.elasticsearch._
@@ -35,7 +35,7 @@ class ThrallEventConsumer(es: ElasticSearch,
   private implicit val executionContext: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
 
-  def processUpdateMessage(updateMessage: ThrallMessage): Future[ThrallMessage]  = {
+  def processUpdateMessage(updateMessage: ExternalThrallMessage): Future[ExternalThrallMessage]  = {
     val marker = updateMessage
 
     val stopwatch = Stopwatch.start

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -30,8 +30,8 @@ class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matc
     encryptionType = ""
   )
 
-  def createReingestionRecord: ReingestionRecord = ReingestionRecord(
-    payload = UpdateMessage(subject = "example-reingestion"),
+  def createMigrationRecord: MigrationRecord = MigrationRecord(
+    payload = UpdateMessage(subject = "example-migration"),
     approximateArrivalTimestamp = OffsetDateTime.now().toInstant
   )
 
@@ -42,14 +42,14 @@ class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matc
     Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
   val automationPrioritySource: Source[KinesisRecord, Future[Done.type]] =
     Source.repeat(createKinesisRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
-  val reingestionPrioritySource: Source[ReingestionRecord, Future[Done.type]] =
-    Source.repeat(createReingestionRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
+  val migrationPrioritySource: Source[MigrationRecord, Future[Done.type]] =
+    Source.repeat(createMigrationRecord).mapMaterializedValue(_ => Future.successful(Done)).take(COUNT_EACH)
 
   lazy val mockConsumer: ThrallEventConsumer = mock[ThrallEventConsumer]
   lazy val streamProcessor = new ThrallStreamProcessor(
     uiPrioritySource,
     automationPrioritySource,
-    reingestionPrioritySource,
+    migrationPrioritySource,
     mockConsumer,
     actorSystem,
     materializer
@@ -81,11 +81,11 @@ class ThrallStreamProcessorTest extends FunSpec with BeforeAndAfterAll with Matc
 
       firstBatch.count(p => p == UiPriority) should be > MINIMUM_RECORDS
       middleBatch.count(p => p == AutomationPriority) should be > MINIMUM_RECORDS
-      lastBatch.count(p => p == ReingestionPriority) should be > MINIMUM_RECORDS
+      lastBatch.count(p => p == MigrationPriority) should be > MINIMUM_RECORDS
 
       output.count(p => p == UiPriority) should be (COUNT_EACH)
       output.count(p => p == AutomationPriority) should be (COUNT_EACH)
-      output.count(p => p == ReingestionPriority) should be (COUNT_EACH)
+      output.count(p => p == MigrationPriority) should be (COUNT_EACH)
     }
   }
 }


### PR DESCRIPTION
## What does this change?

This sets the name of the reingestion to "migration" for want of a unique name.

This takes #3319 and adds an Internal/External distinction, so that when we send messages over kinesis in this form, we don't send Migration ones.

Internal messages refer to those originating from within thrall (which is a new thing). External refers to those messages coming into thrall from outside via the kinesis streams (which is all the existing types of messages handled by thrall).

## Context 

We intend to replace the current aliases `read` and `write` (see #3362) with:
- `Images_Current` _which will be the primary index_
- `Images_Migration` _which will be the index into which the migration is written_

Then, when this message is processed by thrall it will:
1. Check for the `Images_Migration` alias, and halt if present. 
2. Create a new index called `images_YYYY-MM-DDTHH:mm:ss_GITHASH`
3. Point the `Images_Migration` alias at this index.

We then, on all writes, will write the name of this index to a marker field on the elasticsearch record. 

Then on all reads, we'll [augment the response](https://github.com/guardian/grid/blob/6dbe1b6124511b4196d70b44893a8ac4850814a4/media-api/app/lib/ImageResponse.scala#L94-L107)
 with 
```ts
{
	...
	esInfo: {
		migratedTo: ['images'...],
		sourceAlias: 'Images_Migration',
		aliasMappings: {
			Images_Current: 'images....',
			Images_Migration: 'images2...'
		}
	}
}
```
Which will make a nice enough way to understand the migration status of an image. This will be especially usefully initially when we're testing multi-read and multi-write.

## How can success be measured?
- inspection
- a series of unit tests which will shortly be written

## Screenshots
Here is the jamboard between @sihil and I, detailing this.
<img width="2375" alt="image" src="https://user-images.githubusercontent.com/2670496/119377529-245b5580-bcb5-11eb-9a23-f7edb29a0db6.png">



## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
