### PR TITLE
Raise cropSizeWarning to 1000px

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -131,7 +131,7 @@ crop.controller('ImageCropCtrl', [
         ctrl.inputY = ctrl.cropY();
       });
 
-      ctrl.cropSizeWarning = () => ctrl.cropWidth() < 500;
+      ctrl.cropSizeWarning = () => ctrl.cropWidth() < 1000;
 
       function crop() {
         // TODO: show crop

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -96,7 +96,7 @@
 
 <div class="warning" ng-if="ctrl.cropSizeWarning()">
     This crop is very small and will result in a low-quality image.
-    Please try to use a larger crop.
+    Please try to use a larger crop or an alternative image.
 </div>
 
 <div class="easel">


### PR DESCRIPTION
## What does this change?
It’s 2021 and 500px is too small for anything. Composer warns at 1000px, which is still small, but better. This makes the warning show up below 1000px wide. Ideally, the [warning overlay wouldn’t make the page shift](https://github.com/guardian/grid/pull/688#issue-34446595), but that’s beyond my abilities.

This also changes the warning text to suggest using an alternative image.

## How can success be measured?
Users more aware of modern resolution requirements.

## Screenshots
![Picture 19](https://user-images.githubusercontent.com/6032869/128180706-cd3e46d9-673d-47cf-8b37-18da78b93c93.jpg)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
