### PR TITLE
introduce is:deleted search filter

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -81,7 +81,8 @@ const isSearch = [
     `${staffPhotographerOrganisation}-owned-photo`,
     `${staffPhotographerOrganisation}-owned-illustration`,
     `${staffPhotographerOrganisation}-owned`,
-  'under-quota'
+  'under-quota',
+  'deleted'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {

--- a/media-api/app/lib/querysyntax/Parser.scala
+++ b/media-api/app/lib/querysyntax/Parser.scala
@@ -2,8 +2,14 @@ package lib.querysyntax
 
 object Parser {
 
-  def run(input: String): List[Condition] =
-    normalise(parse(input))
+  def run(input: String): List[Condition] = {
+    normalise(
+      parse(
+        if(input.contains("is:deleted")) input
+        else input.concat(" -is:deleted").trim
+      )
+    )
+  }
 
   def parse(input: String): List[Condition] =
     new QuerySyntax(input.trim).Query.run().map(_.toList) getOrElse List()

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -13,46 +13,46 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
 
   describe("text") {
     it("should match single terms") {
-      Parser.run("cats") should be (List(Match(AnyField, Words("cats"))))
+      Parser.run("cats") should be (List(Match(AnyField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match single terms with accents") {
-      Parser.run("séb") should be (List(Match(AnyField, Words("séb"))))
+      Parser.run("séb") should be (List(Match(AnyField,Words("séb")), Negation(Match(IsField,IsValue("deleted")))))
     }
     it("should match single terms with curly apostrophe") {
-      Parser.run("l’apostrophe") should be (List(Match(AnyField, Words("l’apostrophe"))))
+      Parser.run("l’apostrophe") should be (List(Match(AnyField, Words("l’apostrophe")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should ignore surrounding whitespace") {
-      Parser.run(" cats ") should be (List(Match(AnyField, Words("cats"))))
+      Parser.run(" cats ") should be (List(Match(AnyField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms") {
-      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats dogs"))))
+      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats dogs")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms separated by multiple whitespace") {
-      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats dogs"))))
+      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats dogs")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms including 'in'") {
-      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats in dogs"))))
+      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats in dogs")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms including 'by'") {
-      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats by dogs"))))
+      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats by dogs")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms including apostrophes") {
-      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's a cat"))))
+      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's a cat")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms including commas") {
-      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats, dogs"))))
+      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats, dogs")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple terms including single double quotes") {
-      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\" cats"))))
+      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\" cats")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     // it("should match multiple terms including '#' character") {
@@ -61,24 +61,26 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
     // }
 
     it("should match a quoted phrase") {
-      Parser.run(""""cats dogs"""") should be (List(Match(AnyField, Phrase("cats dogs"))))
+      Parser.run(""""cats dogs"""") should be (List(Match(AnyField, Phrase("cats dogs")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match faceted terms") {
-      Parser.run("credit:cats") should be (List(Match(creditField, Words("cats"))))
+      Parser.run("credit:cats") should be (List(Match(creditField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match multiple faceted terms on the same facet") {
       Parser.run("label:cats label:dogs") should be (List(
         Match(labelsField, Words("cats")),
-        Match(labelsField, Words("dogs"))
+        Match(labelsField, Words("dogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match multiple faceted terms on different facets") {
       Parser.run("credit:cats label:dogs") should be (List(
         Match(creditField, Words("cats")),
-        Match(labelsField, Words("dogs"))
+        Match(labelsField, Words("dogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
   }
@@ -95,7 +97,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-12-31T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -106,7 +109,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-31T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -117,7 +121,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-31T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -128,7 +133,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -139,7 +145,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -150,7 +157,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -161,7 +169,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -172,7 +181,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -183,7 +193,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -210,7 +221,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2000-01-02T00:00:00.000Z"),
               new DateTime("2000-01-02T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -221,7 +233,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2000-01-01T00:00:00.000Z"),
               new DateTime("2000-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -241,7 +254,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
             SingleField("usages"),
             SingleField("usages.status"),
             Phrase("pending")
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -254,7 +268,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               "usages.references.name"
             )),
             Phrase("foo")
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -267,7 +282,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               "usages.references.name"
             )),
             Phrase("https://generic.cms/1234")
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
     }
@@ -281,7 +297,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("1970-01-01T01:00:00.000+01:00"),
               new DateTime("2012-01-01T00:00:00.000Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -294,7 +311,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
                 new DateTime("1970-01-01T01:00:00.000+01:00"),
                 new DateTime("2012-01-01T00:00:00.000Z")
               )
-            ))
+            ),
+            Negation(Match(IsField,IsValue("deleted"))))
           )
         }
 
@@ -311,7 +329,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -322,7 +341,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -333,7 +353,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
               new DateTime("2014-01-01T00:00:00.000Z"),
               new DateTime("2014-01-01T23:59:59.999Z")
             )
-          ))
+          ),
+          Negation(Match(IsField,IsValue("deleted"))))
         )
       }
 
@@ -345,7 +366,8 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
       // TODO: or better, return parse error to client?
       it("should ignore an invalid date argument") {
         Parser.run("date:NAZGUL") should be (List(
-          Match(SingleField("date"), Words("NAZGUL"))
+          Match(SingleField("date"), Words("NAZGUL")),
+          Negation(Match(IsField,IsValue("deleted")))
         ))
       }
 
@@ -356,11 +378,11 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
   describe("negation") {
 
     it("should match negated single terms") {
-      Parser.run("-cats") should be (List(Negation(Match(AnyField, Words("cats")))))
+      Parser.run("-cats") should be (List(Negation(Match(AnyField, Words("cats"))), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match negated quoted terms") {
-      Parser.run("""-"cats dogs"""") should be (List(Negation(Match(AnyField, Phrase("cats dogs")))))
+      Parser.run("""-"cats dogs"""") should be (List(Negation(Match(AnyField, Phrase("cats dogs"))), Negation(Match(IsField,IsValue("deleted")))))
     }
 
   }
@@ -369,15 +391,16 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
   describe("aliases") {
 
     it("should match aliases to a single canonical field") {
-      Parser.run("by:cats") should be (List(Match(bylineField, Words("cats"))))
+      Parser.run("by:cats") should be (List(Match(bylineField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match aliases to multiple fields") {
-      Parser.run("in:berlin") should be (List(Match(MultipleField(List("subLocation", "city", "state", "country").map(getFieldPath)), Words("berlin"))))
+      Parser.run("in:berlin") should be (List(Match(MultipleField(List("subLocation", "city", "state", "country").map(getFieldPath)),
+        Words("berlin")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
     it("should match #terms as labels") {
-      Parser.run("#cats") should be (List(Match(labelsField, Words("cats"))))
+      Parser.run("#cats") should be (List(Match(labelsField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
     }
 
   }
@@ -388,21 +411,24 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
     it("should combination of terms (negated faceted word, word)") {
       Parser.run("""-credit:cats dogs""") should be (List(
         Negation(Match(creditField, Words("cats"))),
-        Match(AnyField, Words("dogs"))
+        Match(AnyField, Words("dogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should combination of terms (negated faceted phrase, word)") {
       Parser.run("""-credit:"cats dogs" unicorns""") should be (List(
         Negation(Match(creditField, Phrase("cats dogs"))),
-        Match(AnyField, Words("unicorns"))
+        Match(AnyField, Words("unicorns")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should combination of terms (multiple words, label)") {
       Parser.run("""cats dogs #unicorns""") should be (List(
         Match(AnyField, Words("cats dogs")),
-        Match(labelsField, Words("unicorns"))
+        Match(labelsField, Words("unicorns")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
@@ -410,14 +436,16 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
       Parser.run("""cats #unicorns dogs""") should be (List(
         Match(AnyField, Words("cats")),
         Match(labelsField, Words("unicorns")),
-        Match(AnyField, Words("dogs"))
+        Match(AnyField, Words("dogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should combination of terms (negated word, word)") {
       Parser.run("""-cats dogs""") should be (List(
         Negation(Match(AnyField, Words("cats"))),
-        Match(AnyField, Words("dogs"))
+        Match(AnyField, Words("dogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
@@ -426,27 +454,31 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
   describe("has filter") {
     it("should find images with crops") {
       Parser.run("has:crops") should be (List(
-        Match(HasField, HasValue("crops"))
+        Match(HasField, HasValue("crops")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match multiple terms and the has query") {
       Parser.run("cats dogs has:rightsSyndication") should be (List(
         Match(AnyField, Words("cats dogs")),
-        Match(HasField, HasValue("rightsSyndication"))
+        Match(HasField, HasValue("rightsSyndication")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match negated has queries") {
       Parser.run("-has:foo") should be (List(
-        Negation(Match(HasField, HasValue("foo")))
+        Negation(Match(HasField, HasValue("foo"))),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match aliases and a has query") {
       Parser.run("by:cats has:paws") should be (List(
         Match(bylineField, Words("cats")),
-        Match(HasField, HasValue("paws"))
+        Match(HasField, HasValue("paws")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
   }
@@ -454,51 +486,59 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
   describe("fileType filter") {
     it("should find jpegs images") {
       Parser.run("fileType:jpeg") should be (List(
-        Match(SingleField(getFieldPath("mimeType")), Words("image/jpeg"))
+        Match(SingleField(getFieldPath("mimeType")), Words("image/jpeg")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should find png images") {
       Parser.run("fileType:png") should be (List(
-        Match(SingleField(getFieldPath("mimeType")), Words("image/png"))
+        Match(SingleField(getFieldPath("mimeType")), Words("image/png")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should find tiff images when searching for file type 'tif'") {
       Parser.run("fileType:tif") should be (List(
-        Match(SingleField(getFieldPath("mimeType")), Words("image/tiff"))
+        Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should find tiff images when searching for file type 'tiff'") {
       Parser.run("fileType:tiff") should be (List(
-        Match(SingleField(getFieldPath("mimeType")), Words("image/tiff"))
+        Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match multiple terms and the fileType query") {
       Parser.run("fileType:tiff cats dogs") should be (List(
         Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
-        Match(AnyField, Words("cats dogs"))
+        Match(AnyField, Words("cats dogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match negated fileType queries") {
       Parser.run("-fileType:jpeg") should be (List(
-        Negation(Match(SingleField(getFieldPath("mimeType")), Words("image/jpeg")))
+        Negation(Match(SingleField(getFieldPath("mimeType")), Words("image/jpeg"))),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match aliases and a fileType query") {
       Parser.run("by:cats fileType:tiff") should be (List(
         Match(bylineField, Words("cats")),
-        Match(SingleField(getFieldPath("mimeType")), Words("image/tiff"))
+        Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should not match unrelated file types") {
       Parser.run("fileType:catsdogs") should be (List(
-        Match(SingleField("fileType"), Words("catsdogs"))
+        Match(SingleField("fileType"), Words("catsdogs")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
   }
@@ -506,39 +546,45 @@ class ParserTest extends FunSpec with Matchers with BeforeAndAfter with ImageFie
   describe("quoted field search") {
     it("should match a quoted field search") {
       Parser.run(""""fieldDogs":cats""") should be (List(
-        Match(SingleField("fieldDogs"), Words("cats"))
+        Match(SingleField("fieldDogs"), Words("cats")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match a quoted field search with  colons") {
       Parser.run(""""fieldDogs:dinosaur:lemur":cats""") should be (List(
-        Match(SingleField("fieldDogs:dinosaur:lemur"), Words("cats"))
+        Match(SingleField("fieldDogs:dinosaur:lemur"), Words("cats")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match a quoted field search colons, and a search term with quotes and colons") {
       Parser.run(""""fieldDogs":"cats:are:fun"""") should be (List(
-        Match(SingleField("fieldDogs"), Phrase("cats:are:fun"))
+        Match(SingleField("fieldDogs"), Phrase("cats:are:fun")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match a quoted field search with colons and spaces") {
       Parser.run(""""fieldDogs: dinosaur:lemur":cats""") should be (List(
-        Match(SingleField("fieldDogs: dinosaur:lemur"), Words("cats"))
+        Match(SingleField("fieldDogs: dinosaur:lemur"), Words("cats")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match a field search with colons and spaces") {
       Parser.run("fieldDogs : dinosaur:lemur:cats") should be (List(
         Match(AnyField,Words("fieldDogs :")),
-        Match(SingleField("dinosaur"),Words("lemur:cats"))
+        Match(SingleField("dinosaur"),Words("lemur:cats")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
 
     it("should match two field queries") {
       Parser.run("fieldDogs:dinosaur lemur:cats") should be (List(
         Match(SingleField("fieldDogs"),Words("dinosaur")),
-        Match(SingleField("lemur"),Words("cats"))
+        Match(SingleField("lemur"),Words("cats")),
+        Negation(Match(IsField,IsValue("deleted")))
       ))
     }
   }


### PR DESCRIPTION
## What does this change?
introduces a new "advanced search" filter for searching by soft-deleted, named "is:deleted".

## How can success be measured?
Given images in the Images Catalogue
When the user has set the search query filter is:deleted
Then the user should be able to see all the soft-deleted images in the Images Catalogue

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![Screenshot from 2021-07-07 03-57-13](https://user-images.githubusercontent.com/33189781/124725548-3d3e6400-df0d-11eb-83f9-ced1a907ffff.png)
![Screenshot from 2021-07-07 03-57-40](https://user-images.githubusercontent.com/33189781/124725570-40d1eb00-df0d-11eb-9aad-759e8a3dcd6f.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
