### PR TITLE
Extract Guardian specific messages into config

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -41,12 +41,7 @@ class KahunaController(
       config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists)),
       config.staffPhotographerOrganisation,
       config.homeLinkHtml,
-      config.systemName,
-      config.dropzoneExplanation,
-      config.advancedSearchExampleExplanation,
-      config.exampleEmail,
-      config.exampleLabel,
-      config.institution
+      config.systemName
     ))
   }
 

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -40,7 +40,13 @@ class KahunaController(
       fieldAliases,
       config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists)),
       config.staffPhotographerOrganisation,
-      config.homeLinkHtml
+      config.homeLinkHtml,
+      config.systemName,
+      config.dropzoneExplanation,
+      config.advancedSearchExampleExplanation,
+      config.exampleEmail,
+      config.exampleLabel,
+      config.institution
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -32,11 +32,6 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val staffPhotographerOrganisation: String = stringOpt("branding.staffPhotographerOrganisation").filterNot(_.isEmpty).getOrElse("GNM")
   val homeLinkHtml: Option[String] = stringOpt("branding.homeLinkHtml").filterNot(_.isEmpty)
   val systemName: String = stringOpt("branding.systemName").filterNot(_.isEmpty).getOrElse("the Grid")
-  val dropzoneExplanation: Option[String] = stringOpt("branding.dropzoneExplanation").filterNot(_.isEmpty)
-  val advancedSearchExampleExplanation: Option[String] = stringOpt("branding.advancedSearchExampleExplanation").filterNot(_.isEmpty)
-  val exampleEmail: Option[String] = stringOpt("branding.exampleEmail").filterNot(_.isEmpty)
-  val exampleLabel: Option[String] = stringOpt("branding.exampleLabel").filterNot(_.isEmpty)
-  val institution: Option[String] = stringOpt("branding.institution").filterNot(_.isEmpty)
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources")

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -28,8 +28,15 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)
   val invalidSessionHelpLink: Option[String]= stringOpt("links.invalidSessionHelp").filterNot(_.isEmpty)
   val supportEmail: Option[String]= stringOpt("links.supportEmail").filterNot(_.isEmpty)
+
   val staffPhotographerOrganisation: String = stringOpt("branding.staffPhotographerOrganisation").filterNot(_.isEmpty).getOrElse("GNM")
   val homeLinkHtml: Option[String] = stringOpt("branding.homeLinkHtml").filterNot(_.isEmpty)
+  val systemName: String = stringOpt("branding.systemName").filterNot(_.isEmpty).getOrElse("the Grid")
+  val dropzoneExplanation: Option[String] = stringOpt("branding.dropzoneExplanation").filterNot(_.isEmpty)
+  val advancedSearchExampleExplanation: Option[String] = stringOpt("branding.advancedSearchExampleExplanation").filterNot(_.isEmpty)
+  val exampleEmail: Option[String] = stringOpt("branding.exampleEmail").filterNot(_.isEmpty)
+  val exampleLabel: Option[String] = stringOpt("branding.exampleLabel").filterNot(_.isEmpty)
+  val institution: Option[String] = stringOpt("branding.institution").filterNot(_.isEmpty)
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources")

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -13,7 +13,13 @@
   fieldAliases: String,
   scriptsToLoad: List[ScriptToLoad],
   staffPhotographerOrganisation: String,
-  homeLinkHtml: Option[String]
+  homeLinkHtml: Option[String],
+  systemName: String,
+  dropzoneExplanation: Option[String],
+  advancedSearchExampleExplanation: Option[String],
+  exampleEmail: Option[String],
+  exampleLabel: Option[String],
+  institution: Option[String]
 )
 <!DOCTYPE html>
 <html>
@@ -21,7 +27,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title ui-title ui-title-suffix="the grid">the grid</title>
+    <title ui-title ui-title-suffix="@systemName">@systemName</title>
     <!-- htmllint line-ending-style="false" -->
 
 
@@ -53,13 +59,19 @@
           supportEmail: "@Html(supportEmail.getOrElse(""))",
           staffPhotographerOrganisation: "@Html(staffPhotographerOrganisation)",
           fieldAliases: @Html(fieldAliases),
-          homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))'
+          homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))',
+          systemName: "@Html(systemName)",
+          dropzoneExplanation: "@Html(dropzoneExplanation.getOrElse("Drop files or GuardianWitness URLs here to upload them instantly to the Grid"))",
+          advancedSearchExampleExplanation: "@Html(advancedSearchExampleExplanation.getOrElse("Grid-specific Usage Rights categories."))",
+          exampleEmail: "@Html(exampleEmail.getOrElse("jo.doe@guardian.co.uk"))",
+          exampleLabel: "@Html(exampleLabel.getOrElse("Observer"))",
+          institution: "@Html(institution.getOrElse("The Guardian"))"
         }
     </script>
 
   </head>
   <body>
-    <p class="loader" ng-hide="true">Loading the grid…</p>
+    <p class="loader" ng-hide="true">Loading @systemName…</p>
 
     <div ui-view></div>
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -14,12 +14,7 @@
   scriptsToLoad: List[ScriptToLoad],
   staffPhotographerOrganisation: String,
   homeLinkHtml: Option[String],
-  systemName: String,
-  dropzoneExplanation: Option[String],
-  advancedSearchExampleExplanation: Option[String],
-  exampleEmail: Option[String],
-  exampleLabel: Option[String],
-  institution: Option[String]
+  systemName: String
 )
 <!DOCTYPE html>
 <html>
@@ -60,12 +55,7 @@
           staffPhotographerOrganisation: "@Html(staffPhotographerOrganisation)",
           fieldAliases: @Html(fieldAliases),
           homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))',
-          systemName: "@Html(systemName)",
-          dropzoneExplanation: "@Html(dropzoneExplanation.getOrElse("Drop files or GuardianWitness URLs here to upload them instantly to the Grid"))",
-          advancedSearchExampleExplanation: "@Html(advancedSearchExampleExplanation.getOrElse("Grid-specific Usage Rights categories."))",
-          exampleEmail: "@Html(exampleEmail.getOrElse("jo.doe@guardian.co.uk"))",
-          exampleLabel: "@Html(exampleLabel.getOrElse("Observer"))",
-          institution: "@Html(institution.getOrElse("The Guardian"))"
+          systemName: "@Html(systemName)"
         }
     </script>
 

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
@@ -32,7 +32,7 @@
                      gr-search="ctrl.suggestedLabelsSearch(q)">
           <input type="text"
                class="text-input show-no-error"
-               placeholder="e.g. observer"
+               placeholder="e.g. {{ctrl.exampleLabel}}"
                required
                gr-auto-focus
                gr-datalist-input

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
@@ -20,6 +20,7 @@ presetLabels.controller('GrPresetLabelsCtrl', [
         let ctrl = this;
 
         ctrl.active = false;
+        ctrl.exampleLabel = window._clientConfig.exampleLabel;
 
         ctrl.presetLabels = presetLabelService.getLabels();
 

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
@@ -7,6 +7,8 @@ import '../../directives/gr-auto-focus';
 import '../../services/preset-label';
 import {mediaApi} from '../../services/api/media-api';
 
+import strings from '../../strings.json';
+
 export var presetLabels = angular.module('gr.presetLabels', [
     'gr.autoFocus',
     'kahuna.services.presetLabel',
@@ -20,7 +22,7 @@ presetLabels.controller('GrPresetLabelsCtrl', [
         let ctrl = this;
 
         ctrl.active = false;
-        ctrl.exampleLabel = window._clientConfig.exampleLabel;
+        ctrl.exampleLabel = strings.exampleLabel;
 
         ctrl.presetLabels = presetLabelService.getLabels();
 

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -143,7 +143,7 @@
         </section>
 
         <section>
-            <span class="edit_metadata__warning" ng-if="!ctrl.userCanEdit">WARNING: This image is already in The Grid. Since you're not the original uploader, you are not allowed to edit its metadata.</span>
+            <span class="edit_metadata__warning" ng-if="!ctrl.userCanEdit">WARNING: This image is already in {{ctrl.systemName}}. Since you're not the original uploader, you are not allowed to edit its metadata.</span>
             <h1 ng-class="{'section__disabled': !ctrl.userCanEdit}">Image Metadata</h1>
             <ui-required-metadata-editor
                 class="result-editor__metadata-editor"

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -54,6 +54,7 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.status = ctrl.image.data.valid ? 'ready' : 'invalid';
     ctrl.usageRights = imageService(ctrl.image).usageRights;
     ctrl.invalidReasons = ctrl.image.data.invalidReasons;
+    ctrl.systemName = window._clientConfig.systemName;
 
     //TODO put collections in their own directive
     ctrl.addCollection = false;

--- a/kahuna/public/js/errors/global.html
+++ b/kahuna/public/js/errors/global.html
@@ -17,7 +17,7 @@
         <div>
             We are looking into this but if the problem persists please
             <a href="{{ctrl.supportEmailLink}}"
-            class="coloured-link">email the Grid team</a>.
+            class="coloured-link">email {{ctrl.systemName}} team</a>.
         </div>
 
         <div>
@@ -35,7 +35,7 @@
 
     <div class="global-error warning" ng-message="unknown">
         An unknown error has occurred.
-        If the problem persists please <a href="{{ctrl.supportEmailLink}}" class="coloured-link">email the Grid team</a>.
+        If the problem persists please <a href="{{ctrl.supportEmailLink}}" class="coloured-link">email {{ctrl.systemName}} team</a>.
 
         <gr-icon class="global-error__close"
                  title="Close"
@@ -43,7 +43,7 @@
     </div>
 
     <div class="global-error error" ng-message="server">
-        A server error has occurred; the Grid may not be fully functional at this time.
-        If the problem persists please <a href="{{ctrl.supportEmailLink}}" class="coloured-link">email the Grid team</a>.
+        A server error has occurred; {{ctrl.systemName}} may not be fully functional at this time.
+        If the problem persists please <a href="{{ctrl.supportEmailLink}}" class="coloured-link">email {{ctrl.systemName}} team</a>.
     </div>
 </ng-messages>

--- a/kahuna/public/js/errors/global.js
+++ b/kahuna/public/js/errors/global.js
@@ -43,6 +43,7 @@ globalErrors.controller('GlobalErrorsCtrl',
 
     ctrl.invalidSessionHelpLink = window._clientConfig.invalidSessionHelpLink;
     ctrl.supportEmailLink = window._clientConfig.supportEmail;
+    ctrl.systemName = window._clientConfig.systemName;
 
     // handy as these can happen anywhere
     ctrl.getCurrentLocation = () => $location.url();

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -43,7 +43,7 @@
                 <gr-chip-example gr-filter-field="category" gr-example-search="screengrab"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
-                Grid-specific Usage Rights categories.
+                {{advancedSearchExampleExplanation}}
             </dd>
         </dl>
         <dl class="advanced-search-example">
@@ -161,7 +161,7 @@
         </dl>
         <dl class="advanced-search-example">
             <dt class="advanced-search-example__field">
-                <gr-chip-example gr-filter-field="uploader" gr-example-search="jo.doe@guardian.co.uk"></gr-chip-example>
+                <gr-chip-example gr-filter-field="uploader" gr-example-search="{{exampleEmail}}"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
                 Search by person (email) or ftp source (folder).

--- a/kahuna/public/js/search/syntax/syntax.js
+++ b/kahuna/public/js/search/syntax/syntax.js
@@ -3,6 +3,8 @@ import angular from 'angular';
 import template from './syntax.html';
 import {grChipExample} from '../../directives/gr-chip-example';
 
+import strings from '../../strings.json';
+
 export const syntax = angular.module('grSyntax', [grChipExample.name]);
 
 syntax.directive('grSyntax', [function () {
@@ -11,8 +13,8 @@ syntax.directive('grSyntax', [function () {
         template: template,
         transclude: 'replace',
         link: function($scope) {
-            $scope.exampleEmail = window._clientConfig.exampleEmail;
-            $scope.advancedSearchExampleExplanation = window._clientConfig.advancedSearchExampleExplanation;
+            $scope.exampleEmail = strings.exampleEmail;
+            $scope.advancedSearchExampleExplanation = strings.advancedSearchExampleExplanation;
         }
     };
 }]);

--- a/kahuna/public/js/search/syntax/syntax.js
+++ b/kahuna/public/js/search/syntax/syntax.js
@@ -9,6 +9,10 @@ syntax.directive('grSyntax', [function () {
     return {
         restrict: 'E',
         template: template,
-        transclude: 'replace'
+        transclude: 'replace',
+        link: function($scope) {
+            $scope.exampleEmail = window._clientConfig.exampleEmail;
+            $scope.advancedSearchExampleExplanation = window._clientConfig.advancedSearchExampleExplanation;
+        }
     };
 }]);

--- a/kahuna/public/js/strings.json
+++ b/kahuna/public/js/strings.json
@@ -1,0 +1,7 @@
+{
+    "dropzoneExplanation": "Drop files or GuardianWitness URLs here to upload them instantly to the Grid",
+    "advancedSearchExampleExplanation": "Grid-specific Usage Rights categories.",
+    "exampleEmail": "jo.doe@guardian.co.uk",
+    "exampleLabel": "Observer",
+    "institution": "The Guardian"      
+}

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -12,6 +12,7 @@ upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', function(uploadMan
     var ctrl = this;
 
     ctrl.supportEmailLink = window._clientConfig.supportEmail;
+    ctrl.systemName = window._clientConfig.systemName;
 
     mediaApi.canUserUpload().then(canUpload => {
         ctrl.canUpload = canUpload;

--- a/kahuna/public/js/upload/dnd-uploader.html
+++ b/kahuna/public/js/upload/dnd-uploader.html
@@ -1,7 +1,7 @@
 <div class="dnd-uploader" ng-if="dndUploader.activated">
     <div class="dnd-uploader__info">
         <div class="dnd-uploader__heading">Dropzone!</div>
-        <div class="dnd-uploader__explainer">Drop files or GuardianWitness URLs here to upload them instantly to the Grid</div>
+        <div class="dnd-uploader__explainer">{{dndUploader.dropzoneExplanation}}</div>
     </div>
 </div>
 

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -3,6 +3,8 @@ import template from './dnd-uploader.html';
 
 import {witnessApi} from '../services/api/witness';
 
+import strings from '../strings.json';
+
 export var dndUploader = angular.module('kahuna.upload.dndUploader', [
     'kahuna.upload.manager',
     witnessApi.name,
@@ -107,7 +109,7 @@ dndUploader.directive('dndUploader', ['$window', '$rootScope', 'delay', 'safeApp
         bindToController: true,
         link: (scope, element, attrs, ctrl) => {
             let dragging = false; // [1]
-            ctrl.dropzoneExplanation = window._clientConfig.dropzoneExplanation;
+            ctrl.dropzoneExplanation = strings.dropzoneExplanation;
             const $$window = angular.element($window);
 
             const activate    = () => safeApply(scope, () => ctrl.activated = true);

--- a/kahuna/public/js/upload/dnd-uploader.js
+++ b/kahuna/public/js/upload/dnd-uploader.js
@@ -107,6 +107,7 @@ dndUploader.directive('dndUploader', ['$window', '$rootScope', 'delay', 'safeApp
         bindToController: true,
         link: (scope, element, attrs, ctrl) => {
             let dragging = false; // [1]
+            ctrl.dropzoneExplanation = window._clientConfig.dropzoneExplanation;
             const $$window = angular.element($window);
 
             const activate    = () => safeApply(scope, () => ctrl.activated = true);

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -61,7 +61,7 @@
                 <input
                     data-cy="image-metadata-credit"
                     type="text"
-                    placeholder="eg The Guardian (source, agency or institution which owns the image)"
+                    placeholder="eg {{ctrl.institution}} (source, agency or institution which owns the image)"
                     class="text-input job-info__credit"
                     required
                     gr-datalist-input

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -7,6 +7,8 @@ import '../../edits/service';
 import '../../forms/datalist';
 import '../../components/gr-description-warning/gr-description-warning';
 
+import strings from '../../strings.json';
+
 export var jobs = angular.module('kahuna.upload.jobs.requiredMetadataEditor', [
     'kahuna.edits.service',
     'kahuna.forms.datalist',
@@ -21,7 +23,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     var ctrl = this;
 
-    ctrl.institution = window._clientConfig.institution;
+    ctrl.institution = strings.institution;
     editsService.canUserEdit(ctrl.image).then(editable => {
         ctrl.userCanEdit = editable;
     });

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -21,6 +21,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
 
     var ctrl = this;
 
+    ctrl.institution = window._clientConfig.institution;
     editsService.canUserEdit(ctrl.image).then(editable => {
         ctrl.userCanEdit = editable;
     });

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -141,8 +141,10 @@ jobs.controller('UploadJobsCtrl', [
         }, error => {
             const reason = error.body && error.body.errorKey;
 
+            const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
+
             const message = reason === 'unsupported-type' ?
-                'The Grid only supports JPG, PNG and TIFF images.' +
+            `${capitalize(window._clientConfig.systemName)} only supports JPG, PNG and TIFF images.` +
                 ' Please convert the image and try again.' :
                 error.body && error.body.errorMessage || 'unknown';
 

--- a/kahuna/public/js/upload/prompt/prompt.html
+++ b/kahuna/public/js/upload/prompt/prompt.html
@@ -1,5 +1,5 @@
 <div class="message">
-    Either drag 'n drop images onto this screen or click <file-uploader></file-uploader> to get your images on the Grid.
+    Either drag 'n drop images onto this screen or click <file-uploader></file-uploader> to get your images on {{systemName}}.
 </div>
 
 <div class="preset-labels">

--- a/kahuna/public/js/upload/prompt/prompt.html
+++ b/kahuna/public/js/upload/prompt/prompt.html
@@ -4,7 +4,7 @@
 
 <div class="preset-labels">
     <p class="preset-labels__heading">Apply
-        <span ng-if="ctrl.presetLabels.length === 0 && !ctrl.active">label e.g. Observer </span>
+        <span ng-if="ctrl.presetLabels.length === 0 && !ctrl.active">label e.g. {{exampleLabel}} </span>
     </p>
     <gr-preset-labels></gr-preset-labels>
     <p class="preset-labels__heading">to all uploads</p>

--- a/kahuna/public/js/upload/prompt/prompt.js
+++ b/kahuna/public/js/upload/prompt/prompt.js
@@ -4,6 +4,8 @@ import './prompt.css';
 import template from './prompt.html';
 import '../../components/gr-preset-labels/gr-preset-labels';
 
+import strings from '../../strings.json';
+
 export let prompt = angular.module('kahuna.upload.prompt', [
     'gr.presetLabels'
 ]);
@@ -16,7 +18,7 @@ prompt.directive('filePrompt', [function () {
         template: template,
         link: function($scope) {
             $scope.systemName = window._clientConfig.systemName;
-            $scope.exampleLabel = window._clientConfig.exampleLabel;
+            $scope.exampleLabel = strings.exampleLabel;
         }
     };
 }]);

--- a/kahuna/public/js/upload/prompt/prompt.js
+++ b/kahuna/public/js/upload/prompt/prompt.js
@@ -13,6 +13,10 @@ prompt.directive('filePrompt', [function () {
         restrict: 'E',
         transclude: 'replace',
         scope: {}, // ensure isolated scope
-        template: template
+        template: template,
+        link: function($scope) {
+            $scope.systemName = window._clientConfig.systemName;
+            $scope.exampleLabel = window._clientConfig.exampleLabel;
+        }
     };
 }]);

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -27,6 +27,6 @@
         <recent-uploads></recent-uploads>
     </section>
 </div>
-<div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images. <a href="{{ctrl.supportEmailLink}}" class="coloured-link">Send an email to the Grid team</a> if you think this is incorrect.</div>
+<div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images. <a href="{{ctrl.supportEmailLink}}" class="coloured-link">Send an email to {{ctrl.systemName}} team</a> if you think this is incorrect.</div>
 
 <dnd-uploader ng-if="ctrl.canUpload"></dnd-uploader>


### PR DESCRIPTION
## What does this change?
Currently, there are many Guardian-specific messages in the UI. This is an effort to make these messages configurable.

The following are some of the things that BBC wants to customise:
- References to "the Grid" will be changed to "BBC Images".
- References to "The Guardian" will be changed to "BBC".
- References to "The Observer" will be changed to "BBC Studio".

Regarding the systemName config, I've noticed there's not a uniform capitalisation of it; some places it's written as "the grid", some as "the Grid", others as "The Grid". My approach was to default systemName to "the Grid" to avoid having to add 3 different configs for this value. However, there's one place where I had to capitalise the first letter via code, because it was at the start of a sentence.

In one place "Grid" was used without the article ("Grid-specific usage rights") so I decided to make that whole text configurable.

The other message I extracted completely was "Drop files or GuardianWitness URLs here to upload them instantly to the Grid". BBC wants this phrase to read as "Drop files or URLs here to upload them instantly to BBC Images".

Same thing for the usage of "Observer". One instance had lowercase while the other had uppercase first letter. I decided to use "Observer" as default value.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
@guardian/digital-cms


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
