### PR TITLE
local: take jvms suggestion for using a better GC

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,4 @@
 -J-Xmx8192M
 -J-XX:MaxMetaspaceSize=2048M
+-J-XX:+UseG1GC
 -DSTAGE=DEV


### PR DESCRIPTION
## What does this change?

When running locally, I occasionally see warnings like the following:

```
[warn] In the last 10 seconds, 5.073 (54.5%) were spent in GC. [Heap: 1.50GB free of 7.11GB, max 7.11GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
```

We've previously taken the first suggestion (increasing `-Xmx` up to 8GB), so this time let's try `-XX:+UseG1GC` (anecdotally, performance is better with this option)

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
