### PR TITLE
Handle timeouts of migration status refresh

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -37,13 +37,14 @@ trait MigrationStatusProvider {
         case Some(index) => InProgress(index.name)
         case None => NotRunning
       }
-      .recover {
-        case e if !bubbleErrors =>
-          logger.error("Failed to get name of index for ongoing migration", e)
-          StatusRefreshError(cause = e, preErrorStatus = migrationStatusRef.get())
-      }
 
-    Await.result(statusFuture, atMost = 5.seconds)
+    try {
+      Await.result(statusFuture, atMost = 5.seconds)
+    } catch {
+      case e if !bubbleErrors =>
+        logger.error("Failed to get name of index for ongoing migration", e)
+        StatusRefreshError(cause = e, preErrorStatus = migrationStatusRef.get())
+    }
   }
 
   private def refreshMigrationStatus(): Unit = {


### PR DESCRIPTION
## What does this change?

We've seen occasional responses to `getIndexForAlias` take over 5 seconds, and the refresher ceasing to refresh on that instance. When the 5 second timeout is exceeded, the `Await.result` call will return an exception, but we don't currently have any code to handle those errors.

This PR moves the existing error handling code to encompass the call to `Await.result` and handle errors in a similar way. ie. If the callsite asks for errors to be bubbled, do so, otherwise place a  `StatusRefreshError` into the migration status cache.

## How can success be measured?

Next time we see a status refresh take over 5 seconds, refreshes still continue afterwards.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
