### PR TITLE
fast png

### DIFF
--- a/image-loader/app/model/upload/OptimiseOps.scala
+++ b/image-loader/app/model/upload/OptimiseOps.scala
@@ -32,7 +32,7 @@ object OptimiseWithPngQuant extends OptimiseOps {
     )
 
     Stopwatch("pngquant") {
-      val result = Seq("pngquant", "--quality", "1-85", file.getAbsolutePath, "--output", optimisedFilePath).!
+      val result = Seq("pngquant","-s10",  "--quality", "1-85", file.getAbsolutePath, "--output", optimisedFilePath).!
       if (result>0)
         throw new Exception(s"pngquant failed to convert to optimised png file (rc = $result)")
     }(marker)


### PR DESCRIPTION
## What does this change?
This adds a pngquant speed param on loader to match cropper and to speed up creation of `optimisedPng` preview prerender. It was taking up to 10 minutes for some large TIFFs. It’s not a perfect solution, but a really useful plaster.

This should speed pngquant phase 8 times according to [the docs](https://pngquant.org/#options).

## How can success be measured?
Large TIFFs actually upload.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [X] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
