### PR TITLE
wire up thrall 'start migration button' to send `CreateMigrationIndexMessage`

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -4,9 +4,12 @@ play {
   application.loader = "AppLoader"
   application.langs = "en"
 
-  http.session {
-    httpOnly = false
-    secure = true
+  http{
+    session {
+      httpOnly = false
+      secure = true
+    }
+    forwarded.trustedProxies=["0.0.0.0/0", "::/0"]
   }
 
   # Quick hack

--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -17,7 +17,6 @@ GET     /assets/*file                                 controllers.Assets.version
 GET     /management/healthcheck                       com.gu.mediaservice.lib.management.Management.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest
 GET     /management/whoAmI                            com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.whoAmI(depth: Int)
-GET     /management/innerServiceStatusCheck           com.gu.mediaservice.lib.management.InnerServiceStatusCheckController.statusCheck(depth: Int)
 
 # Shoo robots away
 GET     /robots.txt                                   com.gu.mediaservice.lib.management.Management.disallowRobots

--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -1,18 +1,28 @@
 package controllers
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
 import com.gu.mediaservice.lib.auth.{Authentication, BaseControllerWithLoginRedirects}
+import com.gu.mediaservice.lib.aws.ThrallMessageSender
 import com.gu.mediaservice.lib.config.Services
+import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.model.CreateMigrationIndexMessage
 import lib.elasticsearch.ElasticSearch
+import org.joda.time.{DateTime, DateTimeZone}
 import play.api.mvc.ControllerComponents
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext}
 
 class ThrallController(
   es: ElasticSearch,
+  messageSender: ThrallMessageSender,
+  actorSystem: ActorSystem,
   override val auth: Authentication,
   override val services: Services,
   override val controllerComponents: ControllerComponents
-)(implicit val ec: ExecutionContext) extends BaseControllerWithLoginRedirects {
+)(implicit val ec: ExecutionContext) extends BaseControllerWithLoginRedirects with GridLogging {
 
   def index = withLoginRedirectAsync {
     for {
@@ -25,6 +35,45 @@ class ThrallController(
         migrationAlias = es.imagesMigrationAlias,
         migrationIndex = migrationIndex
       ))
+    }
+  }
+
+  implicit val pollingMaterializer:ActorMaterializer = ActorMaterializer()(actorSystem)
+
+  def startMigration = withLoginRedirectAsync {
+    val msgFailedToFetchIndex = s"Could not fetch ES index details for alias '${es.imagesMigrationAlias}'"
+    es.getIndexForAlias(es.imagesMigrationAlias) recover { case error: Throwable =>
+      logger.error(msgFailedToFetchIndex, error)
+      InternalServerError(msgFailedToFetchIndex)
+    } map {
+      case Some(index) =>
+        BadRequest(s"There is already an index '${index}' for alias '${es.imagesMigrationAlias}', and thus a migration underway.")
+      case None =>
+        messageSender.publish(CreateMigrationIndexMessage(
+          migrationStart = DateTime.now(DateTimeZone.UTC),
+          gitHash = utils.buildinfo.BuildInfo.gitCommitId
+        ))
+        // poll until images migration alias is created, giving up after 10 seconds
+        Await.result(
+          Source(1 to 20)
+            .throttle(1, 500 millis)
+            .mapAsync(parallelism = 1)(_ => es.getIndexForAlias(es.imagesMigrationAlias))
+            .takeWhile(_.isEmpty, inclusive = true)
+            .runWith(Sink.last)
+            .map(_.fold {
+              val timedOutMessage = s"Still no index for alias '${es.imagesMigrationAlias}' after 10 seconds."
+              logger.error(timedOutMessage)
+              InternalServerError(timedOutMessage)
+            }{ _ =>
+              Redirect(routes.ThrallController.index)
+            })
+            .recover { case error: Throwable =>
+              logger.error(msgFailedToFetchIndex, error)
+              InternalServerError(msgFailedToFetchIndex)
+            },
+          atMost = 12 seconds
+        )
+
     }
   }
 

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -1,24 +1,29 @@
+@import helper._
 
 @(currentAlias: String,
   currentIndex: String,
   migrationAlias: String,
   migrationIndex: Option[String]
 )
-@migrationNameCell = {
+
+@migrationIndexCell = {
     @migrationIndex match {
         case Some(indexName) => {
             @indexName <button>Migrate single image</button>
         }
         case None => {
-            <button>Start migration</button>
+            @form(routes.ThrallController.startMigration()) {
+                <input type="submit" value="Start migration">
+            }
         }
     }
 }
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Current elasticsearch indices</title>
+    <title>Thrall Control Panel</title>
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
@@ -34,7 +39,7 @@
         </tr>
         <tr>
             <td>@migrationAlias</td>
-            <td>@migrationNameCell</td>
+            <td>@migrationIndexCell</td>
         </tr>
     </table>
 </body>

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -4,6 +4,9 @@
 
 GET     /                                             controllers.ThrallController.index
 
++ nocsrf
+POST    /startMigration                               controllers.ThrallController.startMigration
+
 # Management
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck
 GET     /management/manifest                          com.gu.mediaservice.lib.management.Management.manifest


### PR DESCRIPTION
## What does this change?
Adds a new `POST /startMigration` endpoint to `thrall` which sends the `CreateMigrationIndexMessage` (via the UI priority [a.k.a. high priority] kinesis stream) and then polls for 10 seconds (server-side) to wait for the new migration index to be created, redirecting back to the index page if it does and ... 
![image](https://user-images.githubusercontent.com/19289579/127151915-a67ae8d7-2324-496d-abc1-11d04a5ef514.png)
... if it doesn't.

To invoke this new endpoint the button on the control panel has been changed to a form...
![image](https://user-images.githubusercontent.com/19289579/127152260-7d102278-52fc-4c5e-ae71-116796eb71e2.png)

In order for this POST endpoint to be called from the browser (via the form POST) it required changes to `application.conf` to configure the `trustedProxies` to allow traffic from nginx locally and from the ELB when in AWS - as per https://www.playframework.com/documentation/2.8.x/HTTPServer#Configuring-trusted-proxies . Also worth noting that in order to work properly locally it required a fix to `dev-nginx` - see https://github.com/guardian/grid/pull/3403#issuecomment-887455841 and https://github.com/guardian/dev-nginx/pull/25

## How can success be measured?
Combined with https://github.com/guardian/grid/pull/3401 we can start migrations all from the UI, making it easier for us to progress with the migration project (f.k.a. reingestion project).

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
Worth mentioning I've created [`start-migration-PLUS-aw-migration`](https://github.com/guardian/grid/compare/start-migration-PLUS-aw-migration) branch to combine this PR with https://github.com/guardian/grid/pull/3401 so we can see this work end-to-end.

- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
