### PR TITLE
Cast unknown type

### DIFF
--- a/image-counter-lambda/package-lock.json
+++ b/image-counter-lambda/package-lock.json
@@ -791,15 +791,6 @@
       "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
       "dev": true
     },
-    "@types/node-fetch": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
-      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1717,6 +1708,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
     "data-urls": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
@@ -2185,6 +2181,14 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
+      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.0.3"
       }
     },
     "file-uri-to-path": {
@@ -5335,9 +5339,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
+      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
+      "requires": {
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^3.1.2"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -6859,6 +6867,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.0.tgz",
+      "integrity": "sha512-wO9r1YnYe7kFBLHyyVEhV1H8VRWoNiNnuP+v/HUUmSTaRF8F93Kmd3JMrETx0f11GXxRek6OcL2QtjFIdc5WYw=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/image-counter-lambda/package.json
+++ b/image-counter-lambda/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.937.0",
-    "node-fetch": "latest"
+    "node-fetch": "^3.0.0"
   }
 }

--- a/image-counter-lambda/package.json
+++ b/image-counter-lambda/package.json
@@ -15,7 +15,6 @@
     "@guardian/node-riffraff-artifact": "^0.1.5",
     "@types/jest": "^24.9.0",
     "@types/node": "^13.1.8",
-    "@types/node-fetch": "^2.5.4",
     "@zeit/ncc": "^0.21.0",
     "jest": "^24.9.0",
     "ts-jest": "^24.3.0",

--- a/image-counter-lambda/src/handler.ts
+++ b/image-counter-lambda/src/handler.ts
@@ -22,7 +22,7 @@ const getImageCount = async (
   };
   const response = await fetch(endpoint, params);
 
-  return await response.json();
+  return await response.json() as ImageCounts;
 };
 
 const metric = (key: string, value: number) => ({


### PR DESCRIPTION
## What does this change?

A new major version (v3.0.0) of node-fetch was released yesterday, which was automatically pulled into builds as image-counter-lambda dependency is declared as `latest`.

The only breaking change observed so far is that the newly bundled type definitions declare the response to be `unknown` rather than `any`, which requires us to explicitly cast to the expected type, implemented in this PR.

Alternate solutions/proposals:

- Use `npm ci` in the Github Actions workflow, to ensure the same version is used in subsequent builds.
- Restrict the version range of node-fetch.

## How can success be measured?

Status checks go green.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
