### PR TITLE
Keep restrictions when Usage Rights are changed

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -152,7 +152,7 @@ usageRightsEditor.controller(
     };
 
     ctrl.reset = () => {
-        ctrl.model = {};
+        ctrl.model = {restrictions: ctrl.model.restrictions};
         ctrl.showRestrictions = undefined;
     };
 


### PR DESCRIPTION
## What does this change?

When I select a single image, which I need to change the usage rights for,
When I select the new Rights,
the current restriction text will appear in the new usage right restriction text area in the usage rights form

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
