### PR TITLE
Fix location of ImageSupplierImageID to read supplierReference better for AP pics

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -238,7 +238,7 @@ object ApParser extends ImageProcessor {
   val PersonInvisionAp = "(.+)\\s*/invision/ap$".r
 
   def getSuppliersReference(image: Image) = {
-    image.fileMetadata.readXmpHeadStringProp("xmp.plus:ImageSupplierImageID").orElse(image.metadata.suppliersReference)
+    image.fileMetadata.readXmpHeadStringProp("plus:ImageSupplierImageID").orElse(image.metadata.suppliersReference)
     // This is also available in a more structured way
     // https://github.com/guardian/grid/pull/3328#issuecomment-849080100
     // But that field is json so let's not.


### PR DESCRIPTION
## What does this change?
This is a tiny followup fix for https://github.com/guardian/grid/pull/3328.

## How can success be measured?
Data is read correctly.

## Tested?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
