### PR TITLE
Configure suppliers through UsageRightsConfigurationProvider

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -93,5 +93,7 @@ usageRightsConfigProvider = {
       "CC BY-SA-4.0",
       "CC BY-ND-4.0"
     ]
+    freeSuppliers = []
+    suppliersCollectionExcl {}
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -98,6 +98,10 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
    *        "CC BY-SA-4.0",
    *        "CC BY-ND-4.0"
    *      ]
+   *      freeSuppliers = ["Supplier 1", "Supplier 2"]
+   *      suppliersCollectionExcl {
+   *        Supplier 1 = ["Coll 1", "Coll 2"]
+   *      }
    *    }
    *   }
    * }}}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/UsageRightsConfig.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.config
 
 import com.gu.mediaservice.model.{ContractPhotographer, Photographer, StaffPhotographer}
+import com.typesafe.config.Config
 import play.api.{ConfigLoader, Configuration}
 
 import scala.collection.JavaConverters._
@@ -29,6 +30,8 @@ trait UsageRightsConfigProvider extends Provider {
   val contractIllustrators: List[PublicationPhotographers]
   val staffIllustrators: List[String]
   val creativeCommonsLicense: List[String]
+  val freeSuppliers: List[String]
+  val suppliersCollectionExcl: Map[String, List[String]]
 
   // this is lazy in order to ensure it is initialised after the values above are defined
   lazy val staffPhotographers: List[PublicationPhotographers] = UsageRightsConfigProvider.flattenPublicationList(
@@ -51,90 +54,6 @@ trait UsageRightsConfigProvider extends Provider {
       case PublicationPhotographers(name, photographers) if photographers.map(_.toLowerCase) contains lookup.toLowerCase() => Some(lookup, name)
       case _ => None
     }.find(_.isDefined).flatten
-
-  /* These are currently hardcoded */
-  val payGettySourceList = List(
-    "Arnold Newman Collection",
-    "360cities.net Editorial",
-    "360cities.net RM",
-    "age fotostock RM",
-    "Alinari",
-    "Arnold Newman Collection",
-    "ASAblanca",
-    "Bob Thomas Sports Photography",
-    "Carnegie Museum of Art",
-    "Catwalking",
-    "Contour",
-    "Contour RA",
-    "Corbis Premium Historical",
-    "Editorial Specials",
-    "Reportage Archive",
-    "Gamma-Legends",
-    "Genuine Japan Editorial Stills",
-    "Genuine Japan Creative Stills",
-    "George Steinmetz",
-    "Getty Images Sport Classic",
-    "Iconic Images",
-    "Iconica",
-    "Icon Sport",
-    "Kyodo News Stills",
-    "Lichfield Studios Limited",
-    "Lonely Planet Images",
-    "Lonely Planet RF",
-    "Masters",
-    "Major League Baseball Platinum",
-    "Moment Select",
-    "Mondadori Portfolio Premium",
-    "National Geographic",
-    "National Geographic RF",
-    "National Geographic Creative",
-    "National Geographic Magazines",
-    "NBA Classic",
-    "Neil Leifer Collection",
-    "Newspix",
-    "PA Images",
-    "Papixs",
-    "Paris Match Archive",
-    "Paris Match Collection",
-    "Pele 10",
-    "Photonica",
-    "Photonica World",
-    "Popperfoto",
-    "Popperfoto Creative",
-    "Premium Archive",
-    "Reportage Archive",
-    "SAMURAI JAPAN",
-    "Sports Illustrated",
-    "Sports Illustrated Classic",
-    "Sygma Premium",
-    "Terry O'Neill",
-    "The Asahi Shimbun Premium",
-    "The LIFE Premium Collection",
-    "ullstein bild Premium",
-    "Ulrich Baumgarten",
-    "VII Premium",
-    "Vision Media",
-    "Xinhua News Agency"
-  )
-
-  val freeSuppliers = List(
-    "AAP",
-    "Alamy",
-    "Allstar Picture Library",
-    "AP",
-    "EPA",
-    "Getty Images",
-    "PA",
-    "Reuters",
-    "Rex Features",
-    "Ronald Grant Archive",
-    "Action Images",
-    "Action Images/Reuters"
-  )
-
-  val suppliersCollectionExcl = Map(
-    "Getty Images" -> payGettySourceList
-  )
 }
 
 
@@ -157,4 +76,17 @@ class RuntimeUsageRightsConfig(configuration: Configuration) extends UsageRights
   val contractIllustrators: List[PublicationPhotographers] = configuration.getOptional[List[PublicationPhotographers]]("contractIllustrators").getOrElse(Nil)
   val staffIllustrators: List[String] = configuration.getOptional[Seq[String]]("staffIllustrators").map(_.toList).getOrElse(Nil)
   val creativeCommonsLicense: List[String] = configuration.getOptional[Seq[String]]("creativeCommonsLicense").map(_.toList).getOrElse(Nil)
+  val freeSuppliers: List[String] = configuration.getOptional[Seq[String]]("freeSuppliers").map(_.toList).getOrElse(Nil)
+  val suppliersCollectionExcl: Map[String, List[String]] = if (configuration.has("suppliersCollectionExcl")) {
+    val suppliersCollectionExclConfig: Config = configuration
+      .underlying
+      .getConfig("suppliersCollectionExcl")
+    suppliersCollectionExclConfig
+      .entrySet()
+      .asScala
+      .map(entry => (entry.getKey, suppliersCollectionExclConfig.getStringList(entry.getKey).asScala.toList))
+      .toMap
+  } else {
+    Map.empty[String, List[String]]
+  }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -128,4 +128,88 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
     "CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0"
   )
 
+  /* These are currently hardcoded */
+  val payGettySourceList = List(
+    "Arnold Newman Collection",
+    "360cities.net Editorial",
+    "360cities.net RM",
+    "age fotostock RM",
+    "Alinari",
+    "Arnold Newman Collection",
+    "ASAblanca",
+    "Bob Thomas Sports Photography",
+    "Carnegie Museum of Art",
+    "Catwalking",
+    "Contour",
+    "Contour RA",
+    "Corbis Premium Historical",
+    "Editorial Specials",
+    "Reportage Archive",
+    "Gamma-Legends",
+    "Genuine Japan Editorial Stills",
+    "Genuine Japan Creative Stills",
+    "George Steinmetz",
+    "Getty Images Sport Classic",
+    "Iconic Images",
+    "Iconica",
+    "Icon Sport",
+    "Kyodo News Stills",
+    "Lichfield Studios Limited",
+    "Lonely Planet Images",
+    "Lonely Planet RF",
+    "Masters",
+    "Major League Baseball Platinum",
+    "Moment Select",
+    "Mondadori Portfolio Premium",
+    "National Geographic",
+    "National Geographic RF",
+    "National Geographic Creative",
+    "National Geographic Magazines",
+    "NBA Classic",
+    "Neil Leifer Collection",
+    "Newspix",
+    "PA Images",
+    "Papixs",
+    "Paris Match Archive",
+    "Paris Match Collection",
+    "Pele 10",
+    "Photonica",
+    "Photonica World",
+    "Popperfoto",
+    "Popperfoto Creative",
+    "Premium Archive",
+    "Reportage Archive",
+    "SAMURAI JAPAN",
+    "Sports Illustrated",
+    "Sports Illustrated Classic",
+    "Sygma Premium",
+    "Terry O'Neill",
+    "The Asahi Shimbun Premium",
+    "The LIFE Premium Collection",
+    "ullstein bild Premium",
+    "Ulrich Baumgarten",
+    "VII Premium",
+    "Vision Media",
+    "Xinhua News Agency"
+  )
+
+  val freeSuppliers = List(
+    "AAP",
+    "Alamy",
+    "Allstar Picture Library",
+    "AP",
+    "EPA",
+    "Getty Images",
+    "PA",
+    "Reuters",
+    "Rex Features",
+    "Ronald Grant Archive",
+    "Action Images",
+    "Action Images/Reuters"
+  )
+
+  val suppliersCollectionExcl = Map(
+    "Getty Images" -> payGettySourceList
+  )
+
 }

--- a/common-lib/src/test/resources/application.conf
+++ b/common-lib/src/test/resources/application.conf
@@ -52,5 +52,7 @@ usageRightsConfigProvider = {
     contractIllustrators = []
     staffIllustrators = []
     creativeCommonsLicense = []
+    freeSuppliers = []
+    suppliersCollectionExcl {}
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/config/PhotographersConfigTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/config/PhotographersConfigTest.scala
@@ -29,7 +29,11 @@ class PhotographersConfigTest extends FreeSpec with Matchers {
             Map("name" -> "Company B", "photographers" -> List("CC")),
           ),
           "staffIllustrators" -> List("S", "SS"),
-          "creativeCommonsLicense" -> List("CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0")
+          "creativeCommonsLicense" -> List("CC BY-4.0", "CC BY-SA-4.0", "CC BY-ND-4.0"),
+          "freeSuppliers" -> List("S1", "S2"),
+          "suppliersCollectionExcl" -> Map(
+            "S1" -> List("S1Coll1", "S1Coll2")
+          )
         )
       )
     ))
@@ -59,6 +63,12 @@ class PhotographersConfigTest extends FreeSpec with Matchers {
 
       conf.creativeCommonsLicense.nonEmpty shouldBe true
       conf.creativeCommonsLicense.length shouldBe 3
+
+      conf.freeSuppliers.nonEmpty shouldBe true
+      conf.freeSuppliers.length shouldBe 2
+
+      conf.suppliersCollectionExcl.nonEmpty shouldBe true
+      conf.suppliersCollectionExcl.keySet.size shouldBe 1
     }
 
     "should return staff photographers" in {
@@ -102,6 +112,19 @@ class PhotographersConfigTest extends FreeSpec with Matchers {
     "should not return photographer" in {
       val photographer = conf.getPhotographer("D")
       photographer.isEmpty shouldBe true
+    }
+
+    "should return suppliers" in {
+      val freeSuppliers = conf.freeSuppliers
+      freeSuppliers.contains("S1") shouldBe true
+      freeSuppliers.contains("S2") shouldBe true
+    }
+
+    "should return suppliersExclColl" in {
+      val suppliersCollectionExcl = conf.suppliersCollectionExcl
+      suppliersCollectionExcl.get("S1") shouldBe defined
+      suppliersCollectionExcl("S1").nonEmpty shouldBe true
+      suppliersCollectionExcl("S1").length shouldBe 2
     }
   }
 


### PR DESCRIPTION
## What does this change?

Introduces the ability to define a list of suppliers via the `UsageRightsConfigurationProvider` implementation, allowing adopters to specify their own suppliers. Builds on [Add pluggable usage rights configuration PR](https://github.com/guardian/grid/pull/3279) that allows the configuration of usage rights via UsageRightsConfigurationProvider. 

This new ability is achieved by moving the current existing list of Guardian suppliers to `GuardianUsageRightsConfig` and adding `freeSuppliers` and `suppliersCollectionExcl` abstract fields to the `UsageRightsConfigurationProvider` trait so that any provider extending the trait can implement the fields as they wish e.g. `GuardianUsageRightsConfig` from code and `RuntimeUsageRightsConfig` from  `application.conf`.

## How can success be measured?

From the sample configuration, the following suppliers _("Supplier One", "Supplier Two", "Supplier Three" and "Supplier N")_ should be visible on the UI during image search by supplier and configuring the `Agency` usage right on an image.

```hocon
usageRightsConfigProvider = {
  className: "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig"
  config {
    externalStaffPhotographers = []
    internalStaffPhotographers = []
    contractedPhotographers = []
    contractIllustrators = []
    staffIllustrators = []
    creativeCommonsLicense = [
      "CC BY-4.0",
      "CC BY-SA-4.0",
      "CC BY-ND-4.0"
    ]
    freeSuppliers = [
      "Supplier One",
      "Supplier Two",
      "Supplier Three",
      "Supplier N"
    ]
    suppliersCollectionExcl {
        Supplier One = ["Coll1", "Coll2"]
     }
  }
}
```

## Screenshots

### Image search supplier hint

![Search](https://user-images.githubusercontent.com/12212239/119644095-2cd29e00-be25-11eb-821b-6540a3a1e686.png)

### Usage right selection - Image view

![Usage right selection - Image view](https://user-images.githubusercontent.com/12212239/119644188-44118b80-be25-11eb-8ccc-2a5a46741919.png)


### Usage right selection - My Uploads

![Usage right selection - My Uploads](https://user-images.githubusercontent.com/12212239/119644228-5095e400-be25-11eb-88e6-9db83027d909.png)

## Who should look at this?

@AWare and @guardian/digital-cms

## Tested?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
