### PR TITLE
Double metaspace size for running on dev

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
 -J-Xmx8192M
--J-XX:MaxMetaspaceSize=1024M
+-J-XX:MaxMetaspaceSize=2048M
 -DSTAGE=DEV


### PR DESCRIPTION
## What does this change?

Several of us running locally have started seeing `java.lang.OutOfMemoryError: Metaspace` errors. Double the allocated metaspace to help avoid these errors. 

Our memory footprint when running locally has been increasing recently (see also 8cf0b46f773 from last month), which we should keep an eye on.

## How can success be measured?

Local running has fewer errors.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
