### PR TITLE
Add configurable homeLinkHtml

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -39,7 +39,8 @@ class KahunaController(
       config.supportEmail,
       fieldAliases,
       config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists)),
-      config.staffPhotographerOrganisation
+      config.staffPhotographerOrganisation,
+      config.homeLinkHtml
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -29,6 +29,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val invalidSessionHelpLink: Option[String]= stringOpt("links.invalidSessionHelp").filterNot(_.isEmpty)
   val supportEmail: Option[String]= stringOpt("links.supportEmail").filterNot(_.isEmpty)
   val staffPhotographerOrganisation: String = stringOpt("branding.staffPhotographerOrganisation").filterNot(_.isEmpty).getOrElse("GNM")
+  val homeLinkHtml: Option[String] = stringOpt("branding.homeLinkHtml").filterNot(_.isEmpty)
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources")

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -12,7 +12,8 @@
   supportEmail: Option[String],
   fieldAliases: String,
   scriptsToLoad: List[ScriptToLoad],
-  staffPhotographerOrganisation: String
+  staffPhotographerOrganisation: String,
+  homeLinkHtml: Option[String]
 )
 <!DOCTYPE html>
 <html>
@@ -51,7 +52,8 @@
           invalidSessionHelpLink: "@Html(invalidSessionHelpLink.getOrElse(""))",
           supportEmail: "@Html(supportEmail.getOrElse(""))",
           staffPhotographerOrganisation: "@Html(staffPhotographerOrganisation)",
-          fieldAliases: @Html(fieldAliases)
+          fieldAliases: @Html(fieldAliases),
+          homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))'
         }
     </script>
 

--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
@@ -22,7 +22,7 @@ topBar.directive('grTopBarNav', [function() {
         transclude: true,
         // Annoying to have to hardcode root route here, but only
         // way I found to clear $stateParams from uiRouter...
-        template: `<a href="/search" class="home-link" title="Home">Home</a>
+        template: `${window._clientConfig.homeLinkHtml || '<a href="/search" class="home-link" title="Home">Home</a>'}
                    <ng:transclude></ng:transclude>`
     };
 }]);


### PR DESCRIPTION
## What does this change?
This allows to add a different html for the home link via configuration. 

This is needed for the BBC because it is required to have 2 home link buttons instead of one. 

If the configuration is empty, the default value in the js file is used.

## How can success be measured?
The Guardian can see no difference in the UI with this change.
BBC sees 2 home buttons instead of one.

## Screenshots
BBC view:
![BBC Images - Top Nav LIVE](https://user-images.githubusercontent.com/20479781/119535936-eadf2480-bd5e-11eb-9e06-73284f4f4ffb.png)


## Who should look at this?
@guardian/digital-cms


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
