### PR TITLE
Correctly identify CMYK JPEGs

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -260,6 +260,7 @@ object ImageOperations {
           colourModel = output.headOption
         } yield colourModel match {
           case Some("GRAYSCALE") => Some("Greyscale")
+          case Some("CMYK") => Some("CMYK")
           case _ => Some("RGB")
         }
       case Tiff =>


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/grid/pull/3604 introduced a regression that prevented supporting CMYK JPEGs. This fixes it.

## How can success be measured?
CMYK JPEGs can be uploaded again.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
