### PR TITLE
introduce soft delete image endpoint

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -101,6 +101,17 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
       valueMapWithNullForEmptyString(Map(":value" -> value))
     )
 
+  def stringListSet(id: String, keyValues: (String, JsValue)*)
+                   (implicit ex: ExecutionContext): Future[JsObject] = {
+    val keyValueMap = keyValues.toMap
+    val expressionParts = keyValueMap.keys.map(key => s"$key = :$key")
+    val valueMap = keyValueMap.map {case (key, value) => (s":$key", value)}
+    update(
+      id,
+      expression = s"SET ${expressionParts.mkString(",")}",
+      valueMapWithNullForEmptyString(valueMap)
+    )
+  }
 
   def setGet(id: String, key: String)
             (implicit ex: ExecutionContext): Future[Set[String]] =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -42,6 +42,7 @@ object UpdateMessage extends GridLogging {
         (__ \ "id").readNullable[String] ~
         (__ \ "usageNotice").readNullable[UsageNotice] ~
         (__ \ "edits").readNullable[Edits] ~
+        (__ \ "softDeletedMetadata").readNullable[SoftDeletedMetadata] ~
         // We seem to get messages from _somewhere which don't have last modified on them.
         (__ \ "lastModified").readNullable[DateTime].map{ d => d match {
           case Some(date) => date
@@ -67,6 +68,7 @@ case class UpdateMessage(
   id: Option[String] = None,
   usageNotice: Option[UsageNotice] = None,
   edits: Option[Edits] = None,
+  softDeletedMetadata: Option[SoftDeletedMetadata] = None,
   lastModified: DateTime = DateTime.now(DateTimeZone.UTC),
   collections: Option[Seq[Collection]] = None,
   leaseId: Option[String] = None,

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -21,6 +21,7 @@ object MappingTest {
   private val imageImported: DateTime = imageTaken.plus(Period.days(1).plusHours(1))
   private val imageModified: DateTime = imageImported.plus(Period.hours(2))
   private val imageDenyLeaseExpiry: DateTime = new DateTime(2030, 3, 26, 12, 0)
+  private val imageSoftDeleted: DateTime = imageImported.plus(Period.hours(2))
 
   private val testImageMetadata: ImageMetadata = ImageMetadata(
     dateTaken = Some(imageTaken),
@@ -57,6 +58,7 @@ object MappingTest {
     id = "abcdef1234567890",
     uploadTime = imageImported,
     uploadedBy = testUploader, // Do not change this, we use it to clean up old test images
+    softDeletedMetadata = Some(SoftDeletedMetadata(DateTime.now, "user@test.uk")),
     lastModified = Some(imageModified),
     identifiers = Map("id1" -> "value1"),
     uploadInfo = UploadInfo(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -52,6 +52,7 @@ object Mappings {
         exportsMapping("exports"),
         dateField("uploadTime"),
         keywordField("uploadedBy"),
+        softDeletedMetadataMapping("softDeletedMetadata"),
         dateField("lastModified"),
         dynamicObj("identifiers"),
         uploadInfoMapping("uploadInfo"),
@@ -281,6 +282,11 @@ object Mappings {
   def leasesMapping(name: String): ObjectField = nonDynamicObjectField(name).fields(
     leaseMapping("leases"),
     dateField("lastModified")
+  )
+
+  def softDeletedMetadataMapping(name: String) = nonDynamicObjectField(name).fields(
+    dateField("deleteTime"),
+    keywordField("deletedBy")
   )
 
   private def nonDynamicObjectField(name: String) = ObjectField(name).dynamic("strict")

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -7,11 +7,11 @@ import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-
 case class Image(
   id:                  String,
   uploadTime:          DateTime,
   uploadedBy:          String,
+  softDeletedMetadata: Option[SoftDeletedMetadata],
   lastModified:        Option[DateTime],
   identifiers:         Map[String, String],
   uploadInfo:          UploadInfo,
@@ -82,6 +82,7 @@ object Image {
     (__ \ "id").read[String] ~
       (__ \ "uploadTime").read[String].map(unsafeParseDateTime) ~
       (__ \ "uploadedBy").read[String] ~
+      (__ \ "softDeletedMetadata").readNullable[SoftDeletedMetadata] ~
       (__ \ "lastModified").readNullable[String].map(parseOptDateTime) ~
       (__ \ "identifiers").readNullable[Map[String, String]].map(_ getOrElse Map()) ~
       (__ \ "uploadInfo").readNullable[UploadInfo].map(_ getOrElse UploadInfo()) ~
@@ -106,6 +107,7 @@ object Image {
     (__ \ "id").write[String] ~
       (__ \ "uploadTime").write[String].contramap(printDateTime) ~
       (__ \ "uploadedBy").write[String] ~
+      (__ \ "softDeletedMetadata").writeNullable[SoftDeletedMetadata] ~
       (__ \ "lastModified").writeNullable[String].contramap(printOptDateTime) ~
       (__ \ "identifiers").write[Map[String, String]] ~
       (__ \ "uploadInfo").write[UploadInfo] ~
@@ -125,6 +127,5 @@ object Image {
       (__ \ "syndicationRights").writeNullable[SyndicationRights] ~
       (__ \ "userMetadataLastModified").writeNullable[String].contramap(printOptDateTime)
     )(unlift(Image.unapply))
-
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/SoftDeletedMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/SoftDeletedMetadata.scala
@@ -1,0 +1,35 @@
+package com.gu.mediaservice.model
+
+import org.joda.time.DateTime
+import play.api.libs.json._
+import play.api.libs.json.JodaReads._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.functional.syntax._
+
+
+case class SoftDeletedMetadata(
+  deleteTime: DateTime,
+  deletedBy: String,
+)
+
+object SoftDeletedMetadata {
+
+  implicit val SoftDeletedMetadataReads: Reads[SoftDeletedMetadata] = (
+    (__ \ "deleteTime").read[DateTime] ~
+    (__ \ "deletedBy").read[String]
+  )(SoftDeletedMetadata.apply _)
+
+  implicit val SoftDeletedMetadataWrites: Writes[SoftDeletedMetadata] = (
+    (__ \ "deleteTime").write[DateTime] ~
+    (__ \ "deletedBy").write[String]
+  )(unlift(SoftDeletedMetadata.unapply))
+}
+
+trait SoftDeletedMetadataResponse {
+
+  // the types are in the arguments because of a whining scala compiler
+  def SoftDeletedMetadataEntity(id: String): Writes[SoftDeletedMetadata] = (
+      (__ \ "deleteTime").write[DateTime] ~
+      (__ \ "deletedBy").write[String]
+    )(unlift(SoftDeletedMetadata.unapply))
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -31,6 +31,7 @@ object ThrallMessage{
   implicit val usageNoticeFormat: OFormat[UsageNotice] = Json.format[UsageNotice]
   implicit val replaceImageLeasesMessageFormat: OFormat[ReplaceImageLeasesMessage] = Json.format[ReplaceImageLeasesMessage]
   implicit val deleteImageMessageFormat: OFormat[DeleteImageMessage] = Json.format[DeleteImageMessage]
+  implicit val softDeleteImageMessageFormat: OFormat[SoftDeleteImageMessage] = Json.format[SoftDeleteImageMessage]
   implicit val updateImageSyndicationMetadataMessageFormat: OFormat[UpdateImageSyndicationMetadataMessage] = Json.format[UpdateImageSyndicationMetadataMessage]
   implicit val setImageCollectionsMessageFormat: OFormat[SetImageCollectionsMessage] = Json.format[SetImageCollectionsMessage]
   implicit val updateImageUserMetadataMessageFormat: OFormat[UpdateImageUserMetadataMessage] = Json.format[UpdateImageUserMetadataMessage]
@@ -55,6 +56,8 @@ case class ImageMessage(lastModified: DateTime, image: Image) extends ThrallMess
 }
 
 case class DeleteImageMessage(id: String, lastModified: DateTime) extends ThrallMessage
+
+case class SoftDeleteImageMessage(id: String, lastModified: DateTime, softDeletedMetadata: SoftDeletedMetadata) extends ThrallMessage
 
 case class DeleteImageExportsMessage(id: String, lastModified: DateTime) extends ThrallMessage
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -5,6 +5,7 @@ trait MessageSubjects {
   val Image = "image"
   val ReingestImage = "reingest-image" // FIXME: this will conflict with reingest, suggest remove
   val DeleteImage = "delete-image"
+  val SoftDeleteImage = "soft-delete-image"
   val UpdateImage = "update-image" // TODO: this appears unused https://logs.gutools.co.uk/s/editorial-tools/goto/f0a03ca3c37261985b2e6292adb8de0f
   val DeleteImageExports = "delete-image-exports"
   val UpdateImageExports = "update-image-exports"

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/MetadataHelper.scala
@@ -15,6 +15,7 @@ trait MetadataHelper {
       metadata = metadataMap,
       uploadTime = DateTime.now,
       uploadedBy = "tester",
+      softDeletedMetadata = None,
       lastModified = None,
       identifiers = Map(),
       uploadInfo = UploadInfo(),

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonOrderingTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonOrderingTest.scala
@@ -23,6 +23,7 @@ class JsonOrderingTest extends FreeSpec with Matchers {
       uploadTime = dt,
       identifiers = Map.empty,
       uploadedBy = "Biden",
+      softDeletedMetadata = None,
       lastModified = None,
       uploadInfo = UploadInfo(None),
       source = Asset(new URI("fileUri"), None, None, None),

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/ImageTest.scala
@@ -139,6 +139,7 @@ object ImageTest {
       id = id,
       uploadTime = DateTime.now(),
       uploadedBy = "test.user@theguardian.com",
+      softDeletedMetadata = None,
       lastModified = None,
       identifiers = Map.empty,
       uploadInfo = UploadInfo(filename = Some(s"test_$id.jpeg")),

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -39,6 +39,7 @@ case object ImageUpload {
       uploadRequest.imageId,
       uploadRequest.uploadTime,
       uploadRequest.uploadedBy,
+      None,
       Some(uploadRequest.uploadTime),
       uploadRequest.identifiers,
       uploadRequest.uploadInfo,

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -127,6 +127,7 @@ class ProjectorTest extends FreeSpec with Matchers with ScalaFutures with Mockit
       id = id,
       uploadTime = new DateTime("2020-01-24T17:36:08.456Z").withZone(DateTimeZone.UTC),
       uploadedBy = "test",
+      softDeletedMetadata = None,
       lastModified = Some(new DateTime("2020-01-24T17:36:08.456Z").withZone(DateTimeZone.UTC)),
       identifiers = Map(),
       uploadInfo = UploadInfo(Some("getty.jpg")),

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -243,6 +243,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     (__ \ "id").write[String] ~
       (__ \ "uploadTime").write[DateTime] ~
       (__ \ "uploadedBy").write[String] ~
+      (__ \ "softDeletedMetadata").writeNullable[SoftDeletedMetadata] ~
       (__ \ "lastModified").writeNullable[DateTime] ~
       (__ \ "identifiers").write[Map[String, String]] ~
       (__ \ "uploadInfo").write[UploadInfo] ~

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -22,6 +22,7 @@ GET     /images/:imageId/export                       controllers.MediaApi.getIm
 GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised            controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
 DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
+DELETE  /soft-delete/images/:id                       controllers.MediaApi.softDeleteImage(id: String)
 GET     /images                                       controllers.MediaApi.imageSearch
 
 # completion

--- a/media-api/test/lib/TestUtils.scala
+++ b/media-api/test/lib/TestUtils.scala
@@ -9,6 +9,7 @@ object TestUtils {
     id = "test-id",
     uploadTime = now(),
     uploadedBy = "user",
+    softDeletedMetadata = None,
     lastModified = None,
     identifiers = Map.empty,
     uploadInfo = null,

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -54,6 +54,7 @@ trait Fixtures {
       id = id,
       uploadTime = DateTime.now(),
       uploadedBy = testUser,
+      softDeletedMetadata = None,
       lastModified = None,
       identifiers = Map.empty,
       uploadInfo = UploadInfo(filename = Some(s"test_$id.jpeg")),

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -27,6 +27,7 @@ class ImageExtrasTest extends FunSpec with Matchers with MockitoSugar {
     id = "id",
     uploadTime = new DateTime(),
     uploadedBy = "uploadedBy",
+    softDeletedMetadata = None,
     lastModified = None,
     identifiers = Map(),
     uploadInfo = UploadInfo(),

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -18,6 +18,7 @@ import com.gu.mediaservice.model._
 import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
 import lib.Edit
+import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc.{BaseController, ControllerComponents}
@@ -61,6 +62,7 @@ class EditsController(
 
   val metadataBaseUri = config.services.metadataBaseUri
   private val AuthenticatedAndAuthorised = auth andThen authorisation.CommonActionFilters.authorisedForArchive
+
   private def getUploader(imageId: String, user: Principal): Future[Option[String]] = gridClient.getUploadedBy(imageId, auth.getOnBehalfOfPrincipal(user))
 
   private def authorisedForEditMetadataOrUploader(imageId: String) = authorisation.actionFilterForUploaderOr(imageId, EditMetadata, getUploader)
@@ -211,7 +213,6 @@ class EditsController(
   def metadataAsMap(metadata: ImageMetadata) = {
     (Json.toJson(metadata).as[JsObject]).as[Map[String, JsValue]]
   }
-
 
 }
 

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -24,6 +24,7 @@ class MessageProcessor(es: ElasticSearch,
     updateMessage match {
       case message: ImageMessage => indexImage(message, logMarker)
       case message: DeleteImageMessage => deleteImage(message, logMarker)
+      case message: SoftDeleteImageMessage => softDeleteImage(message, logMarker)
       case message: DeleteImageExportsMessage => deleteImageExports(message, logMarker)
       case message: UpdateImageExportsMessage => updateImageExports(message, logMarker)
       case message: UpdateImageUserMetadataMessage => updateImageUserMetadata(message, logMarker)
@@ -61,6 +62,9 @@ class MessageProcessor(es: ElasticSearch,
 
     Future.sequence(
       es.deleteImageExports(message.id, message.lastModified)(ec, logMarker))
+
+  private def softDeleteImage(message: SoftDeleteImageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
+    Future.sequence(es.applySoftDelete(message.id, message.softDeletedMetadata, message.lastModified)(ec, logMarker))
 
   private def updateImageUserMetadata(message: UpdateImageUserMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
     Future.sequence(es.applyImageMetadataOverride(message.id, message.edits, message.lastModified)(ec, logMarker))

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -2,7 +2,7 @@ package lib.kinesis
 
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging.GridLogging
-import com.gu.mediaservice.model.{AddImageLeaseMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, ThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
+import com.gu.mediaservice.model.{AddImageLeaseMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, ThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
 import com.gu.mediaservice.syntax.MessageSubjects._
 
 object MessageTranslator extends GridLogging {
@@ -15,6 +15,10 @@ object MessageTranslator extends GridLogging {
         }
       case DeleteImage => (updateMessage.id) match {
         case (Some(id)) => Right(DeleteImageMessage(id, updateMessage.lastModified))
+        case _ => Left(MissingFieldsException(updateMessage.subject))
+      }
+      case SoftDeleteImage => (updateMessage.id, updateMessage.softDeletedMetadata) match {
+        case (Some(id) , Some(deletedMetadata)) => Right(SoftDeleteImageMessage(id, updateMessage.lastModified ,deletedMetadata))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
       case DeleteImageExports => (updateMessage.id) match {

--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -23,6 +23,7 @@ trait Fixtures {
      id = id,
      uploadTime = now,
      uploadedBy = "yellow.giraffe@theguardian.com",
+     softDeletedMetadata = None,
      lastModified = None,
      identifiers = Map.empty,
      uploadInfo = UploadInfo(filename = Some(s"test_$id.jpeg")),


### PR DESCRIPTION
## What does this change?
This implements a new endpoint: Soft Delete images

## How can success be measured?
Given `DELETE     media-api/soft-delete/images/:id` endpoint
and the endpoint hit with proper image-id
Then `softDeletedMetadata` fields should be added in the root of the document 
`                      "softDeletedMetadata": {
                        "deleteTime": "2021-06-17T03:52:37.084+02:00",
                        "deletedBy": "johndoe@example.com"
                    }`

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
