### PR TITLE
reusing DeleteImages Permission on the soft-delete endpoint

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -73,7 +73,6 @@ class MediaApi(
 
     val maybeLoaderLink: Option[Link] = Some(Link("loader", config.loaderUri)).filter(_ => userCanUpload)
     val maybeArchiveLink: Option[Link] = Some(Link("archive", s"${config.metadataUri}/metadata/{id}/archived")).filter(_ => userCanArchive)
-
     val indexLinks = List(
       searchLink,
       Link("image",           s"${config.rootUri}/images/{id}"),
@@ -230,18 +229,28 @@ class MediaApi(
     implicit val r = request
 
     elasticSearch.getImageById(id) map {
-      case Some(_) =>
-        messageSender.publish(
-          UpdateMessage(
-            subject = SoftDeleteImage,
-            id = Some(id),
-            softDeletedMetadata = Some(SoftDeletedMetadata(
-              deleteTime = DateTime.now(DateTimeZone.UTC),
-              deletedBy = request.user.accessor.identity
-            ))
-          )
-        )
-        Accepted
+      case Some(image) if hasPermission(request.user, image) =>
+        val imageCanBeDeleted = imageResponse.canBeDeleted(image)
+        if (imageCanBeDeleted){
+          val canDelete = authorisation.isUploaderOrHasPermission(request.user, image.uploadedBy, DeleteImagePermission)
+          if(canDelete){
+            messageSender.publish(
+              UpdateMessage(
+                subject = SoftDeleteImage,
+                id = Some(id),
+                softDeletedMetadata = Some(SoftDeletedMetadata(
+                  deleteTime = DateTime.now(DateTimeZone.UTC),
+                  deletedBy = request.user.accessor.identity
+                ))
+              )
+            )
+            Accepted
+          } else {
+            ImageDeleteForbidden
+          }
+        } else {
+          ImageCannotBeDeleted
+        }
       case _ => ImageNotFound(id)
     }
   }


### PR DESCRIPTION
## What does this change?
reusing DeleteImages Permission on the soft-delete endpoint to control which users can view or soft-delete images on the Grid

## How can success be measured?
- Given `DELETE     media-api/soft-delete/images/:id` endpoint
And a user who is in the right group 
and the endpoint hit with proper image-id
Then `softDeletedMetadata` fields should be added in the root of the document 
`                      "softDeletedMetadata": {
                        "deleteTime": "2021-06-17T03:52:37.084+02:00",
                        "deletedBy": "johndoe@example.com"
                    }`
                    

- Given `DELETE     media-api/soft-delete/images/:id` endpoint
And a user who isn't in the right group 
and the endpoint hit with proper image-id
Then it should respond with `permission-denied`

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
