### PR TITLE
Support sending `ExternalThrallMessage` over Kinesis

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Kinesis.scala
@@ -2,16 +2,14 @@ package com.gu.mediaservice.lib.aws
 
 import java.nio.ByteBuffer
 import java.util.UUID
-
 import com.amazonaws.services.kinesis.model.PutRecordRequest
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
-import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.json.JsonByteArrayUtil
 import com.gu.mediaservice.model.usage.UsageNotice
 import net.logstash.logback.marker.{LogstashMarker, Markers}
 import play.api.libs.json.{JodaWrites, Json, Writes}
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 import org.joda.time.DateTime
 
 case class KinesisSenderConfig(
@@ -30,7 +28,7 @@ class Kinesis(config: KinesisSenderConfig) extends GridLogging{
 
   private lazy val kinesisClient: AmazonKinesis = getKinesisClient
 
-  def publish(message: UpdateMessage) {
+  def publish[T <: LogMarker](message: T)(implicit messageWrites: Writes[T]) {
     val partitionKey = UUID.randomUUID().toString
 
     implicit val yourJodaDateWrites: Writes[DateTime] = JodaWrites.JodaDateTimeWrites

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ThrallMessageSender.scala
@@ -1,13 +1,11 @@
 package com.gu.mediaservice.lib.aws
 
-import com.gu.mediaservice.lib.config.CommonConfig
-import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap}
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
 import com.gu.mediaservice.model.usage.UsageNotice
-import net.logstash.logback.marker.LogstashMarker
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps}
 import play.api.libs.json.{JodaReads, JodaWrites, Json, __}
 
 // TODO MRB: replace this with the simple Kinesis class once we migrate off SNS
@@ -15,7 +13,11 @@ class ThrallMessageSender(config: KinesisSenderConfig) {
   private val kinesis = new Kinesis(config)
 
   def publish(updateMessage: UpdateMessage): Unit = {
-    kinesis.publish(updateMessage)
+    kinesis.publish(updateMessage)(UpdateMessage.writes)
+  }
+
+  def publish(externalThrallMessage: ExternalThrallMessage) = {
+    kinesis.publish(externalThrallMessage)
   }
 }
 


### PR DESCRIPTION
## What does this change?
Follows on from https://github.com/guardian/grid/pull/3394 (which added parsing of `ExternalThrallMessage` directly from Kinesis - i.e. avoiding translation from `UpdateMessage`) - this PR refactors the sending to also support sending `ExternalThrallMessage` directly over Kinesis.

## How can success be measured?
Simplicity.

## Who should look at this?
@guardian/digital-cms 


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
