### PR TITLE
Allow sending full frame crops to pinboard

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -75,6 +75,12 @@
                             <span class="flex-spacer"></span>
                             <span class="image-crop__creator" title="Cropped by {{:: crop.author}} at {{:: crop.date | date:'medium'}}">{{:: crop.author | getInitials}}</span>
                         </div>
+                        <asset-handle
+                            data-source="grid"
+                            data-source-type="crop"
+                            data-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
+                            data-embeddable-url="{{ctrl.getEmbeddableUrl(crop.id)}}"
+                        ></asset-handle>
                     </a>
                     <div ng-switch-when="false"
                          draggable="false"


### PR DESCRIPTION
## What does this change?

Adds the add to pinboard button on full frame crops too

## How can success be measured?

More images sent through pinboard

## Screenshots
 

After
<img width="129" alt="image" src="https://user-images.githubusercontent.com/10963046/158844613-5a079916-7b7f-44d7-b21f-8dfe698b0e34.png">



## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
