### PR TITLE
remove client-side search limit distinction between filtered and not, and up search limit to huge 100k

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -133,7 +133,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
       // https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html
       // Override to 25,000 to preserve the existing behaviour without comprising the Elastic cluster.
       // The grid UI should consider scrolling by datetime offsets if possible.
-      val maximumPaginationOverride = Map("max_result_window" -> 25000)
+      val maximumPaginationOverride = Map("max_result_window" -> 101000)
 
       val nonRecommendenedIndexSettingOverrides = maximumFieldsOverride ++ maximumPaginationOverride
       logger.warn("Applying non recommended index setting overrides; please consider altering the application " +

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -117,13 +117,8 @@ results.controller('SearchResultsCtrl', [
         ctrl.getLastSeenVal = getLastSeenVal;
         ctrl.imageHasBeenSeen = imageHasBeenSeen;
 
-        // Arbitrary limit of number of results; too many and the
-        // scrollbar becomes hyper-sensitive
-        const searchFilteredLimit = 5000;
-        // When reviewing all images, we accept a degraded scroll
-        // experience to allow seeing around one day's worth of images
-        const searchAllLimit = 20000;
-        ctrl.maxResults = $stateParams.query ? searchFilteredLimit : searchAllLimit;
+        // large limit, but still a limit to ensure users don't reach unusable levels of performance
+        ctrl.maxResults = 100000;
 
         // If not reloading a previous search, discard any previous
         // state related to the last search


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak 
Co-Authored-By: @paperboyo 
Co-Authored-By: @blishen 

## What does this change?
With an ever increasing number of images daily, the current limits on search results, which manifest like...
![image](https://user-images.githubusercontent.com/19289579/156171648-2580b71b-d7ae-4b69-ae46-a84d1587b78c.png)
... were far too low - and users complained.

After some discussion we decided to remove the distinction between filtered and unfiltered, and to set an overall limit of 100k (which should cover daily volumes for a long time to come). Browsers have moved on since these lower limits, such that scroll bar is still reasonable effective (and users mainly use keyboard shortcuts [Up, Down, PageUp & PageDown]) also ES performance is still reasonable even down at the bottom of a 100k results.

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
