### PR TITLE
facilitate easier grouping of migration failures

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -31,8 +31,8 @@ case class MigrateImageMessage(id: String, maybeImageWithVersion: Either[String,
 object MigrateImageMessage {
   def apply(imageId: String, maybeProjection: Option[Image], maybeVersion: Option[Long]): MigrateImageMessage = (maybeProjection, maybeVersion) match {
     case (Some(projection), Some(version)) => MigrateImageMessage(imageId, scala.Right((projection, version)))
-    case (None, _) => MigrateImageMessage(imageId, Left(s"There was no projection returned for id: ${imageId}"))
-    case _ => MigrateImageMessage(imageId, Left(s"There was no version returned for id: ${imageId}"))
+    case (None, _) => MigrateImageMessage(imageId, Left("There was no projection returned"))
+    case _ => MigrateImageMessage(imageId, Left("There was no version returned"))
   }
 }
 

--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -141,7 +141,7 @@ class ThrallController(
         maybeVersion <- es.getImageVersion(imageId)
       } yield MigrateImageMessage(imageId, maybeProjection, maybeVersion)
     ).recover {
-      case error => MigrateImageMessage(imageId, Left(s"Failed to project image for id: ${imageId}, message: ${error}"))
+      case error => MigrateImageMessage(imageId, Left(error.toString))
     }
 
     val msgFailedToMigrateImage = s"Failed to send migrate image message ${imageId}"

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -99,7 +99,7 @@ object MigrationSourceWithSender extends GridLogging {
           maybeVersion = Some(searchHit.version)
         } yield MigrateImageMessage(imageId, maybeProjection, maybeVersion)
       ).recover {
-        case error => MigrateImageMessage(imageId, Left(s"Failed to project image for id: ${imageId}, message: ${error}"))
+        case error => MigrateImageMessage(imageId, Left(error.toString))
       }
       migrateImageMessageFuture.map(message => MigrationRecord(message, java.time.Instant.now()))
     }}

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -65,7 +65,7 @@ class MessageProcessor(
     )
 
   private def migrateImage(message: MigrateImageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) = {
-    implicit val implicitLogMarker: LogMarker = logMarker
+    implicit val implicitLogMarker: LogMarker = logMarker ++ Map("imageId" -> message.id)
     val maybeStart = message.maybeImageWithVersion match {
       case Left(errorMessage) =>
         Future.failed(ProjectionFailure(errorMessage))


### PR DESCRIPTION
…by no longer including imageId in the migration failure messages (since the failures are attached to image document in ES anyway, so we have that relationship)

Co-Authored-By: @andrew-nowak 