### PR TITLE
ensure accurate usages stored to ES

### DIFF
--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -117,7 +117,6 @@ class UsageRecorder(usageMetrics: UsageMetrics, usageTable: UsageTable, usageStr
       def buildNotifications(usages: Set[MediaUsage]) = Observable.from(
         usages
           .filter(_.isGridLikeId)
-          .map(_.mediaId)
           .toList.distinct.map(usageNotice.build))
 
       val usageGroup = matchedUsageUpdates.matchUsageGroup.usageGroup


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 

Following on from our failed attempt (https://github.com/guardian/grid/pull/3638) to work around DynamoDB eventual consistency (given we query immediately after writing) this is an alternative approach...

## What does this change?
We now check the results returned from the query of all usages for a mediaId (done when building the `UsageNotice` list that goes off to thrall/ElasticSearch) and if the just written MediaUsage is present OR missing we log accordingly. If it is missing however, we now supplement the query results with the just written MediaUsage.

## How can success be measured?
Hopefully more reliable/accurate usages 🤞

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/153257033-c779c4ac-d3fc-40ab-b4fd-09b5c34a0e0f.png)

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
