### PR TITLE
Add a count of documents to the thrall dashboard

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -65,12 +65,11 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     executeAndLog(request, "Healthcheck").map { _ => true}.recover { case _ => false}
   }
 
-
-  def countImages(): Future[ElasticSearchImageCounts] = {
+  def countImages(indexName: String = "images"): Future[ElasticSearchImageCounts] = {
     implicit val logMarker = MarkerMap()
-    val queryCatCount = catCount("images") // document count only of index including live documents, not deleted documents which have not yet been removed by the merge process
-    val queryImageSearch = search("images") limit 0 // hits that match the query defined in the request
-    val queryStats = indexStats("images") // total accumulated values of an index for both primary and replica shards
+    val queryCatCount = catCount(indexName) // document count only of index including live documents, not deleted documents which have not yet been removed by the merge process
+    val queryImageSearch = search(indexName) limit 0 // hits that match the query defined in the request
+    val queryStats = indexStats(indexName) // total accumulated values of an index for both primary and replica shards
 
     for {
       catCount <- executeAndLog(queryCatCount, "Images cat count")
@@ -79,7 +78,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     } yield
       ElasticSearchImageCounts(catCount.result.count,
                                imageSearch.result.hits.total.value,
-                               stats.result.indices("images").total.docs.count)
+                               stats.result.indices(indexName).total.docs.count)
   }
 
   def ensureIndexExists(index: String): Unit = {

--- a/thrall/app/lib/OptionalFutureRunner.scala
+++ b/thrall/app/lib/OptionalFutureRunner.scala
@@ -1,0 +1,16 @@
+package lib
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Optionally executes an asynchronous function if param is a Some, wrapping the result back into a Some.
+  * If the param is empty, runner completes with a successful empty future.
+  */
+object OptionalFutureRunner {
+  def run[A, B](f: A => Future[B])(param: Option[A])(implicit ex: ExecutionContext): Future[Option[B]] = {
+    param match {
+      case Some(value) => f(value).map(Some(_))
+      case None => Future.successful(None)
+    }
+  }
+}

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -2,8 +2,10 @@
 
 @(currentAlias: String,
   currentIndex: String,
+  currentIndexCount: String,
   migrationAlias: String,
-  migrationIndex: Option[String]
+  migrationIndex: Option[String],
+  migrationIndexCount: String,
 )
 
 @migrationIndexCell = {
@@ -32,14 +34,17 @@
         <tr>
             <th>Alias</th>
             <th>Index</th>
+            <th>Image count</th>
         </tr>
         <tr>
             <td>@currentAlias</td>
             <td>@currentIndex</td>
+            <td>@currentIndexCount</td>
         </tr>
         <tr>
             <td>@migrationAlias</td>
             <td>@migrationIndexCell</td>
+            <td>@migrationIndexCount</td>
         </tr>
     </table>
 </body>


### PR DESCRIPTION
## What does this change?
Adds a count of documents to the thrall dashboard

## How can success be measured?
Open thrall dashboard, see how many images are in each index.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![image](https://user-images.githubusercontent.com/10963046/128003652-c7b7b3d9-2236-44ff-a089-1a37cd23af81.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
