### PR TITLE
Bump metadata-extractor to 2.16.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.15.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.16.0"
   )
 }
 


### PR DESCRIPTION
Ronseal. To stay up to date before the migration. Will test…

EDIT
https://github.com/drewnoakes/metadata-extractor/releases/tag/2.16.0
![image](https://user-images.githubusercontent.com/19289579/145307873-8b933bbe-df30-4634-9339-32414a0de0d0.png)


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
