### PR TITLE
Remove box dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,6 @@ lazy val commonLib = project("common-lib").settings(
     "com.sksamuel.elastic4s" %% "elastic4s-core" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-domain" % elastic4sVersion,
-    "com.gu" %% "box" % "0.2.0",
     "com.gu" %% "thrift-serializer" % "5.0.2",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
     "org.im4java" % "im4java" % "1.4.0",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/KeyStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/KeyStore.scala
@@ -14,7 +14,7 @@ class KeyStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionConte
   def findKey(prefix: String): Option[String] = s3.syncFindKey(bucket, prefix)
 
   def update(): Unit = {
-    store.send(fetchAll)
+    store.set(fetchAll)
   }
 
   private def fetchAll: Map[String, ApiAccessor] = {

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -141,17 +141,16 @@ class UsageStore(
     }
   }
 
-  def getUsageStatus(): Future[StoreAccess] = Future.successful((for {
-      s <- store
-      l <- lastUpdated
-    } yield StoreAccess(s,l)).get())
+  def getUsageStatus(): Future[StoreAccess] = {
+    Future.successful(StoreAccess(store.get(), lastUpdated.get()))
+  }
 
   def overQuotaAgencies: List[Agency] = store.get.collect {
     case (_, status) if status.exceeded => status.usage.agency
   }.toList
 
   def update(): Unit = {
-    store.send(fetchUsage)
+    store.set(fetchUsage)
   }
 
   private def fetchUsage: Map[String, UsageStatus] = {
@@ -208,7 +207,7 @@ class QuotaStore(
   def getQuota: Map[String, SupplierUsageQuota] = store.get()
 
   def update(): Unit = {
-    store.send(fetchQuota)
+    store.set(fetchQuota)
   }
 
   private def fetchQuota: Map[String, SupplierUsageQuota] = {


### PR DESCRIPTION
## What does this change?

Removes the dependency upon <https://github.com/guardian/box>, which has not received updates in several years. The dependency is a single file which provides an alternate API to AtomicReference. This PR removes the dependency by implementing the direct API for AtomicReference.

## How can success be measured?

No regressions, one step closer to upgrading to 2.13

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
