### PR TITLE
Exclude `gu-fc-` from Grid-like mediaIds

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -24,7 +24,7 @@ case class MediaUsage(
 ) extends GridLogging {
 
   def isGridLikeId: Boolean = {
-    if (mediaId.startsWith("gu-image-")) || (mediaId.startsWith("gu-fc-")) {
+    if (mediaId.startsWith("gu-image-") || mediaId.startsWith("gu-fc-")) {
       // remove events from CAPI that represent images previous to Grid existing
       logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
       false

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -24,7 +24,7 @@ case class MediaUsage(
 ) extends GridLogging {
 
   def isGridLikeId: Boolean = {
-    if (mediaId.startsWith("gu-image-")) {
+    if (mediaId.startsWith("gu-image-")) || (mediaId.startsWith("gu-fc-")) {
       // remove events from CAPI that represent images previous to Grid existing
       logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
       false


### PR DESCRIPTION
## What does this change?
CAPI `mediaId`s starting with `gu-fc-` do not come from Grid ([example](https://www.theguardian.com/discover-culture/2014/aug/07/stephen-hough-in-recital-sydney)). This excludes those from Usage checks.

## How can success be measured?
I learn if `||` found on the Internet does what I need it to.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
