### PR TITLE
UI to display migration failures

### DIFF
--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -65,10 +65,14 @@ class ThrallController(
   }
 
   def migrationFailures = withLoginRedirectAsync {
+    val maxReturn = 200
     es.migrationStatus match {
       case InProgress(migrationIndexName) =>
-        es.getMigrationFailures(es.imagesCurrentAlias, migrationIndexName, 200).map(details =>
-          Ok(views.html.migrationFailures(details, 200))
+        es.getMigrationFailures(es.imagesCurrentAlias, migrationIndexName, maxReturn).map(failures =>
+          Ok(views.html.migrationFailures(
+            failures = failures,
+            migrateSingleImageForm = migrateSingleImageForm
+          ))
         )
       case _ => Future.successful(Ok("No current migration"))
     }

--- a/thrall/app/lib/FailedMigrationDetails.scala
+++ b/thrall/app/lib/FailedMigrationDetails.scala
@@ -1,0 +1,3 @@
+package lib
+
+final case class FailedMigrationDetails(imageId: String, cause: String)

--- a/thrall/app/lib/FailedMigrationDetails.scala
+++ b/thrall/app/lib/FailedMigrationDetails.scala
@@ -1,3 +1,5 @@
 package lib
 
 final case class FailedMigrationDetails(imageId: String, cause: String)
+
+final case class FailedMigrationSummary(totalFailed: Long, totalFailedRelation: String, returned: Long, details: Seq[FailedMigrationDetails])

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -15,8 +15,8 @@ import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, Query}
 import com.sksamuel.elastic4s.requests.searches.sort.SortOrder
 import com.sksamuel.elastic4s.requests.update.{UpdateRequest, UpdateResponse}
-import com.sksamuel.elastic4s.{Executor, Functor, Handler, Response}
-import lib.ThrallMetrics
+import com.sksamuel.elastic4s.{ElasticDsl, Executor, Functor, Handler, Response}
+import lib.{FailedMigrationDetails, ThrallMetrics}
 import org.joda.time.DateTime
 import play.api.libs.json._
 

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -63,7 +63,7 @@ class ElasticSearch(
     Future.sequence(List(runForCurrentIndex, runForMigrationIndex)).map(_.flatten.head)
   }
 
-  def setMigrationInfo(imageId: String, migrationInfo: Either[MigrationFailure, MigrationTo])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Response[Any]] = {
+  def setMigrationInfo(imageId: String, migrationInfo: MigrationInfo)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Response[Any]] = {
     val esInfo = EsInfo(migration = Some(migrationInfo))
     val container = Json.obj("esInfo" -> Json.toJson(esInfo))
 

--- a/thrall/app/lib/elasticsearch/EsInfo.scala
+++ b/thrall/app/lib/elasticsearch/EsInfo.scala
@@ -23,7 +23,7 @@ object EsInfo {
       MigrationTo.format.reads(json) map {
         Right(_)
       }
-    } orElse{
+    } orElse {
       MigrationFailure.format.reads(json) map {
         Left(_)
       }

--- a/thrall/app/lib/elasticsearch/EsInfo.scala
+++ b/thrall/app/lib/elasticsearch/EsInfo.scala
@@ -1,38 +1,13 @@
 package lib.elasticsearch
 
-import play.api.libs.json.{Format, JsResult, JsValue, Json}
+import play.api.libs.json.Json
 
-case class MigrationTo(
-  migratedTo: String
-)
-object MigrationTo {
-  implicit val format = Json.format[MigrationTo]
+case class MigrationInfo(failures: Option[Map[String, String]] = None, migratedTo: Option[String] = None)
+object MigrationInfo {
+  implicit val format = Json.format[MigrationInfo]
 }
 
-case class MigrationFailure(
-  failures: Map[String, String]
-)
-object MigrationFailure {
-  implicit val format = Json.format[MigrationFailure]
-}
-
-case class EsInfo(migration: Option[Either[MigrationFailure, MigrationTo]] = None)
+case class EsInfo(migration: Option[MigrationInfo] = None)
 object EsInfo {
-  implicit val eitherFormat: Format[Either[MigrationFailure, MigrationTo]] = new Format[Either[MigrationFailure, MigrationTo]] {
-    def reads(json: JsValue): JsResult[Either[MigrationFailure, MigrationTo]] = {
-      MigrationTo.format.reads(json) map {
-        Right(_)
-      }
-    } orElse {
-      MigrationFailure.format.reads(json) map {
-        Left(_)
-      }
-    }
-
-    def writes(c: Either[MigrationFailure, MigrationTo]) = c match {
-      case Left(a) => MigrationFailure.format.writes(a)
-      case Right(b) => MigrationTo.format.writes(b)
-    }
-  }
   implicit val format = Json.format[EsInfo]
 }

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -5,12 +5,15 @@ import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.sksamuel.elastic4s.ElasticApi.{existsQuery, matchQuery, not}
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.SearchHit
+import lib.FailedMigrationDetails
+import play.api.libs.json.{JsError, JsSuccess, Json, Reads, __}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 
 
 final case class ScrolledSearchResults(hits: List[SearchHit], scrollId: Option[String])
+final case class EsInfoContainer(esInfo: EsInfo)
 
 trait ThrallMigrationClient extends MigrationStatusProvider {
   self: ElasticSearchClient =>
@@ -47,5 +50,37 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
       _ = logger.info(logMarker, s"Assigned migration index $imagesMigrationAlias to $newIndexName")
       _ = refreshAndRetrieveMigrationStatus()
     } yield ()
+  }
+
+
+  def getMigrationFailures(
+    currentIndexName: String, migrationIndexName: String, maxReturn: Int
+  )(implicit ec: ExecutionContext, logMarker: LogMarker = MarkerMap()): Future[Seq[FailedMigrationDetails]] = {
+
+
+    val q = ElasticDsl.search(currentIndexName).size(maxReturn) query must(
+      existsQuery(s"esInfo.migration.failures.$migrationIndexName"),
+      not(matchQuery("esInfo.migration.migratedTo", migrationIndexName))
+    )
+    executeAndLog(q, s"retrieving list of migration failures")
+      .map { resp =>
+        logger.info(logMarker, s"failed migrations - got ${resp.result.hits.size} hits")
+        val failedMigrationDetails: Seq[FailedMigrationDetails] = resp.result.hits.hits
+          .map(hit => {
+            logger.info(logMarker, s"failed migrations - got hit $hit.id")
+            val source = hit.sourceAsString
+            val cause = Json.parse(source).validate(Json.reads[EsInfoContainer]) match {
+              case JsSuccess(EsInfoContainer(EsInfo(Some(Left(migrationFailure)))), _) =>
+                migrationFailure.failures.getOrElse(migrationIndexName, "UNKNOWN - NO FAILURE MATCHING MIGRATION INDEX NAME")
+              case JsError(errors) =>
+                logger.error(logMarker, s"Could not parse EsInfo for ${hit.id} - $errors")
+                "Could not extract migration info from ES due to parsing failure"
+              case _ => "UNKNOWN - NO FAILURE MATCHING MIGRATION INDEX NAME"
+            }
+            FailedMigrationDetails(imageId = hit.id, cause = cause)
+        })
+
+        failedMigrationDetails
+      }
   }
 }

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -54,9 +54,9 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
   }
 
   def getMigrationFailures(
-    currentIndexName: String, migrationIndexName: String, maxReturn: Int
+    currentIndexName: String, migrationIndexName: String, from: Int, pageSize: Int
   )(implicit ec: ExecutionContext, logMarker: LogMarker = MarkerMap()): Future[FailedMigrationSummary] = {
-    val search = ElasticDsl.search(currentIndexName).size(maxReturn) query must(
+    val search = ElasticDsl.search(currentIndexName).from(from).size(pageSize) query must(
       existsQuery(s"esInfo.migration.failures.$migrationIndexName"),
       not(matchQuery("esInfo.migration.migratedTo", migrationIndexName))
     )

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -67,8 +67,8 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
             logger.info(logMarker, s"failed migrations - got hit $hit.id")
             val source = hit.sourceAsString
             val cause = Json.parse(source).validate(Json.reads[EsInfoContainer]) match {
-              case JsSuccess(EsInfoContainer(EsInfo(Some(Left(migrationFailure)))), _) =>
-                migrationFailure.failures.getOrElse(migrationIndexName, "UNKNOWN - NO FAILURE MATCHING MIGRATION INDEX NAME")
+              case JsSuccess(EsInfoContainer(EsInfo(Some(MigrationInfo(Some(failures), _)))), _) =>
+                failures.getOrElse(migrationIndexName, "UNKNOWN - NO FAILURE MATCHING MIGRATION INDEX NAME")
               case JsError(errors) =>
                 logger.error(logMarker, s"Could not parse EsInfo for ${hit.id} - $errors")
                 "Could not extract migration info from ES due to parsing failure"

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -76,7 +76,7 @@ class MessageProcessor(
         case Failure(exception) => Future.failed(GetVersionFailure(exception.toString))
       }
     }.flatMap {
-      case (image, expectedVersion, currentVersion) => if (expectedVersion == currentVersion) {
+      case (image, expectedVersion, currentVersion) => if (expectedVersion != currentVersion) {
         Future.successful(image)
       } else {
         Future.failed(VersionComparisonFailure(s"Version comparison failed for image id: ${image.id} -> current = $currentVersion, expected = $expectedVersion"))

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -88,7 +88,7 @@ class MessageProcessor(
       }
     ).flatMap { insertResult =>
       logger.info(logMarker, s"Successfully migrated image with id: ${message.id}, setting 'migratedTo' on current index")
-      es.setMigrationInfo(imageId = message.id, migrationInfo = Right(MigrationTo(migratedTo = insertResult.head.indexNames.head)))
+      es.setMigrationInfo(imageId = message.id, migrationInfo = MigrationInfo(migratedTo = Some(insertResult.head.indexNames.head)))
     }.recoverWith {
       case failure: MigrationFailure =>
         logger.error(logMarker, s"Failed to migrate image with id: ${message.id}: cause: ${failure.getMessage}, attaching failure to document in current index")
@@ -96,7 +96,7 @@ class MessageProcessor(
           case InProgress(migrationIndexName) => migrationIndexName
           case _ => "Unknown migration index name"
         }
-        es.setMigrationInfo(imageId = message.id, migrationInfo = Left(MigrationFailure(failures = Map(migrationIndexName -> failure.getMessage))))
+        es.setMigrationInfo(imageId = message.id, migrationInfo = MigrationInfo(failures = Some(Map(migrationIndexName -> failure.getMessage))))
     }
   }
 

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -76,7 +76,7 @@ class MessageProcessor(
         case Failure(exception) => Future.failed(GetVersionFailure(exception.toString))
       }
     }.flatMap {
-      case (image, expectedVersion, currentVersion) => if (expectedVersion != currentVersion) {
+      case (image, expectedVersion, currentVersion) => if (expectedVersion == currentVersion) {
         Future.successful(image)
       } else {
         Future.failed(VersionComparisonFailure(s"Version comparison failed for image id: ${image.id} -> current = $currentVersion, expected = $expectedVersion"))

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -21,7 +21,7 @@
             }
         }
         case None => {
-            @form(routes.ThrallController.startMigration()) {
+            @form(routes.ThrallController.startMigration) {
                 <input type="submit" value="Start migration">
             }
         }

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -58,5 +58,9 @@
     <h2>MigrationStatus (from the MigrationStatusProvider, a.k.a. 'migration status refresher')</h2>
     <pre>@migrationStatusProviderValue</pre>
     <em>Note that the above represents the value at the point this page was loaded.</em>
+
+    @if(migrationStatusProviderValue.startsWith("InProgress")) {
+        <p><a href="@routes.ThrallController.migrationFailures(None)">View images that have failed to migrate and retry.</a></p>
+    }
 </body>
 </html>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -1,0 +1,41 @@
+@import lib.FailedMigrationDetails
+
+@(failures: Seq[FailedMigrationDetails],
+    maxDisplayableFailures: Int)
+
+@truncatedFailures = @{ failures.size > maxDisplayableFailures }
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>All images that have failed to migrate</title>
+    <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
+</head>
+<body>
+    <h1>
+        Showing
+        @if(failures.size > maxDisplayableFailures) {
+            first @maxDisplayableFailures
+        } else {
+            all
+        }
+        images that have failed to migrate:
+    </h1>
+    <table>
+        <tr>
+            <th>Image ID</th>
+            <th>Failure cause</th>
+        </tr>
+        @for(failure <- failures.take(maxDisplayableFailures)) {
+            <tr>
+                <td>@failure.imageId</td>
+                <td>@failure.cause</td>
+            </tr>
+        }
+    </table>
+    @if(truncatedFailures) {
+        <p>... and @(failures.size - maxDisplayableFailures) more!</p>
+    }
+</body>
+</html>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -1,59 +1,63 @@
 @import lib.FailedMigrationSummary
 
 @import views.html.helper.form
-@(failures: FailedMigrationSummary, migrateSingleImageForm: Form[MigrateSingleImageForm])
+@(
+    failures: FailedMigrationSummary,
+    migrateSingleImageForm: Form[MigrateSingleImageForm],
+    apiBaseUrl: String,
+    uiBaseUrl: String,
+    page: Int,
+)
 
-@truncatedFailures = @{ failures.returned < failures.totalFailed }
+@navigation = {
+    @if(page > 1) {
+        <a href="?page=@(page - 1)">Previous page</a>
+    }
+    <a href="?page=@(page + 1)">Next page</a>
+}
 
-@quantityMoreFailures = @{
-    ("... and " + failures.totalFailedRelation match {
+@totalFailures = @{
+    (failures.totalFailedRelation match {
         case "lte" | "lt" => "Less than "
         case "gte" | "gt" => "More than "
         case _ => ""
-    }) + (failures.totalFailed - failures.returned) + "more!"
+    }) + failures.totalFailed + " images failed in total!"
 }
 
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>All images that have failed to migrate</title>
+    <title>Migration Failures - Page @(page)</title>
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
-    @if(failures.details.nonEmpty) {
-        <h1>
-            Showing
-            @if(truncatedFailures) {
-                first @failures.returned
-            } else {
-                all
-            }
-            images that have failed to migrate:
-        </h1>
-        <table>
+    <h1>
+        Migration Failures - Page @(page)
+    </h1>
+    <p>@totalFailures</p>
+    @navigation
+    <table>
+        <tr>
+            <th>Image ID</th>
+            <th>Failure cause</th>
+            <th>Click to reattempt migration</th>
+        </tr>
+        @for(failure <- failures.details) {
             <tr>
-                <th>Image ID</th>
-                <th>Failure cause</th>
-                <th>Click to reattempt migration</th>
+                <td><pre class="imageId">@failure.imageId</pre>
+                    <a href="@uiBaseUrl/images/@failure.imageId" target="_blank">[Grid]</a>
+                    <a href="@apiBaseUrl/images/@failure.imageId" target="_blank">[API]</a>
+                </td>
+                <td>@failure.cause</td>
+                <td>@form(action = routes.ThrallController.migrateSingleImage){
+                    <label for="id" class="hidden">Image ID:</label>
+                    <input type="text" id="id" value="@failure.imageId" name="id" class="hidden">
+                    <input type="submit" value="Reattempt migration">
+                }</td>
             </tr>
-            @for(failure <- failures.details) {
-                <tr>
-                    <td>@failure.imageId</td>
-                    <td>@failure.cause</td>
-                    <td>@form(action = routes.ThrallController.migrateSingleImage){
-                        <label for="id" class="hidden">Image ID:</label>
-                        <input type="text" id="id" value="@failure.imageId" name="id" class="hidden">
-                        <input type="submit" value="Reattempt migration">
-                    }</td>
-                </tr>
-            }
-        </table>
-    } else {
-        <h1>No failures in current migration!</h1>
-    }
-    @if(truncatedFailures) {
-        <p>... and @(failures.totalFailed - failures.returned) more!</p>
-    }
+        }
+    </table>
+    @navigation
 </body>
 </html>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -1,9 +1,17 @@
-@import lib.FailedMigrationDetails
+@import lib.FailedMigrationSummary
 
-@(failures: Seq[FailedMigrationDetails],
-    maxDisplayableFailures: Int)
+@import views.html.helper.form
+@(failures: FailedMigrationSummary, migrateSingleImageForm: Form[MigrateSingleImageForm])
 
-@truncatedFailures = @{ failures.size > maxDisplayableFailures }
+@truncatedFailures = @{ failures.returned < failures.totalFailed }
+
+@quantityMoreFailures = @{
+    ("... and " + failures.totalFailedRelation match {
+        case "lte" | "lt" => "Less than "
+        case "gte" | "gt" => "More than "
+        case _ => ""
+    }) + (failures.totalFailed - failures.returned) + "more!"
+}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -13,29 +21,39 @@
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
-    <h1>
-        Showing
-        @if(failures.size > maxDisplayableFailures) {
-            first @maxDisplayableFailures
-        } else {
-            all
-        }
-        images that have failed to migrate:
-    </h1>
-    <table>
-        <tr>
-            <th>Image ID</th>
-            <th>Failure cause</th>
-        </tr>
-        @for(failure <- failures.take(maxDisplayableFailures)) {
+    @if(failures.details.nonEmpty) {
+        <h1>
+            Showing
+            @if(truncatedFailures) {
+                first @failures.returned
+            } else {
+                all
+            }
+            images that have failed to migrate:
+        </h1>
+        <table>
             <tr>
-                <td>@failure.imageId</td>
-                <td>@failure.cause</td>
+                <th>Image ID</th>
+                <th>Failure cause</th>
+                <th>Click to reattempt migration</th>
             </tr>
-        }
-    </table>
+            @for(failure <- failures.details) {
+                <tr>
+                    <td>@failure.imageId</td>
+                    <td>@failure.cause</td>
+                    <td>@form(action = routes.ThrallController.migrateSingleImage){
+                        <label for="id" class="hidden">Image ID:</label>
+                        <input type="text" id="id" value="@failure.imageId" name="id" class="hidden">
+                        <input type="submit" value="Reattempt migration">
+                    }</td>
+                </tr>
+            }
+        </table>
+    } else {
+        <h1>No failures in current migration!</h1>
+    }
     @if(truncatedFailures) {
-        <p>... and @(failures.size - maxDisplayableFailures) more!</p>
+        <p>... and @(failures.totalFailed - failures.returned) more!</p>
     }
 </body>
 </html>

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -3,6 +3,7 @@
 # ~~~~
 
 GET     /                                             controllers.ThrallController.index
+GET     /migrationFailures                            controllers.ThrallController.migrationFailures
 
 +nocsrf
 POST    /startMigration                               controllers.ThrallController.startMigration

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 GET     /                                             controllers.ThrallController.index
-GET     /migrationFailures                            controllers.ThrallController.migrationFailures
+GET     /migrationFailures                            controllers.ThrallController.migrationFailures(page: Option[Int])
 
 +nocsrf
 POST    /startMigration                               controllers.ThrallController.startMigration

--- a/thrall/public/stylesheets/main.css
+++ b/thrall/public/stylesheets/main.css
@@ -9,3 +9,7 @@ td, th {
 .hidden {
   display: none;
 }
+
+.imageId {
+  display: inline;
+}

--- a/thrall/public/stylesheets/main.css
+++ b/thrall/public/stylesheets/main.css
@@ -5,3 +5,7 @@ table, td, th {
 td, th {
   padding: 10px 20px;
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## What does this change?

Adds a UI to display migration failures. As part of this, refactors the migration info field to support parsing an image that has both successes and failures listed - this is important as images may have succeeded in a previous (abandoned) migration but failed in the current migration. The previous implementation (modelling esInfo.migration as an Either) would correctly find such an image in its query for failed images, but would not parse the failures field in the document (as it preferred the success field, if it exists, even if that field references a previous migration). This version will parse both successes and failure fields, allowing the failures page to find the relevant failure.

## How can success be measured?

A list of failed migrations can be found, and can be used to reattempt migrations one by one.

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/140777853-9965d873-1f16-453c-9746-e709c610e6bb.png)

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
