### PR TITLE
Further exclusions from Getty sniffing

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -300,7 +300,7 @@ object GettyXmpParser extends ImageProcessor with GettyProcessor {
       "Empics Sports Photography Ltd.", "EMPICS Entertainment", "Empics Entertainment", "MatchDay Images Limited",
       "S&G and Barratts/EMPICS Archive", "PPAUK", "SWNS.COM", "Euan Cherry", "Plumb Images", "Mercury Press", "SWNS",
       "Athena Pictures", "Flick.digital", "Matthew Horwood", "Focus Images Ltd", "www.scottishphotographer.com",
-      "ZUMAPRESS.com"
+      "ZUMAPRESS.com", "Huw Evans Agency", "Media6", "Alpha Press"
     )
 
     val excludedSource = List(


### PR DESCRIPTION
Ronseal. We really need to fix this processor! (preferably before the big reingestion)

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
