### PR TITLE
Switch all imaging operations to ImageMagick

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -249,24 +249,20 @@ object ImageOperations {
   val optimisedMimeType = Png
   def identifyColourModel(sourceFile: File, mimeType: MimeType)(implicit ec: ExecutionContext): Future[Option[String]] = {
     // TODO: use mimeType to lookup other properties once we support other formats
+    val op = new IMOperation()
+    val formatter = format(op)("%[colorspace]")
+    val withSource = addDestImage(formatter)(sourceFile)
 
     mimeType match {
       case Jpeg =>
-        val source = addImage(sourceFile)
-        val formatter = format(source)("%[colorspace]")
-
         for {
-          output <- runIdentifyCmd(formatter, false)
+          output <- runIdentifyCmd(withSource, true)
           colourModel = output.headOption
         } yield colourModel match {
           case Some("GRAYSCALE") => Some("Greyscale")
           case _ => Some("RGB")
         }
       case Tiff =>
-        val op = new IMOperation()
-        val formatter = format(op)("%[colorspace]")
-        val withSource = addDestImage(formatter)(sourceFile)
-
         for {
           output <- runIdentifyCmd(withSource, true)
           colourModel = output.headOption
@@ -287,9 +283,6 @@ object ImageOperations {
           case _ => colourModel
         }
       case Png =>
-        val op = new IMOperation()
-        val formatter = format(op)("%[colorspace]")
-        val withSource = addDestImage(formatter)(sourceFile)
 
         for {
           output <- runIdentifyCmd(withSource, true)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -95,7 +95,7 @@ class ImageOperations(playPath: String) extends GridLogging {
       cropped       = crop(profiled)(bounds)
       depthAdjusted = depth(cropped)(8)
       addOutput     = addDestImage(depthAdjusted)(outputFile)
-      _             <- runConvertCmd(addOutput, useImageMagick = sourceMimeType.contains(Tiff))
+      _             <- runConvertCmd(addOutput, useImageMagick = true)
       _             <- checkForOutputFileChange(outputFile)
     }
     yield outputFile
@@ -116,7 +116,7 @@ class ImageOperations(playPath: String) extends GridLogging {
       qualified    = quality(resizeSource)(qual)
       resized      = scale(qualified)(dimensions)
       addOutput    = addDestImage(resized)(outputFile)
-      _           <- runConvertCmd(addOutput, useImageMagick = sourceMimeType.contains(Tiff))
+      _           <- runConvertCmd(addOutput, useImageMagick = true)
     }
     yield outputFile
   }
@@ -180,7 +180,7 @@ class ImageOperations(playPath: String) extends GridLogging {
     val interlaced     = interlace(qualified)(interlacedHow)
     val addOutput      = {file:File => addDestImage(interlaced)(file)}
     for {
-      _          <- runConvertCmd(addOutput(outputFile), useImageMagick = browserViewableImage.mimeType == Tiff)
+      _          <- runConvertCmd(addOutput(outputFile), useImageMagick = true)
       _ = logger.info(addLogMarkers(stopwatch.elapsed), "Finished creating thumbnail")
     } yield (outputFile, thumbMimeType)
   }
@@ -205,7 +205,7 @@ class ImageOperations(playPath: String) extends GridLogging {
       profiled        = applyOutputProfile(stripped, optimised = true)
       depthAdjusted   = depth(profiled)(8)
       addOutput       = addDestImage(depthAdjusted)(outputFile)
-      _               <- runConvertCmd(addOutput, useImageMagick = sourceMimeType.contains(Tiff))
+      _               <- runConvertCmd(addOutput, useImageMagick = true)
       _               <- checkForOutputFileChange(outputFile)
       _ = logger.info(addLogMarkers(stopwatch.elapsed), "Finished creating browser-viewable image")
     } yield (outputFile, optimisedMimeType)
@@ -253,7 +253,7 @@ object ImageOperations {
     mimeType match {
       case Jpeg =>
         val source = addImage(sourceFile)
-        val formatter = format(source)("%[JPEG-Colorspace-Name]")
+        val formatter = format(source)("%[colorspace]")
 
         for {
           output <- runIdentifyCmd(formatter, false)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -260,6 +260,7 @@ object ImageOperations {
           colourModel = output.headOption
         } yield colourModel match {
           case Some("GRAYSCALE") => Some("Greyscale")
+          case Some("CMYK") => Some("CMYK")
           case _ => Some("RGB")
         }
       case Tiff =>

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -259,7 +259,7 @@ object ImageOperations {
           output <- runIdentifyCmd(withSource, true)
           colourModel = output.headOption
         } yield colourModel match {
-          case Some("GRAYSCALE") => Some("Greyscale")
+          case Some("Gray") => Some("Greyscale")
           case Some("CMYK") => Some("CMYK")
           case _ => Some("RGB")
         }

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -212,13 +212,11 @@ object FileMetadataReader extends GridLogging {
     }
 
   def getColorModelInformation(image: File, metadata: Metadata, mimeType: MimeType): Future[Map[String, String]] = {
-
-    val source = addImage(image)
-
     val op = new IMOperation()
     val formatter = format(op)("%r")
+    val withSource = addDestImage(formatter)(image)
 
-    runIdentifyCmd(formatter, useImageMagick = true).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
+    runIdentifyCmd(withSource, useImageMagick = true).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
       .recover { case _ => getColourInformation(metadata, None, mimeType) }
   }
 

--- a/image-loader/app/lib/imaging/FileMetadataReader.scala
+++ b/image-loader/app/lib/imaging/FileMetadataReader.scala
@@ -17,6 +17,7 @@ import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.lib.metadata.ImageMetadataConverter
 import com.gu.mediaservice.model._
 import model.upload.UploadRequest
+import org.im4java.core.IMOperation
 import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json.JsValue
@@ -214,9 +215,10 @@ object FileMetadataReader extends GridLogging {
 
     val source = addImage(image)
 
-    val formatter = format(source)("%r")
+    val op = new IMOperation()
+    val formatter = format(op)("%r")
 
-    runIdentifyCmd(formatter, useImageMagick = false).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
+    runIdentifyCmd(formatter, useImageMagick = true).map{ imageType => getColourInformation(metadata, imageType.headOption, mimeType) }
       .recover { case _ => getColourInformation(metadata, None, mimeType) }
   }
 


### PR DESCRIPTION
## What does this change?
[A Sense of History](https://www.imdb.com/title/tt0105355/): Grid started by only using GraphicsMagick, probably because it was thought to be both more performant and more secure. In time, as we added more file formats, its limitations started to show, so we’ve introduced ImageMagick and decided to use them [for some operations](https://github.com/guardian/grid/pull/2579). ~Today we have found a perfectly fine JPEG, a format still serviced by GraphicsMagick, that wouldn’t upload. ImageMagick has no problems with this file.~ (EDIT: this was our fault and fixed now in https://github.com/guardian/grid/pull/3622)

This PR switches all imaging and metadata operations to run off ImageMagick. The reasons are:
- IM is more often more reliable (Lab TIFFs, some ICC profiles etc)
- GM has fallen a bit behind because an undue stress is put on a sole maintainer
- since we have IM anyway, security is not a concern. Or at least – not any more
- performance gains, if any, are not so well publicised for us to be able to refer to them here
- we [should be using libvips](https://github.com/guardian/grid/issues/155) anyway!

## How can success be measured?
~A [particular file](https://trello.com/c/IxKWJhU4/2578-gm-fails-on-some-icc-profiles) uploads correctly. There are no regressions in any imaging and metadata operations relying on GM and IM.~
[EDIT: this only presents a case for removing GM and keeping only IM]

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
