### PR TITLE
Manually parse fixture id into suppliers ref for reuters, getty, epa and ap images only

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -363,20 +363,32 @@ object PaParser extends ImageProcessor {
 }
 
 object ReutersParser extends ImageProcessor {
+  def extractFixtureID(image:Image) = image.fileMetadata.iptc.get("Fixture Identifier")
+
   def apply(image: Image): Image = image.metadata.credit match {
+
     // Reuters and other misspellings
     // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
     case Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUETRS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("via Reuters") => image.copy(
       usageRights = Agency("Reuters"),
-      metadata = image.metadata.copy(credit = Some("Reuters"))
+      metadata = image.metadata.copy(
+        credit = Some("Reuters"),
+        suppliersReference = extractFixtureID(image) orElse image.metadata.suppliersReference
+      )
     )
     // Others via Reuters
     case Some("USA TODAY Sports") => image.copy(
-      metadata = image.metadata.copy(credit = Some("USA Today Sports")),
+      metadata = image.metadata.copy(
+        credit = Some("USA Today Sports"),
+        suppliersReference = extractFixtureID(image) orElse image.metadata.suppliersReference
+      ),
       usageRights = Agency("Reuters")
     )
     case Some("USA Today Sports") | Some("TT NEWS AGENCY") => image.copy(
-      usageRights = Agency("Reuters")
+      usageRights = Agency("Reuters"),
+      metadata = image.metadata.copy(
+        suppliersReference = extractFixtureID(image) orElse image.metadata.suppliersReference
+      )
     )
     case _ => image
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -312,7 +312,7 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
 
     val isExcludedByCredit = image.metadata.credit.exists(isExcluded(_, excludedCredit))
     val isExcludedBySource = image.metadata.source.exists(isExcluded(_, excludedSource))
-    val hasGettyMetadata = image.fileMetadata.getty.nonEmpty && getSuppliersReference(image).nonEmpty
+    val hasGettyMetadata = image.fileMetadata.getty.nonEmpty
 
 
     if(!hasGettyMetadata){

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -312,7 +312,7 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
 
     val isExcludedByCredit = image.metadata.credit.exists(isExcluded(_, excludedCredit))
     val isExcludedBySource = image.metadata.source.exists(isExcluded(_, excludedSource))
-    val hasGettyMetadata = image.fileMetadata.getty.nonEmpty
+    val hasGettyMetadata = image.fileMetadata.getty.nonEmpty && getSuppliersReference(image).nonEmpty
 
 
     if(!hasGettyMetadata){

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -237,14 +237,22 @@ object ApParser extends ImageProcessor {
   val InvisionFor = "^invision for (.+)".r
   val PersonInvisionAp = "(.+)\\s*/invision/ap$".r
 
+  def getSuppliersReference(image: Image) = {
+    image.fileMetadata.readXmpHeadStringProp("xmp.plus:ImageSupplierImageID").orElse(image.metadata.suppliersReference)
+    // This is also available in a more structured way
+    // https://github.com/guardian/grid/pull/3328#issuecomment-849080100
+    // But that field is json so let's not.
+  }
+
   def apply(image: Image): Image = image.metadata.credit.map(_.toLowerCase) match {
     case Some("ap") | Some("associated press") => image.copy(
       usageRights = Agency("AP"),
-      metadata    = image.metadata.copy(credit = Some("AP"))
+      metadata    = image.metadata.copy(credit = Some("AP"), suppliersReference = getSuppliersReference(image))
     )
     case Some("invision") | Some("invision/ap") |
          Some(InvisionFor(_)) | Some(PersonInvisionAp(_)) => image.copy(
-      usageRights = Agency("AP", Some("Invision"))
+      usageRights = Agency("AP", Some("Invision")),
+      metadata = image.metadata.copy(suppliersReference = getSuppliersReference(image))
     )
     case _ => image
   }
@@ -260,9 +268,13 @@ object CorbisParser extends ImageProcessor {
 }
 
 object EpaParser extends ImageProcessor {
+  def getSuppliersReference(image: Image) = {
+    image.fileMetadata.iptc.get("Unique Document Identifier").orElse(image.metadata.suppliersReference)
+  }
   def apply(image: Image): Image = image.metadata.credit match {
     case Some(x) if x.matches(".*\\bEPA\\b.*") => image.copy(
-      usageRights = Agency("EPA")
+      usageRights = Agency("EPA"),
+      metadata = image.metadata.copy(suppliersReference = getSuppliersReference(image))
     )
     case _ => image
   }
@@ -275,6 +287,11 @@ trait GettyProcessor {
 }
 
 object GettyXmpParser extends ImageProcessor with GettyProcessor {
+  def getSuppliersReference(image: Image)={
+    // String defined in ImageMetadataConvertor
+    image.fileMetadata.getty.get("Asset ID").orElse(image.metadata.suppliersReference)
+  }
+
   def apply(image: Image): Image = {
     val excludedCredit = List(
       "Replay Images", "newspix international", "i-images", "photoshot", "Ian Jones", "Photo News/Panoramic",
@@ -297,13 +314,23 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
     val isExcludedBySource = image.metadata.source.exists(isExcluded(_, excludedSource))
     val hasGettyMetadata = image.fileMetadata.getty.nonEmpty
 
-    if(!hasGettyMetadata || isExcludedByCredit || isExcludedBySource) {
+
+    if(!hasGettyMetadata){
       image
+    } else if(isExcludedByCredit || isExcludedBySource) {
+      image.copy(
+        metadata = image.metadata.copy(
+          suppliersReference = getSuppliersReference(image)
+        )
+      )
     } else {
       image.copy(
         usageRights = gettyAgencyWithCollection(image.metadata.source),
         // Set a default "credit" for when Getty is too lazy to provide one
-        metadata    = image.metadata.copy(credit = Some(image.metadata.credit.getOrElse("Getty Images")))
+        metadata = image.metadata.copy(
+          credit = Some(image.metadata.credit.getOrElse("Getty Images")),
+          suppliersReference = getSuppliersReference(image)
+        )
       )
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -72,6 +72,7 @@ object ImageMetadataConverter extends GridLogging {
                             fileMetadata.iptc.get("Copyright Notice") orElse
                             fileMetadata.exif.get("Copyright"),
       // Here we combine two separate fields, based on bad habits of our suppliers.
+      // see https://github.com/guardian/grid/pull/3328#issuecomment-849080100
       suppliersReference  = fileMetadata.readXmpHeadStringProp("photoshop:TransmissionReference") orElse
                             fileMetadata.iptc.get("Original Transmission Reference") orElse
                             fileMetadata.readXmpHeadStringProp("dc:title") orElse

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -307,7 +307,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   describe("Getty Images") {
     it("should detect getty file metadata and use source as suppliersCollection") {
       val image = createImageFromMetadata("credit" -> "AFP/Getty", "source" -> "AFP")
-      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Asset ID" -> "SOME ID", "Original Filename" -> "lol.jpg")))
+      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Asset ID" -> "SOME ID","Original Filename" -> "lol.jpg")))
       val processedImage = applyProcessors(gettyImage)
       processedImage.usageRights should be(Agency("Getty Images", Some("AFP")))
       processedImage.metadata.credit should be(Some("AFP/Getty"))
@@ -316,21 +316,21 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
 
     it("should exclude images that have Getty metadata that aren't from Getty") {
       val image = createImageFromMetadata("credit" -> "NEWSPIX INTERNATIONAL")
-      val notGettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Composition" -> "Headshot")))
+      val notGettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Asset ID" -> "SOME ID","Composition" -> "Headshot")))
       val processedImage = applyProcessors(notGettyImage)
       processedImage.usageRights should be(NoRights)
     }
 
     it("should exclude images that have Getty metadata that also have 'Pinnacle Photo Agency Ltd' as source") {
       val image = createImageFromMetadata("source" -> "Pinnacle Photo Agency Ltd")
-      val notGettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("dummy" -> "metadata")))
+      val notGettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Asset ID" -> "SOME ID","dummy" -> "metadata")))
       val processedImage = applyProcessors(notGettyImage)
       processedImage.usageRights should be(NoRights)
     }
 
     it("should use 'Getty Images' as credit if missing from the file metadata") {
       val image = createImageFromMetadata()
-      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "lol.jpg")))
+      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Asset ID" -> "SOME ID","Original Filename" -> "lol.jpg")))
       val processedImage = applyProcessors(gettyImage)
       processedImage.metadata.credit should be(Some("Getty Images"))
     }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -307,7 +307,7 @@ class SupplierProcessorsTest extends FunSpec with Matchers with MetadataHelper {
   describe("Getty Images") {
     it("should detect getty file metadata and use source as suppliersCollection") {
       val image = createImageFromMetadata("credit" -> "AFP/Getty", "source" -> "AFP")
-      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Original Filename" -> "lol.jpg")))
+      val gettyImage = image.copy(fileMetadata = FileMetadata(getty = Map("Asset ID" -> "SOME ID", "Original Filename" -> "lol.jpg")))
       val processedImage = applyProcessors(gettyImage)
       processedImage.usageRights should be(Agency("Getty Images", Some("AFP")))
       processedImage.metadata.credit should be(Some("AFP/Getty"))

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -145,6 +145,8 @@ object FileMetadataReader {
 
       def readAssetId: Option[String] = readProperty("GettyImagesGIFT:AssetId").orElse(readProperty("GettyImagesGIFT:AssetID"))
 
+      // Not to live in a glass house and throw stones, but this looks awfully like a case class
+      // Don't change the field names mind.
       Map(
         "Asset ID" -> readAssetId,
         "Call For Image" -> readProperty("GettyImagesGIFT:CallForImage"),


### PR DESCRIPTION
## What does this change?

This adds iptc fixture id as suppliers reference to the Reuters cleaner. 

Would also suggest that we put the suppliers reference extraction in the individual supplier cleaners.

## How can success be measured?

- When we finish reindex, we should be able to make the Suppliers Ref better searchable. 
- That @paperboyo is happy


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
