### PR TITLE
include syndication rights in projection

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -55,6 +55,7 @@ object ImageDataMerger extends LazyLogging {
     val leasesF = gridClient.getLeases(mediaId, authFunction)
     val usagesF = gridClient.getUsages(mediaId, authFunction)
     val cropsF = gridClient.getCrops(mediaId, authFunction)
+    val syndicationRightsF = gridClient.getSyndicationRights(mediaId, authFunction)
     for {
       collections <- collectionsF
       edits <- editsF
@@ -62,6 +63,7 @@ object ImageDataMerger extends LazyLogging {
       leases <- leasesF
       usages <- usagesF
       crops <- cropsF
+      syndicationRights <- syndicationRightsF
     } yield {
       val updatedImage = image.copy(
         softDeletedMetadata = softDeletedMetadata.flatMap(meta => meta.isDeleted match {
@@ -74,7 +76,8 @@ object ImageDataMerger extends LazyLogging {
         usages = usages,
         exports = crops,
         metadata = ImageDataMerger.mergeMetadata(edits, image.metadata),
-        usageRights = edits.flatMap(e => e.usageRights).getOrElse(image.usageRights)
+        usageRights = edits.flatMap(e => e.usageRights).getOrElse(image.usageRights),
+        syndicationRights = syndicationRights
       )
       val inferredLastModified = ImageDataMerger.inferLastModifiedDate(updatedImage)
       updatedImage.copy(


### PR DESCRIPTION
## What does this change?

Fetch syndication rights data and include in aggregated data for image projections

## How can success be measured?

Syndication rights data is included with projected images

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
