### PR TITLE
Do not log to stdout when running locally

### DIFF
--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -37,18 +37,13 @@
     <logger name="application" level="INFO" />
     <logger name="request" level="INFO" />
 
-    <if condition='property("STAGE").contains("DEV")'>
-      <then>
-        <root level="INFO">
-          <appender-ref ref="LOGFILE"/>
-        </root>
-      </then>
-      <else>
-        <root level="INFO">
-          <appender-ref ref="LOGFILE"/>
+    <root level="INFO">
+      <appender-ref ref="LOGFILE"/>
+      <if condition='!property("STAGE").contains("DEV")'>
+        <then>
           <appender-ref ref="ASYNCSTDOUT"/>
-        </root>
-      </else>
-    </if>
+        </then>
+      </if>
+    </root>
 
 </configuration>

--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -37,9 +37,18 @@
     <logger name="application" level="INFO" />
     <logger name="request" level="INFO" />
 
-    <root level="INFO">
-        <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="ASYNCSTDOUT"/>
-    </root>
+    <if condition='property("STAGE").contains("DEV")'>
+      <then>
+        <root level="INFO">
+          <appender-ref ref="LOGFILE"/>
+        </root>
+      </then>
+      <else>
+        <root level="INFO">
+          <appender-ref ref="LOGFILE"/>
+          <appender-ref ref="ASYNCSTDOUT"/>
+        </root>
+      </else>
+    </if>
 
 </configuration>


### PR DESCRIPTION
## What does this change?

There is a high volume of output when running the grid locally (due to
running multiple microservices in the same session), which are difficult
to grok. In addition (anecdotally) running with stdout logging on
reduces the ability to interact with the sbt shell. I found it very
difficult to get sbt to respond to my ctrl-C inputs, which can be a
symptom of the terminal emulator struggling to keep up with the volume
of output.

This PR disables stdout logging when running locally (ie. when stage ==
DEV), which I have found (anecdotally) to significantly improve
responsiveness from sbt.


## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
