### PR TITLE
Change warning message in usage deletion

### DIFF
--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
@@ -36,9 +36,9 @@ deleteUsages.controller('grDeleteUsagesCtrl', [
 
         const superSure = $window.prompt(
           stripMargin`
-            |You're about to delete the ALL USAGES for this image.
-            |This will NOT remove the image from content,
-            |however it will remove it from Grid's database.
+            |You’re about to delete ALL USAGE INFORMATION for this image.
+            |This will NOT remove the image from places it’s been used in,
+            |but it WILL remove all the details of who and where used it.
             |
             |Enter ${deleteConfirmText} below to confirm.
             |`


### PR DESCRIPTION
## What does this change?
This changes the alert message that pops up when trying to delete an image's usages. The text change is intended to remove ambiguity and make clear that the image itself won't be deleted, only the usages.

## How can success be measured?
The text shown in the alert displays the following text:

You're about to delete ALL USAGE INFORMATION for this image.
This will NOT remove the image from places it's been used in, but it WILL remove all the details of who and where used it.
Enter DELETE below to confirm

## Who should look at this?
@guardian/digital-cms

## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
