### PR TITLE
FIX `AwaitingReviewForSyndication` queue bug

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
@@ -9,13 +9,24 @@ trait ElasticSearchExecutions extends GridLogging {
 
   def client: ElasticClient
 
+  def executeAndLog[T, U](handler: Handler[T, U])(request: T, message: String)(implicit
+                                                                               functor: Functor[Future],
+                                                                               executor: Executor[Future],
+                                                                               manifest: Manifest[U],
+                                                                               executionContext: ExecutionContext,
+                                                                               logMarkers: LogMarker
+  ): Future[Response[U]] = {
+    implicit val implicitHandler = handler
+    executeAndLog(request, message)
+  }
+
   def executeAndLog[T, U](request: T, message: String, notFoundSuccessful: Boolean = false)(implicit
-                                                       functor: Functor[Future],
-                                                       executor: Executor[Future],
-                                                       handler: Handler[T, U],
-                                                       manifest: Manifest[U],
-                                                       executionContext: ExecutionContext,
-                                                       logMarkers: LogMarker
+                                                                                            functor: Functor[Future],
+                                                                                            executor: Executor[Future],
+                                                                                            handler: Handler[T, U],
+                                                                                            manifest: Manifest[U],
+                                                                                            executionContext: ExecutionContext,
+                                                                                            logMarkers: LogMarker
   ): Future[Response[U]] = {
     val stopwatch = Stopwatch.start
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -292,7 +292,7 @@ object Mappings {
     dateField("startDate"),
     dateField("endDate"),
     keywordField("access"),
-    keywordField("active"),
+    keywordField("active"), //TODO should probably not be stored in ES, as its a snapshot in time rather than a calculated field
     sStemmerAnalysed("notes"),
     keywordField("mediaId"),
     dateField("createdAt")

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -132,6 +132,7 @@ function getMediaApiConfig(config) {
         |metrics.request.enabled=false
         |image.record.download=false
         |dynamo.table.softDelete.metadata="SoftDeletedMetadataTable"
+        |syndication.review.useRuntimeFieldsFix=true
         |`;
 }
 

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -68,5 +68,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val syndicationStartDate: Option[DateTime] = Try {
     stringOpt("syndication.start").map(d => DateTime.parse(d).withTimeAtStartOfDay())
   }.toOption.flatten
+  val useRuntimeFieldsToFixSyndicationReviewQueueQuery = boolean("syndication.review.useRuntimeFieldsFix")
 
 }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -209,7 +209,7 @@ class ElasticSearch(
     val searchRequest = prepareSearch(withFilter).copy(trackHits = Some(true)) from params.offset size params.length sortBy sort
 
     val searchHandler =
-      if(params.syndicationStatus.contains(AwaitingReviewForSyndication)) // TODO consider also checking the ES version, if available from the client
+      if(params.syndicationStatus.contains(AwaitingReviewForSyndication) && config.useRuntimeFieldsToFixSyndicationReviewQueueQuery)
         SearchHandlerWithRuntimeFields(
           (msg: String) => logger.info(msg),
           Map(

--- a/media-api/app/lib/elasticsearch/SearchHandlerWithRuntimeFields.scala
+++ b/media-api/app/lib/elasticsearch/SearchHandlerWithRuntimeFields.scala
@@ -1,0 +1,34 @@
+package lib.elasticsearch
+
+import com.sksamuel.elastic4s.HttpEntity.StringEntity
+import com.sksamuel.elastic4s.{ElasticRequest, Handler}
+import com.sksamuel.elastic4s.requests.searches.{SearchHandlers, SearchRequest, SearchResponse}
+import play.api.libs.json.{JsObject, JsValue, Json}
+
+case class RuntimeFieldScript(source: String)
+
+case class RuntimeFieldDefinition(`type`: String, script: RuntimeFieldScript)
+
+case class SearchHandlerWithRuntimeFields(logInfo: String => Unit, fieldScripts: Map[String, RuntimeFieldDefinition])
+  extends Handler[SearchRequest, SearchResponse] with SearchHandlers {
+
+  implicit val writesRuntimeFieldScript = Json.writes[RuntimeFieldScript]
+  implicit val writesRuntimeFieldDefinition = Json.writes[RuntimeFieldDefinition]
+
+  override def build(t: SearchRequest): ElasticRequest = {
+    val originalRequest = SearchHandler.build(t)
+    val maybeBodyStr = originalRequest.entity.map(_.get)
+    val maybeBodyJSON = maybeBodyStr.map(Json.parse).flatMap(_.asOpt[JsObject])
+    val runtimeFieldsJSON: JsValue = Json.toJson(fieldScripts)
+    val maybeBodyWithRuntimeFields = maybeBodyJSON.map(_ + ("runtime_mappings" -> runtimeFieldsJSON)).map(Json.stringify)
+    maybeBodyWithRuntimeFields.fold(
+      originalRequest
+    ) { bodyContent =>
+      logInfo(s"Modified SearchRequest, body: $bodyContent")
+      originalRequest.copy(entity = Some(StringEntity(
+        content = bodyContent,
+        contentCharset = originalRequest.entity.flatMap(_.contentCharset))
+      ))
+    }
+  }
+}

--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -5,6 +5,7 @@ import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.queries.{NestedQuery, Query}
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
+import com.sksamuel.elastic4s.requests.searches.term.TermQuery
 import org.joda.time.DateTime
 import scalaz.NonEmptyList
 import scalaz.syntax.foldable1._
@@ -19,7 +20,7 @@ object filters {
     should(queries.list: _*)
   }
 
-  def boolTerm(field: String, value: Boolean): Query = termQuery(field, value)
+  def boolTerm(field: String, value: Boolean): TermQuery = termQuery(field, value)
 
   def date(field: String, from: Option[DateTime], to: Option[DateTime]): Option[Query] =
     if (from.isDefined || to.isDefined) {


### PR DESCRIPTION
## RELIES ON: https://github.com/guardian/grid/pull/3550

Co-Authored-By: @andrew-nowak 

## What does this change?

https://trello.com/c/haSpms31/584-bug-grid-syndication-review-queue-shows-already-reviewed-images

The `leases` field is interpreted as a flat array, which has an unfortunate side effect of, images which have an active DenySyndicationLease AND any **expired** non-syndication lease, showing up in the syndication review queue (https://media.gutools.co.uk/search?syndicationStatus=review). 

A possible proper fix is to interpret this field as 'nested' (although this has some performance concerns) but this would require another migration (and could have said performance problems). 

**So instead this PR** introduces an alternate approach, using a new feature called [Runtime Fields](https://www.elastic.co/guide/en/elasticsearch/reference/master/runtime-search-request.html) (unlocked by https://github.com/guardian/grid/pull/3550) which allows us to run a _painless_ script on each of the initial query results to correctly assert that there is no **Active** Deny Syndication lease and then further filter on that.

Despite bumping `elastic4s` to latest there is no support for [Runtime Fields](https://www.elastic.co/guide/en/elasticsearch/reference/master/runtime-search-request.html) (even though they've been around for quite a few ES versions now) so instead we created `SearchHandlerWithRuntimeFields` (which uses the existing `SearchHandler` builder) and retroactively adds the top-level `runtime_mappings` fields to the outgoing request body - in the longer term we hope/plan to make an open source contribution to add support officially (unless `sksamuel` gets there first).

## How can success be measured?
Happier syndication reviewers.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
