### PR TITLE
Add "download" as a "usages@platform" search filter suggestion

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -103,6 +103,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   val fieldAliasConfigs: Seq[FieldAlias] = configuration.get[Seq[FieldAlias]]("field.aliases")
 
+  val recordDownloadAsUsage: Boolean = boolean("image.record.download")
+
   /**
    * Load in a list of external staff photographers, internal staff photographers, contracted photographers,
    * contract illustrators, staff illustrators and creative commons licenses. For example:

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -17,6 +17,7 @@ function getCommonConfig(config) {
         |thrall.kinesis.lowPriorityStream.name="${config.coreStackProps.ThrallLowPriorityMessageStream}"
         |es.index.aliases.current="Images_Current"
         |es.index.aliases.migration="Images_Migration"
+        |image.record.download=false
         |`;
 }
 
@@ -130,7 +131,6 @@ function getMediaApiConfig(config) {
         |quota.store.key="rcs-quota.json"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false
-        |image.record.download=false
         |dynamo.table.softDelete.metadata="SoftDeletedMetadataTable"
         |`;
 }

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -50,7 +50,8 @@ class KahunaController(
       config.homeLinkHtml,
       config.systemName,
       config.canDownloadCrop,
-      domainMetadataSpecs
+      domainMetadataSpecs,
+      config.recordDownloadAsUsage
     ))
   }
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -16,7 +16,8 @@
   homeLinkHtml: Option[String],
   systemName: String,
   canDownloadCrop: Boolean,
-  domainMetadataSpecs: String
+  domainMetadataSpecs: String,
+  recordDownloadAsUsage: Boolean
 )
 <!DOCTYPE html>
 <html>
@@ -59,7 +60,8 @@
           homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))',
           systemName: "@Html(systemName)",
           canDownloadCrop: @canDownloadCrop,
-          domainMetadataSpecs: @Html(domainMetadataSpecs)
+          domainMetadataSpecs: @Html(domainMetadataSpecs),
+          recordDownloadAsUsage: @recordDownloadAsUsage
         }
     </script>
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -168,7 +168,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
     function getFilterSuggestions(field, value) {
         switch (field) {
         case 'usages@status': return ['published', 'pending', 'removed'];
-        case 'usages@platform': return ['print', 'digital'];
+        case 'usages@platform': return ['print', 'digital', 'download'];
         case 'subject':  return prefixFilter(value)(subjects);
         case 'fileType': return prefixFilter(value)(fileTypes);
         case 'label':    return suggestLabels(value);

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -165,10 +165,19 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         then(results => results.data.map(res => res.key));
     }
 
+    function listUsagesPlatforms() {
+      let suggestions = ['print', 'digital'];
+      if (window._clientConfig.recordDownloadAsUsage === true) {
+        suggestions.push('download');
+      }
+
+      return suggestions;
+    }
+
     function getFilterSuggestions(field, value) {
         switch (field) {
         case 'usages@status': return ['published', 'pending', 'removed'];
-        case 'usages@platform': return ['print', 'digital', 'download'];
+        case 'usages@platform': return listUsagesPlatforms();
         case 'subject':  return prefixFilter(value)(subjects);
         case 'fileType': return prefixFilter(value)(fileTypes);
         case 'label':    return suggestLabels(value);

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -165,7 +165,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         then(results => results.data.map(res => res.key));
     }
 
-    function listUsagesPlatforms() {
+    function listUsagePlatforms() {
       let suggestions = ['print', 'digital'];
       if (window._clientConfig.recordDownloadAsUsage === true) {
         suggestions.push('download');
@@ -177,7 +177,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
     function getFilterSuggestions(field, value) {
         switch (field) {
         case 'usages@status': return ['published', 'pending', 'removed'];
-        case 'usages@platform': return listUsagesPlatforms();
+        case 'usages@platform': return listUsagePlatforms();
         case 'subject':  return prefixFilter(value)(subjects);
         case 'fileType': return prefixFilter(value)(fileTypes);
         case 'label':    return suggestLabels(value);

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -123,7 +123,7 @@
                 <gr-chip-example gr-filter-field="usages@platform" gr-example-search="print"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
-                Filter by print, digital or download usage.
+                Filter by print, digital or other usage.
             </dd>
         </dl>
          <dl class="advanced-search-example">

--- a/kahuna/public/js/search/syntax/syntax.html
+++ b/kahuna/public/js/search/syntax/syntax.html
@@ -123,7 +123,7 @@
                 <gr-chip-example gr-filter-field="usages@platform" gr-example-search="print"></gr-chip-example>
             </dt>
             <dd class="advanced-search-example__explanation">
-                Filter by print or digital usage.
+                Filter by print, digital or download usage.
             </dd>
         </dl>
          <dl class="advanced-search-example">

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -20,8 +20,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   // quota updates can only be turned off in DEV
   val quotaUpdateEnabled: Boolean = if (isDev) boolean("quota.update.enabled") else true
 
-  val recordDownloadAsUsage: Boolean = boolean("image.record.download")
-
   //Lazy allows this to be empty and not break things unless used somewhere
   lazy val imgPublishingBucket = string("publishing.image.bucket")
 


### PR DESCRIPTION
## What does this change?
This PR adds _"download"_ among the list of available hints on the _"usages@platform"_ search filter when `image.record.download` config is set to `true`.

Since both media-api and kahuna use the `image.record.download` config, though optional it is now defined in the common config file and not media-api config file.

## How can success be measured?

Given the `image.record.download` config is set to `true`
Then the _"download"_ should be included as a suggested _"usages@platform"_ filter and should filter images that have a recorded "download" usage.

![demo](https://user-images.githubusercontent.com/12212239/143427820-05cb63a8-0294-49eb-b6d1-a8cf35b10933.gif)

## Screenshots

![Search filter hint](https://user-images.githubusercontent.com/12212239/143428149-3cfdbb44-028e-4518-b0cc-38558ed1d292.png)

![Search filter description](https://user-images.githubusercontent.com/12212239/143428173-c8f189dc-90ca-4283-9100-888a2f3dec12.png)


## Who should look at this?
@guardian/digital-cms 

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
