### PR TITLE
Refine DeleteCrops permission

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -5,7 +5,7 @@ import com.google.common.net.HttpHeaders
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model.{Action, _}
 import com.gu.mediaservice.lib.auth.Authentication._
-import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCrops, EditMetadata, UploadImages, DeleteImage => DeleteImagePermission}
+import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCropsOrUsages, EditMetadata, UploadImages, DeleteImage => DeleteImagePermission}
 import com.gu.mediaservice.lib.auth._
 import com.gu.mediaservice.lib.aws.{S3Metadata, ThrallMessageSender, UpdateMessage}
 import com.gu.mediaservice.lib.formatting.printDateTime
@@ -108,7 +108,7 @@ class MediaApi(
   }
 
   def canUserDeleteCropsOrUsages(principal: Principal): Boolean =
-    authorisation.hasPermissionTo(DeleteCrops)(principal)
+    authorisation.hasPermissionTo(DeleteCropsOrUsages)(principal)
 
   private def isAvailableForSyndication(image: Image): Boolean = image.syndicationRights.exists(_.isAvailableForSyndication)
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -1,9 +1,8 @@
 package com.gu.mediaservice.lib.auth
 
-import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, Principal, Request, UserPrincipal}
-import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteImage, EditMetadata, PrincipalFilter, UploadImages}
+import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCropsOrUsages, PrincipalFilter, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.AuthorisationProvider
 import play.api.mvc.{ActionFilter, Result, Results}
 
@@ -57,6 +56,7 @@ class Authorisation(provider: AuthorisationProvider, executionContext: Execution
   object CommonActionFilters {
     lazy val authorisedForUpload = actionFilterFor(UploadImages)
     lazy val authorisedForArchive = actionFilterFor(ArchiveImages)
+    lazy val authorisedForDeleteCropsOrUsages = actionFilterFor(DeleteCropsOrUsages)
   }
 
   def isUploaderOrHasPermission(

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
@@ -15,7 +15,7 @@ object Permissions {
 
   case object EditMetadata extends SimplePermission
   case object DeleteImage extends SimplePermission
-  case object DeleteCrops extends SimplePermission
+  case object DeleteCropsOrUsages extends SimplePermission
   case object ShowPaid extends SimplePermission
   case object Pinboard extends SimplePermission // FIXME ideally factor this out in favour of something more generic
   case object UploadImages extends SimplePermission

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -53,7 +53,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
     permissionContext match {
       case EditMetadata => hasPermission(Permissions.EditMetadata)
       case DeleteImage => hasPermission(Permissions.DeleteImage)
-      case DeleteCrops => hasPermission(Permissions.DeleteCrops)
+      case DeleteCropsOrUsages => hasPermission(Permissions.DeleteCrops)
       case ShowPaid => hasPermission(Permissions.ShowPaid)
       case Pinboard => hasPermission(Permissions.Pinboard)
       case UploadImages => true

--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -34,7 +34,7 @@ class UsageComponents(context: Context) extends GridComponents(context, new Usag
     Future.successful(())
   })
 
-  val controller = new UsageApi(auth, usageTable, usageGroup, notifications, config, usageRecorder, liveContentApi, controllerComponents, playBodyParsers)
+  val controller = new UsageApi(auth, authorisation, usageTable, usageGroup, notifications, config, usageRecorder, liveContentApi, controllerComponents, playBodyParsers)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 


### PR DESCRIPTION
## What does this change?
Currently DeleteCrops permission is used to determine if the user can delete crops OR usages. This renames DeleteCrops permission to DeleteCropsOrUsages to make its reach clearer. It also implements permissions on usage DELETE endpoint.

## How can success be measured?
A user without DeleteCropsOrUsages permission cannot delete crops or usages.
A user with DeleteCropsOrUsages permission can delete crops and usages.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
