### PR TITLE
Add filter suggestions to field aliases

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
@@ -7,10 +7,10 @@ import scala.collection.JavaConverters._
 
 case class FieldAlias(elasticsearchPath: String,
                       label: String,
-                      displayInAdditionalMetadata: Boolean = true,
-                      displaySearchHint: Boolean = false,
+                      displayInAdditionalMetadata: Boolean,
+                      displaySearchHint: Boolean,
                       alias: String,
-                      searchHintOptions: List[String] = List.empty)
+                      searchHintOptions: List[String])
 
 object FieldAlias {
   implicit val FieldAliasWrites: Writes[FieldAlias] =
@@ -21,7 +21,7 @@ object FieldAlias {
       _.asScala.map(
         config => {
           val displayInAdditionalMetadata = if (config.hasPath("displayInAdditionalMetadata"))
-            config.getBoolean("displayInAdditionalMetadata") else false
+            config.getBoolean("displayInAdditionalMetadata") else true
           val displaySearchHint = if (config.hasPath("displaySearchHint"))
             config.getBoolean("displaySearchHint") else false
           val searchHintOptions = if (config.hasPath("searchHintOptions"))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
@@ -8,7 +8,8 @@ import scala.collection.JavaConverters._
 case class FieldAlias(elasticsearchPath: String,
                       label: String,
                       displaySearchHint: Boolean = false,
-                      alias: String)
+                      alias: String,
+                      searchHintOptions: List[String] = List.empty)
 
 object FieldAlias {
   implicit val FieldAliasWrites: Writes[FieldAlias] =
@@ -17,10 +18,20 @@ object FieldAlias {
   implicit val configLoader: ConfigLoader[Seq[FieldAlias]] =
     ConfigLoader(_.getConfigList).map(
       _.asScala.map(
-        config =>
-          FieldAlias(config.getString("elasticsearchPath"),
+        config => {
+          val displaySearchHint = if (config.hasPath("displaySearchHint"))
+            config.getBoolean("displaySearchHint") else false
+          val searchHintOptions = if (config.hasPath("searchHintOptions"))
+            config.getStringList("searchHintOptions").asScala.toList.filter(_.nonEmpty) else List.empty
+
+          FieldAlias(
+            config.getString("elasticsearchPath"),
             config.getString("label"),
-            config.getBoolean("displaySearchHint"),
-            config.getString("alias")))
+            displaySearchHint,
+            config.getString("alias"),
+            searchHintOptions
+          )
+        }
+      )
     )
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
@@ -7,6 +7,7 @@ import scala.collection.JavaConverters._
 
 case class FieldAlias(elasticsearchPath: String,
                       label: String,
+                      displayInAdditionalMetadata: Boolean = true,
                       displaySearchHint: Boolean = false,
                       alias: String,
                       searchHintOptions: List[String] = List.empty)
@@ -19,6 +20,8 @@ object FieldAlias {
     ConfigLoader(_.getConfigList).map(
       _.asScala.map(
         config => {
+          val displayInAdditionalMetadata = if (config.hasPath("displayInAdditionalMetadata"))
+            config.getBoolean("displayInAdditionalMetadata") else false
           val displaySearchHint = if (config.hasPath("displaySearchHint"))
             config.getBoolean("displaySearchHint") else false
           val searchHintOptions = if (config.hasPath("searchHintOptions"))
@@ -27,6 +30,7 @@ object FieldAlias {
           FieldAlias(
             config.getString("elasticsearchPath"),
             config.getString("label"),
+            displayInAdditionalMetadata,
             displaySearchHint,
             config.getString("alias"),
             searchHintOptions

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -170,14 +170,12 @@ module.controller('grImageMetadataCtrl', [
       ctrl.additionalMetadata = Object.fromEntries(
         Object.entries(ctrl.singleImage.data.aliases)
           .map(([key, val]) => {
-            let match = ctrl.fieldAliases.find(_ => _.alias === key);
-            if (match) {
-              return [match.label, val];
-            } else {
-              return [key, val];
+            let fieldAlias = ctrl.fieldAliases.find(_ => _.alias === key);
+            if (fieldAlias && fieldAlias.displayInAdditionalMetadata === true) {
+              return [fieldAlias.label, val];
             }
-        })
-      );
+          })
+          .filter(_ => _ !== undefined));
 
       registerSectionStore('additionalMetadata');
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -198,7 +198,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'photoshoot': return suggestPhotoshoot(value);
         case 'is': return isSearch;
         // No suggestions
-        default: return fieldAliases.hasOwnProperty(field) ? suggestFieldAliasOptions(field) : [];
+        default: return fieldAliases.hasOwnProperty(field) ? prefixFilter(value)(suggestFieldAliasOptions(field)) : [];
         }
     }
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -7,9 +7,12 @@ export const querySuggestions = angular.module('querySuggestions', [
     mediaApi.name
 ]);
 
-const fieldAliases = window._clientConfig.fieldAliases.
-                                  filter(entry => entry.displaySearchHint === true).
-                                  map(entry => entry.alias);
+const fieldAliases = window._clientConfig.fieldAliases
+  .filter(entry => entry.displaySearchHint === true)
+  .reduce(function(map, obj) {
+    map[obj.alias] = obj;
+    return map;
+  }, {});
 
 // FIXME: get fields and subjects from API
 export const filterFields = [
@@ -43,7 +46,7 @@ export const filterFields = [
     'photoshoot',
     'leasedBy',
     'is',
-    ... fieldAliases
+    ... Object.keys(fieldAliases)
 ].sort();
 // TODO: add date fields
 
@@ -174,6 +177,10 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
       return suggestions;
     }
 
+    function suggestFieldAliasOptions(fieldAlias) {
+      return fieldAliases[fieldAlias].searchHintOptions;
+    }
+
     function getFilterSuggestions(field, value) {
         switch (field) {
         case 'usages@status': return ['published', 'pending', 'removed'];
@@ -191,7 +198,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'photoshoot': return suggestPhotoshoot(value);
         case 'is': return isSearch;
         // No suggestions
-        default:         return [];
+        default: return fieldAliases.hasOwnProperty(field) ? suggestFieldAliasOptions(field) : [];
         }
     }
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -8,9 +8,9 @@ export const querySuggestions = angular.module('querySuggestions', [
 ]);
 
 const fieldAliases = window._clientConfig.fieldAliases
-  .filter(entry => entry.displaySearchHint === true)
-  .reduce(function(map, obj) {
-    map[obj.alias] = obj;
+  .filter(fieldAlias => fieldAlias.displaySearchHint === true)
+  .reduce(function(map, fieldAlias) {
+    map[fieldAlias.alias] = fieldAlias;
     return map;
   }, {});
 

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -198,7 +198,7 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
         case 'photoshoot': return suggestPhotoshoot(value);
         case 'is': return isSearch;
         // No suggestions
-        default: return fieldAliases.hasOwnProperty(field) ? prefixFilter(value)(suggestFieldAliasOptions(field)) : [];
+          default: return fieldAliases.hasOwnProperty(field) ? prefixFilter(value)(suggestFieldAliasOptions(field)) : [];
         }
     }
 


### PR DESCRIPTION
## What does this change?

Introduces search hint options to `fieldAliases` that can be defined via configuration. An improvement on [Ability to search for extra metadata fields on the UI feature.](https://github.com/guardian/grid/pull/3205)

As a fix to avoid repetition of metadata fields in the "Additional metadata" and "Domain metadata" sections, a new fieldAlias configuration `displayInAdditionalMetadata` of type `Boolean` can be used to explicitly display or not display a fieldAlias in the "Additional metadata" section. The default value of this config if not specified is `true`.

## How can success be measured?

Configuring a list of strings as a `searchHintOptions` to the  `programmeGenre` fieldAlias should allow a user to select an "aliased" search hint and select an option from the configured list on the UI.

```hocon
field.aliases = [
  {
    elasticsearchPath = "fileMetadata.xmp.additional:programme_genre"
    alias = "programmeGenre"
    label = "Programme Genre"
    displayInAdditionalMetadata = true
    displaySearchHint = true
    searchHintOptions = [
      "Genre A"
      "Genre B"
      "Genre C"
      "Other Genre"
    ]
  }
]
```


## Screenshots

![Peek 2021-12-28 12-31](https://user-images.githubusercontent.com/12212239/147551854-d430cea1-330f-4953-969a-bf8ade70a775.gif)

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
