### PR TITLE
Close some open image-loader streams

### DIFF
--- a/image-loader/app/lib/imaging/MimeTypeDetection.scala
+++ b/image-loader/app/lib/imaging/MimeTypeDetection.scala
@@ -30,8 +30,14 @@ object MimeTypeDetection extends GridLogging {
   private def usingTika(file: File): MimeType = MimeType(new Tika().detect(file))
 
   private def usingMetadataExtractor(file: File) : MimeType = {
-    val stream = new BufferedInputStream(new FileInputStream(file))
-    val fileType = FileTypeDetector.detectFileType(stream)
-    MimeType(fileType.getMimeType)
+    val fis = new FileInputStream(file)
+    val stream = new BufferedInputStream(fis)
+    try {
+      val fileType = FileTypeDetector.detectFileType(stream)
+      MimeType(fileType.getMimeType)
+    } finally {
+      stream.close()
+      fis.close()
+    }
   }
 }

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -106,6 +106,9 @@ class Projector(config: ImageUploadOpsCfg,
 
       val finalImageFuture = projectImage(digestedFile, extractedS3Meta, requestId, gridClient, onBehalfOfFn)
       val finalImage = Await.result(finalImageFuture, Duration.Inf)
+
+      s3Source.close()
+
       Some(finalImage)
     }
   }


### PR DESCRIPTION
## What does this change?

Cleans up some open file streams the projection endpoint code. These were found to be causing image-loader to keep too many open files during migrations.

This is not an exhaustive pass of unclosed streams - there may well be others lingering in the code base, but this change was sufficient to allow migration to complete without issue.

## How can success be measured?

The number of open file handles (ballpark measurements possible with `sudo ls /proc/$(pgrep java)/fds | wc -l` on an image-loader instance) does not increase over time during heavy usage (eg. during a migration).

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
