### PR TITLE
Set timestamp in output jars from SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,16 @@
 import play.sbt.PlayImport.PlayKeys._
+import sbt.Package.FixedTimestamp
 
 import scala.sys.process._
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
+
+// We need to keep the timestamps to allow caching headers to work as expected on assets.
+// The below should work, but some problem in one of the plugins (possible the play plugin? or sbt-web?) causes
+// the option not to be passed correctly
+//   ThisBuild / packageTimestamp := Package.keepTimestamps
+// Setting as a packageOption seems to bypass that problem, wherever it lies
+ThisBuild / packageOptions += FixedTimestamp(Package.keepTimestamps)
 
 val commonSettings = Seq(
   scalaVersion := "2.12.15",
@@ -291,7 +299,6 @@ def playProject(projectName: String, port: Int, path: Option[String] = None): Pr
     .dependsOn(restLib)
     .settings(commonSettings ++ buildInfo ++ Seq(
       playDefaultPort := port,
-
       debianPackageDependencies := Seq("openjdk-8-jre-headless"),
       Linux / maintainer := "Guardian Developers <dig.dev.software@theguardian.com>",
       Linux / packageSummary := description.value,


### PR DESCRIPTION
## What does this change?

Since SBT 1.4.0, SBT has edited the last modified dates in packaged JARs, which include web assets (css, js, etc.); Grid's current version sets the date to 1 Jan 2010. Play framework uses these dates to calculate the ETag and Last-Modified headers for serving assets. Since the headers are now based upon a static date, caching (especially via Cloudfront) is broken, returning outdated assets.

This commit restores the previous behaviour, so cloudfront should now notice and pick up new assets upon deployment.

See also <https://github.com/playframework/playframework/issues/10572>, <https://github.com/sbt/sbt/pull/6237>

## How can success be measured?

Headers on asset requests to kahuna now return sensible last-modified dates and ETags update on new releases.

## Screenshots

Before:
```sh
$ ls -Gg public/dist
total 8768
-rw-r--r-- 1    1299 Jan  1  2010 a4a15defc84c7e1eef11.png
-rw-r--r-- 1 1738280 Jan  1  2010 build.js
-rw-r--r-- 1    2027 Jan  1  2010 build.js.LICENSE.txt
-rw-r--r-- 1 7213879 Jan  1  2010 build.js.map
-rw-r--r-- 1    1737 Jan  1  2010 quotas.js
-rw-r--r-- 1    6559 Jan  1  2010 quotas.js.map
```
![image](https://user-images.githubusercontent.com/10963046/149552823-9264e587-81c6-4944-82a9-b950f941e07f.png)

after:
```
$ ls -Gg public/dist
total 8768
-rw-r--r-- 1    1299 Jan 13 18:50 a4a15defc84c7e1eef11.png
-rw-r--r-- 1 1738280 Jan 14 13:00 build.js
-rw-r--r-- 1    2027 Jan 14 13:00 build.js.LICENSE.txt
-rw-r--r-- 1 7213879 Jan 14 13:00 build.js.map
-rw-r--r-- 1    1737 Jan 14 13:00 quotas.js
-rw-r--r-- 1    6559 Jan 14 13:00 quotas.js.map
```
![image](https://user-images.githubusercontent.com/10963046/149552889-8bb8cc1b-92c4-4f1f-b8b4-be47f5362872.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
