### PR TITLE
one for the road

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -169,7 +169,8 @@ class ImageOperations(playPath: String) extends GridLogging {
       // png suffix is used by imagemagick to infer the required type
       outputFile      <- createTempFile(s"transformed-", optimisedMimeType.fileExtension, tempDir)
       transformSource = addImage(sourceFile)
-      addOutput       = addDestImage(transformSource)(outputFile)
+      strippedMeta    = stripMeta(transformSource)
+      addOutput       = addDestImage(strippedMeta)(outputFile)
       _               <- runConvertCmd(addOutput, useImageMagick = sourceMimeType.contains(Tiff))
       _               <- checkForOutputFileChange(outputFile)
     } yield (outputFile, optimisedMimeType)


### PR DESCRIPTION
## What does this change?

dont keep all metadata for intermediary png
## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
