### PR TITLE
Remove useless `STAFF` bylines

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -14,6 +14,8 @@ object RedundantTokenRemover extends MetadataCleaner {
     "Pool",
     "POOL",
     "POOL New",
+    "STAFF",
+    "Staff",
     "STRINGER",
     "stringer",
     "Stringer",


### PR DESCRIPTION
## What does this change?
Removes redundant bylines.

## How can success be measured?
Less redundant bylines. Less manual cleanup needed.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
