### PR TITLE
Recognise various Wyborcza credits via Reuters and switch USA Today Sports to depend on copyright

### DIFF
--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -485,25 +485,18 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       processedImage.metadata.credit should be(Some("Reuters"))
     }
 
-    it("should match USA Today Sports credit") {
-      val image = createImageFromMetadata("credit" -> "USA Today Sports")
+    it("should match USA Today Sports copyright") {
+      val image = createImageFromMetadata("copyright" -> "USA Today Sports")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Reuters"))
       processedImage.metadata.credit should be(Some("USA Today Sports"))
     }
 
-    it("should match USA TODAY Sports credit") {
-      val image = createImageFromMetadata("credit" -> "USA TODAY Sports")
+    it("should match USA TODAY Sports copyright") {
+      val image = createImageFromMetadata("copyright" -> "USA TODAY Sports")
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("Reuters"))
       processedImage.metadata.credit should be(Some("USA Today Sports"))
-    }
-
-    it("should match TT NEWS AGENCY credit") {
-      val image = createImageFromMetadata("credit" -> "TT NEWS AGENCY")
-      val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("Reuters"))
-      processedImage.metadata.credit should be(Some("TT NEWS AGENCY"))
     }
   }
 


### PR DESCRIPTION
## What does this change?
This adjusts Reuters processor:

### Agenca Wyborcza.pl

It recognises our Polish friends when they come through Reuters in their various guises. Some examples of credits:

`AGENCJA WYBORCZA/Agencja Wyborcza.pl/REUTERS`
`AGENCJA WYBORCZA.PL/Agencja Wyborcza.pl/REUTERS`
`Agencja Wyborcza.pl/REUTERS`
`Agencja Gazeta/REUTERS`
`AGENCJA GAZETA/via REUTERS`
`AGENCJA GAZETA/REUTERS`
`AGENCJA GAZETA VIA REUTERS`
`AGENCJA/Agencja Gazeta/REUTERS`

Sadly, sometimes the byline is filled with some of the above tokens instead of the name of the photographer, which exists only in the Description. But I wouldn’t know how to scrape it from there…

### USA Today

It switches USA Today sniffing to be based off copyright, as credit sometimes contains a repeated byline.

## How can success be measured?
For Wyborcza, we navigate the stormy seas of years-long inconsistent metadata that survived even the recent controversy-related name changing to arrive at some good images from Ukraine. But real success would be to get Sroczyński back on board…

For USA Today, we catch more.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)