### PR TITLE
during migration, no longer store version comparison failures back to ES (still logged)

### DIFF
--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -92,7 +92,7 @@ class MessageProcessor(
     }.recoverWith {
       case versionComparisonFailure: VersionComparisonFailure =>
         logger.error(logMarker, s"Postponed migration of image with id: ${message.id}: cause: ${versionComparisonFailure.getMessage}, this will get picked up shortly")
-        Future.successful()
+        Future.successful(())
       case failure: MigrationFailure =>
         logger.error(logMarker, s"Failed to migrate image with id: ${message.id}: cause: ${failure.getMessage}, attaching failure to document in current index")
         val migrationIndexName = es.migrationStatus match {

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -90,6 +90,9 @@ class MessageProcessor(
       logger.info(logMarker, s"Successfully migrated image with id: ${message.id}, setting 'migratedTo' on current index")
       es.setMigrationInfo(imageId = message.id, migrationInfo = Right(MigrationTo(migratedTo = insertResult.head.indexNames.head)))
     }.recoverWith {
+      case versionComparisonFailure: VersionComparisonFailure =>
+        logger.error(logMarker, s"Postponed migration of image with id: ${message.id}: cause: ${versionComparisonFailure.getMessage}, this will get picked up shortly")
+        Future.successful()
       case failure: MigrationFailure =>
         logger.error(logMarker, s"Failed to migrate image with id: ${message.id}: cause: ${failure.getMessage}, attaching failure to document in current index")
         val migrationIndexName = es.migrationStatus match {


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 


Storing version comparison failures made sense at the time, but since these occur naturally during a deploy (and are likely already resolved by the other instance of `thrall` during the deployment) we need not add noise to the list of genuine migration failures.

## What does this change?
This change catches those specific errors, and still logs them but does not write back to the `esInfo.migration.failures` field on the old/current index.

## How can success be measured?
Less noise 🎧
