### PR TITLE
FIX bad templating of `esDocAsImageValidationFailures`

### DIFF
--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -64,12 +64,15 @@
                     }</td>
                 }
                 <td>
-                    @failure.esDocAsImageValidationFailures.fold(<span/>)(validationFailures =>
-                        <div>
-                            <strong>Conversion to <code>Image</code> problems</strong>
-                            <p>@validationFailures</p>
-                        </div>
-                    )
+                    @failure.esDocAsImageValidationFailures match {
+                        case Some(validationFailures) => {
+                            <div>
+                                <strong>Conversion to <code>Image</code> problems:</strong>
+                                <p>@validationFailures</p>
+                            </div>
+                        }
+                        case None => {}
+                    }
                     <details>
                         <summary>View JSON</summary>
                         <pre>@failure.sourceJson</pre>


### PR DESCRIPTION
## What does this change?
Patch to #3577 to fix a bad bit of templating

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
