### PR TITLE
fix missing options for the 'publication' field on CommissionedPhotographer and CommissionedIllustrator

### DIFF
--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -53,8 +53,6 @@ object UsageRightsProperty {
   ) = UsageRightsProperty(name, label, "string", required = true, options,
                           optionsMap, optionsMapKey, examples)
 
-  private def publicationField(required: Boolean): UsageRightsProperty = publicationField(required, List.empty)
-
   private def publicationField(required: Boolean, options: Options)  =
     UsageRightsProperty("publication", "Publication", "string", required,
       Some(sortList(options)))
@@ -96,7 +94,7 @@ object UsageRightsProperty {
     )
 
     case CommissionedPhotographer => List(
-      publicationField(required = false),
+      publicationField(required = false, optionsFromPublicationList(p.staffPhotographers)),
       photographerField("Sophia Evans, Murdo MacLeod")
     )
 
@@ -109,7 +107,7 @@ object UsageRightsProperty {
       requiredStringField("creator", "Illustrator", Some(sortList(p.staffIllustrators))))
 
     case CommissionedIllustrator => List(
-      publicationField(required = false),
+      publicationField(required = false, optionsFromPublicationList(p.staffPhotographers)),
       requiredStringField("creator", "Illustrator", examples = Some("Ellie Foreman Peck, Matt Bors")))
 
     case CreativeCommons => List(


### PR DESCRIPTION
https://github.com/guardian/grid/pull/3279

Bug introduced in https://github.com/guardian/grid/pull/3313 which was revert of a revert of https://github.com/guardian/grid/pull/3279 (FYI @ochiengolanga)

## What does this change?
Previously the options for the `publicationField` defaulted to the publications associated with staff photographers (i.e. `The Guardian` & `The Observer`, however in https://github.com/guardian/grid/pull/3279 where these were made configurable CommissionedPhotographer and CommissionedIllustrator were not updated to receive the same which resulted in...
![image](https://user-images.githubusercontent.com/19289579/119874666-c54c4980-bf1d-11eb-9cde-db266805307b.png)

This PR fixes that by passing the same info but from the new config provider approach.


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
