### PR TITLE
Force vertical scroll bar

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -68,6 +68,7 @@ z-index
 }
 
 html {
+    overflow-y: scroll;
     font: 62.5%/1.5 "Guardian Agate Sans Web", Georgia;
 }
 


### PR DESCRIPTION
## What does this change?
This change forces the browser to show the vertical scroll bar, to avoid jumps in the page caused by the scroll bar appearing/disappearing when hovering over elements in the image viewer.

See https://css-tricks.com/eliminate-jumps-in-horizontal-centering-by-forcing-a-scroll-bar/ for more info

## How can success be measured?
The vertical scroll bar is always visible.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
