### PR TITLE
[usage] revert the supplementing of missing 'read-after-write' usage 

### DIFF
--- a/usage/app/lib/UsageNotifier.scala
+++ b/usage/app/lib/UsageNotifier.scala
@@ -16,17 +16,15 @@ class UsageNotifier(config: UsageConfig, usageTable: UsageTable)
   extends ThrallMessageSender(config.thrallKinesisLowPriorityStreamConfig) with GridLogging with MessageSubjects {
 
   def build(mediaUsage: MediaUsage) = Observable.from(
-    usageTable.queryByImageId(mediaUsage.mediaId).map((potentialIncompleteUsages: Set[MediaUsage]) => {
+    usageTable.queryByImageId(mediaUsage.mediaId).map((usages: Set[MediaUsage]) => {
 
-      if(potentialIncompleteUsages.contains(mediaUsage)){
+      if(usages.contains(mediaUsage)){
         logger.info(s"Accurate usages of ${mediaUsage.mediaId} retrieved from DynamoDB and sent to thrall/ElasticSearch")
       } else {
-        logger.info(s"Inaccurate usages of ${mediaUsage.mediaId} retrieved from DynamoDB, so supplemented before being sent to thrall/ElasticSearch")
+        logger.info(s"Inaccurate usages of ${mediaUsage.mediaId} retrieved from DynamoDB and sent to thrall/ElasticSearch")
       }
 
-      val definitelyCompleteUsages = potentialIncompleteUsages + mediaUsage
-
-      val usageJson = Json.toJson(definitelyCompleteUsages.map(UsageBuilder.build)).as[JsArray]
+      val usageJson = Json.toJson(usages.map(UsageBuilder.build)).as[JsArray]
       UsageNotice(mediaUsage.mediaId, usageJson)
     }))
 


### PR DESCRIPTION
https://github.com/guardian/grid/pull/3639 introduced what we thought was a workaround for DynamoDB eventual consistency but is in fact more likely an issue with lack of `.hashCode` implementation on `MediaUsage`. This supplementing behaviour is likely making things even worse, so reverting that part but leaving behind the logging (for now).

Co-Authored-By: @andrew-nowak 

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
