### PR TITLE
undo #2350, make warnings visually distinct, add warning for tass source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dev/.localstack
 dev/config/permissions.json
 
 coverage/
+.bsp

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,7 +1,19 @@
-<div ng-if="ctrl.showInvalidReasons" class="image-notice image-info__group validity validity--invalid validity--invalid--point-up">
-    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">Unusable Image <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon></strong>
-    <strong ng-if="ctrl.isOverridden && !ctrl.isDeleted"><strike>Unusable Image</strike> <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon></strong>
-    <strong ng-if="ctrl.isDeleted">Unusable Image<gr-icon title="This image cannot normally be used in content - image has been deleted">help</gr-icon></strong>
+<div
+    ng-if="ctrl.showInvalidReasons"
+    class="image-notice image-info__group validity validity--invalid validity--point-up"
+    ng-class="{'validity--invalid': ctrl.isDeleted || !ctrl.isOverridden, 'validity--warning': ctrl.isOverridden && !ctrl.isDeleted}"
+>
+    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">Unusable Image
+        <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
+    </strong>
+    <strong ng-if="ctrl.isOverridden && !ctrl.isDeleted">
+        This image can be used, but has warnings:
+        <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon>
+    </strong>
+    <strong ng-if="ctrl.isDeleted">
+        Unusable Image
+        <gr-icon title="This image cannot normally be used in content - image has been deleted">help</gr-icon>
+    </strong>
     <ul ng-if="!ctrl.isDeleted">
         <li ng-repeat="(key, reason) in ctrl.invalidReasons">
             {{reason}}

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -969,6 +969,7 @@ textarea.ng-invalid {
 .cost--overquota {
     background-color: red;
 }
+.validity--warning,
 .cost--conditional {
     background-color: orange;
 }
@@ -986,18 +987,25 @@ textarea.ng-invalid {
 }
 
 /* Hacky pointer to some element above */
-.validity--invalid--point-up {
+.validity--point-up {
     position: relative;
 }
-.validity--invalid--point-up::before {
+.validity--point-up::before {
     content: "";
     border-left: 20px solid rgba(0, 0, 0, 0);
     border-right: 20px solid rgba(0, 0, 0, 0);
-    border-bottom: 10px solid red;
     position: absolute;
     top: -9px;
     right: 30px;
     z-index: 200;
+    border-bottom-width: 10px;
+    border-bottom-style: solid;
+}
+.validity--invalid::before {
+    border-bottom-color: red;
+}
+.validity--warning::before {
+    border-bottom-color: orange;
 }
 
 /* ==========================================================================

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -19,7 +19,8 @@ object ImageExtras {
     "paid_image"                  -> "Paid imagery requires a lease",
     "over_quota"                  -> "The quota for this supplier has been exceeded",
     "conditional_paid"            -> "This image is restricted use",
-    "current_deny_lease"          -> "Cropping has been denied using a lease"
+    "current_deny_lease"          -> "Cropping has been denied using a lease",
+    "tass_agency_image"           -> "Warning: TASS is Russian state-owned agency, information may not be accurate, including geographical names."
   )
 
   def validityOverrides(image: Image, withWritePermission: Boolean): Map[String, Boolean] = Map(
@@ -52,12 +53,13 @@ object ImageExtras {
       "missing_credit"       -> createCheck(!hasCredit(image.metadata), overrideable = false),
       "missing_description"  -> createCheck(!hasDescription(image.metadata), overrideable = false),
       "current_deny_lease"   -> createCheck(hasCurrentDenyLease(image.leases)),
-      "over_quota"           -> createCheck(quotas.isOverQuota(image.usageRights))
+      "over_quota"           -> createCheck(quotas.isOverQuota(image.usageRights)),
+      "tass_agency_image"    -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS"), overrideable = true, shouldOverride = true)
     )
   }
 
   def invalidReasons(validityMap: ValidMap) = validityMap
-    .filter { case (_, v) => !v.isValid }
+    .filter { case (_, v) => v.invalid }
     .map { case (id, _) => id -> validityDescription.get(id) }
     .map {
       case (id, Some(reason)) => id -> reason

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -60,7 +60,8 @@ class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
     "over_quota" -> ValidityCheck(invalid = false,overrideable = true,shouldOverride = false),
     "current_deny_lease" -> ValidityCheck(invalid = false,overrideable = true,shouldOverride = false),
     "no_rights" -> ValidityCheck(invalid = true,overrideable = true,shouldOverride = false),
-    "conditional_paid" -> ValidityCheck(invalid = false,overrideable = true,shouldOverride = false)
+    "conditional_paid" -> ValidityCheck(invalid = false,overrideable = true,shouldOverride = false),
+    "tass_agency_image" -> ValidityCheck(invalid = false, overrideable = true, shouldOverride = true)
   )
 
   describe("Invalid Images") {
@@ -103,8 +104,10 @@ class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
       val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = true)
       val invalidReasons = ImageExtras.invalidReasons(validityMap)
       val expectedInvalidReasons = Map(
+        "paid_image" -> "Paid imagery requires a lease",
         "missing_description" -> "Missing description *",
-        "missing_credit" -> "Missing credit information *"
+        "missing_credit" -> "Missing credit information *",
+        "no_rights" -> "No rights to use this image"
       )
 
       expectedInvalidReasons should be(invalidReasons)


### PR DESCRIPTION
## What does this change?

A previous change hid image validity warnings in UI when the user is able to override them (ie. user has edit metadata permissions, or an allow cropping lease is active). This PR returns them, but with styling tweaks to make them visually distinct from errors (orange rather than red, clearer heading).

This PR also adds a validity check for images sourced from TASS, which have had inaccurate information included in metadata. This check is set to always be overridden, so will never prevent a user from cropping/using the image, but adds a warning reminding them to double check that the included information is accurate. 

## How can success be measured?
Clearer signalling of image use states. Less risk of incorrect metadata/captions. 

## Screenshots
All users, `source:TASS` (before/after):

![image](https://user-images.githubusercontent.com/6032869/155848517-ce944663-61bd-4d39-a33e-981168a77935.png)

Permissioned user, No rights image (before/after):

![image](https://user-images.githubusercontent.com/6032869/155848554-f682d9ae-cbb9-4070-8c8e-3f74780d37c8.png)

Unpermissioned user,  No rights image (before/after):

![image](https://user-images.githubusercontent.com/6032869/155848711-1b35a0e4-a9b2-4c90-addd-c2dc14d5e898.png)

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
