### PR TITLE
re-use the configurable `scriptsToLoad` config to populate the `frame-src` directive of the Content-Security-Policy

### DIFF
--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -39,7 +39,7 @@ object KahunaSecurityConfig {
 
     val gaHost = "www.google-analytics.com"
 
-    val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com"
+    val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com ${config.scriptsToLoad.map(_.host).mkString(" ")}"
     val frameAncestors = s"frame-ancestors ${config.frameAncestors.mkString(" ")}"
     val connectSources = s"connect-src 'self' ${(services :+ config.imageOrigin).mkString(" ")} $gaHost ${config.connectSources.mkString(" ")}"
 


### PR DESCRIPTION
In https://github.com/guardian/editorial-tools-pinboard/pull/58 we introduce an iFrame in pinboard client back to the pinboard domain, Grid's previous `frame-src` blocked that. This PR re-uses the configurable `scriptsToLoad` config to populate the `frame-src` directive of the Content-Security-Policy.