### PR TITLE
Hide the image cost warning - it's available in the validity warnings

### DIFF
--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
@@ -1,17 +1,4 @@
 <div ng-switch="messageState">
-    <div ng-switch-when="no_rights"
-        class="image-notice image-info__group status cost cost--pay">
-        No rights to use this image
-    </div>
-    <div ng-switch-when="overquota"
-        class="image-notice image-info__group status cost cost--pay">
-        Quota exceeded for this supplier
-    </div>
-    <div ng-switch-when="pay"
-         class="image-notice image-info__group status cost cost--pay">
-        Pay to use
-    </div>
-
     <div ng-switch-when="conditional"
          class="image-notice image-info__group cost cost--conditional"
          title="This image can be used but only within certain restrictions">

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,7 +1,7 @@
 <div
     ng-if="ctrl.showInvalidReasons"
     class="image-notice image-info__group validity validity--invalid validity--point-up"
-    ng-class="{'validity--invalid': ctrl.isDeleted || !ctrl.isOverridden, 'validity--warning': ctrl.isOverridden && !ctrl.isDeleted}"
+    ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning}"
 >
     <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">Unusable Image
         <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -14,6 +14,7 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', function ($rootScope
             ctrl.showInvalidReasons = Object.keys(image.data.invalidReasons).length !== 0 || ctrl.isDeleted;
             ctrl.invalidReasons = image.data.invalidReasons;
             ctrl.isOverridden = ctrl.showInvalidReasons && image.data.valid;
+            ctrl.isStrongWarning = ctrl.isDeleted || !ctrl.isOverridden || image.data.cost === "pay";
         });
     }
 


### PR DESCRIPTION
## What does this change?

Hide most variants of the image cost warning as they're covered by the validity warnings. This means that most of the duplicate elements (eg. "No rights to use this image", "Paid imagery requires a lease", etc.) are reduced to a single occurrence. The image cost warning banner remains to display the restriction text when images' cost is conditional. 

The validity warning banner is also set to red if the image's cost has been calculated as `pay`.

## How can success be measured?

Less repetition, clearer to understand 

## Screenshots

x | Before | After
-|---|---
with permissions | ![image](https://user-images.githubusercontent.com/10963046/156413033-8f26fd91-2426-4d6b-8d01-f24a3396364c.png) | ![image](https://user-images.githubusercontent.com/10963046/156413164-fef805db-792b-40d2-aad0-17ef6ea68d00.png)
without permissions | ![image](https://user-images.githubusercontent.com/10963046/156413755-e0ee85b8-68b3-4c6d-bebb-04b1ff376697.png) | ![image](https://user-images.githubusercontent.com/10963046/156414147-aa48caca-c6e9-4453-b7cd-ed5c345db72e.png)





## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
