### PR TITLE
Revert multiple "Bump metadata-extractor" PRs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.15.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.13.0"
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.13.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.11.0"
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.11.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.12.0"
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.16.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.15.0"
   )
 }
 


### PR DESCRIPTION
Reverts guardian/grid#3500 AND https://github.com/guardian/grid/pull/3034 and then goes to 2.12.0 manually.

Experimenting to see if its this version bump that means we get some problematic extra chars on partial dates in xmp fields such as `photoshop:DateCreated`

## Description of the issue
XMP `photoshop:DateCreated` field [according to spec](https://www.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMPSDKReleasecc-2020/XMPSpecificationPart2.pdf#page=6&zoom=auto,-295,768) uses [those date formats](https://www.w3.org/TR/NOTE-datetime) (allowing for partial data):

![image](https://user-images.githubusercontent.com/6032869/145310010-48a1ffe8-a856-4315-8dff-4cf851072cac.png)

When entering just `1978` in Photoshop, exiftool correctly prints out `photoshop:DateCreated=1978`, but we read `"photoshop:DateCreated": "1978-01-01T00:00:00.000Z"` which is not correct. We are trying to establish if metadata-extractor is at fault here… Older reverted in this PR, 2.12.0, is still wrong.