### PR TITLE
Make ids query functional and don't infinite loop

### DIFF
--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -35,8 +35,7 @@ object filters {
   def missing(fields: NonEmptyList[String]): Query =
     fields.map(f => not(existsQuery(f)): Query).foldRight1(and(_, _))
 
-  @scala.annotation.tailrec
-  def ids(idList: List[String]): Query = ids(idList)
+  def ids(idList: List[String]): Query = idsQuery(idList)
 
   def bool() = BoolQuery()
 


### PR DESCRIPTION
## What does this change?

Builder for ids query recursed infinitely. If anyone made a request using this query it would push the media-api instance to 100% CPU and block any users from making requests. My best guess for the intended functionality was that it was meant to use the `idsQuery` function from elastic4s, which makes queries for all of the given ids.

## How can success be measured?

Users can make an `ids` query without taking down media-api.

## Screenshots
![image](https://user-images.githubusercontent.com/10963046/137907713-52bba4ff-9846-485d-ac97-4ce44adf7661.png)
Image loader CPU after making one request using `ids` parameter. Health checks detected and cycled the instance.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
