### PR TITLE
introduce new grouped view of migration failures (aka 'overview')

### DIFF
--- a/thrall/app/lib/FailedMigrationDetails.scala
+++ b/thrall/app/lib/FailedMigrationDetails.scala
@@ -1,6 +1,6 @@
 package lib
 
-final case class FailedMigrationDetails(imageId: String)
+final case class FailedMigrationDetails(imageId: String, lastModified: String, crops: String, usages: String)
 
 final case class FailedMigrationSummary(totalFailed: Long, details: Seq[FailedMigrationDetails])
 

--- a/thrall/app/lib/FailedMigrationDetails.scala
+++ b/thrall/app/lib/FailedMigrationDetails.scala
@@ -1,5 +1,9 @@
 package lib
 
-final case class FailedMigrationDetails(imageId: String, cause: String)
+final case class FailedMigrationDetails(imageId: String)
 
-final case class FailedMigrationSummary(totalFailed: Long, totalFailedRelation: String, returned: Long, details: Seq[FailedMigrationDetails])
+final case class FailedMigrationSummary(totalFailed: Long, details: Seq[FailedMigrationDetails])
+
+final case class FailedMigrationsGrouping(message: String, count: Long, exampleIDs: Seq[String])
+
+final case class FailedMigrationsOverview(totalFailed: Long, grouped: Seq[FailedMigrationsGrouping])

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -6,7 +6,9 @@ import com.sksamuel.elastic4s.ElasticApi.{existsQuery, matchQuery, not}
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.searches.SearchHit
-import lib.{FailedMigrationDetails, FailedMigrationSummary}
+import com.sksamuel.elastic4s.requests.searches.aggs.responses.bucket.Terms
+import com.sksamuel.elastic4s.requests.searches.aggs.responses.metrics.TopHits
+import lib.{FailedMigrationDetails, FailedMigrationSummary, FailedMigrationsGrouping, FailedMigrationsOverview}
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads, __}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -81,34 +83,54 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
     } yield ()
   }
 
-  def getMigrationFailures(
-    currentIndexName: String, migrationIndexName: String, from: Int, pageSize: Int
-  )(implicit ec: ExecutionContext, logMarker: LogMarker = MarkerMap()): Future[FailedMigrationSummary] = {
-    val search = ElasticDsl.search(currentIndexName).from(from).size(pageSize) query must(
+  def getMigrationFailuresOverview(
+    currentIndexName: String, migrationIndexName: String
+  )(implicit ec: ExecutionContext, logMarker: LogMarker = MarkerMap()): Future[FailedMigrationsOverview] = {
+
+    val examplesSubAggregation = topHitsAgg("examples")
+      .fetchSource(false)
+      .size(3)
+
+    val aggregateOnFailureMessage =
+      termsAgg("failures", s"esInfo.migration.failures.$migrationIndexName.keyword")
+        .size(1000)
+        .subAggregations(examplesSubAggregation)
+
+    val aggSearch = ElasticDsl.search(currentIndexName).trackTotalHits(true) query must(
       existsQuery(s"esInfo.migration.failures.$migrationIndexName"),
+      not(matchQuery("esInfo.migration.migratedTo", migrationIndexName))
+    ) aggregations aggregateOnFailureMessage
+
+    executeAndLog(aggSearch, s"retrieving grouped overview of migration failures").map { response =>
+      FailedMigrationsOverview(
+        totalFailed = response.result.hits.total.value,
+        grouped = response.result.aggregations.result[Terms](aggregateOnFailureMessage.name).buckets.map { bucket  =>
+          FailedMigrationsGrouping(
+            message = bucket.key,
+            count = bucket.docCount,
+            exampleIDs = bucket.result[TopHits](examplesSubAggregation.name).hits.map(_.id)
+          )
+        }
+      )
+    }
+  }
+
+  def getMigrationFailures(
+    currentIndexName: String, migrationIndexName: String, from: Int, pageSize: Int, filter: String
+  )(implicit ec: ExecutionContext, logMarker: LogMarker = MarkerMap()): Future[FailedMigrationSummary] = {
+    val search = ElasticDsl.search(currentIndexName).trackTotalHits(true).from(from).size(pageSize) query must(
+      existsQuery(s"esInfo.migration.failures.$migrationIndexName"),
+      termQuery(s"esInfo.migration.failures.$migrationIndexName.keyword", filter),
       not(matchQuery("esInfo.migration.migratedTo", migrationIndexName))
     )
     executeAndLog(search, s"retrieving list of migration failures")
       .map { resp =>
-        logger.info(logMarker, s"failed migrations - got ${resp.result.hits.size} hits")
         val failedMigrationDetails: Seq[FailedMigrationDetails] = resp.result.hits.hits.map { hit =>
-            logger.info(logMarker, s"failed migrations - got hit $hit.id")
-            val source = hit.sourceAsString
-            val cause = Json.parse(source).validate(Json.reads[EsInfoContainer]) match {
-              case JsSuccess(EsInfoContainer(EsInfo(Some(MigrationInfo(Some(failures), _)))), _) =>
-                failures.getOrElse(migrationIndexName, "UNKNOWN - NO FAILURE MATCHING MIGRATION INDEX NAME")
-              case JsError(errors) =>
-                logger.error(logMarker, s"Could not parse EsInfo for ${hit.id} - $errors")
-                "Could not extract migration info from ES due to parsing failure"
-              case _ => "UNKNOWN - NO FAILURE MATCHING MIGRATION INDEX NAME"
-            }
-            FailedMigrationDetails(imageId = hit.id, cause = cause)
+            FailedMigrationDetails(imageId = hit.id)
         }
 
         FailedMigrationSummary(
           totalFailed = resp.result.hits.total.value,
-          totalFailedRelation = resp.result.hits.total.relation,
-          returned = resp.result.hits.hits.length,
           details = failedMigrationDetails
         )
       }

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -80,7 +80,7 @@
     <em>Note that the above represents the value at the point this page was loaded.</em>
 
     @if(migrationStatus.isInstanceOf[Running]) {
-        <p><a href="@routes.ThrallController.migrationFailures(None)">View images that have failed to migrate and retry.</a></p>
+        <p><a href="@routes.ThrallController.migrationFailuresOverview()">View images that have failed to migrate and retry.</a></p>
     }
 </body>
 </html>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
-    <div style="position: sticky; background: white; top: 8px;">
+    <div class="sticky headingSection">
         <a href="@routes.ThrallController.migrationFailuresOverview()">&lt; back to Migration Failures Overview</a>
         <h1>
             Migration Failures - Page @(page) - <code>@filter</code>
@@ -34,8 +34,11 @@
     </div>
 
     <table>
-        <tr style="position: sticky; background: white; top: 158px;">
+        <tr class="sticky headingRow">
             <th>Image ID</th>
+            <th>Last Modified</th>
+            <th>Crop Count</th>
+            <th>Usage Count</th>
             <th>Click to reattempt migration</th>
         </tr>
         @for(failure <- failures.details) {
@@ -43,6 +46,15 @@
                 <td><pre class="imageId">@failure.imageId</pre>
                     <a href="@uiBaseUrl/images/@failure.imageId" target="_blank">[Grid]</a>
                     <a href="@apiBaseUrl/images/@failure.imageId" target="_blank">[API]</a>
+                </td>
+                <td>@failure.lastModified</td>
+                <td>@failure.crops</td>
+                <td>
+                    @failure.usages
+                    <br/>
+                    <a href="https://content.guardianapis.com/search?q=@failure.imageId&format=json&api-key=[KEY]">
+                        Full Usage Search in CAPI
+                    </a>
                 </td>
                 <td>@form(action = routes.ThrallController.migrateSingleImage){
                     <label for="id" class="hidden">Image ID:</label>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -5,41 +5,37 @@
     failures: FailedMigrationSummary,
     apiBaseUrl: String,
     uiBaseUrl: String,
+    filter: String,
     page: Int,
 )
 
 @navigation = {
     @if(page > 1) {
-        <a href="?page=@(page - 1)">Previous page</a>
+        <a href="@routes.ThrallController.migrationFailures(filter, Some(page - 1))">Previous page</a>
     }
-    <a href="?page=@(page + 1)">Next page</a>
-}
-
-@totalFailures = @{
-    (failures.totalFailedRelation match {
-        case "lte" | "lt" => "Less than "
-        case "gte" | "gt" => "More than "
-        case _ => ""
-    }) + failures.totalFailed + " images failed in total!"
+    <a href="@routes.ThrallController.migrationFailures(filter, Some(page + 1))">Next page</a>
 }
 
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Migration Failures - Page @(page)</title>
+    <title>Migration Failures - Page @(page) - @filter</title>
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
-    <h1>
-        Migration Failures - Page @(page)
-    </h1>
-    <p>@totalFailures</p>
-    @navigation
+    <div style="position: sticky; background: white; top: 8px;">
+        <a href="@routes.ThrallController.migrationFailuresOverview()">&lt; back to Migration Failures Overview</a>
+        <h1>
+            Migration Failures - Page @(page) - <code>@filter</code>
+        </h1>
+        <p>@failures.totalFailed images failed with the above message!</p>
+        @navigation
+    </div>
+
     <table>
-        <tr>
+        <tr style="position: sticky; background: white; top: 158px;">
             <th>Image ID</th>
-            <th>Failure cause</th>
             <th>Click to reattempt migration</th>
         </tr>
         @for(failure <- failures.details) {
@@ -48,7 +44,6 @@
                     <a href="@uiBaseUrl/images/@failure.imageId" target="_blank">[Grid]</a>
                     <a href="@apiBaseUrl/images/@failure.imageId" target="_blank">[API]</a>
                 </td>
-                <td>@failure.cause</td>
                 <td>@form(action = routes.ThrallController.migrateSingleImage){
                     <label for="id" class="hidden">Image ID:</label>
                     <input type="text" id="id" value="@failure.imageId" name="id" class="hidden">

--- a/thrall/app/views/migrationFailuresOverview.scala.html
+++ b/thrall/app/views/migrationFailuresOverview.scala.html
@@ -1,0 +1,49 @@
+@import lib.FailedMigrationsOverview
+@(
+    failuresOverview: FailedMigrationsOverview,
+    apiBaseUrl: String,
+    uiBaseUrl: String
+)
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Migration Failures Overview</title>
+    <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
+</head>
+<body>
+    <h1>
+        Migration Failures Overview
+    </h1>
+    <p>@failuresOverview.totalFailed images failed in total!</p>
+    <table>
+        <tr>
+            <th>Failure cause</th>
+            <th>Count</th>
+            <th>Examples</th>
+        </tr>
+        @for(failureGrouping <- failuresOverview.grouped) {
+            <tr>
+                <td>
+                    <a href="@routes.ThrallController.migrationFailures(failureGrouping.message, None)">
+                        @failureGrouping.message
+                    </a>
+                </td>
+                <td>@failureGrouping.count</td>
+                <td>
+                    <ul>
+                    @for(failureExampleID <- failureGrouping.exampleIDs) {
+                        <li>
+                            <pre class="imageId">@failureExampleID</pre>
+                            <a href="@uiBaseUrl/images/@failureExampleID" target="_blank">[Grid]</a>
+                            <a href="@apiBaseUrl/images/@failureExampleID" target="_blank">[API]</a>
+                        </li>
+                    }
+                    </ul>
+                </td>
+            </tr>
+        }
+    </table>
+</body>
+</html>

--- a/thrall/app/views/migrationFailuresOverview.scala.html
+++ b/thrall/app/views/migrationFailuresOverview.scala.html
@@ -13,10 +13,12 @@
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
-    <h1>
-        Migration Failures Overview
-    </h1>
-    <p>@failuresOverview.totalFailed images failed in total!</p>
+    <div class="sticky headingSection">
+        <h1>
+            Migration Failures Overview
+        </h1>
+        <p>@failuresOverview.totalFailed images failed in total!</p>
+    </div>
     <table>
         <tr>
             <th>Failure cause</th>

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -3,7 +3,8 @@
 # ~~~~
 
 GET     /                                             controllers.ThrallController.index
-GET     /migrationFailures                            controllers.ThrallController.migrationFailures(page: Option[Int])
+GET     /migrationFailuresOverview                     controllers.ThrallController.migrationFailuresOverview()
+GET     /migrationFailures                            controllers.ThrallController.migrationFailures(filter: String, page: Option[Int])
 
 +nocsrf
 POST    /startMigration                               controllers.ThrallController.startMigration

--- a/thrall/public/stylesheets/main.css
+++ b/thrall/public/stylesheets/main.css
@@ -1,5 +1,6 @@
 table, td, th {
   border: 1px solid black;
+  margin: 8px;
 }
 
 td, th {
@@ -12,4 +13,22 @@ td, th {
 
 .imageId {
   display: inline;
+}
+
+body {
+  margin: 0;
+}
+
+.sticky {
+  position: sticky;
+  background: white;
+}
+
+.headingSection {
+  padding: 8px;
+  top: 0;
+}
+
+.headingRow {
+  top: 166px;
 }


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak 

_Dependant on #3553_

## What does this change?
Introduces a new 'overview' view of migration failures, grouped by the failure cause/message, with counts and examples. One can then click through to see all the errors of that type (which is the previous migrationFailures view, refactored to take a mandatory filter - but also now including lastModified, crops and usages columns). 

## How can success be measured?
Better insight into migration failures, to help us plan how to address them. 

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/143582531-2dd42042-a371-45ab-aa56-6f235458a4f0.png)

![image](https://user-images.githubusercontent.com/19289579/143582556-fee20ea3-0aee-48c1-997a-f39d887f2cec.png)

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
