### PR TITLE
Fix empty Staff Illustrator Usage Rights

### DIFF
--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -103,8 +103,10 @@ object UsageRightsProperty {
       illustratorField(sortPublicationList(p.contractIllustrators), "publication")
     )
 
-    case StaffIllustrator => List(
-      requiredStringField("creator", "Illustrator", Some(sortList(p.staffIllustrators))))
+    case StaffIllustrator =>
+      val options = if (p.staffIllustrators.isEmpty) None else Some(sortList(p.staffIllustrators))
+      List(
+      requiredStringField("creator", "Illustrator", options))
 
     case CommissionedIllustrator => List(
       publicationField(required = false, optionsFromPublicationList(p.staffPhotographers)),


### PR DESCRIPTION
## What does this change?
There is a bug where if the configuration has an empty option list for staffIllustrators, the backend will still send an options value to the frontend (with an empty list) causing the frontend to not render the text field for the creator input. This makes it impossible to add this usage right, since the creator field is required.

This change makes the backend check if the list is empty, and in that case not send an options value at all, which will allow the frontend to render the text input.

## How can success be measured?
When having an empty option list for staffIllustrators in the usageRightsConfigProvider, users can still select the Staff Illustrator option and input the illustrator's name manually.

## Screenshots
Before change:
![image](https://user-images.githubusercontent.com/20479781/133634297-b164f74e-7da9-46cb-832b-d1bd1fcf06f1.png)

After change:
![image](https://user-images.githubusercontent.com/20479781/133634106-ad7c1960-5bb2-4ed6-9b18-1316e4ebb1b3.png)



## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
