### PR TITLE
confirmation for start or complete migration - to prevent accidental pressing

### DIFF
--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -26,6 +26,7 @@
         }
         case NotRunning => {
             @form(routes.ThrallController.startMigration) {
+                <input type="text" id="start-confirmation" name="start-confirmation" placeholder="Type 'start' to confirm" required>
                 <input type="submit" value="Start migration">
             }
         }
@@ -96,6 +97,7 @@
             If you're happy that the migration is complete (typically when it hasn't migrated any images in a good while
             and we're happy that all images in failure can become inaccessible).
             @form(routes.ThrallController.completeMigration) {
+                <input type="text" id="complete-confirmation" name="complete-confirmation" placeholder="Type 'complete' to confirm" required>
                 <input type="submit" value="ONLY CLICK THIS BUTTON IF YOU'RE SURE">
             }
         </p>


### PR DESCRIPTION
## What does this change?
On reflection (after #3560) we thought it was bit risky to have a single click to complete a migration (despite the scary button text ![image](https://user-images.githubusercontent.com/19289579/144826858-0d47758b-78f0-4ae1-8c95-a37d1a6c80ba.png)).

So (taking inspiration from AWS Console) this PR introduces a text box beside the button where the use must enter a relevant string otherwise clicking the button won't work) - and the same for the 'Start migration' button.

## How can success be measured?
No accidental start/completion of migrations.

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/144642124-1cca3600-3f14-4f57-b61a-205da396f746.png)
![image](https://user-images.githubusercontent.com/19289579/144642475-8bc73a23-5346-4435-885c-e2dbbea38fd7.png)

If you enter no text...
![image](https://user-images.githubusercontent.com/19289579/144642198-716861d3-05a0-4c46-97ab-335857b825fe.png)

If you enter the wrong text...
![image](https://user-images.githubusercontent.com/19289579/144642311-232eeb9b-2353-4e67-9611-7515b0de9b1c.png)



## Who should look at this?
@guardian/digital-cms 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
