### PR TITLE
increase api-poll interval

### DIFF
--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -57,7 +57,7 @@ async.factory("apiPoll", [
   "$q",
   ($q) => {
     const wait = () => new Promise(resolve => {
-      setTimeout(() => resolve(), 500);
+      setTimeout(() => resolve(), 1500);
     });
     const poll = async (func, n) => {
       const [{ status, value }] = await Promise.allSettled([

--- a/kahuna/public/js/util/async.js
+++ b/kahuna/public/js/util/async.js
@@ -56,8 +56,8 @@ const queue = new PQueue({ concurrency: 10 });
 async.factory("apiPoll", [
   "$q",
   ($q) => {
-    const wait = () => new Promise(resolve => {
-      setTimeout(() => resolve(), 1500);
+    const wait = (timeout) => new Promise(resolve => {
+      setTimeout(() => resolve(), timeout);
     });
     const poll = async (func, n) => {
       const [{ status, value }] = await Promise.allSettled([
@@ -72,7 +72,7 @@ async.factory("apiPoll", [
       if (n > 100) {
         throw new Error('gave up after 100 tries (apiPoll failed)');
       }
-      await wait();
+      await wait(500 + n * 10);
       return poll(func, n + 1);
     };
     return func => poll(func, 1);


### PR DESCRIPTION
## What does this change?

increase API poll interval to decrease timeout errors on poor internet connection
## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
