### PR TITLE
Default Antonio Olmos to Observer

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -65,7 +65,19 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
   )
 
   val contractedPhotographers = List(
-    PublicationPhotographers(GuardianPublication, List(
+    PublicationPhotographers(ObserverPublication, List(
+      "Andy Hall",
+      "Antonio Olmos",
+      "Gary Calton",
+      "Jane Bown",
+      "Jonathan Lovekin",
+      "Karen Robinson",
+      "Katherine Anne Rose",
+      "Richard Saker",
+      "Sophia Evans",
+      "Suki Dhanda"
+    )),
+     PublicationPhotographers(GuardianPublication, List(
       "Alicia Canter",
       "Antonio Olmos",
       "Christopher Thomond",
@@ -82,20 +94,8 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Tom Jenkins",
       "Tristram Kenton",
       "Jill Mead",
-    )),
-    PublicationPhotographers(ObserverPublication, List(
-      "Andy Hall",
-      "Antonio Olmos",
-      "Gary Calton",
-      "Jane Bown",
-      "Jonathan Lovekin",
-      "Karen Robinson",
-      "Katherine Anne Rose",
-      "Richard Saker",
-      "Sophia Evans",
-      "Suki Dhanda"
     ))
-  )
+ )
 
   val staffIllustrators = List(
     "Guardian Design"


### PR DESCRIPTION
## What does this change?
Because Antonio Olmost shoots much more frequently for The Observer, this tries to default Usage rights sniffing such. It looks like it [was working correctly](https://github.com/guardian/grid/pull/3056#issuecomment-740596810), but possibly changed after pluggable suppliers processors work?

As he’s the only one in both lists, let’s hope this stupid approach works [EDIT: yes, it does].

## How can success be measured?
Observer isn’t unhappy.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
