### PR TITLE
filter scriptsToLoad based on new property `shouldLoadWhenIFramed`

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -21,6 +21,12 @@ class KahunaController(
 
     val maybeUser: Option[Authentication.Principal] = authentication.authenticationStatus(req).toOption
 
+    val isIFramed = req.headers.get("Sec-Fetch-Dest").contains("iframe")
+
+    val scriptsToLoad = config.scriptsToLoad
+      .filter(_.shouldLoadWhenIFramed.contains(true) || !isIFramed)
+      .filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists))
+
     val okPath = routes.KahunaController.ok.url
     // If the auth is successful, we redirect to the kahuna domain so the iframe
     // is on the same domain and can be read by the JS
@@ -38,7 +44,7 @@ class KahunaController(
       config.invalidSessionHelpLink,
       config.supportEmail,
       fieldAliases,
-      config.scriptsToLoad.filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists)),
+      scriptsToLoad,
       config.staffPhotographerOrganisation,
       config.homeLinkHtml,
       config.systemName

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -8,7 +8,8 @@ case class ScriptToLoad(
   host: String,
   path: String,
   async: Option[Boolean],
-  permission: Option[SimplePermission]
+  permission: Option[SimplePermission],
+  shouldLoadWhenIFramed: Option[Boolean]
 )
 
 class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resources) {
@@ -41,7 +42,8 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     path = entry.getString("path"),
     async = if (entry.hasPath("async")) Some(entry.getBoolean("async")) else None,
     // FIXME ideally the below would not hardcode reference to pinboard - hopefully future iterations of the pluggable authorisation will support evaluating permissions without a corresponding case object
-    permission = if (entry.hasPath("permission") && entry.getString("permission") == "pinboard") Some(Pinboard) else None
+    permission = if (entry.hasPath("permission") && entry.getString("permission") == "pinboard") Some(Pinboard) else None,
+    shouldLoadWhenIFramed = if (entry.hasPath("shouldLoadWhenIFramed")) Some(entry.getBoolean("shouldLoadWhenIFramed")) else None,
   ))
 
 }


### PR DESCRIPTION
## What does this change?
I noticed in the GIF of https://github.com/guardian/prosemirror-elements/pull/45 that pinboard is loading when the Grid is iframed in Composer, this will be confusing for users.

Since the pinboard script is loaded based on configuration, I've added a new optional property `shouldLoadWhenIFramed` on items in `scriptsToLoad` config array. 

Whether UI is loaded in an iframe is determined by [`Sec-Fetch-Dest`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest) header being present and set to `iframe`, as can be seen from network tab when Grid is used in composer...
![image](https://user-images.githubusercontent.com/19289579/123941530-268a9100-d992-11eb-9b89-fa22f5d3bae5.png)


## How can success be measured?
No double vision, i.e. no confused users seeing pinboard in grid, when they already see it in composer thats iframing grid.


## Who should look at this?
@guardian/digital-cms 


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
