### PR TITLE
add a `withOptionalLoginRedirect` to `KahunaController` `index`

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
@@ -1,7 +1,8 @@
 package com.gu.mediaservice.lib.auth
 
 import com.gu.mediaservice.lib.config.Services
-import play.api.mvc.{Action, AnyContent, BaseController, Request, RequestHeader, Result}
+import play.api.mvc.Security.AuthenticatedRequest
+import play.api.mvc._
 
 import java.net.URLEncoder
 import scala.concurrent.Future
@@ -10,20 +11,32 @@ trait BaseControllerWithLoginRedirects extends BaseController {
   def auth: Authentication
   def services: Services
 
-  def withLoginRedirectAsync(handler: Request[AnyContent] => Future[Result]): Action[AnyContent] = Action.async { request =>
+  private def withLoginRedirectAsync(isLoginOptional: Boolean)(handler: Request[AnyContent] => Future[Result]): Action[AnyContent] = Action.async { request =>
     auth.authenticationStatus(request) match {
-      case Left(resultFuture) => auth.loginLinks.headOption.map(link => {
-        val returnTo = s"https://${request.domain}${request.uri}"
-        Future.successful(Redirect(link.href.replace(services.redirectUriPlaceholder,
-          s"?${services.redirectUriParam}=${URLEncoder.encode(returnTo, "UTF-8")}")))
-      }).getOrElse(resultFuture)
-      case Right(_) => handler(request)
+      case Right(principal) =>
+        handler(new AuthenticatedRequest(principal, request))
+      case Left(resultFuture) => auth.loginLinks.headOption match {
+        case None if isLoginOptional => handler(request) // if login is not strictly required, then still perform the action (just the user principal won't be available)
+        case None => resultFuture // if login is strictly required, then return the auth failure result
+        case Some(loginLink) =>
+          val returnTo = s"https://${request.domain}${request.uri}"
+          Future.successful(Redirect(loginLink.href.replace(services.redirectUriPlaceholder,
+            s"?${services.redirectUriParam}=${URLEncoder.encode(returnTo, "UTF-8")}")))
+      }
     }
   }
 
+  def withLoginRedirectAsync(handler: Request[AnyContent] => Future[Result]): Action[AnyContent] =
+    withLoginRedirectAsync(isLoginOptional = false)(handler)
+  def withOptionalLoginRedirectAsync(handler: Request[AnyContent] => Future[Result]): Action[AnyContent] =
+    withLoginRedirectAsync(isLoginOptional = true)(handler)
+
   def withLoginRedirectAsync(handler: => Future[Result]): Action[AnyContent] = withLoginRedirectAsync(_ => handler)
+  def withOptionalLoginRedirectAsync(handler: => Future[Result]): Action[AnyContent] = withOptionalLoginRedirectAsync(_ => handler)
 
   def withLoginRedirect(handler: Request[AnyContent] => Result): Action[AnyContent] = withLoginRedirectAsync(request => Future.successful(handler(request)))
+  def withOptionalLoginRedirect(handler: Request[AnyContent] => Result): Action[AnyContent] = withOptionalLoginRedirectAsync(request => Future.successful(handler(request)))
 
   def withLoginRedirect(handler: => Result): Action[AnyContent] = withLoginRedirect(_ => handler)
+  def withOptionalLoginRedirect(handler: => Result): Action[AnyContent] = withOptionalLoginRedirect(_ => handler)
 }

--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.auth.{Authentication, BaseControllerWithLoginRedirects}


### PR DESCRIPTION
https://trello.com/c/J9S1oGdr/541-improve-auth-situation-in-grid

Right now grid triggers re-auth purely on the client-side i.e. Kahuna serves the html and JS bundle without requiring auth, then it hits the API waiting for OK or 419 (and attempts re-auth if so).
- these 419s keep flagging up in Wazuh (which is noise for InfoSec - but they occasionally get in touch)
- this also means PinBoard doesn't load (see https://github.com/guardian/grid/pull/3179) on first page view after being not logged in (or expired login) which is very annoying

## What does this change?
This refactors/extends the `withLoginRedirect` (introduced for the Thrall dashboard - see https://github.com/guardian/grid/pull/3378) to have a `withOptionalLoginRedirect` and used it on the `KahunaController` `index` handler, which serves...

- GET     `/`                                            
- GET     `/images/$id<[0-9a-z]+>`
- GET     `/images/$id<[0-9a-z]+>/crop`
- GET     `/search`
- GET     `/upload`     

## How can success be measured?

- Fewer 419s (especially no burts of 419s - as people log in in the morning etc.)
- Pinboard loads first time 🎉 

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
