### PR TITLE
add facility to still view migration failures from previous migration (using new alias `Images_Historical`)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -27,6 +27,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
 
   def imagesCurrentAlias: String
   def imagesMigrationAlias: String
+  lazy val imagesHistoricalAlias: String = "Images_Historical"
 
   protected val imagesIndexPrefix = "images"
   protected val imageType = "image"

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -93,7 +93,8 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
           _ <- client.execute { aliases (
             removeAlias(imagesMigrationAlias, running.migrationIndexName),
             removeAlias(imagesCurrentAlias, currentIndexName),
-            addAlias(imagesCurrentAlias, running.migrationIndexName)
+            addAlias(imagesCurrentAlias, running.migrationIndexName),
+            addAlias(imagesHistoricalAlias, currentIndexName)
           )}.transform {
             case Success(response) if response.result.success =>
               Success(())

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -10,7 +10,8 @@
   currentIndexCount: String,
   migrationAlias: String,
   migrationIndexCount: String,
-  migrationStatus: MigrationStatus
+  migrationStatus: MigrationStatus,
+  hasHistoricalIndex: Boolean
 )
 
 @migrationIndexCell = {
@@ -79,9 +80,17 @@
     <pre>@migrationStatus</pre>
     <em>Note that the above represents the value at the point this page was loaded.</em>
 
-    @if(migrationStatus.isInstanceOf[Running]) {
-        <p><a href="@routes.ThrallController.migrationFailuresOverview">View images that have failed to migrate and retry.</a></p>
+    @if(migrationStatus.isInstanceOf[Running] || hasHistoricalIndex) {
+        <p><a href="@routes.ThrallController.migrationFailuresOverview">
+            View images that have failed to migrate @if(migrationStatus.isInstanceOf[Running]) {
+            <span>and retry.</span>
+        } else {
+            <span>in the PREVIOUS MIGRATION.</span>
+        }
+        </a></p>
+    }
 
+    @if(migrationStatus.isInstanceOf[Running]) {
         <h3>Complete Migration?</h3>
         <p>
             If you're happy that the migration is complete (typically when it hasn't migrated any images in a good while
@@ -91,5 +100,6 @@
             }
         </p>
     }
+
 </body>
 </html>

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -7,6 +7,7 @@
     uiBaseUrl: String,
     filter: String,
     page: Int,
+    shouldAllowReattempts: Boolean,
 )
 
 @navigation = {
@@ -39,7 +40,7 @@
             <th>Last Modified</th>
             <th>Crop Count</th>
             <th>Usage Count</th>
-            <th>Click to reattempt migration</th>
+            @if(shouldAllowReattempts) { <th>Click to reattempt migration</th> }
         </tr>
         @for(failure <- failures.details) {
             <tr>
@@ -56,11 +57,13 @@
                         Full Usage Search in CAPI
                     </a>
                 </td>
-                <td>@form(action = routes.ThrallController.migrateSingleImage){
-                    <label for="id" class="hidden">Image ID:</label>
-                    <input type="text" id="id" value="@failure.imageId" name="id" class="hidden">
-                    <input type="submit" value="Reattempt migration">
-                }</td>
+                @if(shouldAllowReattempts) {
+                    <td>@form(action = routes.ThrallController.migrateSingleImage){
+                        <label for="id" class="hidden">Image ID:</label>
+                        <input type="text" id="id" value="@failure.imageId" name="id" class="hidden">
+                        <input type="submit" value="Reattempt migration">
+                    }</td>
+                }
             </tr>
         }
     </table>


### PR DESCRIPTION
## What does this change?
Since we've decided to 'complete' the migration (see #3560) whilst there are still some outstanding failures (~1k, of ~35million images - not bad), it would be useful to still be able to see failures until then next migration begins. This adapts the completion process to add a `Images_Historical` to the old index, and then adapts the failures overview and failure detail pages to show failures from this index when there isn't a migration running, but doesn't offer the `Reattempt migration` button (although we may add that ability in the future).

## How can success be measured?
Visibility on old migration failures (useful not least because those ~1k images will become inaccessible, and we might need to quickly check the list).

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/144610397-429560be-f7aa-45f4-ae62-77305eff10e3.png)

Note no Reattempt column
![image](https://user-images.githubusercontent.com/19289579/144610453-e398a14b-4da1-4fa5-872d-f3b97efaa858.png)


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
