### PR TITLE
Upgrade ElasticSearch to 7.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     services:
       elasticsearch:
-        image: elasticsearch:7.5.2
+        image: elasticsearch:7.15.2
         # Wait for elasticsearch to report healthy before continuing.
         # see https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L28
         options: -e "discovery.type=single-node" --expose 9200 --health-cmd "curl localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     services:
       elasticsearch:
-        image: elasticsearch:7.15.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
         # Wait for elasticsearch to report healthy before continuing.
         # see https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L28
         options: -e "discovery.type=single-node" --expose 9200 --health-cmd "curl localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 10

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
 
 val commonSettings = Seq(
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.12.15",
   description := "grid",
   organization := "com.gu",
   version := "0.1",
@@ -94,6 +94,7 @@ lazy val commonLib = project("common-lib").settings(
     "org.elasticsearch" % "elasticsearch" % "1.7.6",
     "com.sksamuel.elastic4s" %% "elastic4s-core" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
+    "com.sksamuel.elastic4s" %% "elastic4s-domain" % elastic4sVersion,
     "com.gu" %% "box" % "0.2.0",
     "com.gu" %% "thrift-serializer" % "4.0.0",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ Global / concurrentRestrictions := Seq(
 )
 
 val awsSdkVersion = "1.11.302"
-val elastic4sVersion = "7.3.5"
+val elastic4sVersion = "7.15.3"
 val okHttpVersion = "3.12.1"
 
 val bbcBuildProcess: Boolean = System.getenv().asScala.get("BUILD_ORG").contains("bbc")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/IndexSettings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/IndexSettings.scala
@@ -1,8 +1,6 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-import com.sksamuel.elastic4s.requests.analysis.{Analysis, CustomAnalyzer, PathHierarchyTokenizer, StandardTokenizer, StemmerTokenFilter, StopTokenFilter, TokenFilter}
-import com.sksamuel.elastic4s.requests.analyzers.{AsciiFoldingTokenFilter, LowercaseTokenFilter}
-import org.elasticsearch.index.analysis.ASCIIFoldingTokenFilterFactory
+import com.sksamuel.elastic4s.analysis.{Analysis, CustomAnalyzer, PathHierarchyTokenizer, StandardTokenizer, StemmerTokenFilter, StopTokenFilter, TokenFilter}
 
 object IndexSettings {
 
@@ -35,8 +33,8 @@ object IndexSettings {
       standard,
       List(),
       List(
-        LowercaseTokenFilter.name,
-        AsciiFoldingTokenFilter.name,
+        "lowercase",
+        "asciifolding",
         english_possessive_stemmer,
         gu_stopwords,
         s_stemmer
@@ -47,7 +45,7 @@ object IndexSettings {
       hierarchyAnalyserName,
       path_hierarchy,
       List(),
-      List(LowercaseTokenFilter.name)
+      List("lowercase")
     )
 
     val analyzers = List(englishSStemmerAnalyzer, hierarchyAnalyzer)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   elasticsearch:
-    image: elasticsearch:7.5.2
+    image: elasticsearch:7.15.2
     volumes:
       - "./dev/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   elasticsearch:
-    image: elasticsearch:7.15.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
     volumes:
       - "./dev/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
     ports:

--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -3,7 +3,8 @@ package lib.elasticsearch
 import com.gu.mediaservice.lib.formatting.printDateTime
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, NestedQuery, Query}
+import com.sksamuel.elastic4s.requests.searches.queries.{NestedQuery, Query}
+import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import org.joda.time.DateTime
 import scalaz.NonEmptyList
 import scalaz.syntax.foldable1._

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -55,7 +55,7 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
 
 
 
-  def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.5.2")
+  def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.15.2")
     .withPorts(9200 -> Some(9200))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsImageMetadata.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsImageMetadata.scala
@@ -1,20 +1,16 @@
 package com.gu.mediaservice.scripts
 
-import ch.qos.logback.classic.{Level, Logger}
+import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.{ElasticClient, Response}
-import com.sksamuel.elastic4s.requests.indexes.GetIndexResponse
 import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
-import org.slf4j.LoggerFactory
 import play.api.libs.json._
-import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter, Writer}
+
+import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter}
 import java.util.concurrent.TimeUnit
-
 import scala.annotation.tailrec
-
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.{Await, Future}
 
 object EsImageMetadata extends EsScript {
   override def run(esUrl: String, args: List[String]): Unit = {

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -1,15 +1,16 @@
 package com.gu.mediaservice.scripts
 
-import java.util.concurrent.TimeUnit
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, Mappings}
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.handlers.index.GetIndexResponse
 import com.sksamuel.elastic4s.requests.bulk.BulkResponse
-import com.sksamuel.elastic4s.requests.indexes.{GetIndexResponse, IndexRequest}
+import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchResponse}
-import com.sksamuel.elastic4s.{Indexes, IndexesAndType, IndexesAndTypes, Response}
+import com.sksamuel.elastic4s.{Indexes, Response}
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Duration, FiniteDuration, SECONDS}
 import scala.concurrent.{Await, Future}
@@ -202,7 +203,7 @@ object UpdateMapping extends EsScript {
 
         val result = client.execute {
           putMapping(Indexes(index)) as {
-            Mappings.imageMapping.fields
+            Mappings.imageMapping.properties
           }
         }.await
 

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -782,7 +782,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
 
           // does not throw, despite migration index not existing
           Await.result(ES.migrationAwareUpdater(
-            indexName => update(id).in(indexName).doc(updateDoc),
+            indexName => updateById(index = indexName, id = id).doc(updateDoc),
             indexName => s"update $id for $indexName"
           ), fiveSeconds)
 
@@ -805,7 +805,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
 
           // does not throw, despite migration index not containing doc with id `id`
           Await.result(ES.migrationAwareUpdater(
-            indexName => update(id).in(indexName).doc(updateDoc),
+            indexName => updateById(index = indexName, id = id).doc(updateDoc),
             indexName => s"update $id for $indexName"
           ), fiveSeconds)
 
@@ -841,7 +841,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
             |}""".stripMargin
 
           Await.result(ES.migrationAwareUpdater(
-            indexName => update(id).in(indexName).doc(updateDoc),
+            indexName => updateById(index = indexName, id = id).doc(updateDoc),
             indexName => s"update $id for $indexName"
           ), fiveSeconds)
 

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -44,7 +44,7 @@ trait ElasticSearchTestBase extends FreeSpec with Matchers with Fixtures with Be
     replicas = 0
   )
 
-  val esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.5.2")
+  val esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.15.2")
     .withPorts(9200 -> Some(9200))
     .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
     .withReadyChecker(


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak

ElasticSearch data nodes are actually upgraded by changing the version in the Amigo recipe https://amigo.gutools.co.uk/recipes/grid-elasticsearch-bionic so this PR just contains some supporting changes.

## What does this change?

- Bump `elastic4s` to `7.15.3` (as this is the version corresponding to ES 7.15.2, as per https://github.com/sksamuel/elastic4s#release) INCLUDING associated refactors (due to type changes)
- Upgrade to Scala `2.12.15` (to prevent certain deprecation warnings from `elastic4s` to fail the build)

## How can success be measured?
At the very least this ES upgrade unlocks the 'Runtime Fields' feature which helps us fix a long standing issue with the `AwaitingReviewForSyndication` queue (see https://github.com/guardian/grid/pull/3546).

## Screenshots
Tested in TEST...
![image](https://user-images.githubusercontent.com/19289579/143071107-d76ad0e3-2c52-40f3-950e-4f068805a7dd.png)


## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
