### PR TITLE
 Add Undelete in Select View Toolbar Components

### DIFF
--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
@@ -13,13 +13,14 @@ confirmDelete.directive('grConfirmDelete', ['$timeout', function($timeout) {
                 ng:click="showConfirm = true"
                 ng:class="{'gr-confirm-delete--confirm': showConfirm}">
                 <gr-icon-label ng:if="!showConfirm" gr-icon="delete">{{label}}</gr-icon-label>
-                <gr-icon-label ng:if="showConfirm" gr-icon="delete">Confirm delete</gr-icon-label>
+                <gr-icon-label ng:if="showConfirm" gr-icon="delete">{{confirm}}</gr-icon-label>
             </button>`,
 
         link: function(scope, element, attrs) {
             const onChange = () => scope.$eval(attrs.grOnConfirm);
 
             scope.label = attrs.grLabel || 'Delete';
+            scope.confirm = attrs.grConfirm || 'Confirm delete';
 
             element.on('click', function() {
                 element.on('click', onChange);

--- a/kahuna/public/js/components/gr-undelete-image/gr-un-delete-image.js
+++ b/kahuna/public/js/components/gr-undelete-image/gr-un-delete-image.js
@@ -1,0 +1,55 @@
+import angular from 'angular';
+import '../gr-confirm-delete/gr-confirm-delete';
+
+export const undeleteImage = angular.module('gr.undeleteImage', [
+    'gr.confirmDelete',
+    'util.async'
+]);
+
+undeleteImage.controller('grUnDeleteImageCtrl', [
+    '$rootScope', '$q', '$timeout', 'mediaApi', 'apiPoll',
+    function ($rootScope, $q, $timeout, mediaApi, apiPoll) {
+        var ctrl = this;
+
+        function pollDeleted (image) {
+            const findImage = () => mediaApi.find(image.data.id).then(
+                () => $q.reject(),
+                // resolve when image cannot be found, i.e. image has been deleted.
+                () => $q.resolve()
+            );
+
+            apiPoll(findImage);
+        }
+
+        ctrl.unDeleteImage = function (image) {
+            return mediaApi.undelete(image.data.id)
+                .then(() => pollDeleted(image))
+                .catch((err) => {
+                    $rootScope.$emit('image-delete-failure', err, image);
+                });
+        };
+
+        ctrl.delete = function () {
+            // HACK to wait for thrall to process the message so that when we
+            // poll the api, it will be up to date.
+            return $q.all(Array.from(ctrl.images.values()).map(image => ctrl.unDeleteImage(image)))
+                .then(() => $rootScope.$emit('images-deleted', ctrl.images));
+        };
+    }
+]);
+
+undeleteImage.directive('grUnDeleteImage', [function () {
+    return {
+        restrict: 'E',
+        template: `
+            <gr-confirm-delete class="gr-delete-image"
+                               gr-on-confirm="ctrl.delete()" gr-label="Undelete" gr-confirm="Confirm Undelete" gr-tooltip="UnDelete image" >
+            </gr-confirm-delete>`,
+        controller: 'grUnDeleteImageCtrl',
+        controllerAs: 'ctrl',
+        bindToController: true,
+        scope: {
+            images: '='
+        }
+    };
+}]);

--- a/kahuna/public/js/components/gr-undelete-image/gr-un-delete-image.js
+++ b/kahuna/public/js/components/gr-undelete-image/gr-un-delete-image.js
@@ -29,7 +29,7 @@ undeleteImage.controller('grUnDeleteImageCtrl', [
                 });
         };
 
-        ctrl.delete = function () {
+        ctrl.undelete = function () {
             // HACK to wait for thrall to process the message so that when we
             // poll the api, it will be up to date.
             return $q.all(Array.from(ctrl.images.values()).map(image => ctrl.unDeleteImage(image)))
@@ -43,7 +43,7 @@ undeleteImage.directive('grUnDeleteImage', [function () {
         restrict: 'E',
         template: `
             <gr-confirm-delete class="gr-delete-image"
-                               gr-on-confirm="ctrl.delete()" gr-label="Undelete" gr-confirm="Confirm Undelete" gr-tooltip="UnDelete image" >
+                               gr-on-confirm="ctrl.undelete()" gr-label="Undelete" gr-confirm="Confirm Undelete" gr-tooltip="UnDelete image" >
             </gr-confirm-delete>`,
         controller: 'grUnDeleteImageCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/components/gr-undelete-image/gr-un-delete-image.js
+++ b/kahuna/public/js/components/gr-undelete-image/gr-un-delete-image.js
@@ -29,7 +29,7 @@ undeleteImage.controller('grUnDeleteImageCtrl', [
                 });
         };
 
-        ctrl.undelete = function () {
+        ctrl.unDeleteSelected = function () {
             // HACK to wait for thrall to process the message so that when we
             // poll the api, it will be up to date.
             return $q.all(Array.from(ctrl.images.values()).map(image => ctrl.unDeleteImage(image)))
@@ -43,7 +43,7 @@ undeleteImage.directive('grUnDeleteImage', [function () {
         restrict: 'E',
         template: `
             <gr-confirm-delete class="gr-delete-image"
-                               gr-on-confirm="ctrl.undelete()" gr-label="Undelete" gr-confirm="Confirm Undelete" gr-tooltip="UnDelete image" >
+                               gr-on-confirm="ctrl.unDeleteSelected()" gr-label="Undelete" gr-confirm="Confirm Undelete" gr-tooltip="Undelete image" >
             </gr-confirm-delete>`,
         controller: 'grUnDeleteImageCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -13,6 +13,7 @@ import '../components/gr-collection-overlay/gr-collection-overlay';
 import '../components/gr-crop-image/gr-crop-image';
 import '../components/gr-delete-crops/gr-delete-crops';
 import '../components/gr-delete-image/gr-delete-image';
+import '../components/gr-undelete-image/gr-un-delete-image';
 import '../components/gr-downloader/gr-downloader';
 import '../components/gr-export-original-image/gr-export-original-image';
 import '../components/gr-image-cost-message/gr-image-cost-message';
@@ -41,6 +42,7 @@ const image = angular.module('kahuna.image.controller', [
   'gr.cropImage',
   'gr.deleteCrops',
   'gr.deleteImage',
+  'gr.undeleteImage',
   'gr.downloader',
   'gr.exportOriginalImage',
   'gr.imageCostMessage',

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -65,6 +65,11 @@
                                  ng-if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0 && !ctrl.isDeleted">
                 </gr-delete-image>
 
+                <gr-un-delete-image class="results-toolbar-item results-toolbar-item--right"
+                                 images="ctrl.selectedImages"
+                                 ng-if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0 && ctrl.isDeleted">
+                </gr-un-delete-image>
+
                 <gr-archiver class="results-toolbar-item results-toolbar-item--right"
                              gr-images="ctrl.selectedImages"
                              ng-if="ctrl.selectionCount > 0 && !ctrl.isDeleted">

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -67,7 +67,7 @@
 
                 <gr-un-delete-image class="results-toolbar-item results-toolbar-item--right"
                                  images="ctrl.selectedImages"
-                                 ng-if="ctrl.selectionIsDeletable && ctrl.selectionCount > 0 && ctrl.isDeleted">
+                                 ng-if="ctrl.selectionCount > 0 && ctrl.isDeleted">
                 </gr-un-delete-image>
 
                 <gr-archiver class="results-toolbar-item results-toolbar-item--right"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -13,6 +13,7 @@ import '../components/gu-lazy-table-shortcuts/gu-lazy-table-shortcuts';
 import '../components/gu-lazy-preview-shortcuts/gu-lazy-preview-shortcuts';
 import '../components/gr-archiver/gr-archiver';
 import '../components/gr-delete-image/gr-delete-image';
+import '../components/gr-undelete-image/gr-un-delete-image';
 import '../components/gr-downloader/gr-downloader';
 import '../components/gr-batch-export-original-images/gr-batch-export-original-images';
 import '../components/gr-panel-button/gr-panel-button';
@@ -32,6 +33,7 @@ export var results = angular.module('kahuna.search.results', [
     'gr.downloader',
     'gr.batchExportOriginalImages',
     'gr.deleteImage',
+    'gr.undeleteImage',
     'gr.panelButton',
     'gr.toggleButton'
 ]);


### PR DESCRIPTION
Add Undelete in Select View Toolbar Components in soft deleted images view

## What does this change?


## How can success be measured?


## Screenshots

![140482440-fee822e8-d6dc-48ec-b4ed-f7be2fe5ece5](https://user-images.githubusercontent.com/33189781/141281485-7f5904cd-f671-420d-9070-15d13400b0de.png)



## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
