### PR TITLE
Match persisted query with actual persisted reasons

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageFields.scala
@@ -46,6 +46,7 @@ trait ImageFields {
   def usagesField(field: String)      = s"usages.$field"
   def sourceField(field: String)      = s"source.$field"
   def photoshootField(field: String) = editsField(s"photoshoot.$field")
+  def leasesField(field: String) = s"leases.$field"
 
   val fieldAliases = Map(
     "crops"     -> "exports",

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -44,9 +44,9 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   type MediaLeaseEntity = EmbeddedEntity[MediaLease]
   type MediaLeasesEntity = EmbeddedEntity[LeasesByMedia]
 
-  private val imgPersistenceReasons = ImagePersistenceReasons.apply(config.persistedRootCollections, config.persistenceIdentifier)
+  private val imgPersistenceReasons = ImagePersistenceReasons(config.persistedRootCollections, config.persistenceIdentifier)
 
-  def imagePersistenceReasons(image: Image): List[String] = imgPersistenceReasons.getImagePersistenceReasons(image)
+  def imagePersistenceReasons(image: Image): List[String] = imgPersistenceReasons.reasons(image)
 
   def canBeDeleted(image: Image) = image.canBeDeleted
 

--- a/media-api/test/lib/ImagePersistenceReasonsTest.scala
+++ b/media-api/test/lib/ImagePersistenceReasonsTest.scala
@@ -14,42 +14,42 @@ class ImagePersistenceReasonsTest extends FunSpec with Matchers {
 
     val persistedIdentifier = "test-p-id"
     val persistedRootCollections = List("coll1", "coll2", "coll3")
-    val imgPersistenceReasons = ImagePersistenceReasons.apply(persistedRootCollections, persistedIdentifier)
+    val imgPersistenceReasons = ImagePersistenceReasons(persistedRootCollections, persistedIdentifier)
 
-    imgPersistenceReasons.getImagePersistenceReasons(img) shouldBe Nil
+    imgPersistenceReasons.reasons(img) shouldBe Nil
     val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
+    imgPersistenceReasons.reasons(imgWithPersistenceIdentifier) shouldBe List("persistence-identifier")
     val imgWithExports = img.copy(exports = List(Crop(None, None, None, null, None, Nil)))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithExports) shouldBe List("exports")
+    imgPersistenceReasons.reasons(imgWithExports) shouldBe List("exports")
     val imgWithUsages = img.copy(usages = List(Usage("test", Nil, null, "img", null, None, None, now())))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithUsages) shouldBe List("usages")
+    imgPersistenceReasons.reasons(imgWithUsages) shouldBe List("usages")
     val imgWithArchive = img.copy(userMetadata = Some(Edits(archived = true, metadata = ImageMetadata.empty)))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithArchive) shouldBe List("archived")
+    imgPersistenceReasons.reasons(imgWithArchive) shouldBe List("archived")
     val imgWithPhotographerCategory = img.copy(usageRights = ContractPhotographer("test"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithPhotographerCategory) shouldBe List("photographer-category")
+    imgPersistenceReasons.reasons(imgWithPhotographerCategory) shouldBe List("photographer-category")
     val imgWithIllustratorCategory = img.copy(usageRights = StaffIllustrator("test"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithIllustratorCategory) shouldBe List("illustrator-category")
+    imgPersistenceReasons.reasons(imgWithIllustratorCategory) shouldBe List("illustrator-category")
     val imgWithAgencyCommissionedCategory = img.copy(usageRights = CommissionedAgency("test"))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
+    imgPersistenceReasons.reasons(imgWithAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
     val imgWithLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithLeases) shouldBe List("leases")
+    imgPersistenceReasons.reasons(imgWithLeases) shouldBe List("leases")
     val imgWithPersistedRootCollections = img.copy(collections = List(Collection.build(persistedRootCollections.tail, ActionData("testAuthor", now()))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithPersistedRootCollections) shouldBe List("persisted-collection")
+    imgPersistenceReasons.reasons(imgWithPersistedRootCollections) shouldBe List("persisted-collection")
 
     val imgWithPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithPhotoshoot) shouldBe List("photoshoot")
+    imgPersistenceReasons.reasons(imgWithPhotoshoot) shouldBe List("photoshoot")
 
     val imgWithUserEdits = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata(title = Some("test")))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithUserEdits) shouldBe List("edited")
+    imgPersistenceReasons.reasons(imgWithUserEdits) shouldBe List("edited")
 
     val imgWithLabels = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, labels = List("test-label"))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithLabels) shouldBe List("labeled")
+    imgPersistenceReasons.reasons(imgWithLabels) shouldBe List("labeled")
 
     val imgWithMultipleReasons = img.copy(userMetadata = Some(Edits(
       labels = List("test-label"),
       metadata = ImageMetadata(title = Some("test")),
       photoshoot = Some(Photoshoot("test")))))
-    imgPersistenceReasons.getImagePersistenceReasons(imgWithMultipleReasons) should contain theSameElementsAs List("labeled", "edited", "photoshoot")
+    imgPersistenceReasons.reasons(imgWithMultipleReasons) should contain theSameElementsAs List("labeled", "edited", "photoshoot")
   }
 
 }


### PR DESCRIPTION
## What does this change?
There is currently a mismatch between the reasons for setting the "persisted" flag on an image, and the query for retrieving persisted images. Currently, the API query /images?persisted=true does not return images that have leases. 

This adds the leases query, and also refactors the PersistedReasons file so that there cannot be a persistence reason without a corresponding query to ElasticSearch.

## How can success be measured?
The API query /images?persisted=true returns images that have leases on them.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
