### PR TITLE
Default Richard Saker to Guardian publication

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -73,7 +73,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Jonathan Lovekin",
       "Karen Robinson",
       "Katherine Anne Rose",
-      "Richard Saker",
       "Sophia Evans",
       "Suki Dhanda"
     )),
@@ -90,6 +89,7 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Martin Godwin",
       "Mike Bowers",
       "Murdo MacLeod",
+      "Richard Saker",
       "Sarah Lee",
       "Tom Jenkins",
       "Tristram Kenton",


### PR DESCRIPTION
## What does this change?
At the request of PicDesk, if image arrives with Byline `Richard Saker` in the metadata, it will be automatically categorised as `The Guardian` publication.

## How can success be measured?
PicDesk are happy.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
