### PR TITLE
Remove quicklens

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,6 @@ lazy val mediaApi = playProject("media-api", 9001)
       "org.apache.commons" % "commons-email" % "1.5",
       "org.parboiled" %% "parboiled" % "2.1.5",
       "org.http4s" %% "http4s-core" % "0.23.17",
-      "com.softwaremill.quicklens" %% "quicklens" % "1.4.11",
     )
   )
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -7,7 +7,6 @@ import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage._
-import com.softwaremill.quicklens._
 import lib.ImageResponse.extractAliasFieldValues
 import lib.elasticsearch.SourceWrapper
 import lib.usagerights.CostCalculator
@@ -386,12 +385,12 @@ object ImageResponse {
     Json.toJson(normaliseNewLinesInImageMeta(input))
   }
 
-  def normaliseNewLinesInImageMeta(imageMetadata: ImageMetadata): ImageMetadata = imageMetadata.modifyAll(
-    _.description,
-    _.copyright,
-    _.specialInstructions,
-    _.suppliersReference
-  ).using(_.map(ImageResponse.normaliseNewlineChars))
+  def normaliseNewLinesInImageMeta(imageMetadata: ImageMetadata): ImageMetadata = imageMetadata.copy(
+    description = imageMetadata.description.map(ImageResponse.normaliseNewlineChars),
+    copyright = imageMetadata.copyright.map(ImageResponse.normaliseNewlineChars),
+    specialInstructions = imageMetadata.specialInstructions.map(ImageResponse.normaliseNewlineChars),
+    suppliersReference = imageMetadata.suppliersReference.map(ImageResponse.normaliseNewlineChars),
+  )
 
   private val pattern = """[\r\n]+""".r
 


### PR DESCRIPTION
## What does this change?

We're importing the quicklens library into grid for a very narrow usage, which is also accomplished with a `copy`. Replace the usage and remove quicklens.

## How can success be measured?

One less dependency, one step closer to 2.13

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
