### PR TITLE
add mechanism to complete a migration (by updating the aliases)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -81,3 +81,4 @@ trait MigrationStatusProvider {
 }
 
 case class MigrationAlreadyRunningError() extends Exception
+case class MigrationNotRunningError() extends Exception

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -80,6 +80,7 @@ object ExternalThrallMessage{
   implicit val updateImageExportsMessage = Json.format[UpdateImageExportsMessage]
 
   implicit val createMigrationIndexMessage = Json.format[CreateMigrationIndexMessage]
+  implicit val completeMigrationMessage = Json.format[CompleteMigrationMessage]
 
   implicit val writes = Json.writes[ExternalThrallMessage]
   implicit val reads = Json.reads[ExternalThrallMessage]
@@ -142,4 +143,8 @@ case class CreateMigrationIndexMessage(
 
   val newIndexName =
     s"images_${migrationStart.toString(DateTimeFormat.forPattern("yyyy-MM-dd_HH-mm-ss").withZoneUTC())}_${gitHash.take(7)}"
+}
+
+case class CompleteMigrationMessage(lastModified: DateTime) extends ExternalThrallMessage {
+  val id: String = "N/A"
 }

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -47,6 +47,7 @@ class MessageProcessor(
       case message: UpdateImagePhotoshootMetadataMessage => updateImagePhotoshoot(message, logMarker)
       case message: CreateMigrationIndexMessage => createMigrationIndex(message, logMarker)
       case message: MigrateImageMessage => migrateImage(message, logMarker)
+      case _: CompleteMigrationMessage => completeMigration(logMarker)
     }
   }
 
@@ -186,5 +187,9 @@ class MessageProcessor(
     Future {
       es.startMigration(message.newIndexName)(logMarker)
     }
+  }
+
+  def completeMigration(logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Unit] = {
+    es.completeMigration(logMarker)
   }
 }

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -80,7 +80,16 @@
     <em>Note that the above represents the value at the point this page was loaded.</em>
 
     @if(migrationStatus.isInstanceOf[Running]) {
-        <p><a href="@routes.ThrallController.migrationFailuresOverview()">View images that have failed to migrate and retry.</a></p>
+        <p><a href="@routes.ThrallController.migrationFailuresOverview">View images that have failed to migrate and retry.</a></p>
+
+        <h3>Complete Migration?</h3>
+        <p>
+            If you're happy that the migration is complete (typically when it hasn't migrated any images in a good while
+            and we're happy that all images in failure can become inaccessible).
+            @form(routes.ThrallController.completeMigration) {
+                <input type="submit" value="ONLY CLICK THIS BUTTON IF YOU'RE SURE">
+            }
+        </p>
     }
 </body>
 </html>

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 GET     /                                             controllers.ThrallController.index
-GET     /migrationFailuresOverview                     controllers.ThrallController.migrationFailuresOverview()
+GET     /migrationFailuresOverview                    controllers.ThrallController.migrationFailuresOverview()
 GET     /migrationFailures                            controllers.ThrallController.migrationFailures(filter: String, page: Option[Int])
 
 +nocsrf
@@ -14,6 +14,8 @@ POST    /pauseMigration                               controllers.ThrallControll
 POST    /resumeMigration                               controllers.ThrallController.resumeMigration
 +nocsrf
 POST    /migrate                                      controllers.ThrallController.migrateSingleImage
++nocsrf
+POST    /completeMigration                            controllers.ThrallController.completeMigration
 
 # Management
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak 

https://trello.com/c/Ih7AZyNh/2420-mechanism-for-marking-a-migration-as-complete

Relate: #3559 

## What does this change?
This provides a new button (and corresponding endpoint) for 'completing a migration'. This was needed so that the migrationStatus (upon which the behaviour of writes to ES depend) could be updated atomically, following the necessary alias changes...

- removing `Images_Migration` alias
- replacing destination of `Images_Current` alias (to point to where `Images_Migration` used to point)

... but before any further writes would be processed.

## How can success be measured?
We can 'safely' complete migrations.

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/144406579-ea5d1051-6129-47b6-899a-90593bdf578f.png)
![image](https://user-images.githubusercontent.com/19289579/144406663-dcbf0451-f86f-49d1-a5f7-2ee1b6e84405.png)

... then after, clicking the `ONLY CLICK THIS BUTTON IF YOU'RE SURE` button...
![image](https://user-images.githubusercontent.com/19289579/144407656-8de62b88-bc81-4151-9fa5-3130477826c3.png)
![image](https://user-images.githubusercontent.com/19289579/144407692-1df29602-8ae7-4596-8dbd-39f37a9cbed4.png)


## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
