### PR TITLE
handle re-upload soft-deleted images

### DIFF
--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -3,16 +3,16 @@ package auth
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, UserPrincipal}
-import com.gu.mediaservice.lib.auth.Permissions.{ShowPaid, UploadImages}
+import com.gu.mediaservice.lib.auth.Permissions.{DeleteImage, ShowPaid, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.{AuthenticationProviders, LocalAuthenticationProvider}
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, Internal}
 import com.gu.mediaservice.lib.guardian.auth.PandaAuthenticationProvider
 import com.gu.pandomainauth.service.CookieUtils
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, Result}
-
 import java.net.URI
 import java.util.Date
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -48,6 +48,7 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
   def session = auth { request =>
     val showPaid = authorisation.hasPermissionTo(ShowPaid)(request.user)
     val canUpload = authorisation.hasPermissionTo(UploadImages)(request.user)
+    val canDelete = authorisation.hasPermissionTo(DeleteImage)(request.user)
     request.user match {
       case UserPrincipal(firstName, lastName, email, _) =>
 
@@ -61,7 +62,8 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
               "permissions" ->
                 Json.obj(
                   "showPaid" -> showPaid,
-                  "canUpload" -> canUpload
+                  "canUpload" -> canUpload,
+                  "canDelete" -> canDelete,
                 )
             )
           )

--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -174,7 +174,7 @@ class GridClient(services: Services)(implicit wsClient: WSClient) extends LazyLo
 
   def getSoftDeletedMetadata(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[Option[ImageStatusRecord]] = {
     logger.info("attempt to get soft deleted metadata")
-    val url = new URL(s"${services.apiBaseUri}/$mediaId/softDeletedMetadata")
+    val url = new URL(s"${services.apiBaseUri}/images/$mediaId/softDeletedMetadata")
     makeGetRequestAsync(url, authFn) map {
       case Found(json, _) => Some((json \ "data").as[ImageStatusRecord])
       case NotFound(_, _) => None

--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -181,15 +181,6 @@ class GridClient(services: Services)(implicit wsClient: WSClient) extends LazyLo
     }
   }
 
-  def getImageSoftDeletedStatus(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[Boolean] = {
-    logger.info("attempt to get Image Soft Deleted Status")
-    val url = new URL(s"${services.apiBaseUri}/images/$mediaId")
-    makeGetRequestAsync(url, authFn) map {
-      case Found(json, _) if (json \ "data" \ "softDeletedMetadata").isDefined => true
-      case _ => false
-    }
-  }
-
   def getCrops(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[List[Crop]] = {
     logger.info("attempt to get crops")
     val url = new URL(s"${services.cropperBaseUri}/crops/$mediaId")

--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -181,6 +181,15 @@ class GridClient(services: Services)(implicit wsClient: WSClient) extends LazyLo
     }
   }
 
+  def getImageSoftDeletedStatus(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[Boolean] = {
+    logger.info("attempt to get Image Soft Deleted Status")
+    val url = new URL(s"${services.apiBaseUri}/images/$mediaId")
+    makeGetRequestAsync(url, authFn) map {
+      case Found(json, _) if (json \ "data" \ "softDeletedMetadata").isDefined => true
+      case _ => false
+    }
+  }
+
   def getCrops(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[List[Crop]] = {
     logger.info("attempt to get crops")
     val url = new URL(s"${services.cropperBaseUri}/crops/$mediaId")

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageStatusRecord.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageStatusRecord.scala
@@ -1,4 +1,4 @@
-package lib
+package com.gu.mediaservice.model
 
 import play.api.libs.json._
 
@@ -12,3 +12,6 @@ case class ImageStatusRecord(
 object ImageStatusRecord {
   implicit val formats: Format[ImageStatusRecord] = Json.format[ImageStatusRecord]
 }
+//
+//implicit val reads: Reads[Photoshoot] = Json.reads[Photoshoot]
+//implicit val writes: Writes[Photoshoot] = Json.writes[Photoshoot]

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -70,6 +70,7 @@ object ExternalThrallMessage{
   implicit val updateImageUserMetadataMessageFormat = Json.format[UpdateImageUserMetadataMessage]
   implicit val deleteImageExportsMessageFormat = Json.format[DeleteImageExportsMessage]
   implicit val softDeleteImageMessageFormat = Json.format[SoftDeleteImageMessage]
+  implicit val unSoftDeleteImageMessageFormat = Json.format[UnSoftDeleteImageMessage]
   implicit val imageMessageFormat = Json.format[ImageMessage]
   implicit val updateImagePhotoshootMetadataMessage = Json.format[UpdateImagePhotoshootMetadataMessage]
   implicit val deleteUsagesMessage = Json.format[DeleteUsagesMessage]
@@ -96,6 +97,8 @@ case class ImageMessage(lastModified: DateTime, image: Image) extends ExternalTh
 case class DeleteImageMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 
 case class SoftDeleteImageMessage(id: String, lastModified: DateTime, softDeletedMetadata: SoftDeletedMetadata) extends ExternalThrallMessage
+
+case class UnSoftDeleteImageMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 
 case class DeleteImageExportsMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -6,6 +6,7 @@ trait MessageSubjects {
   val ReingestImage = "reingest-image" // FIXME: the new migration process will replace the legacy reingest lambda etc
   val DeleteImage = "delete-image"
   val SoftDeleteImage = "soft-delete-image"
+  val UnSoftDeleteImage = "un-soft-delete-image"
   val UpdateImage = "update-image" // TODO: this appears unused https://logs.gutools.co.uk/s/editorial-tools/goto/f0a03ca3c37261985b2e6292adb8de0f
   val DeleteImageExports = "delete-image-exports"
   val UpdateImageExports = "update-image-exports"

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -239,6 +239,20 @@ Resources:
         AttributeName: expires
         Enabled: true
 
+  SoftDeletedMetadataTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: SoftDeletedMetadataTable
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
+
 Outputs:
   ImageBucket:
     Value: !Ref 'ImageBucket'
@@ -282,3 +296,5 @@ Outputs:
     Value: !Ref 'PreviewContentPollTable'
   UploadStatusTable:
     Value: !Ref 'UploadStatusTable'
+  SoftDeletedMetadataTable:
+    Value: !Ref 'SoftDeletedMetadataTable'

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -131,6 +131,7 @@ function getMediaApiConfig(config) {
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false
         |image.record.download=false
+        |dynamo.table.softDelete.metadata="SoftDeletedMetadataTable"
         |`;
 }
 

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -54,6 +54,16 @@ object FailureResponse extends ArgoHelpers with Results {
     )
   }
 
+  def imageAlreadyExists(exception: Exception): Response = {
+    logger.info(s"Rejected request to load file: image file already exists and is soft deleted", exception)
+
+    Response(
+      BadRequest,
+      "image-already-exists",
+      s"Image already exists: image file already exists and is soft deleted."
+    )
+  }
+
   def internalError(exception: Throwable): Response = {
     logger.info(s"Unhandled exception", exception)
 

--- a/image-loader/app/lib/FailureResponse.scala
+++ b/image-loader/app/lib/FailureResponse.scala
@@ -54,16 +54,6 @@ object FailureResponse extends ArgoHelpers with Results {
     )
   }
 
-  def imageAlreadyExists(exception: Exception): Response = {
-    logger.info(s"Rejected request to load file: image file already exists and is soft deleted", exception)
-
-    Response(
-      BadRequest,
-      "image-already-exists",
-      s"Image already exists: image file already exists and is soft deleted."
-    )
-  }
-
   def internalError(exception: Throwable): Response = {
     logger.info(s"Unhandled exception", exception)
 

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
@@ -15,6 +15,7 @@
     </span>
 
     <button ng-switch-when="archived"
+            ng-if="!ctrl.isDeleted"
             type="button"
             class="gr-archiver-status__button inner-clickable"
             title="Remove from Library"
@@ -23,7 +24,7 @@
         <gr-library-added-icon class="gr-archiver-status__icon"></gr-library-added-icon>
         <gr-library-remove-icon class="gr-archiver-status__icon"></gr-library-remove-icon>
     </button>
-    <button ng-if="ctrl.canArchive" ng-switch-when="unarchived"
+    <button ng-if="ctrl.canArchive && !ctrl.isDeleted" ng-switch-when="unarchived"
             type="button"
             class="gr-archiver-status__button inner-clickable"
             title="Add to Library"
@@ -34,7 +35,7 @@
     <button ng-if="ctrl.canUndelete && ctrl.isDeleted"
             type="button"
             class="gr-archiver-status__button inner-clickable"
-            title="Add to Library"
+            title="Undelete"
             ng-click="ctrl.undelete()">
         <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
     </button>

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
@@ -4,10 +4,16 @@
       ng-class="{'gr-archiver-status--interactive': ctrl.archivedState !== 'kept',
                  'gr-archiver-status--archived':    ctrl.archivedState !== 'unarchived',
                  'gr-archiver-status--unarchived':  ctrl.archivedState === 'unarchived'}">
-    <span ng-switch-when="kept"
+    <span ng-if="!ctrl.isDeleted" ng-switch-when="kept"
           title="Kept in Library because the image has been {{ctrl.archivedExplanation}}.">
         <gr-library-locked-icon class="gr-archiver-status__icon"></gr-library-locked-icon>
     </span>
+
+    <span ng-if="ctrl.isDeleted && !ctrl.canUndelete"
+          title="Image has been deleted">
+        <gr-library-locked-icon class="gr-archiver-status__icon"></gr-library-locked-icon>
+    </span>
+
     <button ng-switch-when="archived"
             type="button"
             class="gr-archiver-status__button inner-clickable"
@@ -23,6 +29,13 @@
             title="Add to Library"
             ng-click="ctrl.archive()"
             ng-disabled="ctrl.archiving">
+        <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
+    </button>
+    <button ng-if="ctrl.canUndelete && ctrl.isDeleted"
+            type="button"
+            class="gr-archiver-status__button inner-clickable"
+            title="Add to Library"
+            ng-click="ctrl.undelete()">
         <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
     </button>
 </span>

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.html
@@ -32,13 +32,6 @@
             ng-disabled="ctrl.archiving">
         <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
     </button>
-    <button ng-if="ctrl.canUndelete && ctrl.isDeleted"
-            type="button"
-            class="gr-archiver-status__button inner-clickable"
-            title="Undelete"
-            ng-click="ctrl.undelete()">
-        <gr-library-add-icon class="gr-archiver-status__icon"></gr-library-add-icon>
-    </button>
 </span>
 
 <span ng-if="ctrl.readonly"

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
@@ -23,7 +23,15 @@ archiver.controller('ArchiverCtrl',
     ctrl.archive = archive;
     ctrl.unarchive = unarchive;
     ctrl.archiving = false;
-    ctrl.canArchive = false;
+    ctrl.canUndelete = false;
+    ctrl.isDeleted = false;
+
+    ctrl.undelete = undelete;
+
+    mediaApi.getSession().then(session => {
+        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+        if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
+    });
 
     mediaApi.canUserArchive().then(canArchive => {
         ctrl.canArchive = canArchive;
@@ -49,6 +57,13 @@ archiver.controller('ArchiverCtrl',
         return promise.
             catch(()  => $window.alert('Failed to save the changes, please try again.')).
             finally(() => ctrl.archiving = false);
+    }
+
+    function undelete() {
+        const imageId = ctrl.image.data.id;
+        mediaApi.undelete(imageId).then(
+            ctrl.canUndelete = ctrl.isDeleted = false
+        );
     }
 }]);
 

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
@@ -29,7 +29,7 @@ archiver.controller('ArchiverCtrl',
     ctrl.undelete = undelete;
 
     mediaApi.getSession().then(session => {
-        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy) { ctrl.canUndelete = true; }
+        if (ctrl.image.data.softDeletedMetadata !== undefined && (session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy)) { ctrl.canUndelete = true; }
         if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
     });
 

--- a/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
+++ b/kahuna/public/js/components/gr-archiver-status/gr-archiver-status.js
@@ -29,7 +29,7 @@ archiver.controller('ArchiverCtrl',
     ctrl.undelete = undelete;
 
     mediaApi.getSession().then(session => {
-        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy) { ctrl.canUndelete = true; }
         if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
     });
 

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -1,11 +1,19 @@
 <div class="batch-archive"
      ng-switch="ctrl.archivedState">
-    <span ng-switch-when="kept"
+    <span ng-if="!ctrl.isDeleted" ng-switch-when="kept"
           class="side-padded batch-archive__button batch-archive__button--disabled"
           gr-tooltip="{{ctrl.archivedExplanation}}"
           gr-tooltip-updates>
         <gr-library-locked-icon class="batch-archive__icon"></gr-library-locked-icon>
         <span class="icon-label">Kept in Library</span>
+    </span>
+
+    <span ng-if="ctrl.isDeleted && !ctrl.canUndelete"
+          class="side-padded batch-archive__button batch-archive__button--disabled"
+          gr-tooltip="Image has been deleted"
+          gr-tooltip-updates>
+        <gr-library-locked-icon class="batch-archive__icon"></gr-library-locked-icon>
+        <span class="icon-label">Image Deleted</span>
     </span>
 
     <button ng-switch-when="archived"
@@ -23,6 +31,15 @@
             class="clickable side-padded batch-archive__button"
             ng-click="ctrl.archive()"
             ng-disabled="ctrl.archiving">
+        <gr-library-add-icon class="batch-archive__icon"></gr-library-add-icon>
+        <span ng-if="!ctrl.archiving">Add to Library</span>
+        <span ng-if="ctrl.archiving">Adding to Library…</span>
+    </button>
+
+    <button ng-if="ctrl.canUndelete && ctrl.isDeleted"
+            type="button"
+            class="clickable side-padded batch-archive__button"
+            ng-click="ctrl.undelete()">
         <gr-library-add-icon class="batch-archive__icon"></gr-library-add-icon>
         <span ng-if="!ctrl.archiving">Add to Library</span>
         <span ng-if="ctrl.archiving">Adding to Library…</span>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.html
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.html
@@ -17,6 +17,7 @@
     </span>
 
     <button ng-switch-when="archived"
+            ng-if="!ctrl.isDeleted"
             type="button"
             class="clickable side-padded batch-archive__button"
             ng-click="ctrl.unarchive()"
@@ -26,7 +27,7 @@
         <span ng-if="ctrl.archiving">Removing from Library…</span>
     </button>
 
-    <button ng-if="ctrl.canArchive" ng-switch-when="unarchived"
+    <button ng-if="ctrl.canArchive && !ctrl.isDeleted" ng-switch-when="unarchived"
             type="button"
             class="clickable side-padded batch-archive__button"
             ng-click="ctrl.archive()"
@@ -41,7 +42,7 @@
             class="clickable side-padded batch-archive__button"
             ng-click="ctrl.undelete()">
         <gr-library-add-icon class="batch-archive__icon"></gr-library-add-icon>
-        <span ng-if="!ctrl.archiving">Add to Library</span>
-        <span ng-if="ctrl.archiving">Adding to Library…</span>
+        <span ng-if="!ctrl.undeleting">Undelete</span>
+        <span ng-if="ctrl.undeleting">Undeleting…</span>
     </button>
 </div>

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -40,6 +40,7 @@ module.controller('grArchiverCtrl', [
 
         ctrl.canUndelete = false;
         ctrl.isDeleted = false;
+        ctrl.undeleting = false;
 
         ctrl.undelete = undelete;
 
@@ -112,10 +113,16 @@ module.controller('grArchiverCtrl', [
                 toArray();
         }
         function undelete() {
+            ctrl.undeleting = true
             const imageId = ctrl.image.data.id;
-            mediaApi.undelete(imageId).then(
-                ctrl.canUndelete = ctrl.isDeleted = false
-            );
+            mediaApi.undelete(imageId)
+                .then(
+                  ctrl.canUndelete = ctrl.isDeleted = false
+                ).catch(() => {
+                     $window.alert('Failed to undelete image, please try again.');
+                }).finally(() => {
+                     ctrl.undeleting = false;
+                });
         }
     }
 ]);

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -45,7 +45,7 @@ module.controller('grArchiverCtrl', [
         ctrl.undelete = undelete;
 
         mediaApi.getSession().then(session => {
-            if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+            if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy) { ctrl.canUndelete = true; }
             if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
         });
 

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -45,7 +45,7 @@ module.controller('grArchiverCtrl', [
         ctrl.undelete = undelete;
 
         mediaApi.getSession().then(session => {
-            if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy) { ctrl.canUndelete = true; }
+            if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined && (session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy)) { ctrl.canUndelete = true; }
             if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
         });
 

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -45,8 +45,8 @@ module.controller('grArchiverCtrl', [
         ctrl.undelete = undelete;
 
         mediaApi.getSession().then(session => {
-            if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
-            if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
+            if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+            if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
         });
 
         mediaApi.canUserArchive().then(canArchive => {

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -38,6 +38,16 @@ module.controller('grArchiverCtrl', [
         ctrl.archiving = false;
         ctrl.canArchive = false;
 
+        ctrl.canUndelete = false;
+        ctrl.isDeleted = false;
+
+        ctrl.undelete = undelete;
+
+        mediaApi.getSession().then(session => {
+            if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+            if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
+        });
+
         mediaApi.canUserArchive().then(canArchive => {
             ctrl.canArchive = canArchive;
         });
@@ -100,6 +110,12 @@ module.controller('grArchiverCtrl', [
                 map(items => new Set(items)).
                 reduce((all, items) => all.union(items)).
                 toArray();
+        }
+        function undelete() {
+            const imageId = ctrl.image.data.id;
+            mediaApi.undelete(imageId).then(
+                ctrl.canUndelete = ctrl.isDeleted = false
+            );
         }
     }
 ]);

--- a/kahuna/public/js/components/gr-archiver/gr-archiver.js
+++ b/kahuna/public/js/components/gr-archiver/gr-archiver.js
@@ -113,13 +113,13 @@ module.controller('grArchiverCtrl', [
                 toArray();
         }
         function undelete() {
-            ctrl.undeleting = true
+            ctrl.undeleting = true;
             const imageId = ctrl.image.data.id;
             mediaApi.undelete(imageId)
                 .then(
                   ctrl.canUndelete = ctrl.isDeleted = false
                 ).catch(() => {
-                     $window.alert('Failed to undelete image, please try again.');
+                     $window.alert('Failed to undelete image!, please try again.');
                 }).finally(() => {
                      ctrl.undeleting = false;
                 });

--- a/kahuna/public/js/components/gr-crop-image/gr-crop-image.js
+++ b/kahuna/public/js/components/gr-crop-image/gr-crop-image.js
@@ -15,7 +15,7 @@ cropImage.controller('grCropImageCtrl', [
 
         function updateState () {
             ctrl.image.get().then(image => {
-                ctrl.canBeCropped = image.data.valid;
+                ctrl.canBeCropped = image.data.valid && image.data.softDeletedMetadata === undefined;
             });
         }
 

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -1,4 +1,5 @@
-<span class="download">
+<span class="download"
+      ng-if="!ctrl.isDeleted">
     <button type="button"
             title="Download images"
             ng-disabled="ctrl.downloading"

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -39,9 +39,9 @@ downloader.controller('DownloaderCtrl', [
 
     ctrl.imagesArray = () => Array.isArray(ctrl.images) ?
         ctrl.images : Array.from(ctrl.images.values());
-
     ctrl.imageCount = () => ctrl.imagesArray().length;
 
+    ctrl.isDeleted = ctrl.images && ctrl.images.length == 1 && ctrl.images[0].data.softDeletedMetadata !== undefined
     const uris$ = imageDownloadsService.getDownloads(ctrl.imagesArray()[0]);
     inject$($scope, uris$, ctrl, 'firstImageUris');
 

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -41,7 +41,7 @@ downloader.controller('DownloaderCtrl', [
         ctrl.images : Array.from(ctrl.images.values());
     ctrl.imageCount = () => ctrl.imagesArray().length;
 
-    ctrl.isDeleted = ctrl.images && ctrl.images.length == 1 && ctrl.images[0].data.softDeletedMetadata !== undefined
+    ctrl.isDeleted = ctrl.images && ctrl.images.length == 1 && ctrl.images[0].data.softDeletedMetadata !== undefined;
     const uris$ = imageDownloadsService.getDownloads(ctrl.imagesArray()[0]);
     inject$($scope, uris$, ctrl, 'firstImageUris');
 

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,7 +1,8 @@
 <div ng-if="ctrl.showInvalidReasons" class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
-    <strong ng-if="!ctrl.isOverridden">Unusable Image <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon></strong>
-    <strong ng-if="ctrl.isOverridden"><strike>Unusable Image</strike> <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon></strong>
-    <ul>
+    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">Unusable Image <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon></strong>
+    <strong ng-if="ctrl.isOverridden && !ctrl.isDeleted"><strike>Unusable Image</strike> <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon></strong>
+    <strong ng-if="ctrl.isDeleted">Unusable Image<gr-icon title="This image cannot normally be used in content - image has been deleted">help</gr-icon></strong>
+    <ul ng-if="!ctrl.isDeleted">
         <li ng-repeat="(key, reason) in ctrl.invalidReasons">
             {{reason}}
         </li>

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -10,7 +10,8 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', function ($rootScope
 
     function updateState() {
         ctrl.image.get().then(image => {
-            ctrl.showInvalidReasons = Object.keys(image.data.invalidReasons).length !== 0;
+            ctrl.isDeleted = image.data.softDeletedMetadata !== undefined;
+            ctrl.showInvalidReasons = Object.keys(image.data.invalidReasons).length !== 0 || ctrl.isDeleted;
             ctrl.invalidReasons = image.data.invalidReasons;
             ctrl.isOverridden = ctrl.showInvalidReasons && image.data.valid;
         });

--- a/kahuna/public/js/edits/image-editor.css
+++ b/kahuna/public/js/edits/image-editor.css
@@ -6,3 +6,12 @@
     color: orange;
     font-size: 13px;
 }
+
+.undelete_button {
+    float: right;
+    padding: 0px;
+}
+
+.deleted_image_warning{
+  margin-top: 10px
+}

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -88,7 +88,7 @@
              ng-class="{
                          'status--invalid': !ctrl.canUndelete
                      }">
-            <span ng-if="ctrl.canUndelete">Image deleted (this image already exists and has been deleted. Click Add to Library to undelete it)</span>
+            <span ng-if="ctrl.canUndelete && ctrl.isDeleted">Image deleted (this image already exists and has been deleted. Click Undelete to recover it)</span>
             <span ng-if="!ctrl.canUndelete">Image deleted (this image already exists and has been deleted. Click View image to see details)</span>
         </div>
 
@@ -256,7 +256,7 @@
                     class="clickable side-padded batch-archive__button undelete_button"
                     ng-click="ctrl.undelete()">
                 <gr-library-add-icon class="batch-archive__icon"></gr-library-add-icon>
-                <span>Add to Library</span>
+                <span>Undelete</span>
             </button>
         </section>
     </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -260,5 +260,4 @@
             </button>
         </section>
     </div>
-<!--    <h1 ng-if="ctrl.canUndelete"></h1>-->
 </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -64,11 +64,14 @@
 
             <div class="result-editor__info-item"
                  ng-switch="ctrl.status">
-                <a class="result-editor__status status status--valid"
+                <a ng-if="ctrl.isDeleted" class="result-editor__status status status--valid"
+                   ui-sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
+
+                <a ng-if="!ctrl.isDeleted" class="result-editor__status status status--valid"
                    ng-switch-when="ready"
                    ui-sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
 
-                <a class="result-editor__status status status--invalid"
+                <a ng-if="!ctrl.isDeleted" class="result-editor__status status status--invalid"
                    ng-switch-when="invalid"
                    ui-sref="image({imageId: ctrl.image.data.id})">
                         Unusable
@@ -80,6 +83,15 @@
                                 image="ctrl.image">
             </gr-archiver-status>
         </div>
+
+        <div ng-if="ctrl.isDeleted" class="job-status status deleted_image_warning"
+             ng-class="{
+                         'status--invalid': !ctrl.canUndelete
+                     }">
+            <span ng-if="ctrl.canUndelete">Image deleted (this image already exists and has been deleted. Click Add to Library to undelete it)</span>
+            <span ng-if="!ctrl.canUndelete">Image deleted (this image already exists and has been deleted. Click View image to see details)</span>
+        </div>
+
         <span class="result-editor__save-status-container">
             <span class="result-editor__save-status"
                   ng-show="ctrl.saving">Saving… <span class="saving">⧖</span>
@@ -93,6 +105,7 @@
     </div>
 
     <div class="result-editor__editor">
+
         <section>
             <h1>Image Rights</h1>
             <div class="result-editor__field-container image-info__wrap">
@@ -237,5 +250,15 @@
                 <div class="result-editor__field-value">{{ctrl.image.data.source.mimeType}}</div>
             </div>
         </section>
+        <section>
+            <button ng-if="ctrl.canUndelete"
+                    type="button"
+                    class="clickable side-padded batch-archive__button undelete_button"
+                    ng-click="ctrl.undelete()">
+                <gr-library-add-icon class="batch-archive__icon"></gr-library-add-icon>
+                <span>Add to Library</span>
+            </button>
+        </section>
     </div>
+<!--    <h1 ng-if="ctrl.canUndelete"></h1>-->
 </div>

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -29,6 +29,7 @@ imageEditor.controller('ImageEditorCtrl', [
     'editsApi',
     'imageService',
     'collections',
+    'mediaApi',
 
     function($rootScope,
              $scope,
@@ -36,9 +37,17 @@ imageEditor.controller('ImageEditorCtrl', [
              editsService,
              editsApi,
              imageService,
-             collections) {
+             collections,
+             mediaApi) {
 
     var ctrl = this;
+    ctrl.canUndelete = false;
+    ctrl.isDeleted = false;
+
+    mediaApi.getSession().then(session => {
+        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+        if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
+    });
 
     editsService.canUserEdit(ctrl.image).then(editable => {
         ctrl.userCanEdit = editable;
@@ -55,6 +64,8 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.usageRights = imageService(ctrl.image).usageRights;
     ctrl.invalidReasons = ctrl.image.data.invalidReasons;
     ctrl.systemName = window._clientConfig.systemName;
+
+    ctrl.undelete = undelete;
 
     //TODO put collections in their own directive
     ctrl.addCollection = false;
@@ -206,6 +217,13 @@ imageEditor.controller('ImageEditorCtrl', [
 
     function getCollectionStyle(collection) {
         return collection.data.cssColour && `background-color: ${collection.data.cssColour}`;
+    }
+
+    function undelete() {
+        const imageId = ctrl.image.data.id;
+        mediaApi.undelete(imageId).then(
+            ctrl.canUndelete = ctrl.isDeleted = false
+        );
     }
 }]);
 

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -45,7 +45,7 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.isDeleted = false;
 
     mediaApi.getSession().then(session => {
-        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete) { ctrl.canUndelete = true; }
+        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy) { ctrl.canUndelete = true; }
         if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
     });
 

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -45,7 +45,7 @@ imageEditor.controller('ImageEditorCtrl', [
     ctrl.isDeleted = false;
 
     mediaApi.getSession().then(session => {
-        if (ctrl.image.data.softDeletedMetadata !== undefined && session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy) { ctrl.canUndelete = true; }
+        if (ctrl.image.data.softDeletedMetadata !== undefined && (session.user.permissions.canDelete || session.user.email === ctrl.image.data.uploadedBy)) { ctrl.canUndelete = true; }
         if (ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
     });
 

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -139,6 +139,7 @@ image.controller('ImageCtrl', [
     ctrl.selectedTab = 'metadata';
 
     ctrl.image = image;
+    if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
     ctrl.optimisedImageUri = optimisedImageUri;
     ctrl.lowResImageUri = lowResImageUri;
 

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -7,7 +7,7 @@
 
     <gr-top-bar-actions>
         <gr-delete-image class="top-bar-item clickable"
-                         ng-if="ctrl.canBeDeleted"
+                         ng-if="ctrl.canBeDeleted && !ctrl.isDeleted"
                          images="[ctrl.image]">
         </gr-delete-image>
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -62,12 +62,12 @@
 
                 <gr-delete-image class="results-toolbar-item results-toolbar-item--right"
                                  images="ctrl.selectedImages"
-                                 ng-if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0">
+                                 ng-if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0 && !ctrl.isDeleted">
                 </gr-delete-image>
 
                 <gr-archiver class="results-toolbar-item results-toolbar-item--right"
                              gr-images="ctrl.selectedImages"
-                             ng-if="ctrl.selectionCount > 0">
+                             ng-if="ctrl.selectionCount > 0 && !ctrl.isDeleted">
                 </gr-archiver>
 
                 <gr-toggle-button class="results-toolbar-item results-toolbar-item--no-hover results-toolbar-item--right"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -96,6 +96,7 @@ results.controller('SearchResultsCtrl', [
         ctrl.collectionsPanel = panels.collectionsPanel;
 
         ctrl.images = [];
+        if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
         ctrl.newImagesCount = 0;
 
         // Preview control
@@ -350,6 +351,7 @@ results.controller('SearchResultsCtrl', [
 
 
         function canBeDeleted(image) {
+            if (image && image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
             return image.getAction('delete').then(angular.isDefined);
         }
         // TODO: move to helper?

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -81,14 +81,11 @@ const isSearch = [
     `${staffPhotographerOrganisation}-owned-photo`,
     `${staffPhotographerOrganisation}-owned-illustration`,
     `${staffPhotographerOrganisation}-owned`,
-  'under-quota'
+  'under-quota',
+  'deleted'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {
-
-    mediaApi.getSession().then(session => {
-        if (session.user.permissions.canDelete) { isSearch.push('deleted'); }
-    });
 
     function prefixFilter(prefix) {
         const lowerPrefix = prefix.toLowerCase();

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -81,11 +81,14 @@ const isSearch = [
     `${staffPhotographerOrganisation}-owned-photo`,
     `${staffPhotographerOrganisation}-owned-illustration`,
     `${staffPhotographerOrganisation}-owned`,
-  'under-quota',
-  'deleted'
+  'under-quota'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {
+
+    mediaApi.getSession().then(session => {
+        if (session.user.permissions.canDelete) { isSearch.push('deleted'); }
+    });
 
     function prefixFilter(prefix) {
         const lowerPrefix = prefix.toLowerCase();

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -92,6 +92,10 @@ mediaApi.factory('mediaApi',
         return root.getLink('loader').then(() => true, () => false);
     }
 
+    function undelete(id) {
+        return root.follow('undelete', {id: id}).put();
+    }
+
     function canUserArchive() {
         return root.getLink('archive').then(() => true, () => false);
     }
@@ -106,6 +110,7 @@ mediaApi.factory('mediaApi',
         labelsSuggest,
         delete: delete_,
         canUserUpload,
-        canUserArchive
+        canUserArchive,
+        undelete
     };
 }]);

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -42,7 +42,7 @@
         </ui-image-editor>
 
         <gr-delete-image class="flex-right"
-                         ng-if="job.canBeDeleted && !ctrl.isDeleted"
+                         ng-if="job.canBeDeleted && !job.isDeleted"
                          images="[job.image]">
         </gr-delete-image>
     </li>

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -36,14 +36,13 @@
                                gr-on-confirm="ctrl.removeJob(job)">
             </gr-confirm-delete>
         </div>
-
         <ui-image-editor ng-if="job.image"
                          image="job.image"
                          with-batch="ctrl.jobs.length > 1">
         </ui-image-editor>
 
         <gr-delete-image class="flex-right"
-                         ng-if="job.canBeDeleted"
+                         ng-if="job.canBeDeleted && !ctrl.isDeleted"
                          images="[job.image]">
         </gr-delete-image>
     </li>

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -79,7 +79,7 @@ jobs.controller('UploadJobsCtrl', [
 
                         imageService(image).states.canDelete.then(deletable => {
                             jobItem.canBeDeleted = deletable;
-                             if (image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
+                             if (image.data.softDeletedMetadata !== undefined) { jobItem.isDeleted = true; }
                         });
 
                         // If the image is updated (e.g. label added,

--- a/kahuna/public/js/upload/jobs/upload-jobs.js
+++ b/kahuna/public/js/upload/jobs/upload-jobs.js
@@ -79,6 +79,7 @@ jobs.controller('UploadJobsCtrl', [
 
                         imageService(image).states.canDelete.then(deletable => {
                             jobItem.canBeDeleted = deletable;
+                             if (image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
                         });
 
                         // If the image is updated (e.g. label added,

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -30,7 +30,9 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val mediaApi = new MediaApi(auth, messageSender, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, wsClient, authorisation)
+  val imageStatusTable = new SoftDeletedMetadataTable(config)
+
+  val mediaApi = new MediaApi(auth, messageSender, imageStatusTable, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, wsClient, authorisation)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -203,6 +203,16 @@ class MediaApi(
 
   }
 
+  def getSoftDeletedMetadata(id: String) = auth.async {
+    imageStatusTable.getStatus(id)
+      .map {
+        case Some(scala.Right(record)) => respond(record)
+        case Some(Left(error)) => respondError(BadRequest, "cannot-get", s"Cannot get soft-deleted metadata ${error}")
+        case None => respondNotFound(s"No soft-deleted metadata found for image id: ${id}")
+      }
+      .recover{ case error => respondError(InternalServerError, "cannot-get", s"Cannot get soft-deleted metadata ${error}") }
+  }
+
   def downloadImageExport(imageId: String, exportId: String, width: Int) = auth.async { request =>
     implicit val r = request
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -225,7 +225,7 @@ class MediaApi(
     }
   }
 
-  def deleteImage(id: String) = auth.async { request =>
+  def hardDeleteImage(id: String) = auth.async { request =>
     implicit val r = request
 
     elasticSearch.getImageById(id) map {
@@ -250,7 +250,7 @@ class MediaApi(
     }
   }
 
-  def softDeleteImage(id: String) = auth.async { request =>
+  def deleteImage(id: String) = auth.async { request =>
     implicit val r = request
 
     elasticSearch.getImageById(id) map {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -89,7 +89,7 @@ class MediaApi(
       Link("permissions",     s"${config.rootUri}/permissions"),
       Link("leases",          config.leasesUri),
       Link("admin-tools",     config.adminToolsUri),
-      Link("undelete",        s"${config.rootUri}/images/{id}/undelete ")
+      Link("undelete",        s"${config.rootUri}/images/{id}/undelete")
     ) ++ maybeLoaderLink.toList ++ maybeArchiveLink.toList
     respond(indexData, indexLinks)
   }

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -399,7 +399,10 @@ class MediaApi(
       links = List(prevLink, nextLink).flatten
     } yield respondCollection(imageEntities, Some(searchParams.offset), Some(totalCount), links)
 
-    val searchParams = SearchParams(request)
+    val _searchParams = SearchParams(request)
+    val hasDeletePermission = authorisation.isUploaderOrHasPermission(request.user, "", DeleteImagePermission)
+    val canViewDeletedImages = _searchParams.query.contains("is:deleted") && !hasDeletePermission
+    val searchParams = if(canViewDeletedImages) _searchParams.copy(uploadedBy = Some(Authentication.getIdentity(request.user))) else _searchParams
 
     SearchParams.validate(searchParams).fold(
       // TODO: respondErrorCollection?

--- a/media-api/app/lib/ImageStatus.scala
+++ b/media-api/app/lib/ImageStatus.scala
@@ -1,0 +1,14 @@
+package lib
+
+import play.api.libs.json._
+
+case class ImageStatusRecord(
+                               id: String,
+                               deletedBy: String,
+                               deleteTime: String,
+                               isDeleted: Boolean
+                             )
+
+object ImageStatusRecord {
+  implicit val formats: Format[ImageStatusRecord] = Json.format[ImageStatusRecord]
+}

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -37,6 +37,8 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val cloudFrontDomainThumbBucket: Option[String] = stringOpt("cloudfront.domain.thumbbucket")
   val cloudFrontKeyPairId: Option[String]         = stringOpt("cloudfront.keypair.id")
 
+ lazy val softDeletedMetadataTable: String = string("dynamo.table.softDelete.metadata")
+
   val rootUri: String = services.apiBaseUri
   val kahunaUri: String = services.kahunaBaseUri
   val cropperUri: String = services.cropperBaseUri

--- a/media-api/app/lib/SoftDeletedMetadataTable.scala
+++ b/media-api/app/lib/SoftDeletedMetadataTable.scala
@@ -1,6 +1,8 @@
 package lib
 
 import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.mediaservice.model.ImageStatusRecord
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 
@@ -10,7 +12,9 @@ import scala.concurrent.Future
 class SoftDeletedMetadataTable(config: MediaApiConfig) extends DynamoDB(config, config.softDeletedMetadataTable) {
   private val softDeletedMetadataTable = Table[ImageStatusRecord](config.softDeletedMetadataTable)
 
-
+  def getStatus(imageId: String) = {
+    ScanamoAsync.exec(client)(softDeletedMetadataTable.get('id -> imageId))
+  }
 
   def setStatus(imageStatus: ImageStatusRecord) = {
     ScanamoAsync.exec(client)(softDeletedMetadataTable.put(imageStatus))

--- a/media-api/app/lib/SoftDeletedMetadataTable.scala
+++ b/media-api/app/lib/SoftDeletedMetadataTable.scala
@@ -1,0 +1,30 @@
+package lib
+
+import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.scanamo._
+import com.gu.scanamo.syntax._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SoftDeletedMetadataTable(config: MediaApiConfig) extends DynamoDB(config, config.softDeletedMetadataTable) {
+  private val softDeletedMetadataTable = Table[ImageStatusRecord](config.softDeletedMetadataTable)
+
+
+
+  def setStatus(imageStatus: ImageStatusRecord) = {
+    ScanamoAsync.exec(client)(softDeletedMetadataTable.put(imageStatus))
+  }
+
+  def updateStatus(imageId: String, isDeleted: Boolean) = {
+    val updateExpression = set('isDeleted -> isDeleted)
+    ScanamoAsync.exec(client)(
+      softDeletedMetadataTable
+        .given(attributeExists('id))
+        .update(
+          'id -> imageId,
+          update = updateExpression
+        )
+    )
+  }
+}

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -24,6 +24,7 @@ GET     /images/:imageId/download                                   controllers.
 GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
 DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
 DELETE  /soft-delete/images/:id                                     controllers.MediaApi.softDeleteImage(id: String)
+PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch
 
 # completion

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -9,6 +9,7 @@ GET     /                                                           controllers.
 GET     /images/metadata/:field                                     controllers.SuggestionController.metadataSearch(field: String, q: Option[String])
 GET     /images/edits/:field                                        controllers.SuggestionController.editsSearch(field: String, q: Option[String])
 
+GET     /images/:id/softDeletedMetadata                             controllers.MediaApi.getSoftDeletedMetadata(id: String)
 GET     /images/aggregations/date/:field                            controllers.AggregationController.dateHistogram(field: String, q: Option[String])
 
 # Images

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -23,7 +23,7 @@ GET     /images/:imageId/export                                     controllers.
 GET     /images/:imageId/download                                   controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
 DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
-DELETE  /soft-delete/images/:id                                     controllers.MediaApi.softDeleteImage(id: String)
+DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch
 

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -261,6 +261,17 @@ class ElasticSearch(
     ).map(_ => ElasticSearchUpdateResponse()))
   }
 
+  def applyUnSoftDelete(id: String, lastModified: DateTime)
+                     (implicit ex: ExecutionContext, logMarker: LogMarker): List[Future[ElasticSearchUpdateResponse]] = {
+    val applyUnSoftDeleteScript = "ctx._source.remove(\"softDeletedMetadata\");"
+    val updateRequest: UpdateRequest = prepareUpdateRequest(
+      id,
+      applyUnSoftDeleteScript,
+      lastModified
+    )
+    List(executeAndLog(updateRequest, s"ES7 un soft delete image $id").map(_ => ElasticSearchUpdateResponse()))
+  }
+
   def getInferredSyndicationRightsImages(photoshoot: Photoshoot, excludedImageId: Option[String])
                                         (implicit ex: ExecutionContext, logMarker: LogMarker): Future[List[Image]] = { // TODO could be a Seq
     val inferredSyndicationRights = not(termQuery("syndicationRights.isInferred", false)) // Using 'not' to include nulls

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -3,6 +3,7 @@ package lib.kinesis
 import com.gu.mediaservice.lib.aws.EsResponse
 import com.gu.mediaservice.lib.elasticsearch.{ElasticNotFoundException, InProgress}
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, combineMarkers}
+import com.gu.mediaservice.model.{AddImageLeaseMessage, CreateMigrationIndexMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, MigrateImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, UnSoftDeleteImageMessage, ThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
 import com.gu.mediaservice.model.usage.{Usage, UsageNotice}
 // import all except `Right`, which otherwise shadows the type used in `Either`s
 import com.gu.mediaservice.model.{Right => _, _}
@@ -32,6 +33,7 @@ class MessageProcessor(
       case message: ImageMessage => indexImage(message, logMarker)
       case message: DeleteImageMessage => deleteImage(message, logMarker)
       case message: SoftDeleteImageMessage => softDeleteImage(message, logMarker)
+      case message: UnSoftDeleteImageMessage => unSoftDeleteImage(message, logMarker)
       case message: DeleteImageExportsMessage => deleteImageExports(message, logMarker)
       case message: UpdateImageExportsMessage => updateImageExports(message, logMarker)
       case message: UpdateImageUserMetadataMessage => updateImageUserMetadata(message, logMarker)
@@ -110,6 +112,9 @@ class MessageProcessor(
 
   private def softDeleteImage(message: SoftDeleteImageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
     Future.sequence(es.applySoftDelete(message.id, message.softDeletedMetadata, message.lastModified)(ec, logMarker))
+
+  private def unSoftDeleteImage(message: UnSoftDeleteImageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
+    Future.sequence(es.applyUnSoftDelete(message.id, message.lastModified)(ec, logMarker))
 
   private def updateImageUserMetadata(message: UpdateImageUserMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
     Future.sequence(es.applyImageMetadataOverride(message.id, message.edits, message.lastModified)(ec, logMarker))

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -2,7 +2,7 @@ package lib.kinesis
 
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging.GridLogging
-import com.gu.mediaservice.model.{AddImageLeaseMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, ExternalThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
+import com.gu.mediaservice.model.{AddImageLeaseMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ExternalThrallMessage, ImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, UnSoftDeleteImageMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
 import com.gu.mediaservice.syntax.MessageSubjects._
 
 object MessageTranslator extends GridLogging {
@@ -19,6 +19,10 @@ object MessageTranslator extends GridLogging {
       }
       case SoftDeleteImage => (updateMessage.id, updateMessage.softDeletedMetadata) match {
         case (Some(id) , Some(deletedMetadata)) => Right(SoftDeleteImageMessage(id, updateMessage.lastModified, deletedMetadata))
+        case _ => Left(MissingFieldsException(updateMessage.subject))
+      }
+      case UnSoftDeleteImage => (updateMessage.id) match {
+        case (Some(id)) => Right(UnSoftDeleteImageMessage(id, updateMessage.lastModified))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
       case DeleteImageExports => (updateMessage.id) match {


### PR DESCRIPTION
## What does this change?

- update the Delete button to call the _soft-delete_ endpoint
- update the upload page to check if an image exists and is soft-deleted and give the ability to undelete it for permissioned users
- implement /undelete endpoint

## How can success be measured?
when re-uploading an image that is soft-deleted, an error message should appear says the Image already exists and has been soft deleted
and  permissioned users are able to undelete that image



## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
Unpermissioned user:
![Screenshot from 2021-09-10 15-02-10](https://user-images.githubusercontent.com/33189781/132857315-0fd97ccf-73ea-428b-8a83-7f34ea153aaf.png)


Permissioned user:
![Screenshot from 2021-09-10 14-57-45](https://user-images.githubusercontent.com/33189781/132857338-4fe30afb-b196-4a92-8ce9-75b5e737ca94.png)





## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
