### PR TITLE
improve migration failures view

### DIFF
--- a/thrall/app/lib/FailedMigrationDetails.scala
+++ b/thrall/app/lib/FailedMigrationDetails.scala
@@ -1,6 +1,15 @@
 package lib
 
-final case class FailedMigrationDetails(imageId: String, lastModified: String, crops: String, usages: String)
+final case class FailedMigrationDetails(
+  imageId: String,
+  lastModified: String,
+  crops: String,
+  usages: String,
+  uploadedBy: String,
+  uploadTime:String,
+  sourceJson: String,
+  esDocAsImageValidationFailures: Option[String]
+)
 
 final case class FailedMigrationSummary(totalFailed: Long, details: Seq[FailedMigrationDetails])
 

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -40,7 +40,10 @@
             <th>Last Modified</th>
             <th>Crop Count</th>
             <th>Usage Count</th>
+            <th>Uploaded By</th>
+            <th>Uploaded Time</th>
             @if(shouldAllowReattempts) { <th>Click to reattempt migration</th> }
+            <th>ES Doc</th>
         </tr>
         @for(failure <- failures.details) {
             <tr>
@@ -50,13 +53,9 @@
                 </td>
                 <td>@failure.lastModified</td>
                 <td>@failure.crops</td>
-                <td>
-                    @failure.usages
-                    <br/>
-                    <a href="https://content.guardianapis.com/search?q=@failure.imageId&format=json&api-key=[KEY]">
-                        Full Usage Search in CAPI
-                    </a>
-                </td>
+                <td>@failure.usages</td>
+                <td>@failure.uploadedBy</td>
+                <td>@failure.uploadTime</td>
                 @if(shouldAllowReattempts) {
                     <td>@form(action = routes.ThrallController.migrateSingleImage){
                         <label for="id" class="hidden">Image ID:</label>
@@ -64,6 +63,18 @@
                         <input type="submit" value="Reattempt migration">
                     }</td>
                 }
+                <td>
+                    @failure.esDocAsImageValidationFailures.fold(<span/>)(validationFailures =>
+                        <div>
+                            <strong>Conversion to <code>Image</code> problems</strong>
+                            <p>@validationFailures</p>
+                        </div>
+                    )
+                    <details>
+                        <summary>View JSON</summary>
+                        <pre>@failure.sourceJson</pre>
+                    </details>
+                </td>
             </tr>
         }
     </table>


### PR DESCRIPTION
## What does this change?
add `uploadTime`, `uploadedBy`, `sourceJson` and `esDocAsImageValidationFaiures` to the migration failures view

also remove CAPI usage search link

## How can success be measured?
we have better visibility on failures and so it's easier to triage

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/145794096-7f967f75-f774-43b2-b912-9aa7a5e80028.png)
With the JSON (of the ES Document) expanded)...
![image](https://user-images.githubusercontent.com/19289579/145794245-862a8b51-1663-428f-8dcd-b161b17b6faa.png)

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
