### PR TITLE
Thrall migration control panel

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -77,7 +77,9 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
 
   val corsAllowedDomains: Set[String] = corsAllowedOrigins.map(baseUri)
 
-  val loginUriTemplate = s"$authBaseUri/login{?redirectUri}"
+  val redirectUriParam = "redirectUri"
+  val redirectUriPlaceholder = s"{?$redirectUriParam}"
+  val loginUriTemplate = s"$authBaseUri/login$redirectUriPlaceholder"
 
   def baseUri(host: String) = s"https://$host"
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
@@ -1,0 +1,29 @@
+package com.gu.mediaservice.lib.auth
+
+import com.gu.mediaservice.lib.config.Services
+import play.api.mvc.{Action, AnyContent, BaseController, RequestHeader, Result}
+
+import java.net.URLEncoder
+import scala.concurrent.Future
+
+trait BaseControllerWithLoginRedirects extends BaseController {
+  def auth: Authentication
+  def services: Services
+
+  def withLoginRedirectAsync(handler: RequestHeader => Future[Result]): Action[AnyContent] = Action.async { request =>
+    auth.authenticationStatus(request) match {
+      case Left(resultFuture) => auth.loginLinks.headOption.map(link => {
+        val returnTo = s"https://${request.domain}${request.uri}"
+        Future.successful(Redirect(link.href.replace(services.redirectUriPlaceholder,
+          s"?${services.redirectUriParam}=${URLEncoder.encode(returnTo, "UTF-8")}")))
+      }).getOrElse(resultFuture)
+      case Right(_) => handler(request)
+    }
+  }
+
+  def withLoginRedirectAsync(handler: => Future[Result]): Action[AnyContent] = withLoginRedirectAsync(_ => handler)
+
+  def withLoginRedirect(handler: RequestHeader => Result): Action[AnyContent] = withLoginRedirectAsync(request => Future.successful(handler(request)))
+
+  def withLoginRedirect(handler: => Result): Action[AnyContent] = withLoginRedirect(_ => handler)
+}

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -1,0 +1,41 @@
+
+@(currentAlias: String,
+  currentIndex: String,
+  migrationAlias: String,
+  migrationIndex: Option[String]
+)
+@migrationNameCell = {
+    @migrationIndex match {
+        case Some(indexName) => {
+            @indexName <button>Migrate single image</button>
+        }
+        case None => {
+            <button>Start migration</button>
+        }
+    }
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Current elasticsearch indices</title>
+    <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
+</head>
+<body>
+    <h1>Current elasticsearch indices</h1>
+    <table>
+        <tr>
+            <th>Alias</th>
+            <th>Index</th>
+        </tr>
+        <tr>
+            <td>@currentAlias</td>
+            <td>@currentIndex</td>
+        </tr>
+        <tr>
+            <td>@migrationAlias</td>
+            <td>@migrationNameCell</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -10,5 +10,7 @@ GET     /management/manifest                          com.gu.mediaservice.lib.ma
 GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck(depth: Int)
 GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
 
+GET     /assets/*file                                 controllers.Assets.versioned(path="/public", file: Asset)
+
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/thrall/public/stylesheets/main.css
+++ b/thrall/public/stylesheets/main.css
@@ -1,0 +1,7 @@
+table, td, th {
+  border: 1px solid black;
+}
+
+td, th {
+  padding: 10px 20px;
+}


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @tjsilver

https://trello.com/c/SAbSEpuM/2337-grid-reingestion-control-panel

## What does this change?

This creates a new dashboard for Thrall, which shows the Elasticsearch aliases used by Thrall, and which indices they are currently pointing to. It also creates placeholder buttons for starting and progressing a migration.

## How can success be measured?

Users can see Elasticsearch aliases and their current status. 

## Screenshots

###  No migration in progress
![image](https://user-images.githubusercontent.com/15648334/124916859-09397080-dfeb-11eb-97c5-c7876030cd4b.png)

### Migration in progress
![image](https://user-images.githubusercontent.com/15648334/124916812-ffb00880-dfea-11eb-8304-63027cc8cdd2.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
