### PR TITLE
Configurable fuzzy search

### DIFF
--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -37,6 +37,12 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val cloudFrontDomainThumbBucket: Option[String] = stringOpt("cloudfront.domain.thumbbucket")
   val cloudFrontKeyPairId: Option[String]         = stringOpt("cloudfront.keypair.id")
 
+  val fuzzySearchEnabled: Boolean = boolean("search.fuzziness.enabled")
+  val fuzzySearchEditDistance: String = stringOpt("search.fuzziness.editDistance") match {
+    case Some(editDistance) if convertToInt(editDistance).isDefined => editDistance
+    case None => "AUTO"
+  }
+
   val rootUri: String = services.apiBaseUri
   val kahunaUri: String = services.kahunaBaseUri
   val cropperUri: String = services.cropperBaseUri


### PR DESCRIPTION
## What does this change?

Typos when searching for images often happen and returning search results based on exact match without handling typos can reduce the user's experience. 

This PR introduces fuzzy search to allow inexact fuzzy matching to return documents in Elasticsearch that contain terms similar to the search term, as measured by a [Levenshtein edit distance](https://en.wikipedia.org/wiki/Levenshtein_distance).

For instance, a fuzzy search for "lightrom" (which is a typo) would match the word "lightroom" and return documents that have the term lightroom.

Fuzzy search is only applied to Word queries e.g. Lightroom Develop and not Phrase queries e.g. "Lightroom Develop" (wrapped in quotes) as multi-match queries are treated as exact term match.

The configurations needed in `media-api.conf` to enable fuzzy search are:

```hocon
search.fuzziness = {
  enabled = true # optional and defaults to false
  editDistance = 2 # optional and defaults to AUTO - Levenshtein edit distance
}
```

## How can success be measured?

Enable fuzzy search by adding `search.fuzziness.enabled = true` configuration to media-api.conf.


## Screenshots

### Sample image with metadata

![Sample image](https://user-images.githubusercontent.com/12212239/132656850-4043034f-7afd-4d8e-9208-ef2148f66c70.png)

### Search results with "lightroom" search term

![Search lightroom](https://user-images.githubusercontent.com/12212239/132657075-5c69792a-3a47-4364-89d3-221b273e15c0.png)

Should return 1 result.

### Search results with a typo in the search term "lightrom" and fuzzy search disabled

![Search lightrom - fuzzysearch disabled](https://user-images.githubusercontent.com/12212239/132657127-7e3dfbfc-b079-4516-9ddd-0f2cb46e3632.png)

Should return 0 results.

### Search results with a typo in the search term "lightrom" and fuzzy search enabled

![Search with typo - fuzzysearch enabled](https://user-images.githubusercontent.com/12212239/132657235-b7966a03-9174-4aaf-97c7-dba02d08ca5e.png)

Should return 1 result.


## Who should look at this?

@guardian/digital-cms


## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [X] relevant documentation added or amended (if needed)
