### PR TITLE
Restore lost data-cy attribute

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -609,6 +609,7 @@
                 <span class="label__value">{{label.data}}</span>
                 <button class="label__remove"
                         title="Remove label from all"
+                        data-cy="it-remove-label-button"
                         ng-click="ctrl.removeLabel(label.data)">
                     <gr-icon>close</gr-icon>
                 </button>


### PR DESCRIPTION
## What does this change?

We lost this data-cy attribute at some point in the past, which has been breaking our integration tests for some time. Add it back.

## How can success be measured?

Integration tests start passing again (after guardian/editorial-tools-integration-tests#127).

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
