### PR TITLE
Recognise source:Shutterstock as Rex

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -430,6 +430,7 @@ object RexParser extends ImageProcessor {
     case (Some("Rex Features"), _)      => image.copy(usageRights = rexAgency)
     case (_, Some(SlashRex()))          => image.copy(usageRights = rexAgency)
     case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = rexAgency)
+    case (_, Some("Shutterstock"))      => image.copy(usageRights = rexAgency)
     case _ => image
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -430,7 +430,7 @@ object RexParser extends ImageProcessor {
     case (Some("Rex Features"), _)      => image.copy(usageRights = rexAgency)
     case (_, Some(SlashRex()))          => image.copy(usageRights = rexAgency)
     case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = rexAgency)
-    case (_, Some("Shutterstock"))      => image.copy(usageRights = rexAgency)
+    case (Some("Shutterstock"), _)      => image.copy(usageRights = rexAgency)
     case _ => image
   }
 }


### PR DESCRIPTION
## What does this change?
Categorises images with `source:Shutterstock` as Rex.

## How can success be measured?
Less manual categorisation.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
