### PR TITLE
Pass last modified date when creating projected s3 objects

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -148,7 +148,7 @@ class ImageDataMerger(gridClient: GridClient, services: Services, authFunction: 
   private def getFullMergedImageData(maybeImage: Option[Image])(implicit ec: ExecutionContext): Future[Option[Image]] = maybeImage match {
     case Some(image) =>
       // TODO I'm suspicious that we don't invoke the cleaners on this pass...
-      val imageWithMetadata = image.copy(originalMetadata = ImageMetadataConverter.fromFileMetadata(image.fileMetadata))
+      val imageWithMetadata = image.copy(originalMetadata = ImageMetadataConverter.fromFileMetadata(image.fileMetadata, latestAllowedDateTime = None))
       ImageDataMerger.aggregate(imageWithMetadata, gridClient, authFunction) map (i => Some(i))
     case None => Future.successful(None)
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageIngestOperations.scala
@@ -1,11 +1,11 @@
 package com.gu.mediaservice.lib
 
 import java.io.File
-
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.aws.S3Object
 import com.gu.mediaservice.lib.logging.LogMarker
 import com.gu.mediaservice.model.{MimeType, Png}
+import org.joda.time.DateTime
 
 import scala.concurrent.Future
 
@@ -59,19 +59,30 @@ sealed trait StorableImage extends ImageWrapper {
     ImageIngestOperations.fileKeyFromId(id),
     file,
     Some(mimeType),
+    lastModified = None,
     meta
   )
 }
 
 case class StorableThumbImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage
-case class StorableOriginalImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage
+case class StorableOriginalImage(id: String, file: File, mimeType: MimeType, lastModified: DateTime, meta: Map[String, String] = Map.empty) extends StorableImage {
+  override def toProjectedS3Object(thumbBucket: String): S3Object = S3Object(
+    thumbBucket,
+    ImageIngestOperations.fileKeyFromId(id),
+    file,
+    Some(mimeType),
+    lastModified = Some(lastModified),
+    meta
+  )
+}
 case class StorableOptimisedImage(id: String, file: File, mimeType: MimeType, meta: Map[String, String] = Map.empty) extends StorableImage {
   override def toProjectedS3Object(thumbBucket: String): S3Object = S3Object(
     thumbBucket,
     ImageIngestOperations.optimisedPngKeyFromId(id),
     file,
     Some(mimeType),
-    meta
+    lastModified = None,
+    meta = meta
   )
 }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -27,7 +27,7 @@ object S3Object {
   def apply(bucket: String, key: String, size: Long, metadata: S3Metadata): S3Object =
     apply(objectUrl(bucket, key), size, metadata)
 
-  def apply(bucket: String, key: String, file: File, mimeType: Option[MimeType],
+  def apply(bucket: String, key: String, file: File, mimeType: Option[MimeType], lastModified: Option[DateTime],
             meta: Map[String, String] = Map.empty, cacheControl: Option[String] = None): S3Object = {
     S3Object(
       bucket,
@@ -37,7 +37,8 @@ object S3Object {
         meta,
         S3ObjectMetadata(
           mimeType,
-          cacheControl
+          cacheControl,
+          lastModified
         )
       )
     )
@@ -59,7 +60,7 @@ object S3Metadata {
   }
 }
 
-case class S3ObjectMetadata(contentType: Option[MimeType], cacheControl: Option[String], lastModified: Option[DateTime] = None)
+case class S3ObjectMetadata(contentType: Option[MimeType], cacheControl: Option[String], lastModified: Option[DateTime])
 
 class S3(config: CommonConfig) extends GridLogging {
   type Bucket = String

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -50,8 +50,6 @@ object ImageMetadataConverter extends GridLogging {
   }
 
   def fromFileMetadata(fileMetadata: FileMetadata, latestAllowedDateTime: Option[DateTime] = None): ImageMetadata = {
-    val xmp = fileMetadata.xmp
-
     ImageMetadata(
       dateTaken           = (fileMetadata.exifSub.get("Date/Time Original Composite") flatMap (parseRandomDate(_, latestAllowedDateTime))) orElse
                             (fileMetadata.iptc.get("Date Time Created Composite") flatMap (parseRandomDate(_, latestAllowedDateTime))) orElse

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -142,11 +142,12 @@ object Uploader extends GridLogging {
       uploadRequest.imageId,
       uploadRequest.tempFile,
       originalMimeType,
+      uploadRequest.uploadTime,
       toMetaMap(uploadRequest)
     )
     val sourceStoreFuture = storeOrProjectOriginalFile(storableOriginalImage)
     val eventualBrowserViewableImage = createBrowserViewableFileFuture(uploadRequest, tempDirForRequest, deps)
-    
+
     val eventualImage = for {
       browserViewableImage <- eventualBrowserViewableImage
       s3Source <- sourceStoreFuture

--- a/image-loader/test/scala/model/ImageUploadTest.scala
+++ b/image-loader/test/scala/model/ImageUploadTest.scala
@@ -53,7 +53,7 @@ class ImageUploadTest extends AsyncFunSuite with Matchers with MockitoSugar {
 
     def mockStore = (a: StorableImage) =>
       Future.successful(
-        S3Object("madeupname", "madeupkey", a.file, Some(a.mimeType), a.meta, None)
+        S3Object("madeupname", "madeupkey", a.file, Some(a.mimeType), None, a.meta, None)
       )
 
     def storeOrProjectOriginalFile: StorableOriginalImage => Future[S3Object] = mockStore


### PR DESCRIPTION
## What does this change?

Include the last modified date in the projected representation of s3 objects for the source image. This should allow the sensible date filter in `ImageDataConverter.fromFileMetadata` to filter out the non-sensible dates generated by odd formats. This method should then fall back to a different field, which can be parsed into a sensible date (ie. before the upload date)

## How can success be measured?

The remaining images which failed to migrate due to odd dates migrate.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
