### PR TITLE
Better tokeniser/dedup and catching more exotic Reuters metadata

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -25,7 +25,7 @@ object BylineCreditReorganise extends MetadataCleaner {
   def removeBylineFromCredit(bylineField: Field, creditField: Field) =
     bylineField.map { byline =>
       val credit = creditField.getOrElse("")
-      val bylineParts = byline.split("(?i)\\W+via\\W+|/").filter(_.nonEmpty)
+      val bylineParts = byline.split("(?i)\\W+via\\W+|/| - |#").filter(_.nonEmpty)
       val creditParts = credit.split("(?i)\\W+via\\W+|/").filter(_.nonEmpty)
 
       // It's very difficult to decide how to reorganise the byline or credits if they're both single tokens

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -26,7 +26,7 @@ object BylineCreditReorganise extends MetadataCleaner {
     bylineField.map { byline =>
       val credit = creditField.getOrElse("")
       val bylineParts = byline.split(" via |/").filter(!_.isEmpty)
-      val creditParts = credit.split(" via |/").filter(!_.isEmpty)
+      val creditParts = credit.split(" via |/|via ").filter(!_.isEmpty)
 
       // It's very difficult to decide how to reorganise the byline or credits if they're both single tokens
       // since we'd need to know what's likely to be a name and what's likely to be an organisation.

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -37,7 +37,14 @@ object BylineCreditReorganise extends MetadataCleaner {
       } else {
         val outputByline = bylineParts.head
 
-        val outputCredit = (bylineParts.tail.filter(!creditParts.contains(_)) ++ creditParts.filter(_ != outputByline)).distinct.mkString("/")
+        val outputBylineLowercase = outputByline.toLowerCase
+        val creditPartsLowercase = creditParts.map(_.toLowerCase)
+
+        val remainingBylinePartsNotInCredit = bylineParts.tail.filter(bp => !creditPartsLowercase.contains(bp.toLowerCase))
+
+        val creditPartsNotInByline = creditParts.filter(_.toLowerCase != outputBylineLowercase)
+
+        val outputCredit = (remainingBylinePartsNotInCredit ++ creditPartsNotInByline).distinct.mkString("/")
 
         (outputByline, outputCredit)
       }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -25,8 +25,8 @@ object BylineCreditReorganise extends MetadataCleaner {
   def removeBylineFromCredit(bylineField: Field, creditField: Field) =
     bylineField.map { byline =>
       val credit = creditField.getOrElse("")
-      val bylineParts = byline.split("(?i)\\Wvia\\W|/").filter(_.nonEmpty)
-      val creditParts = credit.split("(?i)\\Wvia\\W|/").filter(_.nonEmpty)
+      val bylineParts = byline.split("(?i)\\W+via\\W+|/").filter(_.nonEmpty)
+      val creditParts = credit.split("(?i)\\W+via\\W+|/").filter(_.nonEmpty)
 
       // It's very difficult to decide how to reorganise the byline or credits if they're both single tokens
       // since we'd need to know what's likely to be a name and what's likely to be an organisation.

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganise.scala
@@ -25,8 +25,8 @@ object BylineCreditReorganise extends MetadataCleaner {
   def removeBylineFromCredit(bylineField: Field, creditField: Field) =
     bylineField.map { byline =>
       val credit = creditField.getOrElse("")
-      val bylineParts = byline.split(" via |/").filter(!_.isEmpty)
-      val creditParts = credit.split(" via |/|via ").filter(!_.isEmpty)
+      val bylineParts = byline.split("(?i)\\Wvia\\W|/").filter(_.nonEmpty)
+      val creditParts = credit.split("(?i)\\Wvia\\W|/").filter(_.nonEmpty)
 
       // It's very difficult to decide how to reorganise the byline or credits if they're both single tokens
       // since we'd need to know what's likely to be a name and what's likely to be an organisation.
@@ -43,7 +43,7 @@ object BylineCreditReorganise extends MetadataCleaner {
       }
     }
     // Convert the strings back to `Option`s
-    .map{ case (b, c) => (Some(b), Some(c).filter(!_.isEmpty)) }
+    .map{ case (b, c) => (Some(b), Some(c).filter(_.nonEmpty)) }
     // return the defaults if they both didn't exist
     .getOrElse((bylineField, creditField))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -438,7 +438,7 @@ object ReutersParser extends ImageProcessor {
     )
     // Reuters and other misspellings
     // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case (_, Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUETRS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("via Reuters")) => image.copy(
+    case (_, Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUETRS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("Via REUTERS") | Some("via Reuters")) => image.copy(
       usageRights = Agency("Reuters"),
       metadata = image.metadata.copy(
         credit = Some("Reuters"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -418,6 +418,10 @@ object PaParser extends ImageProcessor {
 }
 
 object ReutersParser extends ImageProcessor {
+
+  private val reutersSpellings =
+    List("reuters", "retuers", "reuetrs").flatMap(spelling => List(spelling, s"$spelling/"))
+
   def extractFixtureID(image:Image) = image.fileMetadata.iptc.get("Fixture Identifier")
 
   def apply(image: Image): Image = (image.metadata.copyright.map(_.toUpperCase), image.metadata.credit) match {
@@ -437,8 +441,7 @@ object ReutersParser extends ImageProcessor {
       usageRights = Agency("Reuters")
     )
     // Reuters and other misspellings
-    // TODO: use case-insensitive matching instead once credit is no longer indexed as case-sensitive
-    case (_, Some("REUTERS") | Some("Reuters") | Some("RETUERS") | Some("REUETRS") | Some("REUTERS/") | Some("via REUTERS") | Some("VIA REUTERS") | Some("Via REUTERS") | Some("via Reuters")) => image.copy(
+    case (_, Some(x)) if reutersSpellings.exists(x.toLowerCase.endsWith) => image.copy(
       usageRights = Agency("Reuters"),
       metadata = image.metadata.copy(
         credit = Some("Reuters"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -419,7 +419,7 @@ object PaParser extends ImageProcessor {
 
 object ReutersParser extends ImageProcessor {
 
-  private val reutersSpellings = """(?i) ?(via |/ ?)?(reuters|retuers|reuetrs)/?$""".r
+  private val reutersSpellings = """(?i) ?(/ ?)?(via )?(reuters|retuers|reuetrs)/?$""".r
 
   def extractFixtureID(image:Image) = image.fileMetadata.iptc.get("Fixture Identifier")
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -65,6 +65,16 @@ class BylineCreditReorganiseTest extends AnyFunSpec with Matchers with MetadataH
       .whenCleaned("Philip Glass", "Barcroft Media")
   }
 
+  it ("should remove organisation from byline, ` - ` case") {
+    CreditByline("Philip Glass - Barcroft Media", "Barcroft Media")
+      .whenCleaned("Philip Glass", "Barcroft Media")
+  }
+
+  it ("should remove organisation from byline, # case") {
+    CreditByline("Philip Glass#Barcroft Media", "Barcroft Media")
+      .whenCleaned("Philip Glass", "Barcroft Media")
+  }
+
   it ("should remove organisation from byline, case insensitive") {
     CreditByline("Philip Glass via BaRcRoFt MEDIA", "Barcroft Media")
       .whenCleaned("Philip Glass", "Barcroft Media")

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/BylineCreditReorganiseTest.scala
@@ -65,6 +65,14 @@ class BylineCreditReorganiseTest extends AnyFunSpec with Matchers with MetadataH
       .whenCleaned("Philip Glass", "Barcroft Media")
   }
 
+  it ("should remove organisation from byline, case insensitive") {
+    CreditByline("Philip Glass via BaRcRoFt MEDIA", "Barcroft Media")
+      .whenCleaned("Philip Glass", "Barcroft Media")
+
+    CreditByline("Philip Glass via Barcroft Media", "BaRcRoFt MEDIA")
+      .whenCleaned("Philip Glass", "BaRcRoFt MEDIA")
+  }
+
   it ("should handle empty byline") {
     CreditByline("", "Barcroft Media")
       .whenCleaned("", "Barcroft Media")
@@ -82,6 +90,21 @@ class BylineCreditReorganiseTest extends AnyFunSpec with Matchers with MetadataH
 
   it ("should handle empty credit when byline has organisation names, via case") {
     CreditByline("John Doe via BPI/REX", "")
+      .whenCleaned("John Doe", "BPI/REX")
+  }
+
+  it ("should handle combination slash and via") {
+    CreditByline("John Doe /via BPI/REX", "")
+      .whenCleaned("John Doe", "BPI/REX")
+  }
+
+  it ("should handle any non-word delimiter around via") {
+    CreditByline("John Doe !via! BPI/REX", "")
+      .whenCleaned("John Doe", "BPI/REX")
+  }
+
+  it ("should handle any capitalisation of via") {
+    CreditByline("John Doe vIa BPI/REX", "")
       .whenCleaned("John Doe", "BPI/REX")
   }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -498,6 +498,27 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       processedImage.usageRights should be(Agency("Reuters"))
       processedImage.metadata.credit should be(Some("USA Today Sports"))
     }
+
+    it("should normalise reuters credits when using via") {
+      val image = createImageFromMetadata("credit" -> "John Doe/intermediary/via reuters")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Reuters"))
+      processedImage.metadata.credit should be(Some("John Doe/intermediary/Reuters"))
+    }
+
+    it("should normalise reuters credits when using slash") {
+      val image = createImageFromMetadata("credit" -> "John Doe/intermediary/ REUTERS")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Reuters"))
+      processedImage.metadata.credit should be(Some("John Doe/intermediary/Reuters"))
+    }
+
+    it("should normalise reuters credits when using no delimiter") {
+      val image = createImageFromMetadata("credit" -> "John Doe/intermediary retuERS")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("Reuters"))
+      processedImage.metadata.credit should be(Some("John Doe/intermediary/Reuters"))
+    }
   }
 
 


### PR DESCRIPTION
_Actually authored by @andrew-nowak_

## What does this change?
This:
- replaces more variants of `via` with a forward slash
- tokenises byline field also by ` - ` (space+hyphen+space) and `#` (research shows that it’s useful in a huge majority of cases) 
- deduplicates tokens in byline and credit case-insensitively
- matches more Reuters imagery by looking also at credits which **end** with all variants of `Reuters` spelling

## How can success be measured?
Cleaner and more consistent metadata. More Reuters’ imagery recognised as such.

## Screenshots

Before | After
-------|------
![image](https://user-images.githubusercontent.com/10963046/157442570-e15620bb-c171-4c14-8000-ac6020ab93e2.png) | ![image](https://user-images.githubusercontent.com/6032869/157483807-f494c086-49f9-4c8c-93b0-8f552c1b0488.png)
![image](https://user-images.githubusercontent.com/10963046/157442688-761a70f8-b77d-4ecd-85f5-a93d0d094942.png) | ![image](https://user-images.githubusercontent.com/6032869/157484026-cd42fd47-211d-491b-a937-21029d2a8139.png)
![image](https://user-images.githubusercontent.com/10963046/157443157-52664feb-bd8b-4c60-8afa-a5810cf18454.png) | ![image](https://user-images.githubusercontent.com/6032869/157484185-513d0aaf-9d4b-47b2-a6f4-c82b9af2d883.png)
![image](https://user-images.githubusercontent.com/6032869/157996502-cbd74c33-d8cd-43e9-9298-3191f3364f8c.png) | ![image](https://user-images.githubusercontent.com/6032869/157996530-f6386dd9-d901-4786-942f-9f87bc3b0081.png)
![image](https://user-images.githubusercontent.com/6032869/157996607-ecdd657c-39f2-4adb-879d-ec041bece5a9.png) | ![image](https://user-images.githubusercontent.com/6032869/157996641-ade4e165-09f4-461d-8301-d1ffb7882bb1.png)

Note: all the Reuters images above weren’t and now are correctly recognised as Reuters.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)