### PR TITLE
TEMPORARILY drop any XMP fields (in `fileMetadata`) which begin with `avm:Distance`  

### DIFF
--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -138,7 +138,7 @@ object FileMetadataReader extends GridLogging {
       // if there is no space in the previous one as directories have a maximum size.
       acc ++ xmpDirectoryToMap(dir, imageId).filterKeys(k => !acc.contains(k))
     })
-    redactLongFieldValues(imageId, "XMP")(props)
+    redactLongFieldValues(imageId, "XMP")(props).filterKeys(fieldName => !fieldName.startsWith("avm:Distance"))
   }
   private def exportXmpPropertiesInTransformedSchema(metadata: Metadata, imageId:String): Map[String, JsValue] = {
     val props = exportRawXmpProperties(metadata, imageId)


### PR DESCRIPTION
Tactical so we can 'complete' the current migration (as per https://github.com/guardian/grid/pull/3580#issuecomment-995741062), will revert after!
