### PR TITLE
Count multiple download usages per user and image

### DIFF
--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -44,7 +44,8 @@ class UsageGroupOps(config: UsageConfig, liveContentApi: LiveContentApi, mediaWr
   def buildId(downloadUsageRequest: DownloadUsageRequest): String = s"download/${
     MD5.hash(List(
       downloadUsageRequest.mediaId,
-      downloadUsageRequest.metadata.downloadedBy
+      downloadUsageRequest.metadata.downloadedBy,
+      downloadUsageRequest.dateAdded.getMillis.toString
     ).mkString("_"))
   }"
 


### PR DESCRIPTION
## What does this change?
Currently, the grouping id for a download usage is generated by hashing downloadedBy and mediaId, which causes that 2 usages of the same image by the same user are counted as 1, since the usage is overwritten. With this change, 2 downloads of the same image by the same user will count as 2 different usages.

## How can success be measured?
When a user downloads the same image n times, there are n usages listed in the Usages tab by that user.

## Screenshots
![image](https://user-images.githubusercontent.com/20479781/126496425-9d23eeea-37fc-45e6-84b6-0f151227f087.png)

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
