### PR TITLE
Upgrade Sentry

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -4977,6 +4977,74 @@
         }
       }
     },
+    "@sentry/browser": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.5.1.tgz",
+      "integrity": "sha512-iVLCdEFwsoWAzE/hNknexPQjjDpMQV7mmaq9Z1P63bD6MfhwVTx4hG4pHn8HEvC38VvCVf1wv0v/LxtoODAYXg==",
+      "requires": {
+        "@sentry/core": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.5.1.tgz",
+      "integrity": "sha512-Mh3sl/iUOT1myHmM6RlDy2ARzkUClx/g4DAt1rJ/IpQBOlDYQraplXSIW80i/hzRgQDfwhwgf4wUa5DicKBjKw==",
+      "requires": {
+        "@sentry/hub": "6.5.1",
+        "@sentry/minimal": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.5.1.tgz",
+      "integrity": "sha512-lBRMBVMYP8B4PfRiM70murbtJAXiIAao/asDEMIRNGMP6pI2ArqXfJCBYDkStukhikYD0Kqb4trXq+JYF07Hbg==",
+      "requires": {
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.5.1.tgz",
+      "integrity": "sha512-NYiW0rH7fwv7aRtrRnfCSIiwulfV2NoLjhmghCONsyo10DNtYmOpogLotCytZFWLDnTJW1+pmTomq8UW/OSTcQ==",
+      "requires": {
+        "@sentry/types": "6.5.1",
+        "@sentry/utils": "6.5.1",
+        "localforage": "^1.8.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.5.1.tgz",
+      "integrity": "sha512-q9Do/oreu1RP695CXCLowVDuQyk7ilE6FGdz2QLpTXAfx8247qOwk6+zy9Kea/Djk93+BoSDVQUSneNiVwl0nQ==",
+      "requires": {
+        "@sentry/hub": "6.5.1",
+        "@sentry/types": "6.5.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.5.1.tgz",
+      "integrity": "sha512-b/7a6CMoytaeFPx4IBjfxPw3nPvsQh7ui1C8Vw0LxNNDgBwVhPLzUOWeLWbo5YZCVbGEMIWwtCUQYWxneceZSA=="
+    },
+    "@sentry/utils": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.5.1.tgz",
+      "integrity": "sha512-Wv86JYGQH+ZJ5XGFQX7h6ijl32667ikenoL9EyXMn8UoOYX/MLwZoQZin1P60wmKkYR9ifTNVmpaI9OoTaH+UQ==",
+      "requires": {
+        "@sentry/types": "6.5.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -9122,6 +9190,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immutable": {
       "version": "3.8.2",
@@ -13874,6 +13947,14 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "liftoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
@@ -13936,6 +14017,14 @@
             "minimist": "^1.2.0"
           }
         }
+      }
+    },
+    "localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -15331,11 +15420,6 @@
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
-    },
-    "raven-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-1.3.0.tgz",
-      "integrity": "sha1-33iLbqkx2eeXJb5LDYmeb3EdjWk="
     },
     "react-is": {
       "version": "16.13.1",
@@ -17019,8 +17103,7 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
+    "@sentry/browser": "^6.5.1",
+    "@sentry/integrations": "^6.5.1",
     "angular": "1.6.10",
     "angular-animate": "1.6.10",
     "angular-elastic": "^2.5.1 ",
@@ -20,7 +22,6 @@
     "panda-session": "0.1.6",
     "pandular": "0.1.6",
     "pikaday": "^1.8.2",
-    "raven-js": "^1.1.18",
     "rx": "^2.5.3",
     "rx-angular": "^1.1.3",
     "rx-dom": "^6.0.0",

--- a/kahuna/public/js/sentry/sentry.js
+++ b/kahuna/public/js/sentry/sentry.js
@@ -1,5 +1,7 @@
 import angular from 'angular';
-import raven from 'raven-js';
+import * as Sentry from '@sentry/browser';
+import { CaptureConsole } from '@sentry/integrations';
+
 
 export var sentry = angular.module('sentry', []);
 
@@ -63,7 +65,7 @@ sentry.config(['$provide', function ($provide) {
             // Don't send failed HTTP requests as that's mostly just
             // noise we already get in other logs
             if (!isHttpError(exception)) {
-                raven.captureException(exception, cause);
+                Sentry.captureException(exception, cause);
             }
         };
     }]);
@@ -72,12 +74,14 @@ sentry.config(['$provide', function ($provide) {
 sentry.run(['$rootScope', 'sentryEnabled', 'sentryDsn',
             ($rootScope, sentryEnabled, sentryDsn) => {
     if (sentryEnabled) {
-        raven.config(sentryDsn, {}).install();
-        // Ensures user data is blank
-        raven.setUserContext({});
+      Sentry.init({dsn: sentryDsn,
+        integrations: [
+          new CaptureConsole({})
+        ]});
+      // Ensures user data is blank
+      Sentry.configureScope(scope=>{
+        scope.setData('session_id', window._clientConfig.sessionId);
+      });
 
-        raven.setExtraContext({
-          'session_id': window._clientConfig.sessionId
-        });
     }
 }]);

--- a/kahuna/public/js/sentry/sentry.js
+++ b/kahuna/public/js/sentry/sentry.js
@@ -79,9 +79,6 @@ sentry.run(['$rootScope', 'sentryEnabled', 'sentryDsn',
           new CaptureConsole({})
         ]});
       // Ensures user data is blank
-      Sentry.configureScope(scope=>{
-        scope.setData('session_id', window._clientConfig.sessionId);
-      });
-
+      Sentry.setContext('session_id', window._clientConfig.sessionId);
     }
 }]);


### PR DESCRIPTION
our version of sentry is quite old, this upgrades it to the latest one. 
this allows us better handling of logging, and should let us see into the console logs and get a good idea about the auth timeouts

it will need `https://app.getsentry.com/` in connect-src in kahuna