### PR TITLE
Set images count to default to current alias

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -84,15 +84,20 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     val queryCatCount = catCount(indexName) // document count only of index including live documents, not deleted documents which have not yet been removed by the merge process
     val queryImageSearch = search(indexName) limit 0 // hits that match the query defined in the request
     val queryStats = indexStats(indexName) // total accumulated values of an index for both primary and replica shards
+    val indexForAlias = getIndexForAlias(indexName)
 
     for {
       catCount <- executeAndLog(queryCatCount, "Images cat count")
       imageSearch <- executeAndLog(queryImageSearch, "Images search")
       stats <- executeAndLog(queryStats, "Stats aggregation")
-    } yield
+      maybeRealIndexName <- indexForAlias
+    } yield {
+      // indexName may also be an alias; do a lookup for the real name if it exists
+      val realIndexName = maybeRealIndexName.map(_.name).getOrElse(indexName)
       ElasticSearchImageCounts(catCount.result.count,
                                imageSearch.result.hits.total.value,
-                               stats.result.indices(indexName).total.docs.count)
+                               stats.result.indices(realIndexName).total.docs.count)
+    }
   }
 
   def createIndexIfMissing(index: String): Unit = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -79,7 +79,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
     })
   }
 
-  def countImages(indexName: String = "images"): Future[ElasticSearchImageCounts] = {
+  def countImages(indexName: String = imagesCurrentAlias): Future[ElasticSearchImageCounts] = {
     implicit val logMarker = MarkerMap()
     val queryCatCount = catCount(indexName) // document count only of index including live documents, not deleted documents which have not yet been removed by the merge process
     val queryImageSearch = search(indexName) limit 0 // hits that match the query defined in the request


### PR DESCRIPTION
## What does this change?

Set image counter to default to tracking current alias

## How can success be measured?

media-api's /management/imageCounts tracks the in-progress index

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
