### PR TITLE
Things I had to do to run Grid locally on M1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "9200:9200"
   imgops:
+    platform: 'linux/x86_64'
     build:
       context: ./dev/imgops
     ports:


### PR DESCRIPTION
## What does this change?
This gets me further in being able to run locally on 12.2 M1.

Docker was failing with

```
 => => transferring dockerfile: 37B                                        0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => ERROR [internal] load metadata for docker.io/library/debian:jessie     0.8s
------
 > [internal] load metadata for docker.io/library/debian:jessie:
------
failed to solve with frontend dockerfile.v0: failed to create LLB definition: no match for platform in manifest sha256:32ad5050caffb2c7e969dac873bce2c370015c2256ff984b70c1c08b3a2816a0: not found
ERROR: Service 'imgops' failed to build : Build failed
```
So I found [this thing](https://github.com/laradock/laradock/issues/2969#issuecomment-850957533) on the internet and now, it fails much, much later. 

Probably because openjdk8 isn’t supported on M1 so I’m running… 17. Or because something that uses [this guy](https://github.com/gmethvin/directory-watcher) isn’t updated. I just can’t find what that something is.

## How can success be measured?
Hold on! One step at a time…

## Screenshots
![image](https://user-images.githubusercontent.com/6032869/153316803-bbd3bf69-65b1-4866-840e-91a4283d18c6.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
