### PR TITLE
kahuna: Set jest root dir

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -63,5 +63,8 @@
     "type": "git",
     "url": "git@github.com:guardian/media-service.git"
   },
-  "private": true
+  "private": true,
+  "jest": {
+    "rootDir": "public"
+  }
 }


### PR DESCRIPTION
## What does this change?

Set the `rootDir` property in kahuna to restrict search path for tests. Currently jest will search all of kahuna's directory, but sometimes the js tests can be copied into `kahuna/target`, where they will not function correctly.

To replicate:

```
pushd kahuna
npm install; npm run dist
popd
sbt kahuna/debian:packageBin
pushd kahuna
npm test
```

(replication steps are a little contrived, but the problem has reared its head in CI when output from previous build hasn't been cleared out)

## How can success be measured?

`npm test` will only pick up tests in the expected (`kahuna/public`) directory

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
