### PR TITLE
fix crier usage streams

### DIFF
--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -24,7 +24,7 @@ class UsageComponents(context: Context) extends GridComponents(context, new Usag
   val notifications = new Notifications(config)
 
   if(!config.apiOnly) {
-    val crierReader = new CrierStreamReader(config)
+    val crierReader = new CrierStreamReader(config, executionContext)
     crierReader.start()
   }
 

--- a/usage/app/lib/CrierStreamReader.scala
+++ b/usage/app/lib/CrierStreamReader.scala
@@ -70,9 +70,15 @@ class CrierStreamReader(config: UsageConfig) extends GridLogging {
 
     liveWorkerThread
       .map(_.start)
-      .foreach(_ => logger.info("Starting Crier Live Stream reader"))
+      .fold(
+        e => logger.error("No 'Crier Live Stream reader' thread to start", e),
+        _ => logger.info("Starting Crier Live Stream reader")
+      )
     previewWorkerThread
       .map(_.start)
-      .foreach(_ => logger.info("Starting Crier Preview Stream reader"))
+      .fold(
+        e => logger.error("No 'Crier Preview Stream reader' thread to start", e),
+        _ => logger.info("Starting Crier Preview Stream reader")
+      )
   }
 }

--- a/usage/app/lib/CrierStreamReader.scala
+++ b/usage/app/lib/CrierStreamReader.scala
@@ -2,7 +2,6 @@ package lib
 
 import java.net.InetAddress
 import java.util.UUID
-
 import com.amazonaws.auth._
 import com.amazonaws.auth.InstanceProfileCredentialsProvider
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
@@ -10,7 +9,9 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, Worker}
 import com.gu.mediaservice.lib.logging.GridLogging
 
-class CrierStreamReader(config: UsageConfig) extends GridLogging {
+import scala.concurrent.ExecutionContext
+
+class CrierStreamReader(config: UsageConfig, executionContext: ExecutionContext) extends GridLogging {
 
   lazy val workerId: String = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
@@ -59,23 +60,17 @@ class CrierStreamReader(config: UsageConfig) extends GridLogging {
   lazy val liveWorker = liveConfig.map(new Worker.Builder().recordProcessorFactory(LiveEventProcessorFactory).config(_).build())
   lazy val previewWorker = previewConfig.map(new Worker.Builder().recordProcessorFactory(PreviewEventProcessorFactory).config(_).build())
 
-  private def makeThread(worker: Runnable) =
-    new Thread(worker, s"${getClass.getSimpleName}-$workerId")
-
-  private lazy val liveWorkerThread = liveWorker.map(makeThread)
-  private lazy val previewWorkerThread = previewWorker.map(makeThread)
-
   def start() = {
     logger.info("Trying to start Crier Stream Readers")
 
-    liveWorkerThread
-      .map(_.start)
+    liveWorker
+      .map(executionContext.execute)
       .fold(
         e => logger.error("No 'Crier Live Stream reader' thread to start", e),
         _ => logger.info("Starting Crier Live Stream reader")
       )
-    previewWorkerThread
-      .map(_.start)
+    previewWorker
+      .map(executionContext.execute)
       .fold(
         e => logger.error("No 'Crier Preview Stream reader' thread to start", e),
         _ => logger.info("Starting Crier Preview Stream reader")

--- a/usage/app/lib/UsageConfig.scala
+++ b/usage/app/lib/UsageConfig.scala
@@ -42,22 +42,6 @@ class UsageConfig(resources: GridConfigResources) extends CommonConfig(resources
   val dynamoRegion: Region = RegionUtils.getRegion(string("aws.region"))
   val awsRegionName = string("aws.region")
 
-  val crierLiveKinesisStream = Try { string("crier.live.name") }
-  val crierPreviewKinesisStream = Try { string("crier.preview.name") }
-
-  val crierLiveArn = Try { string("crier.live.arn") }
-  val crierPreviewArn = Try { string("crier.preview.arn") }
-
-  val liveKinesisReaderConfig: Try[KinesisReaderConfig] = for {
-    liveStream <- crierLiveKinesisStream
-    liveArn <- crierLiveArn
-  } yield KinesisReaderConfig(liveStream, liveArn, liveAppName)
-
-  val previewKinesisReaderConfig: Try[KinesisReaderConfig] = for {
-    previewStream <- crierPreviewKinesisStream
-    previewArn <- crierPreviewArn
-  } yield KinesisReaderConfig(previewStream, previewArn, previewAppName)
-
   private val iamClient: AmazonIdentityManagement = withAWSCredentials(AmazonIdentityManagementClientBuilder.standard()).build()
 
   val postfix: String = if (isDev) {
@@ -74,6 +58,22 @@ class UsageConfig(resources: GridConfigResources) extends CommonConfig(resources
 
   val liveAppName = s"media-service-livex-$postfix"
   val previewAppName = s"media-service-previewx-$postfix"
+
+  val crierLiveKinesisStream = Try { string("crier.live.name") }
+  val crierPreviewKinesisStream = Try { string("crier.preview.name") }
+
+  val crierLiveArn = Try { string("crier.live.arn") }
+  val crierPreviewArn = Try { string("crier.preview.arn") }
+
+  val liveKinesisReaderConfig: Try[KinesisReaderConfig] = for {
+    liveStream <- crierLiveKinesisStream
+    liveArn <- crierLiveArn
+  } yield KinesisReaderConfig(liveStream, liveArn, liveAppName)
+
+  val previewKinesisReaderConfig: Try[KinesisReaderConfig] = for {
+    previewStream <- crierPreviewKinesisStream
+    previewArn <- crierPreviewArn
+  } yield KinesisReaderConfig(previewStream, previewArn, previewAppName)
 
   val apiOnly: Boolean = stringOpt("app.name") match {
     case Some("usage-stream") =>


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 

https://github.com/guardian/grid/pull/3011 refactored the `UsageConfig.scala` to replace some `lazy val`s with `val`s and as such the `previewKinesisReaderConfig` and `liveKinesisReaderConfig` end up with a `null` for their `appName` field (because they relied on a forward reference, which used to be fine when it was lazily evaluated, but not fine since that PR). Note the app name is used to uniquely identify the checkpoints on the stream - so pretty important.

This manifests as a (silent) `NullPointerException` when starting to read from the kinesis stream.

This has been failing since October 2020 and as such we haven't had any composer usages since then 🤦 . Nobody complained, probably because composer usages were flakey before that (which is something we'll address in a follow up PR - see https://github.com/guardian/grid/pull/3638 and https://github.com/guardian/grid/pull/3639). 

## What does this change?

- Adds logging for when the `Try` that wraps both the loading of the config and then the starting of the listening worker threads, to expose any exceptions
- Start the threads as part of the execution context rather than standalone `Thread`s
- FIX the order of declarations in `UsageConfig.scala` to eliminate the forward reference so the `previewKinesisReaderConfig` and `liveKinesisReaderConfig` can be built correctly.

## How can success be measured?
We have composer usages again 🎉 

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/153240381-042dd22c-a0d1-4099-9d73-3bc81ce649bb.png)

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
