### PR TITLE
Recover from failed doesObjectExist request by assuming false

### DIFF
--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -211,7 +211,7 @@ class ImageUploadProjectionOps(config: ImageUploadOpsCfg,
     bucket: String, key: String, outFile: File
   )(implicit ec: ExecutionContext, logMarker: LogMarker): Future[Option[(File, MimeType)]] = {
     logger.info(logMarker, s"Trying fetch existing image from S3 bucket - $bucket at key $key")
-    val doesFileExist = Future { s3.doesObjectExist(bucket, key) }
+    val doesFileExist = Future { s3.doesObjectExist(bucket, key) } recover { case _ => false }
     doesFileExist.flatMap {
       case false =>
         logger.warn(logMarker, s"image did not exist in bucket $bucket at key $key")


### PR DESCRIPTION
## What does this change?

It turns out that if the object does not exist, we may not get a `false` back from `S3Client.doesObjectExist`, but instead a `Forbidden` exception. On further consideration, we could just assume that an exception from `doesObjectExist` means that we should return to the fallback mechanism (ie. generate the file) rather than just blowing up.

Exceptions during the download will still blow up as before and cause the projection to fail.

## How can success be measured?

Images which are missing a thumbnail in S3 can be projected/migrated.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
