### PR TITLE
Add TASS via Alamy to validity TASS check

### DIFF
--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -54,7 +54,7 @@ object ImageExtras {
       "missing_description"  -> createCheck(!hasDescription(image.metadata), overrideable = false),
       "current_deny_lease"   -> createCheck(hasCurrentDenyLease(image.leases)),
       "over_quota"           -> createCheck(quotas.isOverQuota(image.usageRights)),
-      "tass_agency_image"    -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS"), overrideable = true, shouldOverride = true)
+      "tass_agency_image"    -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS") | image.metadata.byline.exists(_ == "ITAR-TASS News Agency"), overrideable = true, shouldOverride = true)
     )
   }
 

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -54,7 +54,7 @@ object ImageExtras {
       "missing_description"  -> createCheck(!hasDescription(image.metadata), overrideable = false),
       "current_deny_lease"   -> createCheck(hasCurrentDenyLease(image.leases)),
       "over_quota"           -> createCheck(quotas.isOverQuota(image.usageRights)),
-      "tass_agency_image"    -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS") | image.metadata.byline.exists(_ == "ITAR-TASS News Agency"), overrideable = true, shouldOverride = true)
+      "tass_agency_image"    -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS") | image.originalMetadata.byline.exists(_ == "ITAR-TASS News Agency"), overrideable = true, shouldOverride = true)
     )
   }
 


### PR DESCRIPTION
## What does this change?
This adds Alamy’s TASS imagery to our recent [TASS check](https://github.com/guardian/grid/pull/3661). 

## How can success be measured?
We catch ’em better. Ну, погоди!

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
