### PR TITLE
Truncate migration failures over 256 chars so they fit into ES keyword field

### DIFF
--- a/thrall/app/lib/elasticsearch/EsInfo.scala
+++ b/thrall/app/lib/elasticsearch/EsInfo.scala
@@ -1,11 +1,20 @@
 package lib.elasticsearch
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Writes}
 
 case class MigrationInfo(failures: Option[Map[String, String]] = None, migratedTo: Option[String] = None)
 object MigrationInfo {
-  implicit val format = Json.format[MigrationInfo]
+  implicit val reads = Json.reads[MigrationInfo]
+  implicit val writes: Writes[MigrationInfo] = (migrationInfo: MigrationInfo) => Json.obj(
+    "migratedTo" -> migrationInfo.migratedTo,
+    "failures" -> migrationInfo.failures.map(_.mapValues {
+      case message if message.contains("failed to parse field") => message.substring(0, message.indexOf("in document with id"))
+      case message if message.length > 256 => s"${message.take(253)}..."
+      case message => message
+    })
+  )
 }
+
 
 case class EsInfo(migration: Option[MigrationInfo] = None)
 object EsInfo {


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @paperboyo 

## What does this change?

Truncate the stored failure messages to 256 chars, to ensure that it is stored as a keyword (allows aggregation). Additionally truncate any "failed to parse field" messages to better group, by excluding id and contents.


## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
