### PR TITLE
`ElasticSearchClient` refactors to support current AND migration indexes (phase 1)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageFields.scala
@@ -47,7 +47,7 @@ trait ImageFields {
   def sourceField(field: String)      = s"source.$field"
   def photoshootField(field: String) = editsField(s"photoshoot.$field")
 
-  val aliases = Map(
+  val fieldAliases = Map(
     "crops"     -> "exports",
     "croppedBy" -> "exports.author",
     "filename"  -> "uploadInfo.filename",
@@ -64,7 +64,7 @@ trait ImageFields {
     case f if collectionsFields.contains(f) => collectionsField(f)
     case f if usagesFields.contains(f)      => usagesField(f)
     case f if sourceFields.contains(f)      => sourceField(f)
-    case f => aliases.getOrElse(f, f)
+    case f => fieldAliases.getOrElse(f, f)
   }
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfigWithElastic.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfigWithElastic.scala
@@ -6,13 +6,8 @@ class CommonConfigWithElastic(resources: GridConfigResources) extends CommonConf
 
   val esConfig = ElasticSearchConfig(
     aliases = ElasticSearchAliases(
-      // TODO: reinstate this once everyone's config has been updated...
-//      current = string("es.index.aliases.current"),
-      // TODO: ...and then remove this
-      current = stringOpt("es.index.aliases.read") getOrElse stringOpt("es.index.aliases.write")
-        .getOrElse(string("es.index.aliases.current")),
-
-      migration = stringOpt("es.index.aliases.migration")
+      current = string("es.index.aliases.current"),
+      migration = string("es.index.aliases.migration")
     ),
     url = string("es6.url"),
     cluster =  string("es6.cluster"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchAliases.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchAliases.scala
@@ -1,3 +1,6 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-case class ElasticSearchAliases(current: String, migration: Option[String])
+case class ElasticSearchAliases(
+  current: String,
+  migration: String
+)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -24,7 +24,8 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
 
   def cluster: String
 
-  def imagesAlias: String
+  def imagesCurrentAlias: String
+  def imagesMigrationAlias: String
 
   protected val imagesIndexPrefix = "images"
   protected val imageType = "image"
@@ -41,7 +42,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
   }
 
   def ensureAliasAssigned() {
-    logger.info(s"Checking alias $imagesAlias is assigned to index…")
+    logger.info(s"Checking alias $imagesCurrentAlias is assigned to index…")
     if (getCurrentAlias.isEmpty) {
       ensureIndexExists(initialImagesIndex)
       assignAliasTo(initialImagesIndex)
@@ -60,7 +61,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
 
   def healthCheck(): Future[Boolean] = {
     implicit val logMarker = MarkerMap()
-    val request = search(imagesAlias) limit 0
+    val request = search(imagesCurrentAlias) limit 0
     executeAndLog(request, "Healthcheck").map { _ => true}.recover { case _ => false}
   }
 
@@ -147,16 +148,16 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
   def getCurrentIndices: List[String] = ???
 
   def assignAliasTo(index: String): Unit = {
-    logger.info(s"Assigning alias $imagesAlias to $index")
+    logger.info(s"Assigning alias $imagesCurrentAlias to $index")
     val aliasActionResponse = Await.result(client.execute {
       aliases(
-        addAlias(imagesAlias, index)
+        addAlias(imagesCurrentAlias, index)
       )
     }, tenSeconds)
     logger.info("Got alias action response: " + aliasActionResponse)
   }
 
-  def changeAliasTo(newIndex: String, oldIndex: String, alias: String = imagesAlias): Unit = {
+  def changeAliasTo(newIndex: String, oldIndex: String, alias: String = imagesCurrentAlias): Unit = {
     logger.info(s"Assigning alias $alias to $newIndex")
     val aliasActionResponse = Await.result(client.execute {
       aliases(

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -45,7 +45,7 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
   val elasticConfig = ElasticSearchConfig(
     aliases = ElasticSearchAliases(
       current = "Images_Current",
-      migration = Some("Images_Migration")
+      migration = "Images_Migration"
     ),
     url = es6TestUrl,
     cluster = "media-service-test",

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -25,7 +25,8 @@ object ImageNotDeletable extends Throwable("Image cannot be deleted")
 class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics]) extends ElasticSearchClient
   with ImageFields with ElasticSearchExecutions {
 
-  lazy val imagesAlias: String = config.aliases.current
+  lazy val imagesCurrentAlias: String = config.aliases.current
+  lazy val imagesMigrationAlias: String = config.aliases.migration
   lazy val url: String = config.url
   lazy val cluster: String = config.cluster
   lazy val shards: Int = config.shards
@@ -39,7 +40,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
       val document = Json.stringify(Json.toJson(img))
       (
         requestsSoFar :+
-        indexInto(imagesAlias)
+        indexInto(imagesCurrentAlias)
           .id(img.id)
           .source(document),
         sizeSoFar + document.length()
@@ -87,7 +88,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
       ("update_doc", asNestedMap(asImageUpdate(upsertImageAsJson)))
     )
 
-    val indexRequest = updateById(imagesAlias, id).
+    val indexRequest = updateById(imagesCurrentAlias, id).
       upsert(Json.stringify(insertImageAsJson)).
       script(script)
 
@@ -99,7 +100,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
   }
 
   def getImage(id: String)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Option[Image]] = {
-    executeAndLog(get(imagesAlias, id), s"ES6 get image by $id").map { r =>
+    executeAndLog(get(imagesCurrentAlias, id), s"ES6 get image by $id").map { r =>
       if (r.result.found) {
         Some(Json.parse(r.result.sourceAsString).as[Image])
       } else {
@@ -220,7 +221,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
       filter
     )
 
-    val request = search(imagesAlias) bool filteredMatches limit 200 // TODO no order?
+    val request = search(imagesCurrentAlias) bool filteredMatches limit 200 // TODO no order?
 
     executeAndLog(request, s"ES6 get images in photoshoot ${photoshoot.title} with inferred syndication rights (excluding $excludedImageId)").map { r =>
       r.result.hits.hits.toList.map { h =>
@@ -248,7 +249,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
 
     val syndicationRightsPublishedDescending = fieldSort("syndicationRights.published").order(SortOrder.DESC)
 
-    val request = search(imagesAlias) bool filteredMatches sortBy syndicationRightsPublishedDescending
+    val request = search(imagesCurrentAlias) bool filteredMatches sortBy syndicationRightsPublishedDescending
 
     executeAndLog(request, s"ES6 get image in photoshoot ${photoshoot.title} with latest rcs syndication rights (excluding $excludedImageId)").map { r =>
       r.result.hits.hits.toList.headOption.map { h =>
@@ -269,9 +270,9 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
       nestedQuery("usages").query(existsQuery("usages"))
     )
 
-    val eventualDeleteResponse = executeAndLog(count(imagesAlias).query(deletableImage), s"ES6 searching for image to delete: $id").flatMap { r =>
+    val eventualDeleteResponse = executeAndLog(count(imagesCurrentAlias).query(deletableImage), s"ES6 searching for image to delete: $id").flatMap { r =>
       val deleteFuture = r.result.count match {
-        case 1 => executeAndLog(deleteById(imagesAlias, id), s"ES6 deleting image $id")
+        case 1 => executeAndLog(deleteById(imagesCurrentAlias, id), s"ES6 deleting image $id")
         case _ => Future.failed(ImageNotDeletable)
       }
       deleteFuture
@@ -320,7 +321,7 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
   }
 
   private def getUpdateRequest(id: String, script: String) =
-    updateById(imagesAlias, id)
+    updateById(imagesCurrentAlias, id)
       .script(Script(script = script).lang("painless"))
 
   def replaceImageLeases(id: String, leases: Seq[MediaLease], lastModified: DateTime)
@@ -345,10 +346,10 @@ class ElasticSearch(config: ElasticSearchConfig, metrics: Option[ThrallMetrics])
     Script(script = scriptSource).lang("painless").param("lastModified", printDateTime(lastModified)).params(params)
 
   private def prepareUpdateRequest(id: String, scriptSource: String, lastModified: DateTime, params: (String, Object)*) =
-    updateById(imagesAlias, id).script(prepareScript(scriptSource, lastModified, params:_*))
+    updateById(imagesCurrentAlias, id).script(prepareScript(scriptSource, lastModified, params:_*))
 
   private def prepareUpdateRequest(id: String, scriptSource: String, lastModified: DateTime) =
-    updateById(imagesAlias, id).script(prepareScript(scriptSource, lastModified))
+    updateById(imagesCurrentAlias, id).script(prepareScript(scriptSource, lastModified))
 
   def addImageLease(id: String, lease: MediaLease, lastModified: DateTime)
                    (implicit ex: ExecutionContext, logMarker: LogMarker): List[Future[ElasticSearchUpdateResponse]] = {

--- a/thrall/app/lib/elasticsearch/GoodToGoCheck.scala
+++ b/thrall/app/lib/elasticsearch/GoodToGoCheck.scala
@@ -73,7 +73,7 @@ object GoodToGoCheck extends StrictLogging {
   def deleteTestImage(es: ElasticSearch, imageId: String)(implicit ex: ExecutionContext, lm: LogMarker): Future[Response[DeleteResponse]] = {
     import com.sksamuel.elastic4s.ElasticDsl._
     // this manipulates the underlying ES API as the built in delete API guards against deleting images that are in use
-    es.executeAndLog(deleteById(es.imagesAlias, imageId), s"Deleting good to go test image $imageId")
+    es.executeAndLog(deleteById(es.imagesCurrentAlias, imageId), s"Deleting good to go test image $imageId")
   }
 
   def deleteOldTestImages(es: ElasticSearch, now: DateTime)(implicit ex: ExecutionContext, lm: LogMarker): Future[Long] = {
@@ -86,7 +86,7 @@ object GoodToGoCheck extends StrictLogging {
     )
     // this manipulates the underlying ES API as the built in delete API guards against deleting images that are in use
     val eventualResult = es.executeAndLog(
-      deleteByQuery(es.imagesAlias, query),
+      deleteByQuery(es.imagesCurrentAlias, query),
       s"Deleting any old test images uploaded by ${MappingTest.testImage.uploadedBy}"
     )
     eventualResult.map(_.result.deleted)

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -31,7 +31,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
   val elasticSearchConfig = ElasticSearchConfig(
     aliases = ElasticSearchAliases(
       current = "Images_Current",
-      migration = Some("Images_Migration")
+      migration = "Images_Migration"
     ),
     url = esTestUrl,
     cluster = "media-service-test",


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 
Co-authored-by: @tjsilver 

https://trello.com/c/SAbSEpuM/2337-grid-reingestion-control-panel

## What does this change?

Following https://github.com/guardian/grid/pull/3362 (where we introduced the concept of a 'migration alias') this is the next phase of refactor to make use of that a bit in the `ElasticSearchClient`, this PR includes...

- renaming `val imagesAlias` to `val imagesCurrentAlias`
- removed fallback mechanism for old config (originally added in https://github.com/guardian/grid/pull/3362 )
- added `val imagesMigrationAlias` to `ElasticSearchClient`

IMPORTANT: when working on this PR, we noticed lots of hardcoded references to the `images` index (rather than via the alias) which we'll have to unpick/remove in a future PR, since the name of the index will no longer be fixed (as per the Context section of the description in https://github.com/guardian/grid/pull/3324).

## How can success be measured?
One step closer to grid understanding the concept of two indexes at once (current and migration).

## Screenshots
N/A

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
