### PR TITLE
Es/S3 sync checker

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -67,6 +67,7 @@ trait MigrationStatusProvider {
   ) { () => refreshMigrationStatus() }
 
   def migrationStatus: MigrationStatus = migrationStatusRef.get()
+  def migrationIsInProgress: Boolean = migrationStatus.isInstanceOf[InProgress]
   def refreshAndRetrieveMigrationStatus(): MigrationStatus = {
     refreshMigrationStatus()
     migrationStatus

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -85,7 +85,6 @@ object MigrationSourceWithSender extends GridLogging {
         })
         .filter(_ => {
           es.migrationStatus match {
-            case Paused(_) => false
             case InProgress(_) => true
             case _ => false
           }

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -80,7 +80,9 @@ object MigrationSourceWithSender extends GridLogging {
         .mapAsync(1)(identity)
         // flatten out the list of image ids
         .mapConcat(searchHits => {
-          logger.info(s"Flattening ${searchHits.size} image ids to migrate")
+          if (searchHits.nonEmpty) {
+            logger.info(s"Flattening ${searchHits.size} image ids to migrate")
+          }
           searchHits
         })
         .filter(_ => {

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -85,12 +85,7 @@ object MigrationSourceWithSender extends GridLogging {
           }
           searchHits
         })
-        .filter(_ => {
-          es.migrationStatus match {
-            case InProgress(_) => true
-            case _ => false
-          }
-        })
+        .filter(_ => es.migrationIsInProgress)
 
     val projectedImageSource: Source[MigrationRecord, NotUsed] = esQuerySource.mapAsyncUnordered(parallelism = 50) { searchHit: SearchHit => {
       val imageId = searchHit.id

--- a/thrall/app/lib/SyncChecker.scala
+++ b/thrall/app/lib/SyncChecker.scala
@@ -1,0 +1,45 @@
+package lib
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import com.amazonaws.services.s3.AmazonS3
+import com.gu.mediaservice.lib.elasticsearch.InProgress
+import lib.elasticsearch.ElasticSearch
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.DurationInt
+
+sealed trait SyncCheckPart {}
+case class Prefixed(x: String, y: String, z: String) extends SyncCheckPart
+case object Other extends SyncCheckPart
+
+class SyncChecker(
+  materializer: Materializer,
+  s3: AmazonS3,
+  es: ElasticSearch
+)(implicit ec: ExecutionContext) {
+  private val expectedAlphabet = "0123456789abcdef".split("")
+  private val prefixes: Seq[SyncCheckPart] = (for {
+    x <- expectedAlphabet
+    y <- expectedAlphabet
+    z <- expectedAlphabet
+  } yield Prefixed(x, y, z)) :+ Other
+
+  def checkPrefix(x: String, y: String, z: String): Future[Unit] = {
+
+    val esIds: Seq[String] = es.listImageIdsWithPrefix(s"$x$y$z")
+  }
+
+  val s = Source.cycle(() => prefixes.toIterator)
+    .throttle(1, per = 5.seconds)
+    .filter(_ => {
+      es.migrationStatus match {
+        case InProgress(_) => true
+        case _ => false
+      }
+    })
+    .mapAsync(1) {
+      case Prefixed(x, y, z) => checkPrefix(x, y, z)
+      case Other => checkUnprefixed()
+    }
+}

--- a/thrall/app/lib/SyncChecker.scala
+++ b/thrall/app/lib/SyncChecker.scala
@@ -1,36 +1,128 @@
 package lib
 
+import akka.Done
+import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ListObjectsV2Request
 import com.gu.mediaservice.lib.elasticsearch.InProgress
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap}
 import lib.elasticsearch.ElasticSearch
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.util.{Failure, Success}
 
-sealed trait SyncCheckPart {}
-case class Prefixed(x: String, y: String, z: String) extends SyncCheckPart
-case object Other extends SyncCheckPart
+sealed trait SyncCheckJob {}
+case class Prefix(prefix: String) extends SyncCheckJob
+case object Other extends SyncCheckJob
 
 class SyncChecker(
-  materializer: Materializer,
   s3: AmazonS3,
-  es: ElasticSearch
-)(implicit ec: ExecutionContext) {
+  es: ElasticSearch,
+  imageBucketName: String,
+  actorSystem: ActorSystem
+) extends GridLogging {
+
+  private val mat = Materializer.matFromSystem(actorSystem)
+  private implicit val dispatcher: ExecutionContext = actorSystem.getDispatcher
+
   private val expectedAlphabet = "0123456789abcdef".split("")
-  private val prefixes: Seq[SyncCheckPart] = (for {
+  private val prefixes: Seq[SyncCheckJob] = (for {
     x <- expectedAlphabet
     y <- expectedAlphabet
     z <- expectedAlphabet
-  } yield Prefixed(x, y, z)) :+ Other
+  } yield Prefix(s"$x$y$z")) :+ Other
 
-  def checkPrefix(x: String, y: String, z: String): Future[Unit] = {
-
-    val esIds: Seq[String] = es.listImageIdsWithPrefix(s"$x$y$z")
+  private def paginatedListObjects(request: ListObjectsV2Request, maybeContinuationToken: Option[String] = None): Future[Seq[String]] = {
+    Future {
+      val fullRequest = maybeContinuationToken match {
+        case Some(token) => request.withContinuationToken(token)
+        case None => request
+      }
+      val result = s3.listObjectsV2(fullRequest)
+      val keys = result.getObjectSummaries.asScala.map(_.getKey.split("/").last)
+      val nextContinuationToken = Option(result.getNextContinuationToken)
+      keys -> nextContinuationToken
+    } flatMap {
+      case (keys, None) => Future.successful(keys)
+      case (keys, Some(token)) =>
+        for { extraKeys <- paginatedListObjects(request, Some(token)) } yield keys ++ extraKeys
+    }
   }
 
-  val s = Source.cycle(() => prefixes.toIterator)
+  private def listFilesWithPrefix(prefix: String): Future[Seq[String]] = {
+    val request = new ListObjectsV2Request()
+      .withBucketName(imageBucketName)
+      .withPrefix(prefix)
+    paginatedListObjects(request)
+  }
+  private def listFilesAtRoot(): Future[Seq[String]] = {
+    val request = new ListObjectsV2Request()
+      .withBucketName(imageBucketName)
+      .withDelimiter("/")
+    paginatedListObjects(request)
+  }
+  private def listFilesAtSlash() = {
+    val request = new ListObjectsV2Request()
+      .withBucketName(imageBucketName)
+      .withPrefix("/")
+    paginatedListObjects(request)
+  }
+
+  private def checkPrefix(prefix: String)(implicit logMarker: LogMarker): Future[Unit] = {
+    val esIdsFetch: Future[Set[String]] = es.listImageIdsWithPrefix(prefix).map(_.toSet)
+
+    val s3Prefix = prefix.split("").mkString("/")
+    // TODO String? or more complex?
+    val s3IdsFetch: Future[Set[String]] = listFilesWithPrefix(s3Prefix).map(_.toSet)
+
+    for {
+      esIds <- esIdsFetch
+      s3Ids <- s3IdsFetch
+    } yield {
+      val extrasInS3 = s3Ids diff esIds
+      if (extrasInS3.nonEmpty) {
+        logger.warn(logMarker, s"SyncChecker found ${extrasInS3.size} extra images in S3 under prefix $s3Prefix: ${extrasInS3.mkString(",")}")
+      }
+
+      val extrasInEs = esIds diff s3Ids
+      if (extrasInEs.nonEmpty) {
+        logger.warn(logMarker, s"SyncChecker found ${extrasInEs.size} extra images in Elasticsearch under prefix $prefix: ${extrasInEs.mkString(",")}")
+      }
+    }
+  }
+
+  private def checkUnprefixed()(implicit logMarker: LogMarker): Future[Unit] = {
+    val s3IdsAtRootFetch = listFilesAtRoot()
+    val s3IdsAtSlashFetch = listFilesAtSlash()
+    // TODO fetch all objects at unexpected locations ie. not at /^([0-9a-f]/){6}[0-9a-f]{34}$/
+    //  but that's a lot of prefixes to trawl. better suited to something making use of the s3 inventory that we have?
+
+    val esIdsBadFormatFetch = es.listImageIdsWithUnexpectedFormat()
+
+    for {
+      s3IdsAtRoot <- s3IdsAtRootFetch
+      s3IdsAtSlash <- s3IdsAtSlashFetch
+      esIdsBadFormat <- esIdsBadFormatFetch
+    } yield {
+      if (s3IdsAtRoot.nonEmpty) {
+        logger.warn(logMarker, s"SyncChecker found ${s3IdsAtRoot.size} images in S3 root: ${s3IdsAtRoot.mkString(",")}")
+      }
+
+      if (s3IdsAtSlash.nonEmpty) {
+        logger.warn(logMarker, s"SyncChecker found ${s3IdsAtSlash.size} images in S3 under '/': ${s3IdsAtSlash.mkString(",")}")
+      }
+
+      if (esIdsBadFormat.nonEmpty) {
+        logger.warn(logMarker, s"SyncChecker found ${esIdsBadFormat.size} images in Elasticsearch with unexpected id formats: ${esIdsBadFormat.mkString(",")}")
+      }
+    }
+  }
+
+  private def createStream() = Source.cycle(() => prefixes.toIterator)
     .throttle(1, per = 5.seconds)
     .filter(_ => {
       es.migrationStatus match {
@@ -39,7 +131,18 @@ class SyncChecker(
       }
     })
     .mapAsync(1) {
-      case Prefixed(x, y, z) => checkPrefix(x, y, z)
-      case Other => checkUnprefixed()
+      case Prefix(prefix) => checkPrefix(prefix)(MarkerMap())
+      case Other => checkUnprefixed()(MarkerMap())
     }
+
+  def run(): Future[Done] = {
+    val stream = createStream().run()(mat)
+
+    stream.onComplete {
+      case Failure(exception) => logger.error("SyncChecker stream completed with failure", exception)
+      case Success(_) => logger.info("SyncChecker stream completed with done, probably shutting down")
+    }
+
+    stream
+  }
 }

--- a/thrall/app/lib/SyncChecker.scala
+++ b/thrall/app/lib/SyncChecker.scala
@@ -126,8 +126,8 @@ class SyncChecker(
     .throttle(1, per = 5.seconds)
     .filter(_ => {
       es.migrationStatus match {
-        case InProgress(_) => true
-        case _ => false
+        case InProgress(_) => false
+        case _ => true
       }
     })
     .mapAsync(1) {
@@ -137,6 +137,8 @@ class SyncChecker(
 
   def run(): Future[Done] = {
     val stream = createStream().run()(mat)
+
+    logger.info("SyncChecker stream started")
 
     stream.onComplete {
       case Failure(exception) => logger.error("SyncChecker stream completed with failure", exception)

--- a/thrall/app/lib/SyncChecker.scala
+++ b/thrall/app/lib/SyncChecker.scala
@@ -65,12 +65,6 @@ class SyncChecker(
       .withDelimiter("/")
     paginatedListObjects(request)
   }
-  private def listFilesAtSlash() = {
-    val request = new ListObjectsV2Request()
-      .withBucketName(imageBucketName)
-      .withPrefix("/")
-    paginatedListObjects(request)
-  }
 
   private def checkPrefix(prefix: String)(implicit logMarker: LogMarker): Future[Unit] = {
     val esIdsFetch: Future[Set[String]] = es.listImageIdsWithPrefix(prefix).map(_.toSet)
@@ -93,7 +87,7 @@ class SyncChecker(
 
   private def checkUnprefixed()(implicit logMarker: LogMarker): Future[Unit] = {
     val s3IdsAtRootFetch = listFilesAtRoot()
-    val s3IdsAtSlashFetch = listFilesAtSlash()
+    val s3IdsAtSlashFetch = listFilesWithPrefix("/")
     // TODO fetch all objects at unexpected locations ie. not at /^([0-9a-f]/){6}[0-9a-f]{34}$/
     //  but that's a lot of prefixes to trawl. better suited to something making use of the s3 inventory that we have?
 

--- a/thrall/app/lib/SyncChecker.scala
+++ b/thrall/app/lib/SyncChecker.scala
@@ -114,12 +114,7 @@ class SyncChecker(
 
   private def createStream() = Source.cycle(() => prefixes.toIterator)
     .throttle(1, per = 5.seconds)
-    .filter(_ => {
-      es.migrationStatus match {
-        case InProgress(_) => false
-        case _ => true
-      }
-    })
+    .filterNot(_ => es.migrationIsInProgress)
     .mapAsync(1) {
       case Prefix(prefix) => checkPrefix(prefix)(MarkerMap())
       case Other => checkUnprefixed()(MarkerMap())

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -133,8 +133,8 @@ class ThrallStreamProcessor(
     }
 
     stream.onComplete {
-      case Failure(exception) => logger.error("stream completed with failure", exception)
-      case Success(_) => logger.info("Stream completed with done, probably shutting down")
+      case Failure(exception) => logger.error("Thrall stream completed with failure", exception)
+      case Success(_) => logger.info("Thrall stream completed with done, probably shutting down")
     }
 
     stream

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -548,6 +548,9 @@ class ElasticSearch(
     if (response.result.hits.size >= scrollPageSize && response.result.scrollId.isDefined) {
       continueScrollingImageIds(message, response.result.scrollId.get).map(ids ++ _)
     } else {
+      if (response.result.scrollId.isDefined) {
+        closeScroll(response.result.scrollId.get)
+      }
       Future.successful(ids)
     }
   }

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -576,7 +576,7 @@ class ElasticSearch(
       .size(scrollPageSize)
       .fetchSource(false)
       .scroll(60.seconds)
-      .query(not(regexQuery("id", "^[0-9a-fA-F]{40}$")))
+      .query(not(regexQuery("id", "[0-9a-f]{40}")))
     val message = s"listing ids with unexpected format"
     executeAndLog(req, message).flatMap(response => handleImageIdScrollResponse(message, response))
   }


### PR DESCRIPTION
## What does this change?

Adds new functionality to Thrall to run through elasticsearch and s3 and pick up images which are in one but not the other and output them as warning logs.

There is one part not covered by this: because images in s3 are stored behind prefixes, it is possible that an image is stored behind a nonstandard prefix (eg. an image at `x/y/z/xyzimage` should not have been created by the grid). Traversing the entire bucket to search for all possible nonstandard prefixes is difficult to do with the s3 listobjects api, so I've left out of this functionality.

## How can success be measured?

We can find all the discrepancies between ES and S3.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
