### PR TITLE
Change warning message in usage deletion

### DIFF
--- a/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
+++ b/kahuna/public/js/components/gr-delete-usages/gr-delete-usages.js
@@ -37,11 +37,9 @@ deleteUsages.controller('grDeleteUsagesCtrl', [
         const superSure = $window.prompt(
           stripMargin`
             |You’re about to delete ALL USAGE INFORMATION for this image.
-            |This will NOT remove the image from places it’s been used in,
-            |but it WILL remove all the details of who and where used it.
+            |This will NOT remove the image from the places it has been used in, but WILL remove all details of who used it and where it was used.
             |
-            |Enter ${deleteConfirmText} below to confirm.
-            |`
+            |Enter ${deleteConfirmText} below to confirm.`
         );
 
         if (superSure === deleteConfirmText) {


### PR DESCRIPTION
## What does this change?
This changes the alert message that pops up when trying to delete an image's usages. The text change is a clearer message, along with some newline deletions so that when the message appears the user doesn't need to scroll to see the whole text.

## How can success be measured?
The text shown in the alert displays the following text:

You're about to delete ALL USAGE INFORMATION for this image.
This will NOT remove the image from the places it has been used in, but WILL remove all details of who used it and where it was used.
Enter DELETE below to confirm

## Screenshots
![image](https://user-images.githubusercontent.com/20479781/120357870-47e95600-c2dc-11eb-9e36-bee14f88f0b4.png)


## Who should look at this?
@guardian/digital-cms


## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
