### PR TITLE
Usage Rights To Metadata Processor

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
@@ -1,4 +1,4 @@
-package lib
+package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.model._
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
@@ -1,11 +1,11 @@
-package lib
+package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.model._
 import org.scalatest.{FunSpec, Matchers}
 
 class UsageRightsMetadataMapperTest extends FunSpec with Matchers {
 
-  import UsageRightsMetadataMapper.usageRightsToMetadata
+  import com.gu.mediaservice.lib.metadata.UsageRightsMetadataMapper.usageRightsToMetadata
 
   describe("UsageRights => ImageMetadata") {
     val metadataWithoutCopyright = ImageMetadata(copyright = None)

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -55,7 +55,7 @@ class EditsController(
                      )(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers with EditsResponse with MessageSubjects with Edit {
 
-  import UsageRightsMetadataMapper.usageRightsToMetadata
+  import com.gu.mediaservice.lib.metadata.UsageRightsMetadataMapper.usageRightsToMetadata
 
   val services: Services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   val gridClient: GridClient = GridClient(services)(ws)


### PR DESCRIPTION
## What does this change?
Currently, when changing usage rights there is some logic in UsageRightsToMetadataMapper to assign properties based on the selected usage right. However, this logic is not applied on ingest. This PR adds a Metadata Processor to handle that case. The processor will use the previous logic to assign properties to images that come with usage rights on ingest.

It is important to note that the order of the processors matter, and this processor should be applied after all other processors that assign or change usage rights, since doing it before would assign incorrect properties (based on an outdated usage right). 

## How can success be measured?
When ingesting an image that comes with a usage right, the UsageRightsToMetadataMapper logic is applied and the metadata is changed accordingly (e.g. for staff photographers, byline, credit and copyright are changed)

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
