### PR TITLE
Point projection requests to projection service

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -127,7 +127,7 @@ class GridClient(services: Services)(implicit wsClient: WSClient) extends LazyLo
 
   def getImageLoaderProjection(mediaId: String, authFn: WSRequest => WSRequest)
                               (implicit ec: ExecutionContext): Future[Option[Image]] = {
-    getImageLoaderProjection(mediaId, services.loaderBaseUri, authFn)
+    getImageLoaderProjection(mediaId, services.projectionBaseUri, authFn)
   }
 
   def getImageLoaderProjection(mediaId: String, imageLoaderEndpoint: String, authFn: WSRequest => WSRequest)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -49,6 +49,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
     stringDefault("hosts.kahunaPrefix", s"$rootAppName."),
     stringDefault("hosts.apiPrefix", s"api.$rootAppName."),
     stringDefault("hosts.loaderPrefix", s"loader.$rootAppName."),
+    stringDefault("hosts.projectionPrefix", s"loader-projection.$rootAppName."),
     stringDefault("hosts.cropperPrefix", s"cropper.$rootAppName."),
     stringDefault("hosts.adminToolsPrefix", s"admin-tools.$rootAppName."),
     stringDefault("hosts.metadataPrefix", s"$rootAppName-metadata."),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -4,6 +4,7 @@ case class ServiceHosts(
   kahunaPrefix: String,
   apiPrefix: String,
   loaderPrefix: String,
+  projectionPrefix: String,
   cropperPrefix: String,
   adminToolsPrefix: String,
   metadataPrefix: String,
@@ -24,6 +25,7 @@ object ServiceHosts {
       kahunaPrefix = s"$rootAppName.",
       apiPrefix = s"api.$rootAppName.",
       loaderPrefix = s"loader.$rootAppName.",
+      projectionPrefix = s"loader-projection.$rootAppName",
       cropperPrefix = s"cropper.$rootAppName.",
       adminToolsPrefix = s"admin-tools.$rootAppName.",
       metadataPrefix = s"$rootAppName-metadata.",
@@ -48,10 +50,12 @@ class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: 
   val leasesHost: String      = s"${hosts.leasesPrefix}$domainRoot"
   val authHost: String        = s"${hosts.authPrefix}$domainRoot"
   val adminToolsHost: String  = s"${hosts.adminToolsPrefix}$domainRoot"
+  val projectionHost: String  = s"${hosts.projectionPrefix}$domainRoot"
 
   val kahunaBaseUri      = baseUri(kahunaHost)
   val apiBaseUri         = baseUri(apiHost)
   val loaderBaseUri      = baseUri(loaderHost)
+  val projectionBaseUri  = baseUri(projectionHost)
   val cropperBaseUri     = baseUri(cropperHost)
   val metadataBaseUri    = baseUri(metadataHost)
   val imgopsBaseUri      = baseUri(imgopsHost)

--- a/dev/nginx-mappings.yml.template
+++ b/dev/nginx-mappings.yml.template
@@ -9,6 +9,8 @@ mappings:
   - prefix: loader.media
     port: 9003
     client_max_body_size: 20m
+  - prefix: loader-projection.media
+    port: 9003
   - prefix: media
     port: 9005
   - prefix: cropper.media

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -41,6 +41,7 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val kahunaUri: String = services.kahunaBaseUri
   val cropperUri: String = services.cropperBaseUri
   val loaderUri: String = services.loaderBaseUri
+  val projectionUri: String = services.projectionBaseUri
   val metadataUri: String = services.metadataBaseUri
   val imgopsUri: String = services.imgopsBaseUri
   val usageUri: String = services.usageBaseUri


### PR DESCRIPTION
## What does this change?

Points projection requests to the loader-projection endpoint, introduced in #2836 


## How can success be measured?

Projection requests go to loader-projection, rather than to loader. Allows for easier separation of the traffic.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
