### PR TITLE
Ensure `images` index is not aliased with `Images_Current` at start-up

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -44,11 +44,11 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
   }
 
   //TODO: this function should fail and cause healthcheck fails
-  def ensureAliasAssigned() {
+  def ensureIndexExistsAndAliasAssigned() {
     logger.info(s"Checking alias $imagesCurrentAlias is assigned to index…")
     val indexForCurrentAlias = Await.result(getIndexForAlias(imagesCurrentAlias), tenSeconds)
     if (indexForCurrentAlias.isEmpty) {
-      ensureIndexExists(initialImagesIndex)
+      createIndexIfMissing(initialImagesIndex)
       assignAliasTo(initialImagesIndex, imagesCurrentAlias)
       waitUntilHealthy()
     }
@@ -95,7 +95,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
                                stats.result.indices(indexName).total.docs.count)
   }
 
-  def ensureIndexExists(index: String): Unit = {
+  def createIndexIfMissing(index: String): Unit = {
     logger.info("Checking index exists…")
 
     val eventualIndexExistsResponse: Future[Response[IndexExistsResponse]] = client.execute {

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -26,7 +26,7 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
   applicationLifecycle.addStopHook(() => Future{usageQuota.stopUpdates()})
 
   val elasticSearch = new ElasticSearch(config, mediaApiMetrics, config.esConfig, () => usageQuota.usageStore.overQuotaAgencies, actorSystem.scheduler)
-  elasticSearch.ensureAliasAssigned()
+  elasticSearch.ensureIndexExistsAndAliasAssigned()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -73,7 +73,7 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
   override def beforeAll {
     super.beforeAll()
 
-    ES.ensureAliasAssigned()
+    ES.ensureIndexExistsAndAliasAssigned()
     purgeTestImages
 
     Await.ready(saveImages(images), 1.minute)

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -28,7 +28,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val thrallMetrics = new ThrallMetrics(config)
 
   val es = new ElasticSearch(config.esConfig, Some(thrallMetrics), actorSystem.scheduler)
-  es.ensureAliasAssigned()
+  es.ensureIndexExistsAndAliasAssigned()
 
   val services: Services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   val gridClient: GridClient = GridClient(services)(wsClient)

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -58,8 +58,8 @@ trait ElasticSearchTestBase extends AnyFreeSpec with Matchers with Fixtures with
 
   override def beforeAll {
     super.beforeAll()
-    ES.ensureAliasAssigned()
-    ES.ensureIndexExists(migrationIndexName)
+    ES.ensureIndexExistsAndAliasAssigned()
+    ES.createIndexIfMissing(migrationIndexName)
   }
 
   override protected def beforeEach(): Unit = {


### PR DESCRIPTION
Although we did test https://github.com/guardian/grid/pull/3560 and https://github.com/guardian/grid/pull/3563 we did not attempt a redeploy once the `images` index was no longer aliased by `Images_Current` and therefore missed the fact that this happens during startup, due to some outdated code. This meant `Images_Current` pointed to two places and so writes to ES would fail and API would return double IDs (i.e. breaking the grid quite significantly).

## What does this change?
Fix the check which happened in the `ensureAliasAssigned` function so instead now it checks to ensure the `Images_Current` alias points somewhere - previously it checked explicitly for the presence of the `images` index, which is no longer correct since we've completed our first migration (and the `Images_Current` alias points to a different index now).

Also renamed poorly named functions `ensureIndexExists` to `createIndexIfMissing` and `ensureAliasAssigned` to `ensureIndexExistsAndAliasAssigned`

## How can success be measured?
Thrall should start-up properly and no add an additional `Images_Current` alias and the grid should run smoothly throughout/after deployments.

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
