### PR TITLE
workaround for the fact that sometimes fields like xmp"photoshop:DateCreated" have invalid/partial dates

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -156,11 +156,19 @@ object ImageMetadataConverter extends GridLogging {
   private def safeParsing[A](parse: => A): Option[A] = Try(parse).toOption
 
   private def cleanDateFormat = ISODateTimeFormat.dateTime
-  def cleanDate(dirtyDate: String, fieldName: String = "none", imageId:String = "none"): String = parseRandomDate(dirtyDate) match {
-    case Some(cleanDate) => cleanDateFormat.print(cleanDate)
-    case None => {
-      logger.info(s"Unable to parse date $dirtyDate from field $fieldName for image $imageId")
-      dirtyDate
+  def cleanDate(dirtyDate: String, fieldName: String = "none", imageId:String = "none"): String = {
+    val slightlyCleanedDate = dirtyDate match {
+      case d if d.length == 8 && d.endsWith("0000") => d.take(4) + "0101"
+      case d if d.length == 8 && d.endsWith("00") => d.take(6) + "01"
+      case d => d
+    }
+    parseRandomDate(slightlyCleanedDate) match {
+      case Some(cleanDate) =>
+        cleanDateFormat.print(cleanDate)
+      case None => {
+        logger.info(s"Unable to parse date $dirtyDate from field $fieldName for image $imageId")
+        dirtyDate
+      }
     }
   }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -374,6 +374,12 @@ class ImageMetadataConverterTest extends FunSpec with Matchers {
     ImageMetadataConverter.cleanDate("Tue Dec 16 01:02:03 BST 2014") shouldBe "2014-12-16T00:02:03.000Z"
   }
 
+  it("should clean up partial dates") {
+    ImageMetadataConverter.cleanDate("19250000") shouldBe "1925-01-01T00:00:00.000Z"
+    ImageMetadataConverter.cleanDate("19250200") shouldBe "1925-02-01T00:00:00.000Z"
+    ImageMetadataConverter.cleanDate("19250202") shouldBe "1925-02-02T00:00:00.000Z"
+  }
+
 
   // People in Image
 


### PR DESCRIPTION
Sometimes fields (such as xmp"photoshop:DateCreated") have 'partial' dates, which are padded with zeros, such as `19250200` or `19250000`, these don't parse properly as the date time formatters interpret them as a **really big** year. 

We noticed this during migration, because the existing logic would try to build an ISO date from the really big year, which when projected produced dates like `19250200-01-01T00:00:00.000Z` (which is technically valid, but way way in the future), which would then fail to write to ES (because it rejected this ludicrous date). We don't see this at ingestion, because ingestion filters out dates in the future because they indicate a mistake, for whatever reason, during projection (which executes the same code as ingestion) the value of `s3Source.metadata.objectMetadata.lastModified` is `None` and so no filtering takes place and the mega date isn't dropped like it is with ingestion.

## What does this change?
This PR contains a fairly explicit detection of this scenario where it's already attempting to cleanup metadata dates, with a test of course!

## How can success be measured?
We should be able to successfully retry the 97 images which are failing to migrate because of the above.

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
