### PR TITLE
Bump metadata-extractor to 2.17.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.16.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.17.0"
   )
 }
 


### PR DESCRIPTION
## What does this change?
Bumps metadata-extractor to [latest version](https://github.com/drewnoakes/metadata-extractor/releases/tag/2.17.0). 

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
