### PR TITLE
Remove image-loader-projection from prout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -4,7 +4,6 @@
     "collections": { "url": "https://media-collections.gutools.co.uk/management/manifest", "overdue": "30M" },
     "cropper": { "url": "https://cropper.media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "image-loader": { "url": "https://loader.media.gutools.co.uk/management/manifest", "overdue": "30M" },
-    "image-loader-projection": { "url": "https://loader-projection.media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "kahuna": { "url": "https://media.gutools.co.uk/management/manifest", "overdue": "30M" },
     "leases": { "url": "https://media-leases.gutools.co.uk/management/manifest", "overdue": "30M" },
     "media-api": { "url": "https://api.media.gutools.co.uk/management/manifest", "overdue": "30M" },


### PR DESCRIPTION

## What does this change?
We're not currently using projection boxes so have scaled the instances to 0, so remove from prout until restored

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
