### PR TITLE
Metadata templates

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -102,3 +102,5 @@ usageRightsConfigProvider = {
 }
 
 domainMetadata.specifications = []
+
+metadata.templates = []

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -46,6 +46,7 @@ class KahunaController(
     // is on the same domain and can be read by the JS
     val domainMetadataSpecs: String = Json.toJson(config.domainMetadataSpecs).toString()
     val fieldAliases: String = Json.toJson(config.fieldAliasConfigs).toString()
+    val metadataTemplates: String = Json.toJson(config.metadataTemplates).toString()
     val returnUri = config.rootUri + okPath
     Ok(views.html.main(
       config.mediaApiUri,
@@ -65,7 +66,8 @@ class KahunaController(
       config.systemName,
       config.canDownloadCrop,
       domainMetadataSpecs,
-      config.recordDownloadAsUsage
+      config.recordDownloadAsUsage,
+      metadataTemplates
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -46,5 +46,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     shouldLoadWhenIFramed = if (entry.hasPath("shouldLoadWhenIFramed")) Some(entry.getBoolean("shouldLoadWhenIFramed")) else None,
   ))
 
+  val metadataTemplates: Seq[MetadataTemplate] = configuration.get[Seq[MetadataTemplate]]("metadata.templates")
+
 }
 

--- a/kahuna/app/lib/MetadataTemplateConfig.scala
+++ b/kahuna/app/lib/MetadataTemplateConfig.scala
@@ -1,0 +1,63 @@
+package lib
+
+import play.api.ConfigLoader
+import play.api.libs.json.{Json, Writes}
+
+import scala.collection.JavaConverters._
+
+object FieldResolveStrategy extends Enumeration {
+  val replace = Value("replace")
+  val append = Value("append")
+  val prepend = Value("prepend")
+  val ignore = Value("ignore")
+}
+
+case class MetadataTemplateField(name: String, value: String, resolveStrategy: FieldResolveStrategy.Value)
+
+object MetadataTemplateField {
+  implicit val writes: Writes[MetadataTemplateField] = Json.writes[MetadataTemplateField]
+}
+
+case class MetadataTemplateUsageRights(category: String, restrictions: Option[String] = None)
+
+object MetadataTemplateUsageRights {
+  implicit val writes: Writes[MetadataTemplateUsageRights] = Json.writes[MetadataTemplateUsageRights]
+}
+
+case class MetadataTemplate(
+   templateName: String,
+   metadataFields: Seq[MetadataTemplateField] = Nil,
+   usageRights: Option[MetadataTemplateUsageRights] = None)
+
+object MetadataTemplate {
+  implicit val writes: Writes[MetadataTemplate] = Json.writes[MetadataTemplate]
+
+  implicit val configLoader: ConfigLoader[Seq[MetadataTemplate]] =
+    ConfigLoader(_.getConfigList).map(
+      _.asScala.map(config => {
+        val metadataFields = if (config.hasPath("metadataFields")) {
+          config.getConfigList("metadataFields").asScala.map(fieldConfig => {
+            val resolveStrategy = if (fieldConfig.hasPath("resolveStrategy"))
+              FieldResolveStrategy.withName(fieldConfig.getString("resolveStrategy")) else FieldResolveStrategy.replace
+
+            MetadataTemplateField(
+              fieldConfig.getString("name"),
+              fieldConfig.getString("value"),
+              resolveStrategy
+            )
+          })
+        } else Nil
+
+        val usageRights = if (config.hasPath("usageRights")) {
+          val usageRightConfig = config.getConfig("usageRights")
+
+          Some(MetadataTemplateUsageRights(
+            category = usageRightConfig.getString("category"),
+            restrictions = if (usageRightConfig.hasPath("restrictions"))
+              Some(usageRightConfig.getString("restrictions")) else None
+          ))
+        } else None
+
+        MetadataTemplate(config.getString("templateName"), metadataFields, usageRights)
+      }))
+}

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -17,7 +17,8 @@
   systemName: String,
   canDownloadCrop: Boolean,
   domainMetadataSpecs: String,
-  recordDownloadAsUsage: Boolean
+  recordDownloadAsUsage: Boolean,
+  metadataTemplates: String
 )
 <!DOCTYPE html>
 <html>
@@ -61,7 +62,8 @@
           systemName: "@Html(systemName)",
           canDownloadCrop: @canDownloadCrop,
           domainMetadataSpecs: @Html(domainMetadataSpecs),
-          recordDownloadAsUsage: @recordDownloadAsUsage
+          recordDownloadAsUsage: @recordDownloadAsUsage,
+          metadataTemplates: @Html(metadataTemplates)
         }
     </script>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -1,3 +1,7 @@
 .metadata-people__button {
-    float: right;
+  float: right;
+}
+
+.image-info--editor__input-preview {
+  border: 1px solid #ffbc01;
 }

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -1,4 +1,18 @@
 <div class="image-info">
+    <div class="image-info__group" ng-if="ctrl.displayMetadataTemplates && ctrl.userCanEdit && ctrl.singleImage">
+        <div class="image-info__heading image-info__heading--lease">
+            <span>Fill in from template:</span>
+        </div>
+        <gr-metadata-templates
+            image="ctrl.singleImage"
+            metadata="ctrl.singleImage.data.metadata"
+            usage-rights="ctrl.singleImage.data.usageRights"
+            gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights)"
+            gr-on-metadata-template-applied="ctrl.onMetadataTemplateApplied()"
+            gr-on-metadata-template-cancelled="ctrl.onMetadataTemplateCancelled(metadata, usageRights)"
+            class="metadata-templates-flex">
+        </gr-metadata-templates>
+    </div>
     <div class="image-info__group">
         <dl class="image-info__wrap metadata-line image-info__usage-rights">
         <dt class="metadata-line__key">Rights & restrictions</dt>
@@ -7,7 +21,8 @@
                 ng-if="ctrl.showUsageRights"
                 gr-usage-rights="ctrl.usageRights"
                 gr-on-save="ctrl.showUsageRights = false"
-                gr-on-cancel="ctrl.showUsageRights = false">
+                gr-on-cancel="ctrl.showUsageRights = false"
+                gr-usage-rights-updated-by-template="ctrl.usageRightsUpdatedByTemplate">
             </gr-usage-rights-editor>
 
             <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
@@ -201,74 +216,94 @@
 
             <dt ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
             <dd data-cy="metadata-byline" ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
-                <button data-cy="it-edit-byline-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="bylineEditForm.$show()"
-                        ng-hide="bylineEditForm.$visible"
-                        >✎</button>
-                <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
-                      editable-text="ctrl.metadata.byline"
-                      ng-hide="bylineEditForm.$visible"
-                      onbeforesave="ctrl.updateMetadataField('byline', $data)"
-                      e:form="bylineEditForm"
-                      e:ng-class="{'image-info__editor--error': $error,
-                                   'image-info__editor--saving': bylineEditForm.$waiting,
-                                   'text-input': true}">
+                <span ng-if="ctrl.metadataUpdatedByTemplate.includes('byline')">
+                    <input
+                        type="text"
+                        class="text-input job-info--editor__input job-info--editor__input--byline image-info--editor__input-preview"
+                        ng-model="ctrl.metadata.byline"
+                    />
+                </span>
+                <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('byline')">
+                    <button data-cy="it-edit-byline-button"
+                            class="image-info__edit"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="bylineEditForm.$show()"
+                            ng-hide="bylineEditForm.$visible"
+                    >✎</button>
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.byline)}"
+                          editable-text="ctrl.metadata.byline"
+                          ng-hide="bylineEditForm.$visible"
+                          onbeforesave="ctrl.updateMetadataField('byline', $data)"
+                          e:form="bylineEditForm"
+                          e:ng-class="{'image-info__editor--error': $error,
+                                       'image-info__editor--saving': bylineEditForm.$waiting,
+                                       'text-input': true}">
 
-                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
-                        Multiple bylines (click ✎ to edit <strong>all</strong>)
-                    </span>
-
-                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
-                        Multiple bylines
-                    </span>
-
-                    <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
-                        <span ng-if="ctrl.metadata.byline">
-                            <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && ctrl.userCanEdit">
+                            Multiple bylines (click ✎ to edit <strong>all</strong>)
                         </span>
 
-                        <span class="editable-empty" ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.byline) && !ctrl.userCanEdit">
+                            Multiple bylines
+                        </span>
+
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
+                            <span ng-if="ctrl.metadata.byline">
+                                <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                            </span>
+
+                            <span class="editable-empty" ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                        </span>
                     </span>
                 </span>
+
             </dd>
 
             <dt class="metadata-line image-info__wrap image-info__credit metadata-line__key image-info__group--dl__key--panel">Credit</dt>
             <dd data-cy="metadata-credit" class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel">
-                <button data-cy="it-edit-credit-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="creditEditForm.$show()"
-                        ng-hide="creditEditForm.$visible"
-                        >✎</button>
+                <span ng-if="ctrl.metadataUpdatedByTemplate.includes('credit')">
+                    <input
+                        type="text"
+                        class="text-input job-info--editor__input job-info--editor__input--byline image-info--editor__input-preview"
+                        ng-model="ctrl.metadata.credit"
+                    />
+                </span>
+                <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('credit')">
+                    <button data-cy="it-edit-credit-button"
+                            class="image-info__edit"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="creditEditForm.$show()"
+                            ng-hide="creditEditForm.$visible"
+                    >✎</button>
 
-                <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
-                      editable-text="ctrl.metadata.credit"
-                      ng-hide="creditEditForm.$visible"
-                      e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
-                      onbeforesave="ctrl.updateMetadataField('credit', $data)"
-                      e:form="creditEditForm"
-                      e:ng-class="{'image-info__editor--error': $error,
-                                   'image-info__editor--saving': creditEditForm.$waiting,
-                                   'text-input': true}">
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.credit)}"
+                          editable-text="ctrl.metadata.credit"
+                          ng-hide="creditEditForm.$visible"
+                          e:typeahead="credit for credit in ctrl.credits($viewValue) | limitTo:8"
+                          onbeforesave="ctrl.updateMetadataField('credit', $data)"
+                          e:form="creditEditForm"
+                          e:ng-class="{'image-info__editor--error': $error,
+                                       'image-info__editor--saving': creditEditForm.$waiting,
+                                       'text-input': true}">
 
-                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
-                        Multiple credits (click ✎ to edit <strong>all</strong>)
-                    </span>
-
-                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
-                        Multiple credits
-                    </span>
-
-                    <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
-                        <span ng-if="ctrl.metadata.credit">
-                            <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && ctrl.userCanEdit">
+                            Multiple credits (click ✎ to edit <strong>all</strong>)
                         </span>
 
-                        <span class="editable-empty" ng-if="!ctrl.metadata.credit && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.credit) && !ctrl.userCanEdit">
+                            Multiple credits
+                        </span>
+
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
+                            <span ng-if="ctrl.metadata.credit">
+                                <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                            </span>
+
+                            <span class="editable-empty" ng-if="!ctrl.metadata.credit && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                        </span>
                     </span>
                 </span>
+
             </dd>
 
 
@@ -289,37 +324,47 @@
 
             <dt ng-if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
             <dd data-cy="metadata-copyright" ng-if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                <button data-cy="it-edit-copyright-button"
-                        class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
-                        ng-click="copyrightEditForm.$show()"
-                        ng-hide="copyrightEditForm.$visible"
-                        >✎</button>
-                <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
-                      editable-text="ctrl.metadata.copyright"
-                      ng-hide="copyrightEditForm.$visible"
-                      onbeforesave="ctrl.updateMetadataField('copyright', $data)"
-                      e:form="copyrightEditForm"
-                      e:ng-class="{'image-info__editor--error': $error,
-                                   'image-info__editor--saving': copyrightEditForm.$waiting,
-                                   'text-input': true}">
+                <span ng-if="ctrl.metadataUpdatedByTemplate.includes('copyright')">
+                    <input
+                        type="text"
+                        class="text-input job-info--editor__input job-info--editor__input--byline image-info--editor__input-preview"
+                        ng-model="ctrl.metadata.copyright"
+                    />
+                </span>
+                <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('copyright')">
+                    <button data-cy="it-edit-copyright-button"
+                            class="image-info__edit"
+                            ng-if="ctrl.userCanEdit"
+                            ng-click="copyrightEditForm.$show()"
+                            ng-hide="copyrightEditForm.$visible"
+                    >✎</button>
+                    <span ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)}"
+                          editable-text="ctrl.metadata.copyright"
+                          ng-hide="copyrightEditForm.$visible"
+                          onbeforesave="ctrl.updateMetadataField('copyright', $data)"
+                          e:form="copyrightEditForm"
+                          e:ng-class="{'image-info__editor--error': $error,
+                                       'image-info__editor--saving': copyrightEditForm.$waiting,
+                                       'text-input': true}">
 
-                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
-                        Multiple copyrights (click ✎ to edit <strong>all</strong>)
-                    </span>
-
-                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
-                        Multiple copyrights
-                    </span>
-
-                    <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
-                        <span ng-if="ctrl.metadata.copyright">
-                            <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && ctrl.userCanEdit">
+                            Multiple copyrights (click ✎ to edit <strong>all</strong>)
                         </span>
 
-                        <span class="editable-empty" ng-if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                        <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.copyright) && !ctrl.userCanEdit">
+                            Multiple copyrights
+                        </span>
+
+                        <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
+                            <span ng-if="ctrl.metadata.copyright">
+                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
+                            </span>
+
+                            <span class="editable-empty" ng-if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                        </span>
                     </span>
                 </span>
+
             </dd>
 
             <dt ng-if="ctrl.singleImage" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Uploaded</dt>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -54,7 +54,7 @@
         <dl>
             <div class="image-info__wrap">
                 <button class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
+                        ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                         ng-click="titleEditForm.$show()"
                         ng-hide="titleEditForm.$visible">✎</button>
                 <dt class="metadata-line metadata-line__key">Title</dt>
@@ -95,7 +95,7 @@
             <div data-cy="metadata-description" class="image-info__wrap">
                 <button data-cy="it-edit-description-button"
                         class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
+                        ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                         ng-click="descriptionEditForm.$show()"
                         ng-hide="descriptionEditForm.$visible">✎</button>
                 <dt class="metadata-line metadata-line__key">Description</dt>
@@ -166,7 +166,7 @@
     <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions" role="region" aria-label="Special instructions">
         <dl class="image-info__wrap">
             <button class="image-info__edit"
-                    ng-if="ctrl.userCanEdit"
+                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                     ng-click="specialInstructionsEditForm.$show()"
                     ng-hide="specialInstructionsEditForm.$visible">✎</button>
             <dt class="metadata-line metadata-line__key">Special instructions</dt>
@@ -226,7 +226,7 @@
                 <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('byline')">
                     <button data-cy="it-edit-byline-button"
                             class="image-info__edit"
-                            ng-if="ctrl.userCanEdit"
+                            ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                             ng-click="bylineEditForm.$show()"
                             ng-hide="bylineEditForm.$visible"
                     >✎</button>
@@ -272,7 +272,7 @@
                 <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('credit')">
                     <button data-cy="it-edit-credit-button"
                             class="image-info__edit"
-                            ng-if="ctrl.userCanEdit"
+                            ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                             ng-click="creditEditForm.$show()"
                             ng-hide="creditEditForm.$visible"
                     >✎</button>
@@ -337,7 +337,7 @@
                 <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('copyright')">
                     <button data-cy="it-edit-copyright-button"
                             class="image-info__edit"
-                            ng-if="ctrl.userCanEdit"
+                            ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                             ng-click="copyrightEditForm.$show()"
                             ng-hide="copyrightEditForm.$visible"
                     >✎</button>
@@ -416,7 +416,7 @@
                         ng-class="{'small': ctrl.grSmall}"
                         ng-click="peopleInImageEditForm.$show()"
                         ng-hide="peopleInImageEditForm.$visible"
-                        ng-if="ctrl.userCanEdit"
+                        ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                         gr-tooltip="Add People"
                         gr-tooltip-position="left"
                         aria-label="Add people to image">
@@ -495,7 +495,7 @@
                         <span ng-switch-when="string">
                             <button data-cy="it-edit-{{specField.name}}-button"
                                     class="image-info__edit"
-                                    ng-if="ctrl.userCanEdit"
+                                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                                     ng-click="domainMetadataEditForm.$show()"
                                     ng-hide="domainMetadataEditForm.$visible"
                             >✎</button>
@@ -520,7 +520,7 @@
                         <span ng-switch-when="datetime">
                             <button data-cy="it-edit-{{specField.name}}-button"
                                     class="image-info__edit"
-                                    ng-if="ctrl.userCanEdit"
+                                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                                     ng-click="domainMetadataEditForm.$show()"
                                     ng-hide="domainMetadataEditForm.$visible"
                             >✎</button>
@@ -545,7 +545,7 @@
                         <span ng-switch-when="integer">
                             <button data-cy="it-edit-{{specField.name}}-button"
                                     class="image-info__edit"
-                                    ng-if="ctrl.userCanEdit"
+                                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                                     ng-click="domainMetadataEditForm.$show()"
                                     ng-hide="domainMetadataEditForm.$visible"
                             >✎</button>
@@ -571,7 +571,7 @@
                         <span ng-switch-when="select">
                             <button data-cy="it-edit-{{specField.name}}-button"
                                     class="image-info__edit"
-                                    ng-if="ctrl.userCanEdit"
+                                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                                     ng-click="domainMetadataEditForm.$show()"
                                     ng-hide="domainMetadataEditForm.$visible"
                             >✎</button>
@@ -597,7 +597,7 @@
                         <span ng-switch-default>
                             <button data-cy="it-edit-{{specField.name}}-button"
                                     class="image-info__edit"
-                                    ng-if="ctrl.userCanEdit"
+                                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                                     ng-click="domainMetadataEditForm.$show()"
                                     ng-hide="domainMetadataEditForm.$visible"
                             >✎</button>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -389,17 +389,18 @@ module.controller('grImageMetadataCtrl', [
       ctrl.usageRightsUpdatedByTemplate = false;
 
       if (usageRights.category !== undefined) {
-        if ((ctrl.singleImage.data.userMetadata.data.usageRights.data === undefined) ||
-          (ctrl.singleImage.data.userMetadata.data.usageRights.data.category !== usageRights.category)) {
+        if ((ctrl.singleImage.data.usageRights === undefined) ||
+          (ctrl.singleImage.data.usageRights.category !== usageRights.category)) {
           ctrl.usageRights.first().data = usageRights;
           ctrl.showUsageRights = true;
         }
       }
 
-      const originalUsageRights = ctrl.singleImage.data.userMetadata.data.usageRights.data ? ctrl.singleImage.data.userMetadata.data.usageRights.data : {};
+      const originalUsageRights = ctrl.singleImage.data.usageRights ? ctrl.singleImage.data.usageRights : {};
       if (angular.equals(usageRights, originalUsageRights) === false) {
         ctrl.usageRightsUpdatedByTemplate = true;
       }
+      debugger;
     };
 
     ctrl.onMetadataTemplateApplied = () => {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -55,6 +55,7 @@ module.controller('grImageMetadataCtrl', [
     // Deep copying window._clientConfig.domainMetadataModels
     ctrl.domainMetadataSpecs = JSON.parse(JSON.stringify(window._clientConfig.domainMetadataSpecs));
     ctrl.showUsageRights = false;
+    ctrl.metadataUpdatedByTemplate = [];
     $scope.$watchCollection('ctrl.selectedImages', function() {
       ctrl.singleImage = singleImage();
       ctrl.selectedLabels = selectedLabels();
@@ -387,11 +388,11 @@ module.controller('grImageMetadataCtrl', [
 
       ctrl.showUsageRights = false;
       ctrl.usageRightsUpdatedByTemplate = false;
+      ctrl.usageRights.first().data = usageRights;
 
       if (usageRights.category !== undefined) {
         if ((ctrl.singleImage.data.usageRights === undefined) ||
           (ctrl.singleImage.data.usageRights.category !== usageRights.category)) {
-          ctrl.usageRights.first().data = usageRights;
           ctrl.showUsageRights = true;
         }
       }
@@ -400,7 +401,6 @@ module.controller('grImageMetadataCtrl', [
       if (angular.equals(usageRights, originalUsageRights) === false) {
         ctrl.usageRightsUpdatedByTemplate = true;
       }
-      debugger;
     };
 
     ctrl.onMetadataTemplateApplied = () => {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import Rx from 'rx';
 
+import './gr-image-metadata.css';
 import template from './gr-image-metadata.html';
 import './gr-image-metadata.css';
 import '../../image/service';
@@ -50,6 +51,7 @@ module.controller('grImageMetadataCtrl', [
 
     let ctrl = this;
 
+    ctrl.displayMetadataTemplates = window._clientConfig.metadataTemplates !== undefined && window._clientConfig.metadataTemplates.length > 0;
     // Deep copying window._clientConfig.domainMetadataModels
     ctrl.domainMetadataSpecs = JSON.parse(JSON.stringify(window._clientConfig.domainMetadataSpecs));
     ctrl.showUsageRights = false;
@@ -378,6 +380,41 @@ module.controller('grImageMetadataCtrl', [
     $scope.$on('$destroy', function() {
         freeUpdateListener();
     });
+
+    ctrl.onMetadataTemplateSelected = (metadata, usageRights) => {
+      ctrl.metadataUpdatedByTemplate = Object.keys(metadata).filter(key => ctrl.rawMetadata[key] !== metadata[key]);
+      ctrl.metadata = metadata;
+
+      ctrl.showUsageRights = false;
+      ctrl.usageRightsUpdatedByTemplate = false;
+
+      if (usageRights.category !== undefined) {
+        if ((ctrl.singleImage.data.userMetadata.data.usageRights.data === undefined) ||
+          (ctrl.singleImage.data.userMetadata.data.usageRights.data.category !== usageRights.category)) {
+          ctrl.usageRights.first().data = usageRights;
+          ctrl.showUsageRights = true;
+        }
+      }
+
+      const originalUsageRights = ctrl.singleImage.data.userMetadata.data.usageRights.data ? ctrl.singleImage.data.userMetadata.data.usageRights.data : {};
+      if (angular.equals(usageRights, originalUsageRights) === false) {
+        ctrl.usageRightsUpdatedByTemplate = true;
+      }
+    };
+
+    ctrl.onMetadataTemplateApplied = () => {
+      ctrl.showUsageRights = false;
+      ctrl.usageRightsUpdatedByTemplate = false;
+      ctrl.metadataUpdatedByTemplate = [];
+    };
+
+    ctrl.onMetadataTemplateCancelled = (metadata, usageRights) => {
+      ctrl.metadataUpdatedByTemplate = [];
+      ctrl.showUsageRights = false;
+      ctrl.usageRightsUpdatedByTemplate = false;
+      ctrl.metadata = metadata;
+      ctrl.usageRights.first().data = usageRights;
+    };
 }
 ]);
 

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -101,6 +101,20 @@
             <span ng-if="!ctrl.canUndelete">Image deleted (this image already exists and has been deleted. Click View image to see details)</span>
         </div>
 
+        <div class="image-actions-container" ng-if="ctrl.displayMetadataTemplates">
+            <div class="result-editor__usage-rights-container">
+                <gr-metadata-templates
+                   image="ctrl.image"
+                   metadata="ctrl.image.data.metadata"
+                   usage-rights="ctrl.image.data.usageRights"
+                   gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights)"
+                   gr-on-metadata-template-applied="ctrl.onMetadataTemplateApplied()"
+                   gr-on-metadata-template-cancelled="ctrl.onMetadataTemplateCancelled(metadata, usageRights)"
+                   class="metadata-templates-flex">
+                </gr-metadata-templates>
+            </div>
+        </div>
+
         <span class="result-editor__save-status-container">
             <span class="result-editor__save-status"
                   ng-show="ctrl.saving">Saving… <span class="saving">⧖</span>
@@ -145,7 +159,8 @@
                         class="result-editor__usage-rights"
                         gr-usage-rights="[ctrl.usageRights]"
                         gr-on-save="ctrl.showUsageRights = false"
-                        gr-on-cancel="ctrl.showUsageRights = false">
+                        gr-on-cancel="ctrl.showUsageRights = false"
+                        gr-usage-rights-updated-by-template="ctrl.usageRightsUpdatedByTemplate">
                     </gr-usage-rights-editor>
                 </div>
             </div>

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -151,12 +151,12 @@ imageEditor.controller('ImageEditorCtrl', [
       ctrl.usageRightsUpdatedByTemplate = false;
       ctrl.usageRights.data = usageRights;
 
-      if (ctrl.image.data.userMetadata.data.usageRights.data === undefined ||
-        ctrl.image.data.userMetadata.data.usageRights.data.category !== usageRights.category) {
+      if (ctrl.image.data.usageRights === undefined ||
+        ctrl.image.data.usageRights.category !== usageRights.category) {
         ctrl.showUsageRights = true;
       }
 
-      const originalUsageRights = ctrl.image.data.userMetadata.data.usageRights.data ? ctrl.image.data.userMetadata.data.usageRights.data : {};
+      const originalUsageRights = ctrl.image.data.usageRights ? ctrl.image.data.usageRights : {};
       if (angular.equals(usageRights, originalUsageRights) === false) {
         ctrl.usageRightsUpdatedByTemplate = true;
       }

--- a/kahuna/public/js/metadata-templates/metadata-templates.css
+++ b/kahuna/public/js/metadata-templates/metadata-templates.css
@@ -1,0 +1,4 @@
+.metadata-templates__form {
+  color: #ccc;
+  padding: 10px 0;
+}

--- a/kahuna/public/js/metadata-templates/metadata-templates.html
+++ b/kahuna/public/js/metadata-templates/metadata-templates.html
@@ -1,0 +1,29 @@
+<form class="metadata-templates__form full-width"
+      ng-submit="ctrl.applyTemplate()">
+    <label>
+        <select
+            data-cy="it-metadatatemplate-select"
+            class="full-width"
+            ng-model="ctrl.metadataTemplate"
+            ng-required="required"
+            ng-change="ctrl.selectTemplate()"
+            ng-options="metadataTemplate as metadataTemplate.templateName for metadataTemplate in ctrl.metadataTemplates track by metadataTemplate.templateName">
+            <option ng-selected="true" value="">Please select template</option>
+        </select>
+    </label>
+
+    <div class="ure__bar" ng-if="ctrl.metadataTemplate">
+        <button class="ure__action button-ico button-cancel" type="button"
+                ng-click="ctrl.cancel()"
+                title="Close">
+            <gr-icon-label gr-icon="close">Cancel</gr-icon-label>
+        </button>
+        <button data-cy="apply-metadata-template"
+            class="ure__action button-ico button-save"
+            type="submit"
+            title="Apply template">
+            <gr-icon-label gr-icon="check">Apply</gr-icon-label>
+            <gr-icon ng-if="ctrl.saving">timelapse</gr-icon>
+        </button>
+    </div>
+</form>

--- a/kahuna/public/js/metadata-templates/metadata-templates.js
+++ b/kahuna/public/js/metadata-templates/metadata-templates.js
@@ -1,0 +1,113 @@
+import angular from 'angular';
+import template from './metadata-templates.html';
+
+import '../util/rx';
+
+import './metadata-templates.css';
+
+import '../edits/service';
+
+export const metadataTemplates = angular.module('kahuna.edits.metadataTemplates', [
+  'kahuna.edits.service',
+  'util.rx'
+]);
+
+metadataTemplates.controller('MetadataTemplatesCtrl', [
+  '$scope',
+  '$window',
+  'editsService',
+  function ($scope, $window, editsService) {
+
+  let ctrl = this;
+
+  ctrl.templateSelected = false;
+  ctrl.metadataTemplates = window._clientConfig.metadataTemplates;
+
+  const filterNonEmpty = (list) => list.filter(s => (typeof s === 'string' && s !== "" && s !== " "));
+
+  function resolve(strategy, originalValue, changeToApply) {
+    if (strategy === 'replace') {
+      return changeToApply;
+    } else if (strategy === 'append') {
+      return filterNonEmpty([originalValue, changeToApply]).join(' ');
+    } else if (strategy === 'prepend') {
+      return filterNonEmpty([changeToApply, originalValue]).join(' ');
+    } else {
+      return originalValue;
+    }
+  }
+
+  ctrl.selectTemplate = () => {
+    if (ctrl.metadataTemplate) {
+      const metadata = applyTemplateToMetadata();
+      const usageRights = applyTemplateToUsageRights();
+
+      ctrl.onMetadataTemplateSelected({metadata, usageRights});
+    } else {
+      ctrl.cancel();
+    }
+  };
+
+  function applyTemplateToMetadata() {
+    if (ctrl.metadataTemplate.metadataFields && ctrl.metadataTemplate.metadataFields.length > 0) {
+      ctrl.metadata = angular.copy(ctrl.originalMetadata);
+      ctrl.metadataTemplate.metadataFields.forEach(field => {
+        ctrl.metadata[field.name] = resolve(field.resolveStrategy, ctrl.metadata[field.name], field.value);
+      });
+
+      return ctrl.metadata;
+    }
+  }
+
+  function applyTemplateToUsageRights() {
+    if (ctrl.metadataTemplate.usageRights && ctrl.metadataTemplate.usageRights.hasOwnProperty('category')) {
+      return ctrl.metadataTemplate.usageRights;
+    } else {
+      return ctrl.originalUsageRights;
+    }
+  }
+
+  ctrl.cancel = () => {
+    ctrl.metadataTemplate = null;
+    ctrl.saving = false;
+    ctrl.onMetadataTemplateCancelled({metadata: ctrl.originalMetadata, usageRights: ctrl.originalUsageRights});
+  };
+
+  ctrl.applyTemplate = () => {
+    ctrl.saving = true;
+
+    editsService
+      .update(ctrl.image.data.userMetadata.data.metadata, ctrl.metadata, ctrl.image)
+      .then(resource => ctrl.resource = resource)
+      .then(() => {
+        if (ctrl.metadataTemplate.usageRights) {
+          editsService
+            .update(ctrl.image.data.userMetadata.data.usageRights, ctrl.metadataTemplate.usageRights, ctrl.image)
+            .then(() => editsService.updateMetadataFromUsageRights(ctrl.image, false));
+        }
+      })
+      .finally(() => {
+        ctrl.metadataTemplate = null;
+        ctrl.saving = false;
+        ctrl.onMetadataTemplateApplied();
+      });
+  };
+}]);
+
+metadataTemplates.directive('grMetadataTemplates', [function() {
+  return {
+    restrict: 'E',
+    controller: 'MetadataTemplatesCtrl',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    template: template,
+    scope: {
+      image: '=',
+      originalMetadata: '=metadata',
+      originalUsageRights: '=usageRights',
+      onMetadataTemplateCancelled: '&?grOnMetadataTemplateCancelled',
+      onMetadataTemplateApplied: '&?grOnMetadataTemplateApplied',
+      onMetadataTemplateSelected: '&?grOnMetadataTemplateSelected'
+    }
+  };
+}]);

--- a/kahuna/public/js/metadata-templates/metadata-templates.js
+++ b/kahuna/public/js/metadata-templates/metadata-templates.js
@@ -92,6 +92,12 @@ metadataTemplates.controller('MetadataTemplatesCtrl', [
         ctrl.onMetadataTemplateApplied();
       });
   };
+
+  $scope.$watch('ctrl.originalMetadata', (originalMetadata) => {
+    if (originalMetadata && ctrl.metadataTemplate) {
+      ctrl.selectTemplate();
+    }
+  });
 }]);
 
 metadataTemplates.directive('grMetadataTemplates', [function() {

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -1,3 +1,7 @@
 .job-editor__disabled {
     opacity: 0.4;
 }
+
+.job-info--editor__input-preview {
+  border: 1px solid #ffbc01;
+}

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -12,7 +12,7 @@
                 ng-controller="DescriptionPlaceholderCtrl"
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.originalMetadata['description'] !== ctrl.metadata['description'] }"
                 ng-disabled="!ctrl.userCanEdit"
             ></textarea>
 
@@ -38,7 +38,7 @@
                 ng-model="ctrl.metadata.byline"
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('byline')  }"
                 ng-disabled="!ctrl.userCanEdit"
             />
 
@@ -67,6 +67,7 @@
                     gr-datalist-input
                     ng-model="ctrl.metadata.credit"
                     ng-change="ctrl.save()"
+                    ng-class="{ 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('credit')  }"
                     ng-disabled="!ctrl.userCanEdit"
                     ng-model-options="{ updateOn: 'gr-datalist:update blur' }" />
             </gr-datalist>
@@ -88,7 +89,7 @@
                 ng-model="ctrl.metadata.copyright"
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('copyright') }"
                 ng-disabled="!ctrl.userCanEdit"
             />
 
@@ -110,7 +111,7 @@
                 ng-model="ctrl.metadata.specialInstructions"
                 ng-change="ctrl.save()"
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch }"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('specialInstructions') }"
                 ng-disabled="!ctrl.userCanEdit"
             />
 

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -16,6 +16,7 @@
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.originalMetadata['description'] !== ctrl.metadata['description'] }"
                 ng-disabled="!ctrl.userCanEdit"
+                ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
             ></textarea>
 
             <button
@@ -42,6 +43,7 @@
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('byline')  }"
                 ng-disabled="!ctrl.userCanEdit"
+                ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
             />
 
             <button
@@ -71,6 +73,7 @@
                     ng-change="ctrl.save()"
                     ng-class="{ 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('credit')  }"
                     ng-disabled="!ctrl.userCanEdit"
+                    ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
                     ng-model-options="{ updateOn: 'gr-datalist:update blur' }" />
             </gr-datalist>
 
@@ -93,6 +96,7 @@
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('copyright') }"
                 ng-disabled="!ctrl.userCanEdit"
+                ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
             />
 
             <button
@@ -115,6 +119,7 @@
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('specialInstructions') }"
                 ng-disabled="!ctrl.userCanEdit"
+                ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
             />
 
             <button

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -59,6 +59,22 @@ jobs.controller('RequiredMetadataEditorCtrl',
         });
     };
 
+    $scope.$on('events:metadata-template:template-selected', (e, { metadata } ) => {
+      if (ctrl.userCanEdit) {
+        ctrl.metadataUpdatedByTemplate = Object.keys(metadata).filter(key => ctrl.originalMetadata[key] !== metadata[key]);
+        ctrl.metadata = metadata;
+      }
+    });
+
+    $scope.$on('events:metadata-template:template-applied', () => {
+      ctrl.metadataUpdatedByTemplate = [];
+    });
+
+    $scope.$on('events:metadata-template:template-cancelled', (e, {metadata}) => {
+      ctrl.metadataUpdatedByTemplate = [];
+      ctrl.metadata = metadata;
+    });
+
     // As we make a copy of this, we need to watch it
     // in case the metadata changes from above.
     $scope.$watch(() => ctrl.originalMetadata, metadata =>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.css
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.css
@@ -45,3 +45,7 @@
 .ure__category-invalid {
     border: 1px solid #ed5935;
 }
+
+.ure__category-preview {
+    border: 1px solid #ffbc01;
+}

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -21,7 +21,7 @@
             data-cy="it-rights-select"
             class="full-width"
             ng-model="ctrl.category"
-            ng-disabled="ctrl.saving"
+            ng-disabled="ctrl.saving || ctrl.usageRightsUpdatedByTemplate"
             ng-options="category as category.name for category in ctrl.categories track by category.value"
             ng-change="ctrl.reset()">
         </select>
@@ -70,7 +70,8 @@
                         placeholder="What restrictions apply to this image? e.g. 'Use in relation to the Windsor Triathlon only'"
                         ng-switch-when="true"
                         ng-model="ctrl.model[property.name]"
-                        ng-required="ctrl.showRestrictions"></textarea>
+                        ng-required="ctrl.showRestrictions"
+                        ng-readonly="ctrl.usageRightsUpdatedByTemplate"></textarea>
 
                     <textarea
                         class="text-input form-input-text"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -1,7 +1,7 @@
 <form class="usage-rights-editor ure"
       novalidate
       name="usageRights"
-      ng-class="{'ure__category-invalid': ctrl.categoryInvalid}"
+      ng-class="{'ure__category-invalid': ctrl.categoryInvalid, 'ure__category-preview': ctrl.usageRightsUpdatedByTemplate}"
       ng-submit="usageRights.$valid && ctrl.save()">
 
     <div class="ure__description">
@@ -179,7 +179,7 @@
             </div>
         </div>
     </div>
-    <div class="ure__bar">
+    <div class="ure__bar" ng-if="!ctrl.usageRightsUpdatedByTemplate">
         <button class="ure__action button-ico button-cancel" type="button" ng-click="ctrl.cancel()"
                 title="close usage rights overrides">
             <gr-icon-label gr-icon="close">Cancel</gr-icon-label>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -89,7 +89,6 @@ usageRightsEditor.controller(
             cat.properties.find(prop => prop.name === 'defaultRestrictions');
         const restrictedProp =
             cat.properties.find(prop => prop.name === 'restrictions');
-
         return defaultRestrictions || (restrictedProp && restrictedProp.required);
     });
 
@@ -97,10 +96,12 @@ usageRightsEditor.controller(
     const modelHasRestrictions$ = model$.map(model => angular.isDefined(model.restrictions));
 
     // Stream.<Boolean>
-    const showRestrictions$ = forceRestrictions$.combineLatest(modelHasRestrictions$,
-        (forceRestrictions, showRestrictions) => {
-
+    const showRestrictions$ = forceRestrictions$.combineLatest(modelHasRestrictions$, usageRights$,
+        (forceRestrictions, showRestrictions, usageRights) => {
+        const [urs] = usageRights;
         if (forceRestrictions) {
+            return true;
+        } else if (angular.isDefined(urs.data.restrictions)) {
             return true;
         } else {
             return showRestrictions;
@@ -134,6 +135,20 @@ usageRightsEditor.controller(
         const val = ctrl.model[key];
         return property.optionsMap[val] || [];
     };
+
+    $scope.$watch('ctrl.usageRights', (newUsageRights) => {
+      const [usageRights] = newUsageRights;
+
+      if (usageRights.data.category) {
+        if (ctrl.categories) {
+          ctrl.category = ctrl.categories.find(cat => cat.value === usageRights.data.category);
+        }
+
+        ctrl.model = usageRights.data;
+      } else if (ctrl.categories) {
+        ctrl.category = ctrl.categories.find(cat => cat.value === "");
+      }
+    }, true);
 
     ctrl.save = () => {
         ctrl.saving = true;
@@ -208,9 +223,10 @@ usageRightsEditor.directive('grUsageRightsEditor', [function() {
         bindToController: true,
         template: template,
         scope: {
-            usageRights: '=grUsageRights',
+            usageRights: '=?grUsageRights',
             onCancel: '&?grOnCancel',
-            onSave: '&?grOnSave'
+            onSave: '&?grOnSave',
+            usageRightsUpdatedByTemplate: '=?grUsageRightsUpdatedByTemplate'
         }
     };
 }]);

--- a/kahuna/test/lib/MetadataTemplateConfigTest.scala
+++ b/kahuna/test/lib/MetadataTemplateConfigTest.scala
@@ -1,0 +1,98 @@
+package lib
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.Configuration
+
+class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
+
+  "The config loader" - {
+    val configuration = Configuration.from(Map(
+      "metadata.templates" -> List(
+        Map(
+          "templateName" -> "A",
+          "usageRights" -> Map(
+            "category" -> "social-media",
+            "restrictions" -> "Sample social media restriction"
+          ),
+          "metadataFields" -> List(
+            Map(
+              "name" -> "byline",
+              "value" -> "Sample byline from template",
+              "resolveStrategy" -> "replace"
+            )
+          )
+        ),
+        Map(
+          "templateName" -> "B",
+          "metadataFields" -> List(
+            Map(
+              "name" -> "specialInstructions",
+              "value" -> "Sample special instructions from template",
+              "resolveStrategy" -> "append"
+            )
+          )
+        ),
+        Map(
+          "templateName" -> "C",
+          "usageRights" -> Map(
+            "category" -> "original-source"
+          ),
+        ),
+      )
+    ))
+
+    val metadataTemplates: Seq[MetadataTemplate] = configuration
+      .getOptional[Seq[MetadataTemplate]]("metadata.templates").getOrElse(Seq.empty)
+
+    "should return a list of templates when metadata.templates is configured" in {
+      metadataTemplates.nonEmpty shouldBe true
+      metadataTemplates.length shouldBe 3
+    }
+
+    "should return a template with usage rights and metadata fields" in {
+      metadataTemplates.headOption.nonEmpty shouldBe true
+      val template = metadataTemplates.head
+      template.templateName shouldBe "A"
+      template.usageRights shouldBe defined
+
+      val usageRights = template.usageRights.get
+      usageRights.category shouldBe "social-media"
+      usageRights.restrictions shouldBe Some("Sample social media restriction")
+
+      template.metadataFields.nonEmpty shouldBe true
+      template.metadataFields.length shouldBe 1
+
+      val field = template.metadataFields.head
+      field.name shouldBe "byline"
+      field.value shouldBe "Sample byline from template"
+      field.resolveStrategy shouldBe FieldResolveStrategy.replace
+    }
+
+    "should return a template metadata fields only" in {
+      val template = metadataTemplates.tail.head
+      template.templateName shouldBe "B"
+      template.usageRights shouldBe None
+
+      template.metadataFields.nonEmpty shouldBe true
+      template.metadataFields.length shouldBe 1
+
+      val fieldA = template.metadataFields.head
+      fieldA.name shouldBe "specialInstructions"
+      fieldA.value shouldBe "Sample special instructions from template"
+      fieldA.resolveStrategy shouldBe FieldResolveStrategy.append
+    }
+
+    "should return a template usage rights only" in {
+      val template = metadataTemplates.tail.last
+      template.templateName shouldBe "C"
+      template.metadataFields.isEmpty shouldBe true
+      template.usageRights shouldBe defined
+
+      val usageRights = template.usageRights.get
+      usageRights.category shouldBe "original-source"
+      usageRights.restrictions shouldBe None
+    }
+  }
+
+}


### PR DESCRIPTION
## What does this change?

Introduces new functionality that allows application of metadata field values and usage rights defined in a metadata template to be applied to an image.

## How can success be measured?

Adding the following configuration to kahuna configuration should

- Render "Template select" component on the "My uploads" page and Image view page as shown in the illustrations below.
- Allow a user to select a metadata template and apply the template values to the image metadata and usage rights (if configured)

```hocon
metadata.templates = [
  {
    templateName: "Social Media"
    usageRights: {
      category: "social-media" # usage right category
      restrictions: "SOCIAL MEDIA - Usage requires approval by a Senior Editor" # Optional
    }
    metadataFields: [
      {
        name: "byline" # ImageMetadata field name
        value: "My Byline"
        resolveStrategy: "replace" # Optional, possible values "replace", "prepend", "append" and "ignore". Default value is "replace"
      }
      {
        name: "credit"
        value: "My Credit"
        resolveStrategy: "replace"
      }
      {
        name: "copyright"
        value: "Social media source Copyright"
        resolveStrategy: "replace"
      }
      {
        name: "specialInstructions"
        value: "Approval needed from a senior editor"
        resolveStrategy: "replace"
      }
    ]
  }
  {
    templateName: "User uploads"
    usageRights: {
      category: "Bylines"
      restrictions: "Bylines - Usage requires approval by a Senior Editor"
    }
    metadataFields: [
      {
        name: "copyright"
        value: "My Copyright"
        resolveStrategy: "replace"
      }
    ]
  }
]
```

## Screenshots

### My uploads view

![Upload page](https://user-images.githubusercontent.com/12212239/160836261-24e75412-acbe-4cd8-881c-738475ade89b.gif)

### Search view

![Images page](https://user-images.githubusercontent.com/12212239/160836228-65ac2aea-9c22-43f0-a0ab-c77f6cecccc0.gif)

### Image view

![Image page](https://user-images.githubusercontent.com/12212239/160836292-b75f9115-10cb-4a89-b412-8e620e39d4a1.gif)


## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
