### PR TITLE
Add inner-service authentication (aka cross-service)

### DIFF
--- a/admin-tools/dev/app/AdminToolsComponents.scala
+++ b/admin-tools/dev/app/AdminToolsComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.mediaservice.lib.config.GridConfigResources
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.AdminToolsCtr
 import lib.AdminToolsConfig
@@ -21,6 +22,8 @@ class AdminToolsComponents(context: Context) extends GridComponents(context, Adm
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   val controller = new AdminToolsCtr(config, controllerComponents)(wsClient, ec)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override lazy val router = new Routes(httpErrorHandler, controller, management)
+
+  override lazy val router = new Routes(httpErrorHandler, controller, management, InnerServiceStatusCheckController)
 }

--- a/admin-tools/dev/app/AdminToolsComponents.scala
+++ b/admin-tools/dev/app/AdminToolsComponents.scala
@@ -22,7 +22,7 @@ class AdminToolsComponents(context: Context) extends GridComponents(context, Adm
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   val controller = new AdminToolsCtr(config, controllerComponents)(wsClient, ec)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override lazy val router = new Routes(httpErrorHandler, controller, management, InnerServiceStatusCheckController)

--- a/admin-tools/dev/conf/routes
+++ b/admin-tools/dev/conf/routes
@@ -4,3 +4,4 @@ GET     /images/projection/:id      controllers.AdminToolsCtr.project(id: String
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI

--- a/admin-tools/dev/conf/routes
+++ b/admin-tools/dev/conf/routes
@@ -4,4 +4,4 @@ GET     /images/projection/:id      controllers.AdminToolsCtr.project(id: String
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)

--- a/auth/app/auth/AuthComponents.scala
+++ b/auth/app/auth/AuthComponents.scala
@@ -1,6 +1,6 @@
 package auth
 
-import com.gu.mediaservice.lib.management.Management
+import com.gu.mediaservice.lib.management.{InnerServiceStatusCheckController, Management}
 import com.gu.mediaservice.lib.play.GridComponents
 import play.api.ApplicationLoader.Context
 import play.api.{Configuration, Environment}
@@ -14,8 +14,10 @@ class AuthComponents(context: Context) extends GridComponents(context, new AuthC
 
   val controller = new AuthController(auth, providers, config, controllerComponents, authorisation)
   val permissionsAwareManagement = new Management(controllerComponents, buildInfo)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement)
+
+  override val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement, InnerServiceStatusCheckController)
 }
 
 object AuthHttpConfig {

--- a/auth/app/auth/AuthComponents.scala
+++ b/auth/app/auth/AuthComponents.scala
@@ -14,7 +14,7 @@ class AuthComponents(context: Context) extends GridComponents(context, new AuthC
 
   val controller = new AuthController(auth, providers, config, controllerComponents, authorisation)
   val permissionsAwareManagement = new Management(controllerComponents, buildInfo)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement, InnerServiceStatusCheckController)

--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -2,7 +2,7 @@ package auth
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
-import com.gu.mediaservice.lib.auth.Authentication.{MachinePrincipal, UserPrincipal}
+import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, UserPrincipal}
 import com.gu.mediaservice.lib.auth.Permissions.{ShowPaid, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.AuthenticationProviders
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, Internal}
@@ -63,6 +63,16 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
                 "showPaid" -> showPaid,
                 "canUpload" -> (accessor.tier == Internal)
               )
+          )
+        )
+      )
+      case InnerServicePrincipal(identity, attributes) => respond(
+        Json.obj( "inner-service" ->
+          Json.obj(
+            "identity" -> identity,
+            providers.innerServiceProvider.uuidKey.toString -> attributes.get(providers.innerServiceProvider.uuidKey),
+            providers.innerServiceProvider.timestampKey.toString -> attributes.get(providers.innerServiceProvider.timestampKey),
+            providers.innerServiceProvider.signatureKey.toString -> attributes.get(providers.innerServiceProvider.signatureKey),
           )
         )
       )

--- a/auth/conf/routes
+++ b/auth/conf/routes
@@ -2,16 +2,17 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET     /                           auth.AuthController.index
+GET     /                                             auth.AuthController.index
 
-GET     /login                      auth.AuthController.doLogin(redirectUri: Option[String])
-GET     /oauthCallback              auth.AuthController.oauthCallback
-GET     /logout                     auth.AuthController.logout
-GET     /session                    auth.AuthController.session
+GET     /login                                        auth.AuthController.doLogin(redirectUri: Option[String])
+GET     /oauthCallback                                auth.AuthController.oauthCallback
+GET     /logout                                       auth.AuthController.logout
+GET     /session                                      auth.AuthController.session
 
 # Management
-GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
-GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
+GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
-GET     /robots.txt                 com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/auth/conf/routes
+++ b/auth/conf/routes
@@ -12,7 +12,7 @@ GET     /session                                      auth.AuthController.sessio
 # Management
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -15,7 +15,7 @@ class CollectionsComponents(context: Context) extends GridComponents(context, ne
 
   val collections = new CollectionsController(auth, config, store, controllerComponents)
   val imageCollections = new ImageCollectionsController(auth, config, notifications, controllerComponents)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override val router = new Routes(httpErrorHandler, collections, imageCollections, management, InnerServiceStatusCheckController)

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{CollectionsController, ImageCollectionsController}
 import lib.{CollectionsConfig, CollectionsMetrics, Notifications}
@@ -14,6 +15,8 @@ class CollectionsComponents(context: Context) extends GridComponents(context, ne
 
   val collections = new CollectionsController(auth, config, store, controllerComponents)
   val imageCollections = new ImageCollectionsController(auth, config, notifications, controllerComponents)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override val router = new Routes(httpErrorHandler, collections, imageCollections, management)
+
+  override val router = new Routes(httpErrorHandler, collections, imageCollections, management, InnerServiceStatusCheckController)
 }

--- a/collections/conf/routes
+++ b/collections/conf/routes
@@ -15,7 +15,7 @@ POST    /corrected-collections                          controllers.CollectionsC
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                     com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/collections/conf/routes
+++ b/collections/conf/routes
@@ -15,6 +15,7 @@ POST    /corrected-collections                          controllers.CollectionsC
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
 GET     /robots.txt                                     com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -61,6 +61,19 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
   val authBaseUri        = baseUri(authHost)
   val adminToolsBaseUri  = baseUri(adminToolsHost)
 
+  val allInternalUris = Seq(
+    kahunaBaseUri,
+    apiBaseUri,
+    loaderBaseUri,
+    cropperBaseUri,
+    metadataBaseUri,
+    usageBaseUri,
+    collectionsBaseUri,
+    leasesBaseUri,
+    authBaseUri,
+    adminToolsBaseUri
+  )
+
   val guardianWitnessBaseUri: String = "https://n0ticeapis.com"
 
   val corsAllowedDomains: Set[String] = corsAllowedOrigins.map(baseUri)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -70,8 +70,7 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
     usageBaseUri,
     collectionsBaseUri,
     leasesBaseUri,
-    authBaseUri,
-    adminToolsBaseUri
+    authBaseUri
   )
 
   val guardianWitnessBaseUri: String = "https://n0ticeapis.com"

--- a/cropper/app/CropperComponents.scala
+++ b/cropper/app/CropperComponents.scala
@@ -1,5 +1,5 @@
 import com.gu.mediaservice.lib.imaging.ImageOperations
-import com.gu.mediaservice.lib.management.Management
+import com.gu.mediaservice.lib.management.{InnerServiceStatusCheckController, Management}
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.CropperController
 import lib.{CropStore, CropperConfig, Crops, Notifications}
@@ -17,6 +17,8 @@ class CropperComponents(context: Context) extends GridComponents(context, new Cr
 
   val controller = new CropperController(auth, crops, store, notifications, config, controllerComponents, wsClient, authorisation)
   val permissionsAwareManagement = new Management(controllerComponents, buildInfo)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override lazy val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement)
+
+  override lazy val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement, InnerServiceStatusCheckController)
 }

--- a/cropper/app/CropperComponents.scala
+++ b/cropper/app/CropperComponents.scala
@@ -17,7 +17,7 @@ class CropperComponents(context: Context) extends GridComponents(context, new Cr
 
   val controller = new CropperController(auth, crops, store, notifications, config, controllerComponents, wsClient, authorisation)
   val permissionsAwareManagement = new Management(controllerComponents, buildInfo)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override lazy val router = new Routes(httpErrorHandler, controller, permissionsAwareManagement, InnerServiceStatusCheckController)

--- a/cropper/conf/routes
+++ b/cropper/conf/routes
@@ -8,7 +8,7 @@ DELETE  /crops/:id                                    controllers.CropperControl
 # Management
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/cropper/conf/routes
+++ b/cropper/conf/routes
@@ -1,13 +1,14 @@
-GET     /                           controllers.CropperController.index
+GET     /                                             controllers.CropperController.index
 
-POST    /crops                      controllers.CropperController.export
+POST    /crops                                        controllers.CropperController.export
 
-GET     /crops/:id                  controllers.CropperController.getCrops(id: String)
-DELETE  /crops/:id                  controllers.CropperController.deleteCrops(id: String)
+GET     /crops/:id                                    controllers.CropperController.getCrops(id: String)
+DELETE  /crops/:id                                    controllers.CropperController.deleteCrops(id: String)
 
 # Management
-GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
-GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
+GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
-GET     /robots.txt                 com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/dev/script/the_pingler.sh
+++ b/dev/script/the_pingler.sh
@@ -14,7 +14,7 @@ function pingle() {
   AUTH="https://media-auth.local.dev-gutools.co.uk/management/healthcheck"
   LEASES="https://media-leases.local.dev-gutools.co.uk/management/healthcheck"
   ADMIN_TOOLS="https://admin-tools.media.local.dev-gutools.co.uk/management/healthcheck"
-  INNER_SERVICE_STATUS="https://thrall.media.local.dev-gutools.co.uk/management/innerServiceStatusCheck"
+  INNER_SERVICE_STATUS="https://thrall.media.local.dev-gutools.co.uk/management/innerServiceStatusCheck?depth=2"
 
 
   lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $INNER_SERVICE_STATUS $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"

--- a/dev/script/the_pingler.sh
+++ b/dev/script/the_pingler.sh
@@ -14,8 +14,10 @@ function pingle() {
   AUTH="https://media-auth.local.dev-gutools.co.uk/management/healthcheck"
   LEASES="https://media-leases.local.dev-gutools.co.uk/management/healthcheck"
   ADMIN_TOOLS="https://admin-tools.media.local.dev-gutools.co.uk/management/healthcheck"
+  INNER_SERVICE_STATUS="https://thrall.media.local.dev-gutools.co.uk/management/innerServiceStatusCheck"
 
-  lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"
+
+  lu="$COLLECTIONS $IMAGE_LOADER $CROPPER $METADATA $THRALL $INNER_SERVICE_STATUS $KAHUNA $API $USAGE $AUTH $LEASES $ADMIN_TOOLS"
 
   echo "      \033[35mPingling!\033[m"
   for URL in $lu

--- a/docs/03-apis/01-authentication.md
+++ b/docs/03-apis/01-authentication.md
@@ -1,6 +1,16 @@
 # Authentication
 
-There are two ways to authenticate with Grid.
+There are three ways to authenticate with Grid.
+
+## Inner service
+Services can call other Grid services, typically reusing the credentials of the original using the `onBehalfOf` mechanism. However, sometimes services such as `thrall` will need to originate a call to another Grid service (e.g. during a long-running migration), in which case they can make use of the `innerServiceCall` method on instances of `Authentication` (the same place where one can call `getOnBehalfOfPrincipal`). This `innerServiceCall` method adds the following headers to the request: 
+
+- `X-Inner-Service-Identity`: contains the name of the originating service, e.g. `thrall` and  possibly names of other services the request has gone via (see `onBehalfOf` section below)
+- `X-Inner-Service-UUID`: contains a unique identifier for the request
+- `X-Inner-Service-Timestamp`
+- `X-Inner-Service-Signature`: contains a checksum of the above 3 headers, encrypted using the Play secret (which is already shared between the services),
+
+which are then verified and interpreted as an `InnerServicePrincipal` when received in the service being called.
 
 ## Panda Auth
 This is typically used for client-server authentication.

--- a/docs/07-extending/03-authentication.md
+++ b/docs/07-extending/03-authentication.md
@@ -8,18 +8,23 @@ Overview
 
 ### Authentication
 
-We distinguish between two types of identity:
+We distinguish between three types of identity:
 
-* human users represented by a `UserPrincipal` (people directly using the Grid via the UI)
-* machine users represented by a `MachinePrincipal` (automated ingest, batch processing etc. done by another
+1. internal machine users represented by an `InnerServicePrincipal` (calls originated from internal Grid service to another, e.g. `thrall` calling `media-api`)
+2. external machine users represented by a `MachinePrincipal` (automated ingest, batch processing etc. done by another
   application)
+3. human users represented by a `UserPrincipal` (people directly using the Grid via the UI).
 
-These two types of users are usually be identified using a different strategy. For example, at the Guardian we identify
-machine users by an API key in the header of an API request. Human users are typically identified by looking for a
-cookie that a user has in their browser. If they don't have the cookie, or the cookie is out of date, then we require
-them to authenticate in order to obtain a valid cookie before they can continue using the Grid.
+These three types of users are usually be identified using a different strategy:
 
-In either case, the Grid can make inter-microservice calls. In order to support this a mechanism is provided to call
+1. the internal machine users are identified by the presence of a signature header (this signature is generated from a UUID and timestamp and signed using the shared Play secret) and carries the identity of the originating service and any intermediate services. 
+
+The mechanism for handling the other two types of user is pluggable, for example, at the Guardian:
+
+2. we identify external machine users by an API key in the header of an API request
+3. human users are typically identified by looking for a cookie that a user has in their browser. If they don't have the cookie, or the cookie is out of date, then we require them to authenticate in order to obtain a valid cookie before they can continue using the Grid.
+
+In all cases, the Grid can make further inter-microservice calls. In order to support this a mechanism is provided to call
 other services on behalf of a principal.
 
 ### Authorisation
@@ -42,7 +47,7 @@ permission data can then be used in the function implemented.
 
 ### Authentication
 
-There are separate providers for user and machine authentication which are configured using
+There are separate providers for user and external machine authentication which are configured using
 `authentication.providers.user` and `authentication.providers.machine` respectfully. The provider configured at
 `authentication.providers.user` must implement `UserAuthenticationProvider` and that configured for
 `authentication.providers.machine` must implement `MachineAuthenticationProvider`.

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -3,6 +3,7 @@ import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{ImageLoaderController, UploadStatusController}
 import lib._
@@ -43,6 +44,8 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
   val controller = new ImageLoaderController(
     auth, downloader, store, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient, authorisation)
   val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, config, controllerComponents, authorisation)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override lazy val router = new Routes(httpErrorHandler, controller, uploadStatusController, management)
+
+  override lazy val router = new Routes(httpErrorHandler, controller, uploadStatusController, management, InnerServiceStatusCheckController)
 }

--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -44,7 +44,7 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
   val controller = new ImageLoaderController(
     auth, downloader, store, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient, authorisation)
   val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, config, controllerComponents, authorisation)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override lazy val router = new Routes(httpErrorHandler, controller, uploadStatusController, management, InnerServiceStatusCheckController)

--- a/image-loader/conf/routes
+++ b/image-loader/conf/routes
@@ -12,7 +12,7 @@ POST    /uploadStatus/:imageId                        controllers.UploadStatusCo
 # Management
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/image-loader/conf/routes
+++ b/image-loader/conf/routes
@@ -1,17 +1,18 @@
-GET     /                           controllers.ImageLoaderController.index
-POST    /images                     controllers.ImageLoaderController.loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
-POST    /imports                    controllers.ImageLoaderController.importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
-GET     /images/project/:imageId    controllers.ImageLoaderController.projectImageBy(imageId: String)
+GET     /                                             controllers.ImageLoaderController.index
+POST    /images                                       controllers.ImageLoaderController.loadImage(uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
+POST    /imports                                      controllers.ImageLoaderController.importImage(uri: String, uploadedBy: Option[String], identifiers: Option[String], uploadTime: Option[String], filename: Option[String])
+GET     /images/project/:imageId                      controllers.ImageLoaderController.projectImageBy(imageId: String)
 
 # Upload Status
-GET     /uploadStatus/:imageId      controllers.UploadStatusController.getUploadStatus(imageId: String)
-POST    /uploadStatus/:imageId      controllers.UploadStatusController.updateUploadStatus(imageId: String)
+GET     /uploadStatus/:imageId                        controllers.UploadStatusController.getUploadStatus(imageId: String)
+POST    /uploadStatus/:imageId                        controllers.UploadStatusController.updateUploadStatus(imageId: String)
 
 
 
 # Management
-GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
-GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
+GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
-GET     /robots.txt                 com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -14,7 +14,7 @@ class KahunaComponents(context: Context) extends GridComponents(context, new Kah
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   val controller = new KahunaController(auth, config, controllerComponents, authorisation)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
   final override val router = new Routes(httpErrorHandler, controller, assets, management, InnerServiceStatusCheckController)
 

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.net.URI
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{AssetsComponents, KahunaController}
@@ -13,7 +14,9 @@ class KahunaComponents(context: Context) extends GridComponents(context, new Kah
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   val controller = new KahunaController(auth, config, controllerComponents, authorisation)
-  final override val router = new Routes(httpErrorHandler, controller, assets, management)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+
+  final override val router = new Routes(httpErrorHandler, controller, assets, management, InnerServiceStatusCheckController)
 
 }
 

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -17,6 +17,7 @@ GET     /assets/*file                                 controllers.Assets.version
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
 GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -16,8 +16,8 @@ GET     /assets/*file                                 controllers.Assets.version
 # Management
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
-GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
+GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -2,21 +2,21 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET     /                           controllers.KahunaController.index(ignored="")
-GET     /images/$id<[0-9a-z]+>      controllers.KahunaController.index(id: String)
-GET     /images/$id<[0-9a-z]+>/crop controllers.KahunaController.index(id: String)
-GET     /search                     controllers.KahunaController.index(ignored="")
-GET     /upload                     controllers.KahunaController.index(ignored="")
-GET     /quotas                     controllers.KahunaController.quotas
+GET     /                                             controllers.KahunaController.index(ignored="")
+GET     /images/$id<[0-9a-z]+>                        controllers.KahunaController.index(id: String)
+GET     /images/$id<[0-9a-z]+>/crop                   controllers.KahunaController.index(id: String)
+GET     /search                                       controllers.KahunaController.index(ignored="")
+GET     /upload                                       controllers.KahunaController.index(ignored="")
 
 # Empty page to return to the same domain as the app
-GET     /ok                         controllers.KahunaController.ok
+GET     /ok                                           controllers.KahunaController.ok
 
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET     /assets/*file                                 controllers.Assets.versioned(path="/public", file: Asset)
 
 # Management
-GET     /management/healthcheck     com.gu.mediaservice.lib.management.Management.healthCheck
-GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
+GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
-GET     /robots.txt                 com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/leases/app/LeasesComponents.scala
+++ b/leases/app/LeasesComponents.scala
@@ -12,7 +12,7 @@ class LeasesComponents(context: Context) extends GridComponents(context, new Lea
   val notifications = new LeaseNotifier(config, store)
 
   val controller = new MediaLeaseController(auth, store, config, notifications, controllerComponents)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
   override lazy val router = new Routes(httpErrorHandler, controller, management, InnerServiceStatusCheckController)
 

--- a/leases/app/LeasesComponents.scala
+++ b/leases/app/LeasesComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.MediaLeaseController
 import lib.{LeaseNotifier, LeaseStore, LeasesConfig}
@@ -11,5 +12,8 @@ class LeasesComponents(context: Context) extends GridComponents(context, new Lea
   val notifications = new LeaseNotifier(config, store)
 
   val controller = new MediaLeaseController(auth, store, config, notifications, controllerComponents)
-  override lazy val router = new Routes(httpErrorHandler, controller, management)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+
+  override lazy val router = new Routes(httpErrorHandler, controller, management, InnerServiceStatusCheckController)
+
 }

--- a/leases/conf/routes
+++ b/leases/conf/routes
@@ -14,7 +14,7 @@ POST    /leases                                       controllers.MediaLeaseCont
 # Management
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 
 # Shoo robots away

--- a/leases/conf/routes
+++ b/leases/conf/routes
@@ -1,20 +1,21 @@
-GET     /                                   controllers.MediaLeaseController.index
+GET     /                                             controllers.MediaLeaseController.index
 
 # Leases by Media
-GET     /leases/media/:id                   controllers.MediaLeaseController.getLeasesForMedia(id: String)
-DELETE  /leases/media/:id                   controllers.MediaLeaseController.deleteLeasesForMedia(id: String)
-POST    /leases/media/:id                   controllers.MediaLeaseController.replaceLeasesForMedia(id: String)
+GET     /leases/media/:id                             controllers.MediaLeaseController.getLeasesForMedia(id: String)
+DELETE  /leases/media/:id                             controllers.MediaLeaseController.deleteLeasesForMedia(id: String)
+POST    /leases/media/:id                             controllers.MediaLeaseController.replaceLeasesForMedia(id: String)
 
 # Leases
-GET     /leases/reindex                     controllers.MediaLeaseController.reindex
-GET     /leases/:id                         controllers.MediaLeaseController.getLease(id: String)
-DELETE  /leases/:id                         controllers.MediaLeaseController.deleteLease(id: String)
-POST    /leases                             controllers.MediaLeaseController.postLease
+GET     /leases/reindex                               controllers.MediaLeaseController.reindex
+GET     /leases/:id                                   controllers.MediaLeaseController.getLease(id: String)
+DELETE  /leases/:id                                   controllers.MediaLeaseController.deleteLease(id: String)
+POST    /leases                                       controllers.MediaLeaseController.postLease
 
 # Management
-GET     /management/healthcheck             com.gu.mediaservice.lib.management.Management.healthCheck
-GET     /management/manifest                com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
+GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 
 # Shoo robots away
-GET     /robots.txt                         com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -45,7 +45,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)
   val elasticSearchHealthCheck = new ElasticSearchHealthCheck(controllerComponents, elasticSearch)
   val healthcheckController = new Management(controllerComponents, buildInfo)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
   override val router = new Routes(
     httpErrorHandler,

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,7 +1,7 @@
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
 import com.gu.mediaservice.lib.imaging.ImageOperations
-import com.gu.mediaservice.lib.management.{ElasticSearchHealthCheck, Management}
+import com.gu.mediaservice.lib.management.{InnerServiceStatusCheckController, ElasticSearchHealthCheck, Management}
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers._
 import lib._
@@ -45,6 +45,16 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)
   val elasticSearchHealthCheck = new ElasticSearchHealthCheck(controllerComponents, elasticSearch)
   val healthcheckController = new Management(controllerComponents, buildInfo)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override val router = new Routes(httpErrorHandler, mediaApi, suggestionController, aggController, usageController, elasticSearchHealthCheck, healthcheckController)
+  override val router = new Routes(
+    httpErrorHandler,
+    mediaApi,
+    suggestionController,
+    aggController,
+    usageController,
+    elasticSearchHealthCheck,
+    healthcheckController,
+    InnerServiceStatusCheckController
+  )
 }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -38,7 +38,7 @@ GET     /usage/quotas/:id                             controllers.UsageControlle
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
 GET     /management/imageCounts                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.imageCounts
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -38,6 +38,7 @@ GET     /usage/quotas/:id                             controllers.UsageControlle
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
 GET     /management/imageCounts                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.imageCounts
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.mediaservice.lib.imaging.ImageOperations
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{EditsApi, EditsController, SyndicationController}
 import lib._
@@ -24,7 +25,10 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
   val editsController = new EditsController(auth, editsStore, notifications, config, wsClient, authorisation, controllerComponents)
   val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override val router = new Routes(httpErrorHandler, controller, editsController, syndicationController, management)
+
+
+  override val router = new Routes(httpErrorHandler, controller, editsController, syndicationController, management, InnerServiceStatusCheckController)
 }
 

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -25,7 +25,7 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
   val editsController = new EditsController(auth, editsStore, notifications, config, wsClient, authorisation, controllerComponents)
   val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
 

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -32,7 +32,7 @@ DELETE  /metadata/:id/syndication                       controllers.SyndicationC
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                     com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -32,6 +32,7 @@ DELETE  /metadata/:id/syndication                       controllers.SyndicationC
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
 GET     /robots.txt                                     com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -91,7 +91,8 @@ class Authentication(config: CommonConfig,
       _.compose(_.addHttpHeaders(Authentication.originalServiceHeaderName -> config.appName))
     )
   }
-
+  /** Use this for originating calls to other Grid services (this will sign the request and the receiving service will extract an `InnerServicePrincipal`)
+    * IMPORTANT: Do not use this for simply making ongoing calls to other Grid services - instead use `getOnBehalfOfPrincipal` */
   def innerServiceCall(wsRequest: WSRequest): WSRequest = providers.innerServiceProvider.signRequest(wsRequest)
 }
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.lib.auth
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
-import com.gu.mediaservice.lib.auth.Authentication.{MachinePrincipal, UserPrincipal, OnBehalfOfPrincipal, Principal}
+import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, OnBehalfOfPrincipal, Principal, UserPrincipal}
 import com.gu.mediaservice.lib.auth.provider._
 import com.gu.mediaservice.lib.config.CommonConfig
 import play.api.libs.typedmap.TypedMap
@@ -42,23 +42,29 @@ class Authentication(config: CommonConfig,
     Future.successful(respondError(new Status(419), errorKey = "authentication-expired", errorMessage = "User authentication token has expired", loginLinks))
   }
 
-  def authenticationStatus(requestHeader: RequestHeader) = {
+  def authenticationStatus(requestHeader: RequestHeader): Either[Future[Result], Principal] = {
     def flushToken(resultWhenAbsent: Result): Result = {
       providers.userProvider.flushToken.fold(resultWhenAbsent)(_(requestHeader, resultWhenAbsent))
     }
 
-    // Authenticate request. Try with API authenticator first and then with user authenticator
-    providers.apiProvider.authenticateRequest(requestHeader) match {
+    // Authenticate request. Try with inner service authenticator first, then with API authenticator, and finally with user authenticator
+    providers.innerServiceProvider.authenticateRequest(requestHeader) match {
       case Authenticated(authedUser) => Right(authedUser)
       case Invalid(message, throwable) => Left(unauthorised(message, throwable))
-      case NotAuthorised(message) => Left(forbidden(s"Principal not authorised: $message"))
+      case NotAuthorised(message) => Left(forbidden(s"Principal not authorised: $message")) // TODO: see if we can avoid repetition
       case NotAuthenticated =>
-        providers.userProvider.authenticateRequest(requestHeader) match {
-          case NotAuthenticated => Left(unauthorised("Not authenticated"))
-          case Expired(principal) => Left(expired(principal))
+        providers.apiProvider.authenticateRequest(requestHeader) match {
           case Authenticated(authedUser) => Right(authedUser)
-          case Invalid(message, throwable) => Left(unauthorised(message, throwable).map(flushToken))
+          case Invalid(message, throwable) => Left(unauthorised(message, throwable))
           case NotAuthorised(message) => Left(forbidden(s"Principal not authorised: $message"))
+          case NotAuthenticated =>
+            providers.userProvider.authenticateRequest(requestHeader) match {
+              case NotAuthenticated => Left(unauthorised("Not authenticated"))
+              case Expired(principal) => Left(expired(principal))
+              case Authenticated(authedUser) => Right(authedUser)
+              case Invalid(message, throwable) => Left(unauthorised(message, throwable).map(flushToken))
+              case NotAuthorised(message) => Left(forbidden(s"Principal not authorised: $message"))
+            }
         }
     }
   }
@@ -76,6 +82,7 @@ class Authentication(config: CommonConfig,
     val provider: AuthenticationProvider = principal match {
       case _:MachinePrincipal => providers.apiProvider
       case _:UserPrincipal      => providers.userProvider
+      case _:InnerServicePrincipal => providers.innerServiceProvider
     }
     val maybeEnrichFn: Either[String, WSRequest => WSRequest] = provider.onBehalfOf(principal)
     maybeEnrichFn.fold(
@@ -84,6 +91,8 @@ class Authentication(config: CommonConfig,
       _.compose(_.addHttpHeaders(Authentication.originalServiceHeaderName -> config.appName))
     )
   }
+
+  def innerServiceCall(wsRequest: WSRequest): WSRequest = providers.innerServiceProvider.signRequest(wsRequest)
 }
 
 object Authentication {
@@ -97,6 +106,11 @@ object Authentication {
   }
   /** A machine user doing work automatically for its human programmers */
   case class MachinePrincipal(accessor: ApiAccessor, attributes: TypedMap = TypedMap.empty) extends Principal
+
+  /** A different Grid microservice (e.g. a call to media-api originating from thrall) */
+  case class InnerServicePrincipal(identity: String, attributes: TypedMap = TypedMap.empty) extends Principal {
+    def accessor: ApiAccessor = ApiAccessor(identity, tier = Internal)
+  }
 
   type Request[A] = AuthenticatedRequest[A, Principal]
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationProviders.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationProviders.scala
@@ -1,3 +1,7 @@
 package com.gu.mediaservice.lib.auth.provider
 
-case class AuthenticationProviders(userProvider: UserAuthenticationProvider, apiProvider: MachineAuthenticationProvider)
+case class AuthenticationProviders(
+  userProvider: UserAuthenticationProvider,
+  apiProvider: MachineAuthenticationProvider,
+  innerServiceProvider: InnerServiceAuthenticationProvider
+)

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/InnerServiceAuthentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/InnerServiceAuthentication.scala
@@ -9,10 +9,14 @@ import play.api.mvc.RequestHeader
 
 import java.util.UUID
 
-trait InnerServiceAuthentication {
+object InnerServiceAuthentication {
   val innerServiceIdentityHeaderName = "X-Inner-Service-Identity"
   val innerServiceUUIDHeaderName = "X-Inner-Service-UUID"
   val innerServiceTimestampHeaderName = "X-Inner-Service-Timestamp"
+}
+
+trait InnerServiceAuthentication {
+  import InnerServiceAuthentication._
   val innerServiceSignatureHeaderName = "X-Inner-Service-Signature"
 
   val uuidKey: TypedKey[String] = TypedKey("UUID")

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/InnerServiceAuthentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/InnerServiceAuthentication.scala
@@ -1,0 +1,61 @@
+package com.gu.mediaservice.lib.auth.provider
+
+import com.gu.mediaservice.lib.auth.Authentication.InnerServicePrincipal
+import org.joda.time.{DateTime, DateTimeZone}
+import play.api.libs.crypto.CookieSigner
+import play.api.libs.typedmap.{TypedKey, TypedMap}
+import play.api.libs.ws.WSRequest
+import play.api.mvc.RequestHeader
+
+import java.util.UUID
+
+trait InnerServiceAuthentication {
+  val innerServiceIdentityHeaderName = "X-Inner-Service-Identity"
+  val innerServiceUUIDHeaderName = "X-Inner-Service-UUID"
+  val innerServiceTimestampHeaderName = "X-Inner-Service-Timestamp"
+  val innerServiceSignatureHeaderName = "X-Inner-Service-Signature"
+
+  val uuidKey: TypedKey[String] = TypedKey("UUID")
+  val timestampKey: TypedKey[String] = TypedKey("timestamp")
+  val signatureKey: TypedKey[String] = TypedKey("signature")
+
+  val signer: CookieSigner
+
+  val serviceName: String
+
+  private def generateSignature(headers: Map[String, Seq[String]]): String = {
+    signer.sign(
+      List(
+        headers(innerServiceIdentityHeaderName),
+        headers(innerServiceUUIDHeaderName),
+        headers(innerServiceTimestampHeaderName)
+      ).mkString(".")
+    )
+  }
+
+  def signRequest(wsRequest: WSRequest, identityPrefix: String = ""): WSRequest = {
+    val requestToBeSigned = wsRequest.addHttpHeaders(
+      innerServiceIdentityHeaderName -> (identityPrefix + serviceName),
+      innerServiceUUIDHeaderName -> UUID.randomUUID().toString,
+      innerServiceTimestampHeaderName -> DateTime.now(DateTimeZone.UTC).toString
+    )
+    requestToBeSigned.addHttpHeaders(
+      innerServiceSignatureHeaderName -> generateSignature(requestToBeSigned.headers)
+    )
+  }
+
+  def verifyRequest(request: RequestHeader)(signatureFromHeader: String) = {
+    val signature = generateSignature(request.headers.toMap)
+    if (signature == signatureFromHeader)
+      Right(InnerServicePrincipal(
+        identity = request.headers(innerServiceIdentityHeaderName),
+        attributes = TypedMap.empty + (
+          uuidKey -> request.headers(innerServiceUUIDHeaderName),
+          timestampKey -> request.headers(innerServiceTimestampHeaderName),
+          signatureKey -> signature
+        )
+    ))
+    else
+      Left("Invalid inner service signature")
+  }
+}

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
@@ -1,6 +1,8 @@
 package com.gu.mediaservice.lib.management
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.provider.InnerServiceAuthenticationProvider
 import com.gu.mediaservice.lib.config.Services
 import play.api.libs.json.{Json, Writes}
 import play.api.libs.ws.WSClient
@@ -12,23 +14,24 @@ case class WhoAmIResponse (baseUri: String, status: Int, body: String)
 object WhoAmIResponse { implicit val writes: Writes[WhoAmIResponse] = Json.writes[WhoAmIResponse] }
 
 class InnerServiceStatusCheckController(
+  auth: Authentication,
   override val controllerComponents: ControllerComponents,
   services: Services,
   ws: WSClient
 )(implicit ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
-  def whoAmI = Action {
-    Ok("whoAmI hello!")
+  def whoAmI = auth { request =>
+    Ok(request.user.toString)
   }
 
   def statusCheck = Action.async {
     val whoAmIFutures = services.allInternalUris.map { baseUri =>
-      ws.url(s"$baseUri/management/whoAmI").get.map(resp => WhoAmIResponse(baseUri, resp.status, resp.body.take(50)))
+      auth.innerServiceCall(ws.url(s"$baseUri/management/whoAmI")).get.map(resp => WhoAmIResponse(baseUri, resp.status, resp.body))
     }
 
     Future.sequence(whoAmIFutures).map { whoAmIResponses =>
-      val overallStatus = if (whoAmIResponses.exists(_.status > 299)) MultiStatus else Ok
-      overallStatus(Json.toJson(whoAmIResponses.map(resp => resp.baseUri -> resp).toMap))
+      val overallStatus = whoAmIResponses.map(_.status).max
+      new Status(overallStatus)(Json.toJson(whoAmIResponses.map(resp => resp.baseUri -> resp).toMap))
     }
   }
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
@@ -1,0 +1,34 @@
+package com.gu.mediaservice.lib.management
+
+import com.gu.mediaservice.lib.argo.ArgoHelpers
+import com.gu.mediaservice.lib.config.Services
+import play.api.libs.json.{Json, Writes}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{BaseController, ControllerComponents}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class WhoAmIResponse (baseUri: String, status: Int, body: String)
+object WhoAmIResponse { implicit val writes: Writes[WhoAmIResponse] = Json.writes[WhoAmIResponse] }
+
+class InnerServiceStatusCheckController(
+  override val controllerComponents: ControllerComponents,
+  services: Services,
+  ws: WSClient
+)(implicit ec: ExecutionContext)
+  extends BaseController with ArgoHelpers {
+  def whoAmI = Action {
+    Ok("whoAmI hello!")
+  }
+
+  def statusCheck = Action.async {
+    val whoAmIFutures = services.allInternalUris.map { baseUri =>
+      ws.url(s"$baseUri/management/whoAmI").get.map(resp => WhoAmIResponse(baseUri, resp.status, resp.body.take(50)))
+    }
+
+    Future.sequence(whoAmIFutures).map { whoAmIResponses =>
+      val overallStatus = if (whoAmIResponses.exists(_.status > 299)) MultiStatus else Ok
+      overallStatus(Json.toJson(whoAmIResponses.map(resp => resp.baseUri -> resp).toMap))
+    }
+  }
+}

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
@@ -4,11 +4,12 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.auth.Authentication.InnerServicePrincipal
 import com.gu.mediaservice.lib.config.Services
-import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.libs.json.{JsString, JsValue, Json, Writes}
 import play.api.libs.ws.{WSClient, WSRequest}
 import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 case class WhoAmIResponse (baseUri: String, status: Int, body: JsValue)
 object WhoAmIResponse { implicit val writes: Writes[WhoAmIResponse] = Json.writes[WhoAmIResponse] }
@@ -21,9 +22,17 @@ class InnerServiceStatusCheckController(
 )(implicit ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
+  private def safeJsonParse(maybeJsonStr: String) = Try(Json.parse(maybeJsonStr)).getOrElse(JsString(maybeJsonStr))
+
   private def callAllInternalServices(authenticator: WSRequest => WSRequest) = {
     val whoAmIFutures = services.allInternalUris.map { baseUri =>
-      authenticator(ws.url(s"$baseUri/management/whoAmI")).get.map(resp => WhoAmIResponse(baseUri, resp.status, resp.body[JsValue]))
+        authenticator(ws.url(s"$baseUri/management/whoAmI")).get
+          .map(resp => WhoAmIResponse(baseUri, resp.status, safeJsonParse(resp.body)))
+          .recover{
+            case throwable: Throwable => WhoAmIResponse(baseUri, SERVICE_UNAVAILABLE, Json.obj(
+            "errorMessage" -> throwable.getMessage,
+            "stackTrace" -> throwable.getStackTrace.map(_.toString)
+          ))}
     }
 
     Future.sequence(whoAmIFutures).map { whoAmIResponses =>

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/management/InnerServiceStatusCheckController.scala
@@ -2,15 +2,15 @@ package com.gu.mediaservice.lib.management
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication
-import com.gu.mediaservice.lib.auth.provider.InnerServiceAuthenticationProvider
+import com.gu.mediaservice.lib.auth.Authentication.InnerServicePrincipal
 import com.gu.mediaservice.lib.config.Services
-import play.api.libs.json.{Json, Writes}
-import play.api.libs.ws.WSClient
+import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.libs.ws.{WSClient, WSRequest}
 import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class WhoAmIResponse (baseUri: String, status: Int, body: String)
+case class WhoAmIResponse (baseUri: String, status: Int, body: JsValue)
 object WhoAmIResponse { implicit val writes: Writes[WhoAmIResponse] = Json.writes[WhoAmIResponse] }
 
 class InnerServiceStatusCheckController(
@@ -20,18 +20,30 @@ class InnerServiceStatusCheckController(
   ws: WSClient
 )(implicit ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
-  def whoAmI = auth { request =>
-    Ok(request.user.toString)
-  }
 
-  def statusCheck = Action.async {
+  private def callAllInternalServices(authenticator: WSRequest => WSRequest) = {
     val whoAmIFutures = services.allInternalUris.map { baseUri =>
-      auth.innerServiceCall(ws.url(s"$baseUri/management/whoAmI")).get.map(resp => WhoAmIResponse(baseUri, resp.status, resp.body))
+      authenticator(ws.url(s"$baseUri/management/whoAmI")).get.map(resp => WhoAmIResponse(baseUri, resp.status, resp.body[JsValue]))
     }
 
     Future.sequence(whoAmIFutures).map { whoAmIResponses =>
       val overallStatus = whoAmIResponses.map(_.status).max
       new Status(overallStatus)(Json.toJson(whoAmIResponses.map(resp => resp.baseUri -> resp).toMap))
     }
+  }
+
+  def whoAmI = auth.async { request =>
+    request.user match {
+      case principal: InnerServicePrincipal if !principal.identity.contains(" via ") =>
+        callAllInternalServices(auth.getOnBehalfOfPrincipal(principal))
+      case _ =>
+        Future.successful(
+          Ok(Json.toJson(request.user.toString))
+        )
+    }
+  }
+
+  def statusCheck = Action.async {
+    callAllInternalServices(auth.innerServiceCall)
   }
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -1,7 +1,7 @@
 package com.gu.mediaservice.lib.play
 
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation}
-import com.gu.mediaservice.lib.auth.provider.{AuthenticationProviderResources, AuthenticationProviders, AuthorisationProvider, AuthorisationProviderResources, MachineAuthenticationProvider, UserAuthenticationProvider}
+import com.gu.mediaservice.lib.auth.provider.{AuthenticationProviderResources, AuthenticationProviders, AuthorisationProvider, AuthorisationProviderResources, InnerServiceAuthenticationProvider, MachineAuthenticationProvider, UserAuthenticationProvider}
 import com.gu.mediaservice.lib.config.{ApiAuthenticationProviderLoader, AuthorisationProviderLoader, CommonConfig, GridConfigResources, UserAuthenticationProviderLoader}
 import com.gu.mediaservice.lib.logging.LogConfig
 import com.gu.mediaservice.lib.management.{BuildInfo, Management}
@@ -57,7 +57,8 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
 
   protected val providers: AuthenticationProviders = AuthenticationProviders(
     userProvider = config.configuration.get[UserAuthenticationProvider]("authentication.providers.user")(UserAuthenticationProviderLoader.singletonConfigLoader(authProviderResources, applicationLifecycle)),
-    apiProvider = config.configuration.get[MachineAuthenticationProvider]("authentication.providers.machine")(ApiAuthenticationProviderLoader.singletonConfigLoader(authProviderResources, applicationLifecycle))
+    apiProvider = config.configuration.get[MachineAuthenticationProvider]("authentication.providers.machine")(ApiAuthenticationProviderLoader.singletonConfigLoader(authProviderResources, applicationLifecycle)),
+    innerServiceProvider = new InnerServiceAuthenticationProvider(cookieSigner, serviceName=config.appName)
   )
 
   val auth = new Authentication(config, providers, controllerComponents.parsers.default, executionContext)

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
@@ -14,49 +14,26 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
 
   private val logger = Logger("request")
 
-  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+  override def apply(next: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     val start = System.currentTimeMillis()
-    val result = next(rh)
+    val resultFuture = next(request)
 
-    result onComplete {
+    resultFuture onComplete {
       case Success(response) =>
         val duration = System.currentTimeMillis() - start
-        logSuccess(rh, response, duration)
+        log(request, Right(response), duration)
 
       case Failure(err) =>
         val duration = System.currentTimeMillis() - start
-        logFailure(rh, err, duration)
+        log(request, Left(err), duration)
     }
 
-    result
+    resultFuture
   }
 
-  private def logSuccess(request: RequestHeader, response: Result, duration: Long): Unit = {
+  private def log(request: RequestHeader, outcome: Either[Throwable, Result], duration: Long): Unit = {
     val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
     val referer = request.headers.get("Referer").getOrElse("")
-    val originalService = request.headers.get(Authentication.originalServiceHeaderName)
-    val length = response.header.headers.getOrElse("Content-Length", 0)
-
-    val mandatoryMarkers = Map(
-      "origin" -> originIp,
-      "referrer" -> referer,
-      "method" -> request.method,
-      "status" -> response.header.status,
-      "duration" -> duration
-    )
-
-    val optionalMarkers = originalService
-      .map { s => Map(Authentication.originalServiceHeaderName -> s ) }
-      .getOrElse(Map.empty)
-
-    val markers = MarkerContext(appendEntries((mandatoryMarkers ++ optionalMarkers).asJava))
-    logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ${response.header.status} $length "$referer" ${duration}ms""")(markers)
-  }
-
-  private def logFailure(request: RequestHeader, throwable: Throwable, duration: Long): Unit = {
-    val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
-    val referer = request.headers.get("Referer").getOrElse("")
-    val originalService = request.headers.get(Authentication.originalServiceHeaderName)
 
     val mandatoryMarkers = Map(
       "origin" -> originIp,
@@ -65,12 +42,26 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
       "duration" -> duration
     )
 
-    val optionalMarkers = originalService
-      .map { s => Map(Authentication.originalServiceHeaderName -> s ) }
-      .getOrElse(Map.empty)
+    val optionalMarkers = Map(
+      "status" -> outcome.map(_.header.status).toOption,
+      Authentication.originalServiceHeaderName -> request.headers.get(Authentication.originalServiceHeaderName)
+    ).collect{
+      case (key, Some(value)) => key -> value
+    }
 
     val markers = MarkerContext(appendEntries((mandatoryMarkers ++ optionalMarkers).asJava))
-    logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ERROR "$referer" ${duration}ms""")(markers)
-    logger.error(s"Error for ${request.method} ${request.uri}", throwable)
+
+    outcome.fold(
+      throwable => {
+        logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ERROR "$referer" ${duration}ms""")(markers)
+        logger.error(s"Error for ${request.method} ${request.uri}", throwable)
+      },
+      response => {
+        val length = response.header.headers.getOrElse("Content-Length", 0)
+        logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ${response.header.status} $length "$referer" ${duration}ms""")(markers)
+      }
+
+    )
   }
+
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
@@ -2,6 +2,7 @@ package com.gu.mediaservice.lib.play
 
 import akka.stream.Materializer
 import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.auth.provider.InnerServiceAuthentication
 import net.logstash.logback.marker.Markers.appendEntries
 import play.api.mvc.{Filter, RequestHeader, Result}
 import play.api.{Logger, MarkerContext}
@@ -42,10 +43,18 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
       "duration" -> duration
     )
 
-    val optionalMarkers = Map(
+    val markersFromRequestHeaders = List(
+      Authentication.originalServiceHeaderName,
+      InnerServiceAuthentication.innerServiceIdentityHeaderName,
+      InnerServiceAuthentication.innerServiceUUIDHeaderName,
+      InnerServiceAuthentication.innerServiceTimestampHeaderName
+    ).map { headerName =>
+      headerName -> request.headers.get(headerName)
+    }
+
+    val optionalMarkers = (markersFromRequestHeaders ++ Map(
       "status" -> outcome.map(_.header.status).toOption,
-      Authentication.originalServiceHeaderName -> request.headers.get(Authentication.originalServiceHeaderName)
-    ).collect{
+    )).collect{
       case (key, Some(value)) => key -> value
     }
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -3,6 +3,7 @@ import akka.stream.scaladsl.Source
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
 import com.contxt.kinesis.{KinesisRecord, KinesisSource}
 import com.gu.mediaservice.lib.elasticsearch.ElasticSearchConfig
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import com.typesafe.scalalogging.StrictLogging
 import controllers.{HealthCheck, ThrallController}
@@ -61,6 +62,8 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val thrallController = new ThrallController(controllerComponents)
   val healthCheckController = new HealthCheck(es, streamRunning.isCompleted, config, controllerComponents)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override lazy val router = new Routes(httpErrorHandler, thrallController, healthCheckController, management)
+
+  override lazy val router = new Routes(httpErrorHandler, thrallController, healthCheckController, management, InnerServiceStatusCheckController)
 }

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -62,7 +62,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val thrallController = new ThrallController(controllerComponents)
   val healthCheckController = new HealthCheck(es, streamRunning.isCompleted, config, controllerComponents)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override lazy val router = new Routes(httpErrorHandler, thrallController, healthCheckController, management, InnerServiceStatusCheckController)

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -7,8 +7,8 @@ GET     /                                             controllers.ThrallControll
 # Management
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck(depth: Int)
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -2,11 +2,13 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET     /                           controllers.ThrallController.index
+GET     /                                             controllers.ThrallController.index
 
 # Management
-GET     /management/healthcheck     controllers.HealthCheck.healthCheck
-GET     /management/manifest        com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/healthcheck                       controllers.HealthCheck.healthCheck
+GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck
+GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
-GET     /robots.txt                 com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -35,7 +35,7 @@ class UsageComponents(context: Context) extends GridComponents(context, new Usag
   })
 
   val controller = new UsageApi(auth, usageTable, usageGroup, notifications, config, usageRecorder, liveContentApi, controllerComponents, playBodyParsers)
-  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 
   override lazy val router = new Routes(httpErrorHandler, controller, management, InnerServiceStatusCheckController)

--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.UsageApi
 import lib._
@@ -34,6 +35,8 @@ class UsageComponents(context: Context) extends GridComponents(context, new Usag
   })
 
   val controller = new UsageApi(auth, usageTable, usageGroup, notifications, config, usageRecorder, liveContentApi, controllerComponents, playBodyParsers)
+  val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(controllerComponents, config.services, wsClient)
 
-  override lazy val router = new Routes(httpErrorHandler, controller, management)
+
+  override lazy val router = new Routes(httpErrorHandler, controller, management, InnerServiceStatusCheckController)
 }

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -13,6 +13,7 @@ GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.rei
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
 
 # Shoo robots away
 GET     /robots.txt                                     com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -13,7 +13,7 @@ GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.rei
 # Management
 GET     /management/healthcheck                         com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                            com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI
+GET     /management/whoAmI                              com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                     com.gu.mediaservice.lib.management.Management.disallowRobots


### PR DESCRIPTION
Co-authored-by: @twrichards 

## Context/Problem
https://trello.com/c/UhDV91uo/2333-grid-cross-service-authentication-process

Projection accesses all canonical sources by talking to all miscroservices in order to provide a diff (`/projection/diff`) between a current shape of the data and the shape the data would take would the image be ingested now.

We need to be able to talk freely to all the other microservices in the Grid. Thrall needs to be able to initiate the calls to these microservices itself, and not rely on api-keys or upstream UI actions triggering the calls.

## What does this change?

Introduces a new `InnerServicePrincipal` to be used when **originating** requests from a service in the Grid to another service in the Grid (for example, `thrall` calling `media-api`). This differs from 'MachinePrincipal` which is used when third-party (or services external to the Grid) originate a call to a Grid service and authenticate using an API key. 

This new inner service mechanism applies the following headers to the request: 
- `X-Inner-Service-Identity`: contains the name of the originating service, e.g. `thrall` and  possibly names of other services the request has gone via (see `onBehalfOf` section below)
- `X-Inner-Service-UUID`: contains a unique identifier for the request
- `X-Inner-Service-Timestamp`
- `X-Inner-Service-Signature`: contains a checksum of the above 3 headers, encrypted using the Play secret (which is already shared between the services).

**There is now an `innerServiceCall` on `Authentication` instances (which is already available in lots of the controllers, etc) which takes a `WSRequest`, signs the request using the mechanism above, and returns a new `WSRequest`.**


#### `onBehalfOf`

All `Principal`s require an `onBehalfOf` implementation so that services can call other services reusing the credentials of the service that called them. In the case of the new `InnerServicePrincipal` we append a "via" to the identity, then create a fresh UUID and timestamp and thus a new signature - so there is traceability of the hops taken from service to service. 

#### `innerServiceStatusCheck`

To demonstrate/check this new mechanism, we created `InnerServiceStatusCheckController` and added a `/management/InnerServiceStatusCheck` endpoint to `thrall` **(which is now regularly exercised via [Pingler](https://github.com/guardian/grid/blob/main/docs/02-running/01-running-locally.md#the_pinglersh))**. It calls all other internal services using `auth.innerServiceCall`, which then go on to call all other internal services again using the `auth.getOnBehalfOf` in order to demonstrate the "via" mentioned above.

## How can success be measured?
This unblocks us from progressing with the reingestion project by allowing us to originate calls from `thrall` in a secure way, without having to generate, store/retrieve and rotate API keys.
 

## Who should look at this?
@guardian/digital-cms 


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment

## Images
example logging demonstrating https://github.com/guardian/grid/pull/3342/commits/8026cd6d2ae37fb8c3df188d0b58692800e95c01
![image](https://user-images.githubusercontent.com/19289579/121673683-0f4e3700-caa9-11eb-8cf6-2903e51a9dd2.png)
