### PR TITLE
Action Images cleanup

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -80,7 +80,7 @@ object AapParser extends ImageProcessor {
 object ActionImagesParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
     case Some("Action Images") | Some("Action Images/Reuters") | Some("Action images/Reuters") | Some("Action Images/REUTERS") => image.copy(
-      usageRights = Agency("Action Images")
+      usageRights = Agencies.get("actionImages"),
       metadata    = image.metadata.copy(credit = Some("Action Images/Reuters"))
     )
     case _ => image

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -78,10 +78,16 @@ object AapParser extends ImageProcessor {
 }
 
 object ActionImagesParser extends ImageProcessor {
+
+  def extractFixtureID(image:Image) = image.fileMetadata.iptc.get("Fixture Identifier")
+  
   def apply(image: Image): Image = image.metadata.credit match {
     case Some("Action Images") | Some("Action Images/Reuters") | Some("Action images/Reuters") | Some("Action Images/REUTERS") => image.copy(
       usageRights = Agencies.get("actionImages"),
-      metadata    = image.metadata.copy(credit = Some("Action Images/Reuters"))
+      metadata    = image.metadata.copy(
+        credit = Some("Action Images/Reuters"),
+        suppliersReference = extractFixtureID(image) orElse image.metadata.suppliersReference
+      )
     )
     case _ => image
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -83,7 +83,7 @@ object ActionImagesParser extends ImageProcessor {
   
   def apply(image: Image): Image = image.metadata.credit match {
     case Some("Action Images") | Some("Action Images/Reuters") | Some("Action images/Reuters") | Some("Action Images/REUTERS") => image.copy(
-      usageRights = Agencies.get("actionImages"),
+      usageRights = Agency("Action Images"),
       metadata    = image.metadata.copy(
         credit = Some("Action Images/Reuters"),
         suppliersReference = extractFixtureID(image) orElse image.metadata.suppliersReference

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -79,8 +79,9 @@ object AapParser extends ImageProcessor {
 
 object ActionImagesParser extends ImageProcessor {
   def apply(image: Image): Image = image.metadata.credit match {
-    case Some("Action Images") | Some("Action Images/Reuters") => image.copy(
+    case Some("Action Images") | Some("Action Images/Reuters") | Some("Action images/Reuters") | Some("Action Images/REUTERS") => image.copy(
       usageRights = Agency("Action Images")
+      metadata    = image.metadata.copy(credit = Some("Action Images/Reuters"))
     )
     case _ => image
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -205,7 +205,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
     "Rex Features",
     "Ronald Grant Archive",
     "Action Images",
-    "Action Images/Reuters"
   )
 
   val suppliersCollectionExcl = Map(

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -186,7 +186,8 @@ object Agencies {
     "getty" -> Agency("Getty Images"),
     "rex" -> Agency("Rex Features"),
     "aap" -> Agency("AAP"),
-    "alamy" -> Agency("Alamy")
+    "alamy" -> Agency("Alamy"),
+    "actionImages" -> Agency("Action Images")
   )
 
   def get(id: String) = all.getOrElse(id, Agency(id))

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -186,8 +186,7 @@ object Agencies {
     "getty" -> Agency("Getty Images"),
     "rex" -> Agency("Rex Features"),
     "aap" -> Agency("AAP"),
-    "alamy" -> Agency("Alamy"),
-    "actionImages" -> Agency("Action Images")
+    "alamy" -> Agency("Alamy")
   )
 
   def get(id: String) = all.getOrElse(id, Agency(id))

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -85,13 +85,31 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       val image = createImageFromMetadata("credit" -> "Action Images")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Action Images"))
-      processedImage.metadata.credit should be(Some("Action Images"))
+      processedImage.metadata.credit should be(Some("Action Images/Reuters"))
     }
   }
 
   describe("Action Images/Reuters") {
     it("should match 'Action Images/Reuters' credit") {
       val image = createImageFromMetadata("credit" -> "Action Images/Reuters")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Action Images"))
+      processedImage.metadata.credit should be(Some("Action Images/Reuters"))
+    }
+  }
+
+  describe("Action Images/REUTERS") {
+    it("should match 'Action Images/REUTERS' credit") {
+      val image = createImageFromMetadata("credit" -> "Action Images/REUTERS")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Action Images"))
+      processedImage.metadata.credit should be(Some("Action Images/Reuters"))
+    }
+  }
+
+  describe("Action images/Reuters") {
+    it("should match 'Action images/Reuters' credit") {
+      val image = createImageFromMetadata("credit" -> "Action images/Reuters")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Action Images"))
       processedImage.metadata.credit should be(Some("Action Images/Reuters"))


### PR DESCRIPTION
## What does this change?
We have a hangover of a redundant `supplier` of `Action Images/Reuters`. There were 112 images there, all assigned manually (I reassigned them now). Correct `supplier` is `Action Images` (~100k). There is no `supplierProcessor` assigning `Action Images/Reuters`. This PR:
- removes redundant `supplier` of `Action Images/Reuters`
- catches more instances of spelling credits to categorise more images as `supplier`:`Action Images`
- rewrites credit to be `Action Images/Reuters` for them for consistency
- extracts correct `suppliersReference` (similarly to Reuters)
- adjusts tests

## How can success be measured?
Less confusion. More images categorised correctly.

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
