### PR TITLE
Revert "FIX duplicate images (from new and old index) following re-queueing of images with syndicationRights"

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -336,10 +336,7 @@ class ElasticSearch(
       case _ => List(imagesCurrentAlias)
     }
     val migrationAwareQuery = migrationStatus match {
-      case running: Running => filters.and(query, filters.and(
-        filters.mustNot(filters.term("esInfo.migration.migratedTo", running.migrationIndexName)),
-        filters.mustNot(filters.exists(NonEmptyList("esInfo.migration.failures.syndicationRightsMissing"))
-      )))
+      case running: Running => filters.and(query, filters.mustNot(filters.term("esInfo.migration.migratedTo", running.migrationIndexName)))
       case _ => query
     }
     val searchRequest = ElasticDsl.search(indexes) query migrationAwareQuery


### PR DESCRIPTION
As per the description of https://github.com/guardian/grid/pull/3544 it could be reverted once the affected images (~1.25mil) had been migrated (successfully or failed).