### PR TITLE
Tag S3 object on add to library

### DIFF
--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.mediaservice.lib.aws.S3
 import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
@@ -17,12 +18,14 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
   val metrics = new MetadataEditorMetrics(config)
   val messageConsumer = new MetadataSqsMessageConsumer(config, metrics, editsStore)
 
+  val s3Client = new S3(config)
+
   messageConsumer.startSchedule()
   context.lifecycle.addStopHook {
     () => messageConsumer.actorSystem.terminate()
   }
 
-  val editsController = new EditsController(auth, editsStore, notifications, config, wsClient, authorisation, controllerComponents)
+  val editsController = new EditsController(auth, editsStore, notifications, config, wsClient, s3Client, authorisation, controllerComponents)
   val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
   val controller = new EditsApi(auth, config, controllerComponents)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -7,6 +7,7 @@ import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 class EditsConfig(resources: GridConfigResources) extends CommonConfig(resources) {
   val dynamoRegion: Region = RegionUtils.getRegion(string("aws.region"))
 
+  val imageBucket: String = string("s3.image.bucket")
   val collectionsBucket: String = string("s3.collections.bucket")
 
   val editsTable = string("dynamo.table.edits")
@@ -18,4 +19,7 @@ class EditsConfig(resources: GridConfigResources) extends CommonConfig(resources
   val rootUri: String = services.metadataBaseUri
   val kahunaUri: String = services.kahunaBaseUri
   val loginUriTemplate: String = services.loginUriTemplate
+
+  val archivedTagKey = "archive"
+  val tagArchived = true
 }


### PR DESCRIPTION
## What does this change?
This sets an S3 tag on the image object stored in the main image bucket when the image is added to library.

See https://github.com/guardian/grid/discussions/3382 for discussion on this feature

## How can success be measured?
When a user clicks on Add to Library
Then an S3 tag is added on that image's object stored in the main image bucket

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
