### PR TITLE
Mapping change from mk-more-search

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -105,7 +105,7 @@ object Mappings {
     keywordField("source").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     nonAnalysedList("keywords").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     nonAnalysedList("subjects"),
-    keywordField("specialInstructions"),
+    standardAnalysed("specialInstructions").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     standardAnalysed("subLocation").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     standardAnalysed("city").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     standardAnalysed("state").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),


### PR DESCRIPTION
## What does this change?

This brings in the mappings changes only from https://github.com/guardian/grid/pull/3036 allowing us to merge this before we reingest and https://github.com/guardian/grid/pull/3036 after.

## How can success be measured?

if @paperboyo is happy


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![image](https://user-images.githubusercontent.com/2670496/129876818-91732779-ec36-4924-b37d-dd4661d36a1c.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
