### PR TITLE
Add Fluent Bit logging 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val commonLib = project("common-lib").settings(
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
+    "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
     "com.typesafe.play" %% "play-logback" % "2.6.15", // needed when running the scripts
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
     "org.scalacheck" %% "scalacheck" % "1.14.0",

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,9 @@ lazy val root = project("grid", path = Some("."))
       (packageBin in Debian in mediaApi).value -> s"${(name in mediaApi).value}/${(name in mediaApi).value}.deb",
       // pull in s3watcher build
       file("s3watcher/lambda/target/s3watcher.zip") -> "s3watcher/s3watcher.zip",
-      file("riff-raff.yaml") -> "riff-raff.yaml"
+      file("riff-raff.yaml") -> "riff-raff.yaml",
+      file("fluentbit/td-agent-bit.conf") -> "media-service-fluentbit/td-agent-bit.conf",
+      file("fluentbit/parsers.conf") -> "media-service-fluentbit/parsers.conf"
     )
   )
 
@@ -99,7 +101,7 @@ lazy val commonLib = project("common-lib").settings(
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
+    "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.typesafe.play" %% "play-logback" % "2.6.15", // needed when running the scripts
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
     "org.scalacheck" %% "scalacheck" % "1.14.0",

--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -24,12 +24,22 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="STDOUT" />
+      <appender-ref ref="ASYNCSTDOUT"/>
+    </appender>
+
     <logger name="play" level="INFO" />
     <logger name="application" level="INFO" />
     <logger name="request" level="INFO" />
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -201,6 +201,9 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
   final def boolean(key: String): Boolean =
     configuration.getOptional[Boolean](key).getOrElse(false)
 
+  final def booleanOpt(key: String): Option[Boolean] =
+    configuration.getOptional[Boolean](key)
+
   private def missing(key: String, type_ : String): Nothing =
     sys.error(s"Required $type_ configuration property missing: $key")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LogConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LogConfig.scala
@@ -86,8 +86,11 @@ object LogConfig {
   }
 
   def initKinesisLogging(config: CommonConfig): Unit = {
-    if (config.isDev) {
-      rootLogger.info("Kinesis logging disabled in DEV")
+
+    val kinesisLoggingEnabled = config.booleanOpt("logger.kinesis.enabled").getOrElse(true)
+
+    if (config.isDev || !kinesisLoggingEnabled) {
+      rootLogger.info("Kinesis logging is disabled by config")
     } else {
       Try {
         rootLogger.info("LogConfig initializing")

--- a/fluentbit/parsers.conf
+++ b/fluentbit/parsers.conf
@@ -1,0 +1,4 @@
+# https://docs.fluentbit.io/manual/pipeline/filters/parser
+[PARSER]
+  Name  systemd_json
+  Format  json

--- a/fluentbit/td-agent-bit.conf
+++ b/fluentbit/td-agent-bit.conf
@@ -1,0 +1,68 @@
+[SERVICE]
+  Parsers_File parsers.conf
+
+# https://docs.fluentbit.io/manual/pipeline/inputs/systemd
+[INPUT]
+  Name systemd
+  # To be replaced with the actual value by the CFN
+  Systemd_Filter _SYSTEMD_UNIT=APP_NAME.service
+  Strip_Underscores true
+
+# https://docs.fluentbit.io/manual/pipeline/filters/record-modifier
+# Drop all systemd fields - we only want the message
+[FILTER]
+  Name record_modifier
+  Match *
+  Allowlist_key MESSAGE
+
+# https://docs.fluentbit.io/manual/pipeline/filters/modify
+# Lowercase MESSAGE field for consistency
+[FILTER]
+  Name modify
+  Match *
+  Rename MESSAGE message
+
+# https://docs.fluentbit.io/manual/pipeline/filters/parser
+# Attempt to parse the message field, in case the app is logging structured data
+[FILTER]
+  Name parser
+  Match *
+  Key_Name message
+  Parser systemd_json
+
+# https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace
+# Attempt to group up log lines which are split over multiple lines
+[FILTER]
+  name multiline
+  match *
+  multiline.parser java
+  multiline.key_content message
+
+# https://docs.fluentbit.io/manual/pipeline/filters/aws-metadata
+# Add useful AWS metadata
+[FILTER]
+  Name aws
+  Match *
+  az true
+  ec2_instance_id true
+  ami_id true
+
+# https://docs.fluentbit.io/manual/pipeline/filters/modify
+# Add app identity fields
+[FILTER]
+  Name modify
+  Match *
+  # To be replaced with the actual value by the CFN
+  Add app APP_NAME
+  # To be replaced with the actual value by the CFN
+  Add stage STACK_STAGE
+  Add stack media-service
+  Rename ec2_instance_id instanceId
+
+# https://docs.fluentbit.io/manual/pipeline/outputs/kinesis
+[OUTPUT]
+  Name kinesis_streams
+  Match *
+  region eu-west-1
+  # To be replaced with the actual value by the CFN
+  stream STACK_STREAM

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,8 +9,7 @@ templates:
     type: autoscaling
     parameters:
       bucket: media-service-dist
-    dependencies:
-      - app-ami-update
+    dependencies: [app-ami-update, media-service-fluentbit]
 
   usage-autoscaling:
     type: autoscaling
@@ -121,3 +120,9 @@ deployments:
         PROD:
           filename: s3watcher.zip
           name: media-service-PROD-S3WatcherLamdbaFunction-11VPCX7ETKU5O
+
+  media-service-fluentbit:
+    type: aws-s3
+    parameters:
+      bucket: media-service-dist
+      cacheControl: private

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,9 @@ templates:
     type: autoscaling
     parameters:
       bucket: media-service-dist
-    dependencies: [app-ami-update, media-service-fluentbit]
+    dependencies:
+      - app-ami-update
+      - media-service-fluentbit
 
   usage-autoscaling:
     type: autoscaling
@@ -17,6 +19,9 @@ templates:
     contentDirectory: usage
     parameters:
       bucket: media-service-dist
+    dependencies:
+      - app-ami-update
+      - media-service-fluentbit
 
   usage-deploy:
     template: usage-autoscaling
@@ -61,8 +66,6 @@ deployments:
     template: usage-autoscaling
     actions:
       - uploadArtifacts
-    dependencies:
-      - app-ami-update
 
   usage-api:
     template: usage-deploy


### PR DESCRIPTION
Co-authored-by: @SHession 

## What does this change?
This PR introduces Fluent Bit logging for all the Grid's services. Fluent Bit picks up logs from `stdout` and sends them to Kinesis, so that logging is no longer a concern of the application.

This PR is linked to a [PR in `ed-tools-platform`](https://github.com/guardian/editorial-tools-platform/pull/570) to change the cloudformation template. Please see that PR for more information.

In addition, a change has been made to our config to disable the use of the old logback appender, which will remain in place for the meantime (see notes in the platform PR above).

## How to test
See instructions in the [platform PR](https://github.com/guardian/editorial-tools-platform/pull/570).

## How can success be measured?

We receive logs from Fluent Bit for the above services, and no longer receive logs from the Kinesis logback appender.

<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
