### PR TITLE
Log what image is being cropped and who requested it

### DIFF
--- a/cropper/app/controllers/CropperController.scala
+++ b/cropper/app/controllers/CropperController.scala
@@ -129,6 +129,8 @@ class CropperController(auth: Authentication, crops: Crops, store: CropStore, no
   def executeRequest(exportRequest: ExportRequest, user: Principal, onBehalfOfPrincipal: Authentication.OnBehalfOfPrincipal): Future[(String, Crop)] = {
     implicit val context: RequestLoggingContext = RequestLoggingContext(
       initialMarkers = Map(
+        "user" -> user.identifier,
+        "imageId" -> exportRequest.uri.split("/").lastOption.getOrElse(exportRequest.uri),
         "requestType" -> "executeRequest"
       )
     )

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -100,17 +100,25 @@ object Authentication {
   sealed trait Principal {
     def accessor: ApiAccessor
     def attributes: TypedMap
+
+    def identifier: String
   }
   /** A human user with a name */
   case class UserPrincipal(firstName: String, lastName: String, email: String, attributes: TypedMap = TypedMap.empty) extends Principal {
     def accessor: ApiAccessor = ApiAccessor(identity = email, tier = Internal)
+
+    override def identifier: String = email
   }
   /** A machine user doing work automatically for its human programmers */
-  case class MachinePrincipal(accessor: ApiAccessor, attributes: TypedMap = TypedMap.empty) extends Principal
+  case class MachinePrincipal(accessor: ApiAccessor, attributes: TypedMap = TypedMap.empty) extends Principal {
+    override def identifier: String = accessor.identity
+  }
 
   /** A different Grid microservice (e.g. a call to media-api originating from thrall) */
   case class InnerServicePrincipal(identity: String, attributes: TypedMap = TypedMap.empty) extends Principal {
     def accessor: ApiAccessor = ApiAccessor(identity, tier = Internal)
+
+    override def identifier: String = identity
   }
 
   type Request[A] = AuthenticatedRequest[A, Principal]


### PR DESCRIPTION
## What does this change?

Improves logging in cropper somewhat. Currently we cannot see what image is being cropped, nor who requested it be cropped. This change adds new markers for the image ID (export request URI is the media-api URI, which conveniently has the image ID as the final element of the path) and an identifier for the user (email when a human user, identifying string otherwise).

## How can success be measured?

Easier to debug images failing to crop

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
