### PR TITLE
add `thrall` to PRout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -9,6 +9,7 @@
     "leases": { "url": "https://media-leases.gutools.co.uk/management/manifest", "overdue": "30M" },
     "media-api": { "url": "https://api.media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "metadata-editor": { "url": "https://media-metadata.gutools.co.uk/management/manifest", "overdue": "30M" },
+    "thrall": { "url": "https://thrall.media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "usage": { "url": "https://media-usage.gutools.co.uk/management/manifest", "overdue": "30M" }
   }
 }


### PR DESCRIPTION
## What does this change?
now thrall is exposed to the world (following https://github.com/guardian/editorial-tools-platform/pull/549) we can now get visibility on releases (something that's sorely been missing)

## How can success be measured?
Now when we do deploys, thrall will be reported as 'seen-on-prod' (or indeed 'overdue-on-prod') like all the other modules - there have been times in the past where thrall failed to deploy but we didn't realise for longer than with any other service.

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
