### PR TITLE
add original-source usage-rights

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -84,6 +84,7 @@ object UsageRights {
     case o: Handout => Handout.formats.writes(o)
     case o: Screengrab => Screengrab.formats.writes(o)
     case o: GuardianWitness => GuardianWitness.formats.writes(o)
+    case o: OriginalSource => OriginalSource.formats.writes(o)
     case o: SocialMedia => SocialMedia.formats.writes(o)
     case o: Bylines => Bylines.formats.writes(o)
     case o: Obituary => Obituary.formats.writes(o)
@@ -117,6 +118,7 @@ object UsageRights {
         case Handout.category => json.asOpt[Handout]
         case Screengrab.category => json.asOpt[Screengrab]
         case GuardianWitness.category => json.asOpt[GuardianWitness]
+        case OriginalSource.category => json.asOpt[OriginalSource]
         case SocialMedia.category => json.asOpt[SocialMedia]
         case Bylines.category => json.asOpt[Bylines]
         case Obituary.category => json.asOpt[Obituary]
@@ -298,6 +300,20 @@ object GuardianWitness extends UsageRightsSpec {
 
   implicit val formats: Format[GuardianWitness] =
     UsageRights.subtypeFormat(GuardianWitness.category)(Json.format[GuardianWitness])
+}
+
+final case class OriginalSource(restrictions: Option[String] = None) extends UsageRights {
+  val defaultCost = OriginalSource.defaultCost
+}
+object OriginalSource extends UsageRightsSpec {
+  val category = "original-source"
+  val defaultCost = Some(Free)
+  val name = "OriginalSource"
+  def description(commonConfig: CommonConfig) =
+    "Images provided by members of the public to be shared with Journalist who is out collecting material for stories"
+
+  implicit val formats: Format[OriginalSource] =
+    UsageRights.subtypeFormat(OriginalSource.category)(Json.format[OriginalSource])
 }
 
 


### PR DESCRIPTION
## What does this change?
Add a new usage Rights called "Original Source" 

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
