### PR TITLE
Remove usage rights from Rex images which are "Exclusive"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -425,13 +425,19 @@ object RexParser extends ImageProcessor {
   val rexAgency = Agencies.get("rex")
   val SlashRex = ".+/ Rex Features".r
 
-  def apply(image: Image): Image = (image.metadata.source, image.metadata.credit) match {
+  def apply(image: Image): Image = {
+    val usageRights: UsageRights =
+      if (image.metadata.specialInstructions exists(_.startsWith("Exclusive"))) NoRights
+      else rexAgency
+
+    (image.metadata.source, image.metadata.credit) match {
     // TODO: cleanup byline/credit
-    case (Some("Rex Features"), _)      => image.copy(usageRights = rexAgency)
-    case (_, Some(SlashRex()))          => image.copy(usageRights = rexAgency)
-    case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = rexAgency)
-    case (Some("Shutterstock"), _)      => image.copy(usageRights = rexAgency)
+    case (Some("Rex Features"), _)      => image.copy(usageRights = usageRights)
+    case (_, Some(SlashRex()))          => image.copy(usageRights = usageRights)
+    case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = usageRights)
+    case (Some("Shutterstock"), _)      => image.copy(usageRights = usageRights)
     case _ => image
+  }
   }
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -427,7 +427,7 @@ object RexParser extends ImageProcessor {
 
   def apply(image: Image): Image = {
     val usageRights: UsageRights =
-      if (image.metadata.specialInstructions exists(_.startsWith("Exclusive"))) NoRights
+      if (image.metadata.specialInstructions exists(_.toLowerCase.startsWith("exclusive"))) NoRights
       else rexAgency
 
     (image.metadata.source, image.metadata.credit) match {


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @paperboyo 

[Trello card](https://trello.com/c/zZnKPtO3/2475-action-shutterstock-exclusions)

## What does this change?
We are currently losing money as some Rex/Shutterstock images are displaying as free when in fact they are not. 
This PR addresses the issue by removing usage rights from images with special instructions which start with "Exclusive", ensuring that we don't pay more for images than we should. 

## How can success be measured?
Users will not see paid-for images as free, and money will be saved!

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
