### PR TITLE
Only log parse failure errors for UpdateMessage

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtil.scala
@@ -36,18 +36,15 @@ object JsonByteArrayUtil extends PlayJsonHelpers with GridLogging {
 
   def toByteArray[T](obj: T)(implicit writes: Writes[T]): Array[Byte] = compress(Json.toBytes(Json.toJson(obj)))
 
-  def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Option[T] = {
+  def fromByteArray[T](bytes: Array[Byte])(implicit reads: Reads[T]): Either[JsError, T] = {
     val string = new String(
       if (hasCompressionMarker(bytes)) decompress(bytes) else bytes,
       StandardCharsets.UTF_8
     )
 
     Json.parse(string).validate[T] match {
-      case JsSuccess(obj, _) => Some(obj)
-      case e: JsError => {
-        logParseErrors(e)
-        None
-      }
+      case JsSuccess(obj, _) => Right(obj)
+      case e: JsError => Left(e)
     }
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/json/JsonByteArrayUtilTest.scala
@@ -18,12 +18,12 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
   test("To compressed byte array and back again") {
     val bytes = JsonByteArrayUtil.toByteArray(circle)
     JsonByteArrayUtil.hasCompressionMarker(bytes) shouldBe true
-    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Some(circle)
+    JsonByteArrayUtil.fromByteArray[Shape](bytes) shouldBe Right(circle)
   }
 
   test("From byte array into different type") {
     val bytes = JsonByteArrayUtil.toByteArray(square)
-    JsonByteArrayUtil.fromByteArray[String](bytes) shouldBe None
+    JsonByteArrayUtil.fromByteArray[String](bytes).isLeft shouldBe true
   }
 
   test("Compressing... compresses") {
@@ -35,12 +35,12 @@ class JsonByteArrayUtilTest extends FunSuite with Matchers {
     val compressedBytes = JsonByteArrayUtil.toByteArray(shapes)
     compressedBytes.length < uncompressedBytes.length shouldBe true
 
-    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Some(shapes)
-    JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Some(shapes)
+    JsonByteArrayUtil.fromByteArray[List[Shape]](uncompressedBytes) shouldBe Right(shapes)
+    JsonByteArrayUtil.fromByteArray[List[Shape]](compressedBytes) shouldBe Right(shapes)
   }
 
   test("An uncompressed message can be read") {
     val uncompressedJson = Json.toBytes(Json.toJson(circle))
-    JsonByteArrayUtil.fromByteArray[Shape](uncompressedJson) shouldBe Some(circle)
+    JsonByteArrayUtil.fromByteArray[Shape](uncompressedJson) shouldBe Right(circle)
   }
 }


### PR DESCRIPTION
Co-authored-by: Tom Richards <tom.richards@guardian.co.uk>

## What does this change?

After #3394 we started seeing these error messages:

![image](https://user-images.githubusercontent.com/10963046/126191679-76cc4923-a78b-495a-a507-f6ffe7a0e0c6.png)

This is due to the fact that parsing messages is expected to fail once in the case that they are `UpdateMessage`s, which currently emits a log message regardless of how the error is handled. This PR moves the logging up a level and does not emit these log messages when they can be handled.

## How can success be measured?

No/less logs like in the above screenshot.


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
