### PR TITLE
Better colourModelInformation for JPEGs

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -33,7 +33,7 @@ class ImageOperations(playPath: String) extends GridLogging {
   private val profileLocations = Map(
     "RGB" -> profilePath("srgb.icc"),
     "CMYK" -> profilePath("cmyk.icc"),
-    "GRAYSCALE" -> profilePath("grayscale.icc")
+    "Greyscale" -> profilePath("grayscale.icc")
   )
 
   private def tagFilter(metadata: ImageMetadata) = {
@@ -269,16 +269,16 @@ object ImageOperations {
           colourModel = output.headOption
         } yield colourModel match {
           case Some("sRGB") => Some("RGB")
-          case Some("Gray") => Some("GRAYSCALE")
+          case Some("Gray") => Some("Greyscale")
           case Some("CIELab") => Some("LAB")
           // IM returns doubles for TIFFs with transparency…
           case Some("sRGBsRGB") => Some("RGB")
-          case Some("GrayGray") => Some("GRAYSCALE")
+          case Some("GrayGray") => Some("Greyscale")
           case Some("CIELabCIELab") => Some("LAB")
           case Some("CMYKCMYK") => Some("CMYK")
           // …and triples for TIFFs with transparency and alpha channel(s). I think.
           case Some("sRGBsRGBsRGB") => Some("RGB")
-          case Some("GrayGrayGray") => Some("GRAYSCALE")
+          case Some("GrayGrayGray") => Some("Greyscale")
           case Some("CIELabCIELabCIELab") => Some("LAB")
           case Some("CMYKCMYKCMYK") => Some("CMYK")
           case _ => colourModel
@@ -293,7 +293,7 @@ object ImageOperations {
           colourModel = output.headOption
         } yield colourModel match {
           case Some("sRGB") => Some("RGB")
-          case Some("Gray") => Some("GRAYSCALE")
+          case Some("Gray") => Some("Greyscale")
           case _ => Some("RGB")
         }
       case _ =>

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -258,7 +258,10 @@ object ImageOperations {
         for {
           output <- runIdentifyCmd(formatter, false)
           colourModel = output.headOption
-        } yield colourModel
+        } yield colourModel match {
+          case Some("GRAYSCALE") => Some("Greyscale")
+          case _ => Some("RGB")
+        }
       case Tiff =>
         val op = new IMOperation()
         val formatter = format(op)("%[colorspace]")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/FileMetadataHelper.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/FileMetadataHelper.scala
@@ -6,7 +6,7 @@ object FileMetadataHelper {
 
   def normalisedIccColourSpace(fileMetadata: FileMetadata): Option[String] = {
     fileMetadata.icc.get("Color space") map {
-      case "GRAY" => "GRAYSCALE"
+      case "GRAY" => "Greyscale"
       case other  => other
     }
   }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/imaging/ImageOperationsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/imaging/ImageOperationsTest.scala
@@ -49,11 +49,11 @@ class ImageOperationsTest extends AnyFunSpec with Matchers with ScalaFutures {
       }
     }
 
-    it("should return GRAYSCALE for a JPG image with GRAYSCALE image data and no embedded profile") {
+    it("should return Greyscale for a JPG image with greyscale image data and no embedded profile") {
       val image = fileAt("grayscale-wo-profile.jpg")
       val colourModelFuture = ImageOperations.identifyColourModel(image, Jpeg)
       whenReady(colourModelFuture) { colourModel =>
-        colourModel should be (Some("GRAYSCALE"))
+        colourModel should be (Some("Greyscale"))
       }
     }
   }

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -225,7 +225,8 @@ object FileMetadataReader extends GridLogging {
     val hasAlpha = maybeImageType.map(imageType => if (imageType.contains("Matte")) "true" else "false")
 
     mimeType match {
-      case Png => val metaDir = metadata.getFirstDirectoryOfType(classOf[PngDirectory])
+      case Png =>
+        val metaDir = metadata.getFirstDirectoryOfType(classOf[PngDirectory])
         Map(
           "hasAlpha" -> hasAlpha,
           "colorType" -> Option(metaDir.getDescription(PngDirectory.TAG_COLOR_TYPE)),
@@ -236,7 +237,7 @@ object FileMetadataReader extends GridLogging {
         ).flattenOptions
       case _ =>
         val metaDir = Option(metadata.getFirstDirectoryOfType(classOf[ExifIFD0Directory]))
-        val photometricInterpretation = metaDir.map(_.getDescription(ExifDirectoryBase.TAG_PHOTOMETRIC_INTERPRETATION))
+        val photometricInterpretation = metaDir.flatMap(dir => Option(dir.getDescription(ExifDirectoryBase.TAG_PHOTOMETRIC_INTERPRETATION)))
         mimeType match {
           case Jpeg =>
             Map(

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -220,6 +220,10 @@ object FileMetadataReader extends GridLogging {
       .recover { case _ => getColourInformation(metadata, None, mimeType) }
   }
 
+  // bits per sample might be a useful value, eg. "1", "8"; or it might be annoying like "1 bits/component/pixel", "8 8 8 bits/component/pixel"
+  // either way we want everything up to the first space
+  private def extractBitsPerSample(data: String): Option[String] = data.split(" ").headOption
+
   private def getFromDirectory(maybeDir: Option[Directory])(value: Int): Option[String] =
     maybeDir.flatMap(dir => Option(dir.getDescription(value)))
 
@@ -238,7 +242,7 @@ object FileMetadataReader extends GridLogging {
         Map(
           "hasAlpha" -> hasAlpha,
           "colorType" -> getFromPngDirectory(PngDirectory.TAG_COLOR_TYPE),
-          "bitsPerSample" -> getFromPngDirectory(PngDirectory.TAG_BITS_PER_SAMPLE),
+          "bitsPerSample" -> getFromPngDirectory(PngDirectory.TAG_BITS_PER_SAMPLE).flatMap(extractBitsPerSample),
           "paletteHasTransparency" -> getFromPngDirectory(PngDirectory.TAG_PALETTE_HAS_TRANSPARENCY),
           "paletteSize" -> getFromPngDirectory(PngDirectory.TAG_PALETTE_SIZE),
           "iccProfileName" -> getFromPngDirectory(PngDirectory.TAG_ICC_PROFILE_NAME)
@@ -255,7 +259,7 @@ object FileMetadataReader extends GridLogging {
           "hasAlpha" -> hasAlpha,
           "colorType" -> maybeImageType,
           "photometricInterpretation" -> photometricInterpretation,
-          "bitsPerSample" -> getFromExifDirectory(ExifDirectoryBase.TAG_BITS_PER_SAMPLE)
+          "bitsPerSample" -> getFromExifDirectory(ExifDirectoryBase.TAG_BITS_PER_SAMPLE).flatMap(extractBitsPerSample)
         ).flattenOptions
     }
   }

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -234,17 +234,27 @@ object FileMetadataReader extends GridLogging {
           "paletteSize" -> Option(metaDir.getDescription(PngDirectory.TAG_PALETTE_SIZE)),
           "iccProfileName" -> Option(metaDir.getDescription(PngDirectory.TAG_ICC_PROFILE_NAME))
         ).flattenOptions
-      case _ => val metaDir = Option(metadata.getFirstDirectoryOfType(classOf[ExifIFD0Directory]))
-        Map(
-          "hasAlpha" -> hasAlpha,
-          "colorType" -> maybeImageType,
-          "photometricInterpretation" -> metaDir.map(_.getDescription(ExifDirectoryBase.TAG_PHOTOMETRIC_INTERPRETATION)),
-          "bitsPerSample" -> metaDir.map(_.getDescription(ExifDirectoryBase.TAG_BITS_PER_SAMPLE))
-        ).flattenOptions
+      case _ =>
+        val metaDir = Option(metadata.getFirstDirectoryOfType(classOf[ExifIFD0Directory]))
+        val photometricInterpretation = metaDir.map(_.getDescription(ExifDirectoryBase.TAG_PHOTOMETRIC_INTERPRETATION))
+        mimeType match {
+          case Jpeg =>
+            Map(
+              "hasAlpha" -> Some("false"),
+              "colorType" -> maybeImageType,
+              "photometricInterpretation" -> photometricInterpretation,
+              "bitsPerSample" -> Some("8")
+            ).flattenOptions
+          case _ =>
+            Map(
+              "hasAlpha" -> hasAlpha,
+              "colorType" -> maybeImageType,
+              "photometricInterpretation" -> photometricInterpretation,
+              "bitsPerSample" -> metaDir.map(_.getDescription(ExifDirectoryBase.TAG_BITS_PER_SAMPLE))
+            ).flattenOptions
+        }
+
     }
-
-
-
   }
 
   private def nonEmptyTrimmed(nullableStr: String): Option[String] =

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -232,7 +232,7 @@ object Uploader extends GridLogging {
 
   private def toFileMetadata(f: File, imageId: String, mimeType: Option[MimeType]): Future[FileMetadata] = {
     mimeType match {
-      case Some(Png | Tiff) => FileMetadataReader.fromIPTCHeadersWithColorInfo(f, imageId, mimeType.get)
+      case Some(Png | Tiff | Jpeg) => FileMetadataReader.fromIPTCHeadersWithColorInfo(f, imageId, mimeType.get)
       case _ => FileMetadataReader.fromIPTCHeaders(f, imageId)
     }
   }


### PR DESCRIPTION
## What does this change?

`colourModelInformation` metadata (`hasAlpha`, `bitsPerSample`) wasn’t being returned for JPEGs. But we know them JPEGs! They cannot have transparency and they are always only 8 bit per channel (someone, somewhere saw a 10-bit JPEG once, but nobody ever saw that person…). So we fill them in hard.

It renames `GRAYSCALE` to more British human-readable `Greyscale` in anticipation of a chip. It cleans values for `bitsPerSample`, so that they are more consistent.

Addresses pts. 2–6 in https://github.com/guardian/grid/issues/2594. So, in truth… Fixes https://github.com/guardian/grid/issues/2594.

## How can success be measured?

Slightly more correct colour information for JPEGs.
Future vision from @paperboyo: One day we will be able to search for `+is:Cutout` in chips. For now, we can add this as an alias search…

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
