### PR TITLE
FIX duplicate images (from new and old index) following re-queueing of images with syndicationRights

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -312,7 +312,10 @@ class ElasticSearch(
       case _ => List(imagesCurrentAlias)
     }
     val migrationAwareQuery = migrationStatus match {
-      case running: Running => filters.and(query, filters.mustNot(filters.term("esInfo.migration.migratedTo", running.migrationIndexName)))
+      case running: Running => filters.and(query, filters.and(
+        filters.mustNot(filters.term("esInfo.migration.migratedTo", running.migrationIndexName)),
+        filters.mustNot(filters.exists(NonEmptyList("esInfo.migration.failures.syndicationRightsMissing"))
+      )))
       case _ => query
     }
     val searchRequest = ElasticDsl.search(indexes) query migrationAwareQuery


### PR DESCRIPTION
Originally syndicationRights were missing from 'migrated images' (fixed in https://github.com/guardian/grid/pull/3537). Rather than doing a whole new migration, we removed the `migratedTo` from the affected images to effectively re-queue them for migration. This had the side-effect of them appearing twice in the search API responses and the UI behaves funkily here. 

Fortunately when doing this re-queueing we added a field `esInfo.migration.failures.syndicationRightsMissing` on the affected documents in the old index, so this PR filters those out of the search results to ensure for this odd batch of images (approx 1.25 million) we don't show duplicates. 

This PR can be reverted once all those images have been re-migrated (in a few days).
