### PR TITLE
Remove guardian-specific prefixes

### DIFF
--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -38,7 +38,7 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
     case (false, _) => None
   }
 
-  val services = new Services(config.domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
+  val services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   private val gridClient = GridClient(services)(wsClient)
 
   val controller = new ImageLoaderController(

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -45,7 +45,7 @@ class MediaApi(
                 authorisation: Authorisation
 )(implicit val ec: ExecutionContext) extends BaseController with MessageSubjects with ArgoHelpers {
 
-  val services: Services = new Services(config.domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
+  val services: Services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   val gridClient: GridClient = GridClient(services)(ws)
 
   private val searchParamList = List("q", "ids", "offset", "length", "orderBy",

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -57,7 +57,7 @@ class EditsController(
 
   import UsageRightsMetadataMapper.usageRightsToMetadata
 
-  val services: Services = new Services(config.domainRoot, ServiceHosts.guardianPrefixes, Set.empty)
+  val services: Services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   val gridClient: GridClient = GridClient(services)(ws)
 
   val metadataBaseUri = config.services.metadataBaseUri


### PR DESCRIPTION
## What does this change?
Many services are using Guardian-specific prefixes for uris instead of relying in config, which causes issues for non-Guardian organisations. This replaces most of those usages to rely on config instead.

## How can success be measured?
URI prefixes depend on config and are not hardcoded.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
