### PR TITLE
Deprecation warnings for the index healthcheck code

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -26,9 +26,12 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
 
   def imagesAlias: String
 
+  @deprecated("This index should not be used directly.")
   protected val imagesIndexPrefix = "images"
+
   protected val imageType = "image"
 
+  @deprecated("This should always be used from config (imagesAlias) instead")
   val initialImagesIndex = "images"
 
   def shards: Int
@@ -40,6 +43,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     ElasticClient(client)
   }
 
+  @deprecated("This should be handled by the migration code.")
   def ensureAliasAssigned() {
     logger.info(s"Checking alias $imagesAlias is assigned to index…")
     if (getCurrentAlias.isEmpty) {
@@ -144,8 +148,10 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
   // Elastic only allows one index in an alias set to be the write index.
   // To mirror index updates to all indexes in the alias group, the grid queries the alias set and explicitly executes
   // each update on every aliased index.
+  @deprecated("This does nothing.")
   def getCurrentIndices: List[String] = ???
 
+  @deprecated("This should be handled by the migration code. (Deprecated because of static index/alias reference)")
   def assignAliasTo(index: String): Unit = {
     logger.info(s"Assigning alias $imagesAlias to $index")
     val aliasActionResponse = Await.result(client.execute {
@@ -156,6 +162,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     logger.info("Got alias action response: " + aliasActionResponse)
   }
 
+  @deprecated("This should be part of the migration code. (Deprecated because of static index/alias reference)\")
   def changeAliasTo(newIndex: String, oldIndex: String, alias: String = imagesAlias): Unit = {
     logger.info(s"Assigning alias $alias to $newIndex")
     val aliasActionResponse = Await.result(client.execute {
@@ -167,6 +174,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     logger.info("Got alias action response: " + aliasActionResponse)
   }
 
+  @deprecated("This does nothing.")
  def removeAliasFrom(index: String) = ???
 
 }


### PR DESCRIPTION
Add red ink to the base of ElasticSearchClient to prevent use of hardcoded index/alias values until the index handling logic is superceded by the migration code.

## What does this change?

This adds warnings to all the static references of the images index so we don't use them- and then can delete it all when we get to the index handling in the migration work. 

## How can success be measured?

That we don't use this. 

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] noop
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
