### PR TITLE
[usage] 15 second delay to the DynamoDB read-after-write (to allow for eventual consistency)

### DIFF
--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -117,7 +117,7 @@ class UsageRecorder(usageMetrics: UsageMetrics, usageTable: UsageTable, usageStr
   private def getNotificationStream(dbUpdateStream: Observable[MatchedUsageUpdate]) = {
 
     dbUpdateStream
-      .delay(5.seconds) // give DynamoDB write to have greater chance of reaching eventual consistency, before reading
+      .delay(15.seconds) // give DynamoDB write to have greater chance of reaching eventual consistency, before reading
       .flatMap{ matchedUsageUpdates =>
 
         val usageGroup = matchedUsageUpdates.matchUsageGroup.usageGroup


### PR DESCRIPTION
Tweak to the delay (5sec -> 15sec) introduced in https://github.com/guardian/grid/pull/3641.
