### PR TITLE
Parse Kinesis records as ExternalThrallMessages if possible

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ExternalThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ExternalThrallMessage.scala
@@ -44,6 +44,9 @@ object ExternalThrallMessage{
   implicit val addImageLeaseMessage = Json.format[AddImageLeaseMessage]
   implicit val removeImageLeaseMessage = Json.format[RemoveImageLeaseMessage]
   implicit val updateImageExportsMessage = Json.format[UpdateImageExportsMessage]
+
+  implicit val createMigrationIndexMessage = Json.format[CreateMigrationIndexMessage]
+
   implicit val writes = Json.writes[ExternalThrallMessage]
 
 }
@@ -88,5 +91,19 @@ object DeleteUsagesMessage {
 case class UpdateImageSyndicationMetadataMessage(id: String, lastModified: DateTime, maybeSyndicationRights: Option[SyndicationRights]) extends ExternalThrallMessage
 
 case class UpdateImagePhotoshootMetadataMessage(id: String, lastModified: DateTime, edits: Edits) extends ExternalThrallMessage
+
+/**
+  * Message to start a new 'migration' (for re-index, re-ingestion etc.)
+  * @param migrationStart timestamp representing when a migration commenced
+  * @param gitHash the git commit hash (of the grid repo) at the point the migration commenced
+  */
+case class CreateMigrationIndexMessage(
+  migrationStart: DateTime,
+  gitHash: String
+) extends ExternalThrallMessage {
+  val id: String = "N/A"
+  val lastModified: DateTime = migrationStart
+}
+
 
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ExternalThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ExternalThrallMessage.scala
@@ -48,9 +48,9 @@ object ExternalThrallMessage{
   implicit val createMigrationIndexMessage = Json.format[CreateMigrationIndexMessage]
 
   implicit val writes = Json.writes[ExternalThrallMessage]
+  implicit val reads = Json.reads[ExternalThrallMessage]
 
 }
-
 
 
 case class ImageMessage(lastModified: DateTime, image: Image) extends ExternalThrallMessage {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/InternalThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/InternalThrallMessage.scala
@@ -1,17 +1,6 @@
 package com.gu.mediaservice.model
 
-import org.joda.time.DateTime
-
 sealed trait InternalThrallMessage extends ThrallMessage {
 
 }
 
-/**
-  * Message to start a new 'migration' (for re-index, re-ingestion etc.)
-  * @param migrationStart timestamp representing when a migration commenced
-  * @param gitHash the git commit hash (of the grid repo) at the point the migration commenced
-  */
-case class CreateMigrationIndexMessage(
-  migrationStart: DateTime,
-  gitHash: String
-) extends InternalThrallMessage

--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -1,9 +1,8 @@
 package controllers
 
-import java.util.concurrent.Executors
-
 import play.api.mvc.{BaseController, ControllerComponents}
 
+import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 
 class ThrallController(override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext) extends BaseController {

--- a/thrall/app/lib/MigrationSource.scala
+++ b/thrall/app/lib/MigrationSource.scala
@@ -6,7 +6,7 @@ import akka.stream.alpakka.elasticsearch.ReadResult
 import akka.stream.alpakka.elasticsearch.scaladsl.ElasticsearchSource
 import akka.stream.scaladsl.Source
 import com.gu.mediaservice.lib.aws.UpdateMessage
-import com.gu.mediaservice.model.Image
+import com.gu.mediaservice.model.{ExternalThrallMessage, Image}
 import com.gu.mediaservice.model.Image.ImageReads
 import lib.elasticsearch.ElasticSearch
 import org.elasticsearch.client.RestClient
@@ -16,7 +16,7 @@ import spray.json.{JsObject, JsonFormat}
 
 import scala.concurrent.Future
 
-case class MigrationRecord(payload: UpdateMessage, approximateArrivalTimestamp: Instant)
+case class MigrationRecord(payload: ExternalThrallMessage, approximateArrivalTimestamp: Instant)
 
 object MigrationSource {
   def apply(/*implicit es: RestClient*/): Source[MigrationRecord, Future[Done]] = {

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -36,6 +36,7 @@ class MessageProcessor(es: ElasticSearch,
       case message: DeleteUsagesMessage => deleteAllUsages(message, logMarker)
       case message: UpdateImageSyndicationMetadataMessage => upsertSyndicationRightsOnly(message, logMarker)
       case message: UpdateImagePhotoshootMetadataMessage => updateImagePhotoshoot(message, logMarker)
+      case _: CreateMigrationIndexMessage => Future.successful(logger.warn(logMarker, "TODO implement handler for CreateMigrationIndexMessage"))
     }
   }
 

--- a/thrall/test/lib/kinesis/ThrallEventConsumerTest.scala
+++ b/thrall/test/lib/kinesis/ThrallEventConsumerTest.scala
@@ -1,9 +1,7 @@
 package lib.kinesis
 
-import com.gu.mediaservice.lib.aws.UpdateMessage
 import lib.elasticsearch.ElasticSearchTestBase
 import org.scalatest.mockito.MockitoSugar
-import play.api.libs.json.Json
 
 class ThrallEventConsumerTest extends ElasticSearchTestBase with MockitoSugar {
   "parse message" - {
@@ -11,24 +9,14 @@ class ThrallEventConsumerTest extends ElasticSearchTestBase with MockitoSugar {
       val j =
         """
           |{
-          | "subject":"test"
-          |}
-          |""".stripMargin.getBytes()
-      val m2 = ThrallEventConsumer.parseRecord(j, java.time.Instant.EPOCH)
-      m2.isRight shouldEqual (true)
-      m2.right.get.subject shouldBe "test"
-    }
-    "parse near minimal message" in {
-      val j =
-        """
-          |{
-          | "subject":"test",
+          | "subject":"delete-image",
+          | "id":"123",
           | "lastModified":"2021-01-25T10:21:18.006Z"
           |}
           |""".stripMargin.getBytes()
       val m2 = ThrallEventConsumer.parseRecord(j, java.time.Instant.EPOCH)
       m2.isRight shouldEqual (true)
-      m2.right.get.subject shouldBe "test"
+      m2.right.get.subject shouldBe "DeleteImageMessage"
     }
   }
 }


### PR DESCRIPTION
Co-authored-by: Alex Ware <alex.ware@guardian.co.uk>

## What does this change?

Incoming messages are currently parsed as `UpdateMessage`s - this PR changes to try to parse them as `ExternalThrallMessage`s if possible, and falling back to parsing as `UpdateMessage`s if that fails, then extracting the `ExternalThrallMessage` from that `UpdateMessage`.

## How can success be measured?

All incoming messages are successfully parsed and consumed as `ExternalThrallMessage`s, which is a more flexible type and makes it easier for us to add new message types in the future.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
