### PR TITLE
rename OriginalSource UsageRights name

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -308,7 +308,7 @@ final case class OriginalSource(restrictions: Option[String] = None) extends Usa
 object OriginalSource extends UsageRightsSpec {
   val category = "original-source"
   val defaultCost = Some(Free)
-  val name = "OriginalSource"
+  val name = "Original Source"
   def description(commonConfig: CommonConfig) =
     "Images provided by members of the public to be shared with Journalist who is out collecting material for stories"
 


### PR DESCRIPTION
## What does this change?
Rename OriginalSource UsageRights name from _"OriginalSource"_ to _"Original Source"_

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
