### PR TITLE
workaround for the fact that sometimes fields like xmp"photoshop:DateCreated" have invalid/partial dates with extra chars e.g `19250200-01-01T00:00:00.000Z`

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -150,7 +150,12 @@ object ImageMetadataConverter extends GridLogging {
       // So we refuse the (apparently successful) EU parse result.
       case (None, formatter) => safeParsing(formatter.parseDateTime(str))
         .filter(d => maxDate.forall(md => d.isBefore(md)))
-    }.map(_.withZone(DateTimeZone.UTC))
+    }.map(_.withZone(DateTimeZone.UTC)).flatMap{
+      case date if date.getYear > 2100 && str.length > 8 && str.substring(4,9) == "0000-" => parseRandomDate(str.substring(0, 4)+"0101", maxDate)
+      case date if date.getYear > 2100 && str.length > 8 && str.substring(6,9) ==  "00-" => parseRandomDate(str.substring(0, 6)+"01", maxDate)
+      case date if date.getYear > 2100 && str.length > 8 && str.charAt(8) == '-' => parseRandomDate(str.substring(0, 8), maxDate)
+      case date => Some(date)
+    }
   }
 
   private def safeParsing[A](parse: => A): Option[A] = Try(parse).toOption

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -269,6 +269,23 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     imageMetadata.dateTaken should be(Some(DateTime.parse("2014-12-16T00:00:00Z")))
   }
 
+  it("should populate the dateTaken field of ImageMetadata from partial date but with extra placeholder chars (19250000-01-01T00:00:00.000Z)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("19250000-01-01T00:00:00.000Z")))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be(Some(DateTime.parse("1925-01-01T00:00:00Z")))
+  }
+
+  it("should populate the dateTaken field of ImageMetadata from partial date but with extra placeholder chars (19250200-01-01T00:00:00.000Z)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("19250200-01-01T00:00:00.000Z")))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be(Some(DateTime.parse("1925-02-01T00:00:00Z")))
+  }
+  it("should populate the dateTaken field of ImageMetadata from partial date but with extra placeholder chars (19250201-01-01T00:00:00.000Z)") {
+    val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map("photoshop:DateCreated" -> JsString("19250201-01-01T00:00:00.000Z")))
+    val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
+    imageMetadata.dateTaken should be(Some(DateTime.parse("1925-02-01T00:00:00Z")))
+  }
+
   it("should leave the dateTaken field of ImageMetadata empty if no date present") {
     val fileMetadata = FileMetadata(iptc = Map(), exif = Map(), exifSub = Map(), xmp = Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)


### PR DESCRIPTION
THIS IS GROSS

## What does this change?


## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
