### PR TITLE
keep Free to use and My Upload checkbox in sync with search filters

### DIFF
--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.html
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.html
@@ -1,0 +1,1 @@
+<a ng-click="ctrl.onLogoClick()"  ng-href="/search" class="home-link" title="Home (clear search)" role="link" aria-label="Go to Home">Home</a>

--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import './gr-top-bar.css';
+import template from './gr-top-bar.html';
 
 export var topBar = angular.module('gr.topBar', []);
 
@@ -22,7 +23,7 @@ topBar.directive('grTopBarNav', [function() {
         transclude: true,
         // Annoying to have to hardcode root route here, but only
         // way I found to clear $stateParams from uiRouter...
-        template: `${window._clientConfig.homeLinkHtml || '<a href="/search" class="home-link" title="Home" role="link" aria-label="Go to Home">Home</a>'}
+        template: `${window._clientConfig.homeLinkHtml || template }
                    <ng:transclude></ng:transclude>`
     };
 }]);

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -14,6 +14,7 @@ import '../components/gr-top-bar/gr-top-bar';
 import '../components/gr-info-panel/gr-info-panel';
 import '../components/gr-collections-panel/gr-collections-panel';
 import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
+import '../util/storage';
 
 import '../components/gr-panels/gr-panels';
 
@@ -77,9 +78,9 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         controllerAs: 'ctrl',
         controller: [
             '$scope', '$window', '$stateParams', 'panels', 'shortcutKeys', 'keyboardShortcut',
-            'panelService', 'cropSettings', 'mediaApi',
+            'panelService', 'cropSettings', 'mediaApi', 'storage', '$state',
             function($scope, $window, $stateParams, panels, shortcutKeys, keyboardShortcut,
-                     panelService, cropSettings, mediaApi) {
+                     panelService, cropSettings, mediaApi, storage, $state) {
 
             const ctrl = this;
 
@@ -90,6 +91,18 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             });
 
             cropSettings.set($stateParams);
+
+            ctrl.onLogoClick = () => {
+                mediaApi.getSession().then(session => {
+                const showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
+                const defaultNonFreeFilter = {
+                  isDefault: true,
+                  isNonFree: showPaid ? showPaid : false
+                };
+                storage.setJs("defaultNonFreeFilter", defaultNonFreeFilter, true);
+                $state.go('search.results', {nonFree: defaultNonFreeFilter.isNonFree});
+              });
+            };
 
             ctrl.collectionsPanel = panels.collectionsPanel;
             ctrl.metadataPanel = panels.metadataPanel;


### PR DESCRIPTION
## What does this change?

Description:

When a "Free to Use Only" tick has been selected  to view, 

and then click on an image to view

Return to Search

The tick at the showing at the top of the screen disappears however The filter is still being applied

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
      
![Images Tick 1](https://user-images.githubusercontent.com/33189781/154853652-d296d0aa-1fcb-40cc-974f-2ebfb4548d34.png)
![Images Tick 2](https://user-images.githubusercontent.com/33189781/154853660-8dcbc623-b673-4cad-8768-7625260013e3.png)
![Images Tick 3](https://user-images.githubusercontent.com/33189781/154853668-011950a1-44d8-492a-a58c-c885083716bd.png)





## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
