### PR TITLE
migration pause/resume

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -27,19 +27,21 @@ object StatusRefreshError {
   }
 }
 
+object MigrationStatusProvider {
+  val PAUSED_ALIAS = "MIGRATION_PAUSED"
+}
+
 trait MigrationStatusProvider {
   self: ElasticSearchClient =>
 
   def scheduler: Scheduler
-
-  val PAUSED_ALIAS = "MIGRATION_PAUSED"
 
   private val migrationStatusRef = new AtomicReference[MigrationStatus](fetchMigrationStatus(bubbleErrors = true))
 
   private def fetchMigrationStatus(bubbleErrors: Boolean): MigrationStatus = {
     val statusFuture = getIndexForAlias(imagesMigrationAlias)
       .map {
-        case Some(index) if index.aliases.contains(PAUSED_ALIAS) => Paused(index.name)
+        case Some(index) if index.aliases.contains(MigrationStatusProvider.PAUSED_ALIAS) => Paused(index.name)
         case Some(index) => InProgress(index.name)
         case None => NotRunning
       }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -11,8 +11,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 sealed trait MigrationStatus
 
 case object NotRunning extends MigrationStatus
-case class InProgress(migrationIndexName: String) extends MigrationStatus
-case object Complete extends MigrationStatus
+sealed trait Running extends MigrationStatus {
+  val migrationIndexName: String
+}
+case class InProgress(migrationIndexName: String) extends Running
+case class Paused(migrationIndexName: String) extends Running
 case class StatusRefreshError(cause: Throwable, preErrorStatus: MigrationStatus) extends MigrationStatus
 object StatusRefreshError {
   // custom constructor to unwrap when previousStatus is also Error - prevents nested Errors!
@@ -29,11 +32,14 @@ trait MigrationStatusProvider {
 
   def scheduler: Scheduler
 
+  val PAUSED_ALIAS = "MIGRATION_PAUSED"
+
   private val migrationStatusRef = new AtomicReference[MigrationStatus](fetchMigrationStatus(bubbleErrors = true))
 
   private def fetchMigrationStatus(bubbleErrors: Boolean): MigrationStatus = {
     val statusFuture = getIndexForAlias(imagesMigrationAlias)
       .map {
+        case Some(index) if index.aliases.contains(PAUSED_ALIAS) => Paused(index.name)
         case Some(index) => InProgress(index.name)
         case None => NotRunning
       }

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -1,7 +1,7 @@
 package lib.kinesis
 
 import com.gu.mediaservice.lib.aws.EsResponse
-import com.gu.mediaservice.lib.elasticsearch.{ElasticNotFoundException, InProgress}
+import com.gu.mediaservice.lib.elasticsearch.{ElasticNotFoundException, Running}
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, combineMarkers}
 import com.gu.mediaservice.model.{AddImageLeaseMessage, CreateMigrationIndexMessage, DeleteImageExportsMessage, DeleteImageMessage, DeleteUsagesMessage, ImageMessage, MigrateImageMessage, RemoveImageLeaseMessage, ReplaceImageLeasesMessage, SetImageCollectionsMessage, SoftDeleteImageMessage, UnSoftDeleteImageMessage, ThrallMessage, UpdateImageExportsMessage, UpdateImagePhotoshootMetadataMessage, UpdateImageSyndicationMetadataMessage, UpdateImageUsagesMessage, UpdateImageUserMetadataMessage}
 import com.gu.mediaservice.model.usage.{Usage, UsageNotice}
@@ -98,7 +98,7 @@ class MessageProcessor(
       case failure: MigrationFailure =>
         logger.error(logMarker, s"Failed to migrate image with id: ${message.id}: cause: ${failure.getMessage}, attaching failure to document in current index")
         val migrationIndexName = es.migrationStatus match {
-          case InProgress(migrationIndexName) => migrationIndexName
+          case running: Running => running.migrationIndexName
           case _ => "Unknown migration index name"
         }
         es.setMigrationInfo(imageId = message.id, migrationInfo = MigrationInfo(failures = Some(Map(migrationIndexName -> failure.getMessage))))

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -8,6 +8,7 @@
   migrationIndexCount: String,
   migrateSingleImageForm: Form[MigrateSingleImageForm],
   migrationStatusProviderValue: String,
+  isMigrationRunning: Boolean
 )
 
 @migrationIndexCell = {
@@ -59,7 +60,7 @@
     <pre>@migrationStatusProviderValue</pre>
     <em>Note that the above represents the value at the point this page was loaded.</em>
 
-    @if(migrationStatusProviderValue.startsWith("InProgress")) {
+    @if(isMigrationRunning) {
         <p><a href="@routes.ThrallController.migrationFailures(None)">View images that have failed to migrate and retry.</a></p>
     }
 </body>

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -1,31 +1,34 @@
 @import helper._
+@import com.gu.mediaservice.lib.elasticsearch.MigrationStatus
+@import com.gu.mediaservice.lib.elasticsearch.Running
 
+@import com.gu.mediaservice.lib.elasticsearch.InProgress
+@import com.gu.mediaservice.lib.elasticsearch.Paused
+@import com.gu.mediaservice.lib.elasticsearch.NotRunning
 @(currentAlias: String,
   currentIndex: String,
   currentIndexCount: String,
   migrationAlias: String,
-  migrationIndex: Option[String],
   migrationIndexCount: String,
-  migrateSingleImageForm: Form[MigrateSingleImageForm],
-  migrationStatusProviderValue: String,
-  isMigrationRunning: Boolean
+  migrationStatus: MigrationStatus
 )
 
 @migrationIndexCell = {
-    @migrationIndex match {
-        case Some(indexName) => {
-            @indexName
+    @migrationStatus match {
+        case running: Running => {
+            @running.migrationIndexName
             @form(action = routes.ThrallController.migrateSingleImage){
                 <label for="id">Image ID:</label>
                 <input type="text" id="id" name="id">
                 <input type="submit" value="Migrate single image">
             }
         }
-        case None => {
+        case NotRunning => {
             @form(routes.ThrallController.startMigration) {
                 <input type="submit" value="Start migration">
             }
         }
+        case _ => {}
     }
 }
 
@@ -52,15 +55,31 @@
         <tr>
             <td>@migrationAlias</td>
             <td>@migrationIndexCell</td>
-            <td>@migrationIndexCount</td>
+            <td>
+                @migrationIndexCount
+                @migrationStatus match {
+                    case Paused(_) => {
+                        @form(routes.ThrallController.resumeMigration) {
+                            PAUSED
+                            <input type="submit" value="Resume">
+                        }
+                    }
+                    case InProgress(_) => {
+                        @form(routes.ThrallController.pauseMigration) {
+                            <input type="submit" value="Pause">
+                        }
+                    }
+                    case _ => {}
+                }
+            </td>
         </tr>
     </table>
 
     <h2>MigrationStatus (from the MigrationStatusProvider, a.k.a. 'migration status refresher')</h2>
-    <pre>@migrationStatusProviderValue</pre>
+    <pre>@migrationStatus</pre>
     <em>Note that the above represents the value at the point this page was loaded.</em>
 
-    @if(isMigrationRunning) {
+    @if(migrationStatus.isInstanceOf[Running]) {
         <p><a href="@routes.ThrallController.migrationFailures(None)">View images that have failed to migrate and retry.</a></p>
     }
 </body>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -3,7 +3,6 @@
 @import views.html.helper.form
 @(
     failures: FailedMigrationSummary,
-    migrateSingleImageForm: Form[MigrateSingleImageForm],
     apiBaseUrl: String,
     uiBaseUrl: String,
     page: Int,

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -7,7 +7,10 @@ GET     /migrationFailures                            controllers.ThrallControll
 
 +nocsrf
 POST    /startMigration                               controllers.ThrallController.startMigration
-
++nocsrf
+POST    /pauseMigration                               controllers.ThrallController.pauseMigration
++nocsrf
+POST    /resumeMigration                               controllers.ThrallController.resumeMigration
 +nocsrf
 POST    /migrate                                      controllers.ThrallController.migrateSingleImage
 


### PR DESCRIPTION
https://trello.com/c/f0AuaOgj/2529-add-proper-pause-support-for-grid-migration

## What does this change?
Introduces a new 'pause mode' for migration, where the ongoing/constant query for images to migrate is temporarily halted, but importantly the parallel reads and writes continue to use both indexes (to ensure no inserts/updates are missed, and migration can be resumed without issue).

To avoid any additional calls (and to make it easy to pause manually in cerebro, in the event that thrall dashboard is not accessible) this is achieved simply using an additional _alias_ (`MIGRATION_PAUSED`) on the index in question.

## How can success be measured?
Any of the dev team (and indeed 24/7) can pause/resume a migration in case it's causing too much load etc. in a few simple steps.

## Screenshots
![pause_mode](https://user-images.githubusercontent.com/19289579/142032944-df27a79e-e4af-4535-8bd5-0f4d302467ef.gif)

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
