### PR TITLE
write new images to BOTH 'current' & 'migration' indices, instead of only writing to 'current' index and relying on ongoing migration to write it to 'migration' index

### DIFF
--- a/thrall/app/lib/elasticsearch/ElasticSearchResponse.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearchResponse.scala
@@ -1,5 +1,5 @@
 package lib.elasticsearch
 
+case class ElasticSearchInsertResponse(indexName: String)
 case class ElasticSearchUpdateResponse()
 case class ElasticSearchDeleteResponse()
-case class ElasticSearchBulkUpdateResponse(indexNames: Seq[String])

--- a/thrall/app/lib/elasticsearch/GoodToGoCheck.scala
+++ b/thrall/app/lib/elasticsearch/GoodToGoCheck.scala
@@ -39,7 +39,7 @@ object GoodToGoCheck extends StrictLogging {
         _ <- if (checkAbsent.nonEmpty) deleteTestImage(es, image.id) else Future.successful(())
         // now index and retrieve the test image
         _ <- Future.successful(logger.info(s"Indexing test image ${image.id}"))
-        indexResult <- Future.sequence(es.indexImage(image.id, image, lastModified))
+        indexResult <- Future.sequence(es.migrationAwareIndexImage(image.id, image, lastModified))
         _ <- Future.successful(logger.info(s"Retrieving test image ${image.id}"))
         maybeRetrieveResult <- es.getImage(image.id)
         _ <- Future.successful(logger.info(s"Validating test image"))

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -17,7 +17,6 @@ import scala.concurrent.duration.DurationInt
 
 
 final case class ScrolledSearchResults(hits: List[SearchHit], scrollId: Option[String])
-final case class EsInfoContainer(esInfo: EsInfo)
 
 trait ThrallMigrationClient extends MigrationStatusProvider {
   self: ElasticSearchClient =>

--- a/thrall/test/lib/elasticsearch/ImageModelTest.scala
+++ b/thrall/test/lib/elasticsearch/ImageModelTest.scala
@@ -52,7 +52,7 @@ class ImageModelTest extends ElasticSearchTestBase {
        */
       val image = MappingTest.testImage
 
-      Await.result(Future.sequence(ES.indexImage(image.id, image, image.lastModified.get)), fiveSeconds)
+      Await.result(Future.sequence(ES.migrationAwareIndexImage(image.id, image, image.lastModified.get)), fiveSeconds)
       eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(image.id).map(_.id) shouldBe Some(image.id))
 
       val retrievedImage = reloadedImage(image.id).get


### PR DESCRIPTION
Co-Authored-By: @twrichards 

<https://trello.com/c/Ih7AZyNh/2420-mechanism-for-marking-a-migration-as-complete>

## What does this change?

When a migration is ongoing, write new images into both the current and migration indices.
We write to the migation index first, and then on success write to the current index, but including the `esInfo.migration.migratedTo` field, as we do with migrated images.

## How can success be measured?

Newly uploaded images do not sit in the queue for migration, but are immediately present in both. This means that once all existing images have migrated successfully, we can safely complete the migration at any point (by swapping the `Images_Current` alias to the migration index and dropping the `Images_Migration` alias).



## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
