### PR TITLE
Migration aware reads (search and getImage)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -9,15 +9,6 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.ExecutionContext.Implicits.global
 
 sealed trait MigrationStatus
-object MigrationStatus {
-  import scala.language.implicitConversions
-  implicit def migrationStatusToOptionOfMigrationIndexName(migrationStatus: MigrationStatus): Option[String] =
-    migrationStatus match {
-      case StatusRefreshError(_, previousStatus) => migrationStatusToOptionOfMigrationIndexName(previousStatus)
-      case InProgress(migrationIndexName) => Some(migrationIndexName)
-      case _ => None
-    }
-}
 
 case object NotRunning extends MigrationStatus
 case class InProgress(migrationIndexName: String) extends MigrationStatus

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -104,7 +104,9 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       .flatMap(_.transform(addUsageCost(source)))
       .flatMap(_.transform(addPersistedState(isPersisted, persistenceReasons)))
       .flatMap(_.transform(addSyndicationStatus(image)))
-      .flatMap(_.transform(addAliases(aliases))).get
+      .flatMap(_.transform(addAliases(aliases)))
+      .flatMap(_.transform(addFromIndex(imageWrapper.fromIndex))).get
+
 
     val links: List[Link] = tier match {
       case Internal => imageLinks(id, imageUrl, pngUrl, withWritePermission, valid)
@@ -221,6 +223,9 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 
   def addValidity(valid: Boolean): Reads[JsObject] =
     __.json.update(__.read[JsObject]).map(_ ++ Json.obj("valid" -> valid))
+
+  def addFromIndex(fromIndex: String): Reads[JsObject] =
+  __.json.update(__.read[JsObject]).map(_ ++ Json.obj("fromIndex" -> fromIndex))
 
   def addInvalidReasons(reasons: Map[String, String]): Reads[JsObject] =
     __.json.update(__.read[JsObject]).map(_ ++ Json.obj("invalidReasons" -> Json.toJson(reasons)))

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -273,9 +273,6 @@ class ElasticSearch(
     }
   }
 
-  def totalImages()(implicit ex: ExecutionContext): Future[Long] = client.execute(ElasticDsl.search(imagesCurrentAlias)).map {
-    _.result.totalHits
-  }
 
   def withSearchQueryTimeout(sr: SearchRequest): SearchRequest = sr timeout SearchQueryTimeout
 

--- a/media-api/app/lib/elasticsearch/SourceWrapper.scala
+++ b/media-api/app/lib/elasticsearch/SourceWrapper.scala
@@ -3,4 +3,4 @@ package lib.elasticsearch
 import play.api.libs.json.JsValue
 
 /** A simple case class that carries the original ES source data with the deserialised instance */
-case class SourceWrapper[T](source: JsValue, instance: T)
+case class SourceWrapper[T](source: JsValue, instance: T, fromIndex: String)

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -108,7 +108,7 @@ class ImageResponseTest extends FunSpec with Matchers with Fixtures {
         )))
     )
     val json = Json.toJson(image)
-    val sourceWrapper = SourceWrapper[Image](json, image)
+    val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
 
     val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
 
@@ -127,7 +127,7 @@ class ImageResponseTest extends FunSpec with Matchers with Fixtures {
       fileMetadata = Some(FileMetadata())
     )
     val json = Json.toJson(image)
-    val sourceWrapper = SourceWrapper[Image](json, image)
+    val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
 
     val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -455,7 +455,9 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
     })
   }
 
-  private def totalImages: Long = Await.result(ES.totalImages(), oneHundredMilliseconds)
+  private def totalImages: Long = Await.result(ES.client.execute(ElasticDsl.search(ES.imagesCurrentAlias)).map {
+    _.result.totalHits
+  }, oneHundredMilliseconds)
 
   private def purgeTestImages = {
     implicit val logMarker: LogMarker = MarkerMap()


### PR DESCRIPTION
## What does this change?
- When a migration is in progress (obtained via `MigrationStatus` - see #3436), search across both the current index and the migration index in a single query (using multi-target notation under the hood), filtering out records where `esInfo.migration.migratedTo` equals the name of the in-progress migration index (effectively removing duplicates where documents have been migrated) 
- For getting individual documents, unfortunately ES does not support multi-target notation, so instead if a migration is in progress, then it first attempts to find the document in the migration index, falling back to the current index (in a separate round-trip)
- On all image responses (search and individual), expose which index the image came from in a new field `fromIndex`
- We also removed the implicit conversions (introduced in #3436) in favour of explicit pattern matches on `MigrationStatus`
- Moved the total images count logic into the test as it is only used there.

## How can success be measured?
This allows migrated records to show in the UI/API as images get migrated, giving us better visibility onto the efficacy of the migration (and avoiding a 'big bang reveal' of all the migrated images and any ensuing issues).

## Screenshots

- ![image](https://user-images.githubusercontent.com/15648334/130632293-11509be9-5c36-4847-81fd-ce74ab12e85a.png)
- ![image](https://user-images.githubusercontent.com/15648334/130632387-fd0a1fb6-8ee7-41c3-a541-f57707044351.png)


## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
