### PR TITLE
Extract crop options

### DIFF
--- a/kahuna/public/js/util/constants/cropOptions.js
+++ b/kahuna/public/js/util/constants/cropOptions.js
@@ -1,0 +1,8 @@
+// `ratioString` is sent to the server, being `undefined` for `freeform` is expected 🙈
+export const landscape = {key: 'landscape', ratio: 5 / 3, ratioString: '5:3'};
+export const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
+export const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
+export const square = {key: 'square', ratio: 1, ratioString: '1:1'};
+export const freeform = {key: 'freeform', ratio: null};
+
+export const cropOptions = [landscape, portrait, video, square, freeform];

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -1,20 +1,13 @@
 import angular from 'angular';
 
+import { landscape, portrait, video, square, freeform, cropOptions } from './constants/cropOptions';
+
 const CROP_TYPE_STORAGE_KEY = 'cropType';
 const CUSTOM_CROP_STORAGE_KEY = 'customCrop';
-
-// `ratioString` is sent to the server, being `undefined` for `freeform` is expected 🙈
-const landscape = {key: 'landscape', ratio: 5 / 3, ratioString: '5:3'};
-const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
-const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
-const square = {key: 'square', ratio: 1, ratioString: '1:1'};
-const freeform = {key: 'freeform', ratio: null};
 
 const customCrop = (label, xRatio, yRatio) => {
   return { key:label, ratio: xRatio / yRatio, ratioString: `${xRatio}:${yRatio}`};
 };
-
-const cropOptions = [landscape, portrait, video, square, freeform];
 
 export const cropUtil = angular.module('util.crop', ['util.storage']);
 
@@ -24,7 +17,7 @@ cropUtil.constant('video', video);
 cropUtil.constant('square', square);
 cropUtil.constant('freeform', freeform);
 cropUtil.constant('cropOptions', cropOptions);
-cropUtil.constant('defaultCrop', landscape);
+cropUtil.constant('defaultCrop', cropOptions[0]);
 
 cropUtil.factory('cropSettings', ['storage', function(storage) {
   function getCropOptions() {


### PR DESCRIPTION
## What does this change?
BBC would like to display different cropping options than the ones used by The Guardian. To be able to achieve that, this PR extracts crop options to a file that can be overriden during the build process to modify the options and/or order of the list.

## How can success be measured?
Cropping options are not modified in The Guardian's Grid.
BBC can customize their cropping options.

## Screenshots
How the cropping options would show when customized:
![image](https://user-images.githubusercontent.com/20479781/121787817-d1333f00-cb9e-11eb-84b5-7466cf2232f2.png)

## Who should look at this?
@guardian/digital-cms


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
