### PR TITLE
Set a speed on pngquant to make it faster

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -100,7 +100,7 @@ class ImageOperations(playPath: String) extends GridLogging {
       val fileName: String = resizedFile.getAbsolutePath
 
       val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
-      Seq("pngquant",  "--quality", "1-85", fileName, "--output", optimisedImageName).!
+      Seq("pngquant","-s8",  "--quality", "1-85", fileName, "--output", optimisedImageName).!
 
       new File(optimisedImageName)
     case Jpeg => resizedFile


### PR DESCRIPTION
## What does this change?
Set a speed on pngquant to make it faster

## How can success be measured?
pngquant is faster and less likely to fail 

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
