### PR TITLE
Version clientside assets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,9 @@ lazy val imageLoader = playProject("image-loader", 9003).settings {
   )
 }
 
-lazy val kahuna = playProject("kahuna", 9005)
+lazy val kahuna = playProject("kahuna", 9005).settings(
+  pipelineStages := Seq(digest, gzip)
+)
 
 lazy val leases = playProject("leases", 9012)
 

--- a/build.sbt
+++ b/build.sbt
@@ -238,6 +238,7 @@ lazy val adminToolsDev = playProject("admin-tools-dev", 9013, Some("admin-tools/
 lazy val metadataEditor = playProject("metadata-editor", 9007)
 
 lazy val thrall = playProject("thrall", 9002).settings(
+  pipelineStages := Seq(digest, gzip),
   libraryDependencies ++= Seq(
     "org.codehaus.groovy" % "groovy-json" % "2.4.4",
     "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,7 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")


### PR DESCRIPTION
## What does this change?

Adds the sbt-digest plugin, which creates an md5 of each asset at build time. This allows Play to **automatically** switch to serving versioned assets from its controllers! (We'd already halfway opted into the behaviour by using the 'versioned' assets controllers and reverse routes, but without the digest Play falls back to treating them as unversioned). Now that each version has a unique URL, Play will set the Cache-control header to `Cache-Control: public, max-age=31536000, immutable`.

Also adds the sbt-gzip plugin, which will gzip each asset. This is a smaller optimisation as I think cloudfront is already doing compressing of assets for us, do we need/want compression for the hop between grid -> cloudfront?

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
