### PR TITLE
Download crops

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -76,43 +76,56 @@ class S3(config: CommonConfig) extends GridLogging {
     regex.replaceAllIn(filename, "")
   }
 
-  private def getContentDispositionFilename(image: Image, imageType: ImageType, charset: Charset, maybeCrop: Option[Crop] = None): String = {
+  private def getExtension(image: Image, asset: Asset): String = asset.mimeType match {
+    case Some(mimeType) => mimeType.fileExtension
+    case _ =>
+      logger.warn(image.toLogMarker, "Unrecognised mime type")
+      ""
+  }
 
-    lazy val imageAsset = imageType match {
-      case Source => image.source
-      case Thumbnail => image.thumbnail.getOrElse(image.source)
-      case OptimisedPng => image.optimisedPng.getOrElse(image.source)
-    }
-
-    val asset = maybeCrop.flatMap(_.master).getOrElse(imageAsset)
-
-    val extension: String = asset.mimeType match {
-      case Some(mimeType) => mimeType.fileExtension
-      case _ =>
-        logger.warn(image.toLogMarker, "Unrecognised mime type")
-        ""
-    }
-
-    val maybeCropId = maybeCrop.flatMap(_.id).map(id => s"($id)").getOrElse("")
-    val baseFilename: String = image.uploadInfo.filename match {
-      case Some(f) => s"${removeExtension(f)} (${image.id})$maybeCropId$extension"
-      case _ => s"${image.id}$extension"
-    }
-
-    charset.displayName() match {
+  private def encodedFilename(charset: Charset, baseFilename: String): String = charset.displayName() match {
       case "UTF-8" =>
         // URLEncoder converts ` ` to `+`, replace it with `%20`
         // See http://docs.oracle.com/javase/6/docs/api/java/net/URLEncoder.html
         URLEncoder.encode(baseFilename, "UTF-8").replace("+", "%20")
       case characterSet => baseFilename.getBytes(characterSet).toString
     }
+
+  private def getBaseFilename(image: Image, filenameSuffix: String): String = image.uploadInfo.filename match {
+    case Some(f) => s"${removeExtension(f)} $filenameSuffix"
+    case _ => filenameSuffix
   }
 
-  def getContentDisposition(image: Image, imageType: ImageType, maybeCrop: Option[Crop] = None): String = {
+  private def getContentDisposition(filename: String): String = {
     // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987
     // they'll fallback to `filename`, which will be a UTF-8 string decoded as Latin-1 - this is a rubbish string, but only rubbish browsers don't support RFC 5987 (IE8 back)
     // See http://tools.ietf.org/html/rfc6266#section-5
-    s"""attachment; filename="${getContentDispositionFilename(image, imageType, StandardCharsets.ISO_8859_1, maybeCrop)}"; filename*=UTF-8''${getContentDispositionFilename(image, imageType, StandardCharsets.UTF_8, maybeCrop)}"""
+    val filenameISO = encodedFilename(StandardCharsets.ISO_8859_1, filename)
+    val filenameUTF8 = encodedFilename(StandardCharsets.UTF_8, filename)
+    s"""attachment; filename="$filenameISO"; filename*=UTF-8''$filenameUTF8"""
+  }
+
+  def getContentDisposition(image: Image, crop: Crop, asset: Asset): String = {
+    val cropId: String = crop.id.map(id => s"($id)").getOrElse("")
+    val extension: String = getExtension(image, asset)
+    val dimensions: String = asset.dimensions.map(dims => s"(${dims.width} x ${dims.height})").getOrElse("")
+    val filenameSuffix: String = s"(${image.id})$cropId$dimensions$extension"
+    val baseFilename = getBaseFilename(image, filenameSuffix)
+
+    getContentDisposition(baseFilename)
+  }
+
+  def getContentDisposition(image: Image, imageType: ImageType): String = {
+    val asset = imageType match {
+      case Source => image.source
+      case Thumbnail => image.thumbnail.getOrElse(image.source)
+      case OptimisedPng => image.optimisedPng.getOrElse(image.source)
+    }
+    val extension: String = getExtension(image, asset)
+    val filenameSuffix: String = s"(${image.id})$extension"
+    val baseFilename = getBaseFilename(image, filenameSuffix)
+
+    getContentDisposition(baseFilename)
   }
 
   private def roundDateTime(t: DateTime, d: Duration): DateTime = t minus (t.getMillis - (t.getMillis.toDouble / d.getMillis).round * d.getMillis)

--- a/cropper/app/controllers/CropperController.scala
+++ b/cropper/app/controllers/CropperController.scala
@@ -81,7 +81,7 @@ class CropperController(auth: Authentication, crops: Crops, store: CropStore, no
 
   private val canDeleteCrops: PrincipalFilter = authorisation.hasPermissionTo(DeleteCrops)
 
-  private def downloadExportLink(imageId: String, exportId: String) = Link(s"crop-$exportId-download", s"${config.apiUri}/images/$imageId/export/$exportId/download")
+  private def downloadExportLink(imageId: String, exportId: String, width: Int) = Link(s"crop-download-$exportId-$width", s"${config.apiUri}/images/$imageId/export/$exportId/asset/$width/download")
 
   def getCrops(id: String) = auth.async { httpRequest =>
 
@@ -91,8 +91,11 @@ class CropperController(auth: Authentication, crops: Crops, store: CropStore, no
 
       lazy val cropDownloadLinks = for {
         crop <- crops
+        asset <- crop.assets
+        dimensions <- asset.dimensions
+        width = dimensions.width
         cropId <- crop.id
-      } yield downloadExportLink(id, cropId)
+      } yield downloadExportLink(id, cropId, width)
 
       val links = (for {
         crop <- crops.headOption

--- a/cropper/app/lib/CropperConfig.scala
+++ b/cropper/app/lib/CropperConfig.scala
@@ -8,6 +8,8 @@ import java.io.File
 class CropperConfig(resources: GridConfigResources) extends CommonConfig(resources) {
   val imgPublishingBucket = string("publishing.image.bucket")
 
+  val canDownloadCrop: Boolean = boolean("canDownloadCrop")
+
   val imgPublishingHost = string("publishing.image.host")
   // Note: work around CloudFormation not allowing optional parameters
   val imgPublishingSecureHost = stringOpt("publishing.image.secure.host").filterNot(_.isEmpty)

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -41,7 +41,8 @@ class KahunaController(
       config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists)),
       config.staffPhotographerOrganisation,
       config.homeLinkHtml,
-      config.systemName
+      config.systemName,
+      config.canDownloadCrop
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -33,6 +33,8 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val homeLinkHtml: Option[String] = stringOpt("branding.homeLinkHtml").filterNot(_.isEmpty)
   val systemName: String = stringOpt("branding.systemName").filterNot(_.isEmpty).getOrElse("the Grid")
 
+  val canDownloadCrop: Boolean = boolean("canDownloadCrop")
+
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources")
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -14,7 +14,8 @@
   scriptsToLoad: List[ScriptToLoad],
   staffPhotographerOrganisation: String,
   homeLinkHtml: Option[String],
-  systemName: String
+  systemName: String,
+  canDownloadCrop: Boolean
 )
 <!DOCTYPE html>
 <html>
@@ -55,7 +56,8 @@
           staffPhotographerOrganisation: "@Html(staffPhotographerOrganisation)",
           fieldAliases: @Html(fieldAliases),
           homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))',
-          systemName: "@Html(systemName)"
+          systemName: "@Html(systemName)",
+          canDownloadCrop: @canDownloadCrop
         }
     </script>
 

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -18,8 +18,15 @@
                         <div>{{crop.master.dimensions.width}} x {{crop.master.dimensions.height}}</div>
                     </div>
                     <ul>
-                        <li ng-repeat="asset in crop.assets">
+                        <li ng-if="!ctrl.canDownloadCrop" ng-repeat="asset in crop.assets">
                             <a href="{{asset.file}}">{{asset.dimensions.width}} x {{asset.dimensions.height}}</a>
+                        </li>
+                        <li ng-if="ctrl.canDownloadCrop">
+                            <a href="{{crop.downloadLink}}"
+                                download
+                                rel="noopener"
+                                target="_blank">
+                                {{crop.master.dimensions.width}} x {{crop.master.dimensions.height}}</a>
                         </li>
                     </ul>
                 </li>

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -18,15 +18,8 @@
                         <div>{{crop.master.dimensions.width}} x {{crop.master.dimensions.height}}</div>
                     </div>
                     <ul>
-                        <li ng-if="!ctrl.canDownloadCrop" ng-repeat="asset in crop.assets">
-                            <a href="{{asset.file}}">{{asset.dimensions.width}} x {{asset.dimensions.height}}</a>
-                        </li>
-                        <li ng-if="ctrl.canDownloadCrop">
-                            <a href="{{crop.downloadLink}}"
-                                download
-                                rel="noopener"
-                                target="_blank">
-                                {{crop.master.dimensions.width}} x {{crop.master.dimensions.height}}</a>
+                        <li ng-repeat="asset in crop.assets">
+                            <a href="{{ctrl.canDownloadCrop ? asset.downloadLink : asset.file}}">{{asset.dimensions.width}} x {{asset.dimensions.height}}</a>
                         </li>
                     </ul>
                 </li>

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.js
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.js
@@ -11,6 +11,8 @@ displayCrops.controller('GrDisplayCrops', [function() {
     let ctrl = this;
 
     ctrl.showCrops = false;
+
+    ctrl.canDownloadCrop = window._clientConfig.canDownloadCrop;
 }]);
 
 displayCrops.directive('grDisplayCrops', [function () {

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -14,7 +14,7 @@
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
-    <button ng-if="ctrl.imageCount() == 1 && ctrl.crop"
+    <button ng-if="ctrl.imageCount() == 1 && ctrl.crop && ctrl.canDownloadCrop"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
             ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -14,13 +14,28 @@
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
+    <button ng-if="ctrl.imageCount() == 1 && !ctrl.canDownloadCrop"
+            class="drop-menu clickable inner-clickable side-padded button-right-side"
+            ng-click="showExpandedDownload = !showExpandedDownload">
+        <span>▾</span>
+        <a ng-if="showExpandedDownload"
+            ng-href="{{:: ctrl.firstImageUris.uris.lowResDownloadUri }}"
+            class="drop-menu__items drop-menu__items--nopad"
+            download
+            rel="noopener"
+            target="_blank">
+            <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
+        </a>
+    </button>
+
+
     <button ng-if="ctrl.imageCount() == 1 && ctrl.crop && ctrl.canDownloadCrop"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
             ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
         <a ng-if="showExpandedDownload"
             class="drop-menu__items drop-menu__items--nopad"
-            ng-click="ctrl.downloadCrop(ctrl.crop)">
+            href="{{ ctrl.crop.downloadLink }}" download rel="noopener" target="_blank">
             <gr-icon-label gr-icon="file_download">Download selected crop</gr-icon-label>
         </a>
     </button>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -14,17 +14,14 @@
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
-    <button ng-if="ctrl.imageCount() == 1"
+    <button ng-if="ctrl.imageCount() == 1 && ctrl.crop"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
             ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
         <a ng-if="showExpandedDownload"
-            ng-href="{{:: ctrl.firstImageUris.uris.lowResDownloadUri }}"
             class="drop-menu__items drop-menu__items--nopad"
-            download
-            rel="noopener"
-            target="_blank">
-            <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
+            ng-click="ctrl.downloadCrop(ctrl.crop)">
+            <gr-icon-label gr-icon="file_download">Download selected crop</gr-icon-label>
         </a>
     </button>
 

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -43,6 +43,8 @@ downloader.controller('DownloaderCtrl', [
 
     let ctrl = this;
 
+    ctrl.canDownloadCrop = $window._clientConfig.canDownloadCrop;
+
     ctrl.downloadCrop = async (crop) => {
         const a = document.createElement("a");
         a.href = await toDataURL(crop.master.file);
@@ -50,7 +52,7 @@ downloader.controller('DownloaderCtrl', [
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
-    }
+    };
 
     ctrl.imagesArray = () => Array.isArray(ctrl.images) ?
         ctrl.images : Array.from(ctrl.images.values());
@@ -126,7 +128,7 @@ downloader.directive('grDownloader', function() {
             images: '=',
             crop: '='
         },
-        template: template,
+        template: template
     };
 });
 

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -24,6 +24,14 @@ const bytesToSize = (bytes) => {
         `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`;
 };
 
+async function toDataURL(url) {
+    return fetch(url).then((response) => {
+            return response.blob();
+        }).then(blob => {
+            return URL.createObjectURL(blob);
+        });
+}
+
 downloader.controller('DownloaderCtrl', [
     '$window',
     '$q',
@@ -34,6 +42,15 @@ downloader.controller('DownloaderCtrl', [
     function Controller($window, $q, $scope, inject$, imageDownloadsService) {
 
     let ctrl = this;
+
+    ctrl.downloadCrop = async (crop) => {
+        const a = document.createElement("a");
+        a.href = await toDataURL(crop.master.file);
+        a.download = "crop.jpg";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
 
     ctrl.imagesArray = () => Array.isArray(ctrl.images) ?
         ctrl.images : Array.from(ctrl.images.values());
@@ -106,9 +123,10 @@ downloader.directive('grDownloader', function() {
         controllerAs: 'ctrl',
         bindToController: true,
         scope: {
-            images: '='
+            images: '=',
+            crop: '='
         },
-        template: template
+        template: template,
     };
 });
 

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -24,14 +24,6 @@ const bytesToSize = (bytes) => {
         `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`;
 };
 
-async function toDataURL(url) {
-    return fetch(url).then((response) => {
-            return response.blob();
-        }).then(blob => {
-            return URL.createObjectURL(blob);
-        });
-}
-
 downloader.controller('DownloaderCtrl', [
     '$window',
     '$q',
@@ -44,15 +36,6 @@ downloader.controller('DownloaderCtrl', [
     let ctrl = this;
 
     ctrl.canDownloadCrop = $window._clientConfig.canDownloadCrop;
-
-    ctrl.downloadCrop = async (crop) => {
-        const a = document.createElement("a");
-        a.href = await toDataURL(crop.master.file);
-        a.download = "crop.jpg";
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-    };
 
     ctrl.imagesArray = () => Array.isArray(ctrl.images) ?
         ctrl.images : Array.from(ctrl.images.values());

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -208,7 +208,8 @@ image.controller('ImageCtrl', [
       return ctrl.image.data.source.dimensions;
     }
 
-    mediaCropper.getCropsFor(image).then(crops => {
+    ctrl.cropsForImage = mediaCropper.getCropsFor(image)
+    ctrl.cropsForImage.then(crops => {
       ctrl.crop = crops.find(crop => crop.id === cropKey);
       ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');
       ctrl.crops = crops.filter(crop => crop.specification.type === 'crop');

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -208,8 +208,7 @@ image.controller('ImageCtrl', [
       return ctrl.image.data.source.dimensions;
     }
 
-    ctrl.cropsForImage = mediaCropper.getCropsFor(image)
-    ctrl.cropsForImage.then(crops => {
+    mediaCropper.getCropsFor(image).then(crops => {
       ctrl.crop = crops.find(crop => crop.id === cropKey);
       ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');
       ctrl.crops = crops.filter(crop => crop.specification.type === 'crop');

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -208,7 +208,14 @@ image.controller('ImageCtrl', [
       return ctrl.image.data.source.dimensions;
     }
 
-    mediaCropper.getCropsFor(image).then(crops => {
+    mediaCropper.getCropsFor(image).then(cropsResource => {
+      let crops = cropsResource.data;
+      debugger;
+      if ($window._clientConfig.canDownloadCrop) {
+        crops.forEach((crop) =>
+          crop.downloadLink = cropsResource.links.find(link => link.rel.includes(`crop-${crop.id}-download`))?.href
+        );
+      }
       ctrl.crop = crops.find(crop => crop.id === cropKey);
       ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');
       ctrl.crops = crops.filter(crop => crop.specification.type === 'crop');

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -210,11 +210,15 @@ image.controller('ImageCtrl', [
 
     mediaCropper.getCropsFor(image).then(cropsResource => {
       let crops = cropsResource.data;
-      debugger;
       if ($window._clientConfig.canDownloadCrop) {
-        crops.forEach((crop) =>
-          crop.downloadLink = cropsResource.links.find(link => link.rel.includes(`crop-${crop.id}-download`))?.href
-        );
+        crops.forEach((crop) => {
+          crop.assets.forEach((asset) =>
+            asset.downloadLink = cropsResource.links.find(link => link.rel.includes(`crop-download-${crop.id}-${asset.dimensions.width}`))?.href
+          );
+          //set the download link of the crop to be the largest asset
+          let largestAsset = crop.assets.find(asset => asset.dimensions.width == crop.master.dimensions.width);
+          crop.downloadLink = largestAsset.downloadLink;
+        });
       }
       ctrl.crop = crops.find(crop => crop.id === cropKey);
       ctrl.fullCrop = crops.find(crop => crop.specification.type === 'full');

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -12,7 +12,8 @@
         </gr-delete-image>
 
         <gr-downloader class="top-bar-item"
-                       images="[ctrl.image]">
+                       images="[ctrl.image]"
+                       crop="ctrl.crop">
         </gr-downloader>
 
         <gr-archiver class="top-bar-item"

--- a/kahuna/public/js/services/api/media-cropper.js
+++ b/kahuna/public/js/services/api/media-cropper.js
@@ -54,7 +54,7 @@ cropperApi.factory('mediaCropper', ['mediaApi', function(mediaApi) {
     }
 
     function getCropsFor(image) {
-        return image.follow('crops').getData();
+        return image.follow('crops').get();
     }
 
     return {

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -22,6 +22,9 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfig(resour
 
   val recordDownloadAsUsage: Boolean = boolean("image.record.download")
 
+  //Lazy allows this to be empty and not break things unless used somewhere
+  lazy val imgPublishingBucket = string("publishing.image.bucket")
+
   val imagesAlias: String = string("es.index.aliases.read")
 
   val elasticsearch6Url: String =  string("es6.url")

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -18,6 +18,7 @@ GET     /images/:id/projection/diff                   controllers.MediaApi.diffP
 GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
 GET     /images/:imageId/uploadedBy                   controllers.MediaApi.uploadedBy(imageId: String)
 GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
+GET     /images/:imageId/export/:exportId/download    controllers.MediaApi.downloadImageExport(imageId: String, exportId: String)
 GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised            controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -3,44 +3,44 @@
 # ~~~~
 
 # Home page
-GET     /                                             controllers.MediaApi.index
+GET     /                                                           controllers.MediaApi.index
 
 # Image metadata
-GET     /images/metadata/:field                       controllers.SuggestionController.metadataSearch(field: String, q: Option[String])
-GET     /images/edits/:field                          controllers.SuggestionController.editsSearch(field: String, q: Option[String])
+GET     /images/metadata/:field                                     controllers.SuggestionController.metadataSearch(field: String, q: Option[String])
+GET     /images/edits/:field                                        controllers.SuggestionController.editsSearch(field: String, q: Option[String])
 
-GET     /images/aggregations/date/:field              controllers.AggregationController.dateHistogram(field: String, q: Option[String])
+GET     /images/aggregations/date/:field                            controllers.AggregationController.dateHistogram(field: String, q: Option[String])
 
 # Images
-GET     /images/:id                                   controllers.MediaApi.getImage(id: String)
-GET     /images/:id/_elasticsearch                    controllers.MediaApi.getImageFromElasticSearch(id: String)
-GET     /images/:id/projection/diff                   controllers.MediaApi.diffProjection(id: String)
-GET     /images/:id/fileMetadata                      controllers.MediaApi.getImageFileMetadata(id: String)
-GET     /images/:imageId/uploadedBy                   controllers.MediaApi.uploadedBy(imageId: String)
-GET     /images/:imageId/export/:exportId             controllers.MediaApi.getImageExport(imageId: String, exportId: String)
-GET     /images/:imageId/export/:exportId/download    controllers.MediaApi.downloadImageExport(imageId: String, exportId: String)
-GET     /images/:imageId/export                       controllers.MediaApi.getImageExports(imageId: String)
-GET     /images/:imageId/download                     controllers.MediaApi.downloadOriginalImage(imageId: String)
-GET     /images/:imageId/downloadOptimised            controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
-DELETE  /images/:id                                   controllers.MediaApi.deleteImage(id: String)
-DELETE  /soft-delete/images/:id                       controllers.MediaApi.softDeleteImage(id: String)
-GET     /images                                       controllers.MediaApi.imageSearch
+GET     /images/:id                                                 controllers.MediaApi.getImage(id: String)
+GET     /images/:id/_elasticsearch                                  controllers.MediaApi.getImageFromElasticSearch(id: String)
+GET     /images/:id/projection/diff                                 controllers.MediaApi.diffProjection(id: String)
+GET     /images/:id/fileMetadata                                    controllers.MediaApi.getImageFileMetadata(id: String)
+GET     /images/:imageId/uploadedBy                                 controllers.MediaApi.uploadedBy(imageId: String)
+GET     /images/:imageId/export/:exportId                           controllers.MediaApi.getImageExport(imageId: String, exportId: String)
+GET     /images/:imageId/export/:exportId/asset/:width/download     controllers.MediaApi.downloadImageExport(imageId: String, exportId: String, width: Int)
+GET     /images/:imageId/export                                     controllers.MediaApi.getImageExports(imageId: String)
+GET     /images/:imageId/download                                   controllers.MediaApi.downloadOriginalImage(imageId: String)
+GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
+DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
+DELETE  /soft-delete/images/:id                                     controllers.MediaApi.softDeleteImage(id: String)
+GET     /images                                                     controllers.MediaApi.imageSearch
 
 # completion
-GET     /suggest/metadata/credit                      controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
-GET     /suggest/metadata/photoshoot                  controllers.SuggestionController.suggestPhotoshoot(q: Option[String], size: Option[Int])
+GET     /suggest/metadata/credit                                    controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
+GET     /suggest/metadata/photoshoot                                controllers.SuggestionController.suggestPhotoshoot(q: Option[String], size: Option[Int])
 
 # usage quotas
-GET     /usage/suppliers                              controllers.UsageController.bySupplier
-GET     /usage/suppliers/:id                          controllers.UsageController.forSupplier(id: String)
-GET     /usage/quotas                                 controllers.UsageController.quotas
-GET     /usage/quotas/:id                             controllers.UsageController.quotaForImage(id: String)
+GET     /usage/suppliers                                            controllers.UsageController.bySupplier
+GET     /usage/suppliers/:id                                        controllers.UsageController.forSupplier(id: String)
+GET     /usage/quotas                                               controllers.UsageController.quotas
+GET     /usage/quotas/:id                                           controllers.UsageController.quotaForImage(id: String)
 
 # Management
-GET     /management/healthcheck                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.healthCheck
-GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
-GET     /management/imageCounts                       com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.imageCounts
-GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
+GET     /management/healthcheck                                     com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.healthCheck
+GET     /management/manifest                                        com.gu.mediaservice.lib.management.Management.manifest
+GET     /management/imageCounts                                     com.gu.mediaservice.lib.management.ElasticSearchHealthCheck.imageCounts
+GET     /management/whoAmI                                          com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
 # Shoo robots away
-GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots
+GET     /robots.txt                                                 com.gu.mediaservice.lib.management.Management.disallowRobots


### PR DESCRIPTION
## What does this change?
Currently, when selecting a crop and clicking the Download button, only the original image is downloaded and not the selected crop. Also, when clicking on a link to a crop in the Show Crops section of the metadata, you are redirected to the image instead of downloading it. Another issue is that this doesn't log a usage for the image. 

In this PR I'll try to address these issues by creating an endpoint in the media-api service to download a crop:
`GET     /images/:imageId/export/:exportId/asset/:width/download`

This endpoint will record the download as a usage (if having the 'image.record.download' config), fetch the crop, and return the cropped image the same way the /download endpoint does for original images.

The UI will display an option called "Download selected crop" below "Download low-res" option, and clicking on it will automatically start the download of the crop.

This feature will be hidden behind a config flag: `canDownloadCrop`, since it has been pointed to me that The Guardian doesn't want this functionality.

## How can success be measured?
- The Guardian's Grid maintains its current behaviour. 
- On BBC Grid, when selecting a crop, you can now see a "Download selected crop" option and clicking on it will automatically start the download of the crop. Also, clicking on a link to a crop in the Show Crops section of the metadata will trigger the download and add a usage as well.

## Screenshots
![image](https://user-images.githubusercontent.com/20479781/123163202-d4a0b300-d447-11eb-9831-f899ac7d946a.png)

## Who should look at this?
@guardian/digital-cms

## Tested?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
