### PR TITLE
Set publicReadAcl: false

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -129,3 +129,4 @@ deployments:
     parameters:
       bucket: media-service-dist
       cacheControl: private
+      publicReadAcl: false


### PR DESCRIPTION
## What does this change?

Sets publicReadAcl to false for our fluentbit s3 deployment, per [this change in riffraff](https://github.com/guardian/riff-raff/pull/665).

## How can success be measured?

The application should deploy as before.

The application should continue to log normally.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
