### PR TITLE
Add ARIA landmarks and labels for accessibility

### DIFF
--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -1,7 +1,8 @@
-<nav class="user-actions drop-menu">
+<nav class="user-actions drop-menu" aria-label="Secondary">
     <button class="drop-menu__button"
             type="button"
-            ng-click="showUserActions = !showUserActions">
+            ng-click="showUserActions = !showUserActions"
+            aria-label="Secondary navigation menu">
         <gr-icon>more_vert</gr-icon>
     </button>
     <ul class="drop-menu__items drop-menu__items--right" ng-if="showUserActions">

--- a/kahuna/public/js/components/gr-add-label/gr-add-label.html
+++ b/kahuna/public/js/components/gr-add-label/gr-add-label.html
@@ -4,7 +4,8 @@
         ng-disabled="ctrl.adding"
         ng-if="!ctrl.active"
         gr-tooltip="Add label"
-        gr-tooltip-position="left">
+        gr-tooltip-position="left"
+        aria-label="Add label to image">
 
     <gr-icon ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span>

--- a/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.html
+++ b/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.html
@@ -2,7 +2,8 @@
         class="collection-overlay__button"
         ng-click="ctrl.openCollectionTree()"
         gr-tooltip="Click to add image to a collection"
-        gr-tooltip-position="left">
+        gr-tooltip-position="left"
+        aria-label="Add image to a collection">
     <gr-icon>add_box</gr-icon>
 </button>
 <div ng-if="ctrl.addCollection" class="collection-overlay"

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -12,7 +12,8 @@
 
         <button data-cy="edit-collections-button"
                 ng-class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
-                ng-click="$parent.editing = !$parent.editing">
+                ng-click="$parent.editing = !$parent.editing"
+                aria-label="Edit collections">
             <gr-icon-label ng-if="! $parent.editing"
                            gr-icon="edit">Edit</gr-icon-label>
             <gr-icon-label ng-if="$parent.editing"

--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.js
@@ -11,7 +11,8 @@ confirmDelete.directive('grConfirmDelete', ['$timeout', function($timeout) {
         template: `
             <button class="gr-confirm-delete inner-clickable side-padded" type="button"
                 ng:click="showConfirm = true"
-                ng:class="{'gr-confirm-delete--confirm': showConfirm}">
+                ng:class="{'gr-confirm-delete--confirm': showConfirm}"
+                aria-label="Delete image">
                 <gr-icon-label ng:if="!showConfirm" gr-icon="delete">{{label}}</gr-icon-label>
                 <gr-icon-label ng:if="showConfirm" gr-icon="delete">{{confirm}}</gr-icon-label>
             </button>`,

--- a/kahuna/public/js/components/gr-crop-image/gr-crop-image.html
+++ b/kahuna/public/js/components/gr-crop-image/gr-crop-image.html
@@ -4,7 +4,7 @@
         ui-sref="crop({imageId: ctrl.image.data.id})"
         gr-track-click="Crop image button"
         gr-track-click-data="{'Location': ctrl.trackingLocation}"
-        gr-tooltip="Crop image [C]">
+        gr-tooltip="Crop image [C]" aria-label="Crop image">
         <gr-icon-label gr-icon="crop">Crop image</gr-icon-label>
     </a>
     <a ng-if="!ctrl.hasFullCrop" class="drop-menu clickable inner-clickable side-padded button-right-side" ng-click="showUserActions = !showUserActions">

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -11,12 +11,14 @@
     </button>
 
     <a ng-if="ctrl.imageCount() == 1"
-       href="{{ ctrl.firstImageUris.uris.downloadUri }}" download rel="noopener" target="_blank">
+       href="{{ ctrl.firstImageUris.uris.downloadUri }}" download rel="noopener" target="_blank"
+       aria-label="Download image">
         <gr-icon-label gr-icon="file_download">Download</gr-icon-label>
     </a>
 
     <button ng-if="ctrl.imageCount() == 1 && !ctrl.canDownloadCrop"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
+            aria-label="Download low resolution image"
             ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
         <a ng-if="showExpandedDownload"
@@ -24,7 +26,8 @@
             class="drop-menu__items drop-menu__items--nopad"
             download
             rel="noopener"
-            target="_blank">
+            target="_blank"
+            aria-label="Download low resolution image">
             <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
         </a>
     </button>
@@ -32,22 +35,26 @@
 
     <button ng-if="ctrl.imageCount() == 1 && ctrl.crop && ctrl.canDownloadCrop"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
+            aria-label="Download selected crop"
             ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
         <a ng-if="showExpandedDownload"
             class="drop-menu__items drop-menu__items--nopad"
-            href="{{ ctrl.crop.downloadLink }}" download rel="noopener" target="_blank">
+            href="{{ ctrl.crop.downloadLink }}" download rel="noopener" target="_blank"
+            aria-label="Download selected crop">
             <gr-icon-label gr-icon="file_download">Download selected crop</gr-icon-label>
         </a>
     </button>
 
     <button ng-if="ctrl.imageCount() > 1"
             class="drop-menu clickable inner-clickable side-padded button-right-side"
+            aria-label="Download low resolution"
             ng-click="showExpandedDownload = !showExpandedDownload">
         <span>▾</span>
         <a ng-if="showExpandedDownload"
             ng-click="ctrl.download('lowResDownloadUri')"
-            class="drop-menu__items drop-menu__items--nopad">
+            class="drop-menu__items drop-menu__items--nopad"
+            aria-label="Download low resolution">
             <gr-icon-label gr-icon="file_download">Download low-res</gr-icon-label>
         </a>
     </button>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -1,5 +1,5 @@
 <div class="image-info">
-    <div class="image-info__group">
+    <div class="image-info__group" role="region" aria-label="Rights and restrictions">
         <dl class="image-info__wrap metadata-line image-info__usage-rights">
         <dt class="metadata-line__key">Rights & restrictions</dt>
 
@@ -21,7 +21,7 @@
                 class="image-info__edit">✎</button>
         </dl>
     </div>
-    <div class="image-info__group" ng-if="ctrl.displayLeases()">
+    <div class="image-info__group" ng-if="ctrl.displayLeases()" role="region" aria-label="Leases">
         <dl class="image-info__wrap image-info__leases">
             <div class="image-info__heading image-info__heading--lease">
                 <span>Leases</span>
@@ -35,7 +35,7 @@
         </dl>
     </div>
 
-    <div class="image-info__group">
+    <div class="image-info__group" role="region" aria-label="Title">
         <dl>
             <div class="image-info__wrap">
                 <button class="image-info__edit"
@@ -148,7 +148,7 @@
     </dl>
     </div>
 
-    <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions">
+    <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions" role="region" aria-label="Special instructions">
         <dl class="image-info__wrap">
             <button class="image-info__edit"
                     ng-if="ctrl.userCanEdit"
@@ -193,7 +193,7 @@
        </dl>
     </div>
 
-    <div class="image-info__group">
+    <div class="image-info__group" role="region" aria-label="Image metadata">
         <dl class="image-info__group--dl metadata-line">
             <dt class="metadata-line image-info__wrap metadata-line__key image-info__group--dl__key--panel" ng-if="ctrl.metadata.dateTaken">Taken on</dt>
             <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel" ng-if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
@@ -226,7 +226,8 @@
 
                     <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
                         <span ng-if="ctrl.metadata.byline">
-                            <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})">{{ctrl.metadata.byline}}</a>
+                            <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})"
+                               aria-label="Search images by {{ctrl.metadata.byline}} byline">{{ctrl.metadata.byline}}</a>
                         </span>
 
                         <span class="editable-empty" ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
@@ -263,7 +264,8 @@
 
                     <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
                         <span ng-if="ctrl.metadata.credit">
-                            <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})">{{ctrl.metadata.credit}}</a>
+                            <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})"
+                               aria-label="Search images by {{ctrl.metadata.credit}} credit">{{ctrl.metadata.credit}}</a>
                         </span>
 
                         <span class="editable-empty" ng-if="!ctrl.metadata.credit && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
@@ -276,7 +278,8 @@
             <dd ng-if="ctrl.hasLocationInformation()" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <span ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
                     <span class="metadata-line__info">
-                        <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})">
+                        <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
+                           aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
                             {{ctrl.metadata[prop]}}
                         </a>
                     </span>
@@ -314,7 +317,8 @@
 
                     <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
                         <span ng-if="ctrl.metadata.copyright">
-                            <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})">{{ctrl.metadata.copyright}}</a>
+                            <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})"
+                               aria-label="Search images by {{ctrl.metadata.copyright}} copyright">{{ctrl.metadata.copyright}}</a>
                         </span>
 
                         <span class="editable-empty" ng-if="!ctrl.metadata.copyright && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
@@ -332,7 +336,8 @@
             <dt ng-if="!ctrl.hasMultipleValues(ctrl.extraInfo.uploadedBy)" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Uploader</dt>
             <dd ng-if="!ctrl.hasMultipleValues(ctrl.extraInfo.uploadedBy)" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <span class="metadata-line__info">
-                    <a ui-sref="search.results({query: (ctrl.extraInfo.uploadedBy | queryFilter:'uploader')})">{{ctrl.extraInfo.uploadedBy | stripEmailDomain}}</a>
+                    <a ui-sref="search.results({query: (ctrl.extraInfo.uploadedBy | queryFilter:'uploader')})"
+                       aria-label="Search images uploaded by {{ctrl.extraInfo.uploadedBy}}">{{ctrl.extraInfo.uploadedBy | stripEmailDomain}}</a>
                 </span>
             </dd>
 
@@ -351,7 +356,8 @@
                 class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <span class="metadata-line__info">
                     <span ng-repeat="subject in ctrl.metadata.subjects">
-                        <a ui-sref="search.results({query: (subject | queryFilter:'subject')})">
+                        <a ui-sref="search.results({query: (subject | queryFilter:'subject')})"
+                           aria-label="Search images by {{subject}} subject">
                             {{subject}}
                         </a>
                     </span>
@@ -367,7 +373,8 @@
                         ng-hide="peopleInImageEditForm.$visible"
                         ng-if="ctrl.userCanEdit"
                         gr-tooltip="Add People"
-                        gr-tooltip-position="left">
+                        gr-tooltip-position="left"
+                        aria-label="Add people to image">
 
                     <gr-icon ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
                     <span>
@@ -396,9 +403,10 @@
     </dl>
     </div>
     <!-- FIXME: iff has useful metadata -->
-    <div ng-if="ctrl.singleImage" class="image-info__group image-info__group--full-metadata">
+    <div ng-if="ctrl.singleImage" class="image-info__group image-info__group--full-metadata" role="region" aria-label="Additional metadata">
         <button class="metadata-reveal"
-                ng-click="ctrl.showMetadataSection('additionalMetadata')">
+                ng-click="ctrl.showMetadataSection('additionalMetadata')"
+                aria-label="{{ctrl.isMetadataSectionHidden('additionalMetadata') ? 'Show' : 'Hide'}} additional metadata section">
             <span ng-show="ctrl.isMetadataSectionHidden('additionalMetadata')">▸ Show</span>
             <span ng-hide="ctrl.isMetadataSectionHidden('additionalMetadata')">▾ Hide</span>
             additional metadata
@@ -422,8 +430,10 @@
         </div>
     </div>
 
-    <div ng-if="ctrl.singleImage" ng-repeat="spec in ctrl.domainMetadata" class="image-info__group image-info__group--full-domain-metadata">
-        <button class="metadata-reveal" ng-click="ctrl.showMetadataSection(spec.name)">
+    <div ng-if="ctrl.singleImage" ng-repeat="spec in ctrl.domainMetadata" class="image-info__group image-info__group--full-domain-metadata"
+         role="region" aria-label="Domain metadata">
+        <button class="metadata-reveal" ng-click="ctrl.showMetadataSection(spec.name)"
+                aria-label="{{ctrl.isMetadataSectionHidden(spec.name) ? 'Show' : 'Hide'}} {{spec.label}} domain metadata section">
             <span ng-show="ctrl.isMetadataSectionHidden(spec.name)">▸ Show</span>
             <span ng-hide="ctrl.isMetadataSectionHidden(spec.name)">▾ Hide</span>
             {{spec.label}} metadata
@@ -571,7 +581,7 @@
     </div>
 </div>
 
-<div ng-if="ctrl.singleImage" class="image-info">
+<div ng-if="ctrl.singleImage" class="image-info" role="region" aria-label="Collections">
     <dl class="image-info__group">
         <dt class="flex-container">
             <span class="metadata-line__key  flex-spacer">Collections</span>
@@ -579,7 +589,8 @@
         </dt>
         <dd class="metadata-line__info flex-container"
             ng-repeat="collection in ctrl.singleImage.data.collections">
-            <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})">
+            <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+               aria-label="Search images by {{collection.data.description}} collection">
                 {{collection.data.path.join(' ▸ ')}}
             </a>
             <span class="flex-spacer"></span>
@@ -588,7 +599,8 @@
                     ng-click="ctrl.removeImageFromCollection(collection)"
                     ng-hide="ctrl.removingCollection === collection"
                     gr-tooltip="Remove image from this collection"
-                    gr-tooltip-position="top-left">
+                    gr-tooltip-position="top-left"
+                    aria-label="Remove image from this collection">
                 <gr-icon-label gr-icon="clear"></gr-icon-label>
             </button>
         </dd>
@@ -596,7 +608,7 @@
 </div>
 
 
-<div class="image-info">
+<div class="image-info" role="region" aria-label="Labels">
     <dl class="image-info__group">
         <dt class="flex-container">
             <span class="metadata-line__key  flex-spacer">Labels</span>
@@ -618,7 +630,7 @@
     </dl>
 </div>
 
-<div class="image-info__group">
+<div class="image-info__group" role="region" aria-label="Photoshoot">
     <dl class="image-info__wrap">
         <dt class="metadata-line metadata-line__key">Photoshoot</dt>
         <dd>
@@ -627,7 +639,7 @@
     </dl>
 </div>
 
-<div ng-if="ctrl.singleImage" class="image-info">
+<div ng-if="ctrl.singleImage" class="image-info" role="region" aria-label="Syndication rights">
     <div class="image-info__group">
         <dl class="image-info__wrap">
             <dt class="metadata-line metadata-line__key">Syndication Rights (from RCS)</dt>
@@ -638,7 +650,7 @@
     </div>
 </div>
 
-<div ng-if="ctrl.singleImage" class="image-info">
+<div ng-if="ctrl.singleImage" class="image-info" role="region" aria-label="Keywords">
     <dl class="image-info__group image-info__wrap" ng-if="ctrl.metadata.keywords.length > 0">
         <dt class="image-info__heading image-info__wrap">Keywords</dt>
         <dd class="image-info__keywords">
@@ -646,7 +658,8 @@
                 <ui-list-editor-compact
                     images="ctrl.selectedImages"
                     accessor="ctrl.keywordAccessor"
-                    query-filter="queryFilter:'keyword'">
+                    query-filter="queryFilter:'keyword'"
+                    element-name="keyword">
                 </ui-list-editor-compact>
             </ul>
         </dd>

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -8,7 +8,8 @@
             gr-tooltip="Hide {{:: ctrl.name}} panel"
             gr-tooltip-position="{{:: ctrl.toolTipPosition()}}"
             gr-track-click="{{:: ctrl.trackingName}}"
-            gr-track-click-data="ctrl.trackingData('Hide panel')">
+            gr-track-click-data="ctrl.trackingData('Hide panel')"
+            aria-label="Hide {{ctrl.name}} panel">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
 
@@ -19,7 +20,8 @@
             gr-tooltip="Show {{:: ctrl.name}} panel"
             gr-tooltip-position="{{:: ctrl.toolTipPosition()}}"
             gr-track-click="{{:: ctrl.trackingName}}"
-            gr-track-click-data="ctrl.trackingData('Show panel')">
+            gr-track-click-data="ctrl.trackingData('Show panel')"
+            aria-label="Show {{ctrl.name}} panel">
         <gr-icon>{{ctrl.icon}}</gr-icon>
     </button>
 
@@ -29,7 +31,8 @@
                 ng-if="!ctrl.state.locked"
                 ng-click="ctrl.lockPanel()"
                 gr-track-click="{{:: ctrl.trackingName}}"
-                gr-track-click-data="ctrl.trackingData('Lock panel')">
+                gr-track-click-data="ctrl.trackingData('Lock panel')"
+                aria-label="Lock {{ctrl.name}} panel">
             <gr-icon>lock_open</gr-icon>
         </button>
         <button class="button-ico-square clickable"
@@ -38,7 +41,8 @@
                 ng-click="ctrl.unlockPanel()"
                 ng-class="{'bg-light': ctrl.state.locked}"
                 gr-track-click="{{:: ctrl.trackingName}}"
-                gr-track-click-data="ctrl.trackingData('Unlock panel')">
+                gr-track-click-data="ctrl.trackingData('Unlock panel')"
+                aria-label="Unlock {{ctrl.name}} panel">
             <gr-icon>lock</gr-icon>
         </button>
     </div>

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button.html
@@ -3,7 +3,8 @@
             ng-if="!ctrl.state.hidden" ng-click="ctrl.hidePanel()"
             ng-class="{'bg-light': !ctrl.state.hidden}"
             gr-track-click="{{ctrl.trackingName}}"
-            gr-track-click-data="ctrl.trackingData('Hide panel')">
+            gr-track-click-data="ctrl.trackingData('Hide panel')"
+            aria-label="Hide {{ctrl.name}} panel">
         <gr-icon-label gr-icon="chrome_reader_mode">Hide {{ctrl.name}} panel</gr-icon-label>
     </button>
 
@@ -11,7 +12,8 @@
             ng-if="ctrl.state.hidden"
             ng-click="ctrl.showPanel()"
             gr-track-click="{{ctrl.trackingName}}"
-            gr-track-click-data="ctrl.trackingData('Show panel')">
+            gr-track-click-data="ctrl.trackingData('Show panel')"
+            aria-label="Show {{ctrl.name}} panel">
         <gr-icon-label gr-icon="chrome_reader_mode">Show {{ctrl.name}} panel</gr-icon-label>
     </button>
 
@@ -24,7 +26,8 @@
                 ng-if="!ctrl.state.locked"
                 ng-click="ctrl.lockPanel()"
                 gr-track-click="{{ctrl.trackingName}}"
-                gr-track-click-data="ctrl.trackingData('Lock panel')">
+                gr-track-click-data="ctrl.trackingData('Lock panel')"
+                aria-label="Lock {{ctrl.name}} panel">
             <gr-icon>lock_open</gr-icon>
         </button>
         <button class="button-ico-square clickable" type="button"
@@ -32,7 +35,8 @@
                 ng-click="ctrl.unlockPanel()"
                 ng-class="{'bg-light': ctrl.state.locked}"
                 gr-track-click="{{ctrl.trackingName}}"
-                gr-track-click-data="ctrl.trackingData('Unlock panel')">
+                gr-track-click-data="ctrl.trackingData('Unlock panel')"
+                aria-label="Unlock {{ctrl.name}}" panel>
             <gr-icon>lock</gr-icon>
         </button>
     </div>

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
@@ -4,11 +4,12 @@
         <li class="preset-label"
             ng-repeat="label in ctrl.presetLabels">
             <a ui-sref="search.results({query: (label | queryLabelFilter)})"
-               class="preset-label__value preset-label__link">{{label}}</a>
+               class="preset-label__value preset-label__link"
+               aria-label="Search images by {{label}} label">{{label}}</a>
 
             <button class="preset-label__remove"
                     title="Remove label"
-                    ng-click="ctrl.removePresetLabel(label)">
+                    ng-click="ctrl.removePresetLabel(label)" aria-label="Remove preset label {{label}}">
                 <gr-icon>close</gr-icon>
             </button>
         </li>
@@ -19,7 +20,8 @@
     <button ng-click="ctrl.active = true"
             ng-disabled="ctrl.adding"
             ng-if="!ctrl.active"
-            title="Add a new label">
+            title="Add a new label"
+            aria-label="Add label to all uploads">
 
         <gr-icon ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
         <span ng-show="ctrl.adding">Adding...</span>
@@ -39,18 +41,21 @@
                ng-model-options="{ updateOn: 'gr-datalist:update' }"
                ng-change="ctrl.save()"
                ng-model="ctrl.newLabel"
-               ng-disabled="ctrl.adding" />
+               ng-disabled="ctrl.adding"
+               aria-label="New preset label" />
         </gr-datalist>
 
         <span class="flex-container">
-            <button class="add-preset-label__button button-cancel" type="button" ng-click="ctrl.cancel()" title="Close">
+            <button class="add-preset-label__button button-cancel" type="button" ng-click="ctrl.cancel()" title="Close"
+                    aria-label="Cancel add preset label form">
                 <gr-icon-label gr-icon="close"><span ng-hide="ctrl.grSmall">Cancel</span></gr-icon-label>
             </button>
             <button
                 class="add-preset-label__button button-save"
                 type="submit"
                 title="Save new label"
-                ng-disabled="ctrl.adding">
+                ng-disabled="ctrl.adding"
+                aria-label="Save new preset label">
                 <gr-icon-label gr-icon="check">
                     <span ng-hide="ctrl.grSmall">Save</span>
                 </gr-icon-label>

--- a/kahuna/public/js/components/gr-toggle-button/gr-toggle-button.html
+++ b/kahuna/public/js/components/gr-toggle-button/gr-toggle-button.html
@@ -1,6 +1,6 @@
 <div class="fill-height flex-container flex-container--rtl">
     <button class="inner-clickable clickable" type="button"
-            ng-click="toggle()">
+            ng-click="toggle()" aria-label="{{showHide}} {{name}}">
         <gr-icon-label gr-icon="{{ icon }}">{{ showHide }} {{ name }}</gr-icon-label>
     </button>
 </div>

--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.js
@@ -22,7 +22,7 @@ topBar.directive('grTopBarNav', [function() {
         transclude: true,
         // Annoying to have to hardcode root route here, but only
         // way I found to clear $stateParams from uiRouter...
-        template: `${window._clientConfig.homeLinkHtml || '<a href="/search" class="home-link" title="Home">Home</a>'}
+        template: `${window._clientConfig.homeLinkHtml || '<a href="/search" class="home-link" title="Home" role="link" aria-label="Go to Home">Home</a>'}
                    <ng:transclude></ng:transclude>`
     };
 }]);

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.html
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.html
@@ -3,7 +3,8 @@
             class="gu-date-range__display"
             ng-click="ctrl.showOverlay = !ctrl.showOverlay"
             gr-track-click="{{ctrl.trackingName}}"
-            gr-track-click-data="{ 'Action': 'Show Hide' }">
+            gr-track-click-data="{ 'Action': 'Show Hide' }"
+            aria-label="{{ctrl.showOverlay ? 'Hide' : 'Show'}} date range filter">
         <gr-icon>event</gr-icon>
         <div class="gu-date-range__display--value">
             {{ctrl.guSelectedField}}

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -1,12 +1,13 @@
-<gr-top-bar>
-    <gr-top-bar-nav>
+<gr-top-bar role="banner" aria-label="Top bar">
+    <gr-top-bar-nav role="navigation" aria-label="Primary">
         <a class="top-bar-item clickable side-padded"
            ui-sref="image({ imageId: ctrl.image.data.id })"
-           gr-tooltip="cancel [esc]">
+           gr-tooltip="cancel [esc]"
+           aria-label="Go back to image">
             <gr-icon-label gr-icon="cancel">Cancel</gr-icon-label></a>
     </gr-top-bar-nav>
 
-    <gr-top-bar-actions>
+    <gr-top-bar-actions role="region" aria-label="User actions and secondary navigation">
         <div class="top-bar-item side-padded">
             x:
             <form class="top-bar-item__form">
@@ -99,7 +100,7 @@
     Please try to use a larger crop or an alternative image.
 </div>
 
-<div class="easel">
+<div class="easel" role="main" aria-label="Image cropper">
     <div class="easel__canvas">
         <div class="easel__image-container">
             <img class="easel__image easel__image--cropper"

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -88,7 +88,8 @@
                     type="button"
                     ng-click="ctrl.callCrop()"
                     ng-disabled="ctrl.cropping"
-                    gr-tooltip="Crop [enter]">
+                    gr-tooltip="Crop [enter]"
+                    aria-label="Crop image">
                 <gr-icon-label gr-icon="crop" gr-loading="{{ctrl.cropping}}">Crop<span ng-show="ctrl.cropping">ping…</span></gr-icon-label>
             </button>
         </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -32,7 +32,9 @@
                        rel="noopener"
                        target="_blank"
                        title="Pop out"
-                       ng-href="/images/{{:: ctrl.image.data.id}}">
+                       ng-href="/images/{{:: ctrl.image.data.id}}"
+                       role="link"
+                       aria-label="View image">
                         <gr-icon>open_in_new</gr-icon>
                     </a>
                 </li>
@@ -40,7 +42,9 @@
                 <li>
                     <a class="image-action"
                        title="crop"
-                       ui-sref="crop({ imageId: ctrl.image.data.id })">
+                       ui-sref="crop({ imageId: ctrl.image.data.id })"
+                       role="link"
+                       aria-label="Go to image crop">
                         <gr-icon>crop</gr-icon>
                     </a>
                 </li>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -8,7 +8,8 @@
             <a class="result-editor__img-link"
                ng-switch-when="true"
                ui-sref="image({imageId: ctrl.image.data.id})"
-               ui-drag-data="ctrl.image | asImageDragData">
+               ui-drag-data="ctrl.image | asImageDragData"
+               aria-label="View image">
 
                 <img class="result-editor__img"
                      alt="original image thumbnail"
@@ -65,15 +66,15 @@
             <div class="result-editor__info-item"
                  ng-switch="ctrl.status">
                 <a ng-if="ctrl.isDeleted" class="result-editor__status status status--valid"
-                   ui-sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
+                   ui-sref="image({imageId: ctrl.image.data.id})" aria-label="View image">View image ▸</a>
 
                 <a ng-if="!ctrl.isDeleted" class="result-editor__status status status--valid"
                    ng-switch-when="ready"
-                   ui-sref="image({imageId: ctrl.image.data.id})">View image ▸</a>
+                   ui-sref="image({imageId: ctrl.image.data.id})" aria-label="View image">View image ▸</a>
 
                 <a ng-if="!ctrl.isDeleted" class="result-editor__status status status--invalid"
                    ng-switch-when="invalid"
-                   ui-sref="image({imageId: ctrl.image.data.id})">
+                   ui-sref="image({imageId: ctrl.image.data.id})" aria-label="View image">
                         Unusable
                    <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
                 </a>
@@ -115,7 +116,7 @@
 
     <div class="result-editor__editor">
 
-        <section>
+        <section aria-label="Image usage rights">
             <h1>Image Rights</h1>
             <div class="result-editor__field-container image-info__wrap">
                 <span class="result-editor__field-label flex-no-shrink text-small">
@@ -164,7 +165,7 @@
             </div>
         </section>
 
-        <section>
+        <section aria-label="Image metadata">
             <span class="edit_metadata__warning" ng-if="!ctrl.userCanEdit">WARNING: This image is already in {{ctrl.systemName}}. Since you're not the original uploader, you are not allowed to edit its metadata.</span>
             <h1 ng-class="{'section__disabled': !ctrl.userCanEdit}">Image Metadata</h1>
             <ui-required-metadata-editor
@@ -177,7 +178,7 @@
             ></ui-required-metadata-editor>
         </section>
 
-        <section>
+        <section aria-label="Organisation and grouping">
             <h1>Organisation and Grouping</h1>
             <div class="result-editor__field-container flex-container flex-center">
                 <span class="result-editor__field-label  flex-no-shrink text-small">
@@ -254,7 +255,7 @@
             </div>
         </section>
 
-        <section>
+        <section aria-label="File information">
             <h1>File information</h1>
             <div class="result-editor__field-container" ng-if=":: ctrl.image.data.uploadInfo.filename">
                 <div class="result-editor__field-label text-small">File name</div>

--- a/kahuna/public/js/edits/list-editor-compact.html
+++ b/kahuna/public/js/edits/list-editor-compact.html
@@ -7,7 +7,8 @@
 
             <a class="element__value element__value--compact element__link"
                ng-if="!ctrl.disabled"
-               ui-sref="search.results({query: (element | {{ctrl.queryFilter}})})">
+               ui-sref="search.results({query: (element | {{ctrl.queryFilter}})})"
+               aria-label="Search images by {{element}} {{ctrl.elementName}}">
                 {{element}}
             </a>
         </li>

--- a/kahuna/public/js/edits/list-editor-info-panel.html
+++ b/kahuna/public/js/edits/list-editor-info-panel.html
@@ -7,7 +7,8 @@
             ng-click="ctrl.addElements([element.data])">
         <gr-icon>library_add</gr-icon>
     </button>
-    <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}})})" class="element__value">{{element.data}}</a>
+    <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}})})" class="element__value"
+       aria-label="Search images by {{element.data}} {{ctrl.elementName}}">{{element.data}}</a>
     <button class="element__remove"
             title="Remove {{ctrl.elementName}}{{element.count > 1 ? ' from all' : ''}}"
             ng-click="ctrl.removeElement(element.data)">

--- a/kahuna/public/js/edits/list-editor-info-panel.html
+++ b/kahuna/public/js/edits/list-editor-info-panel.html
@@ -11,7 +11,7 @@
        aria-label="Search images by {{element.data}} {{ctrl.elementName}}">{{element.data}}</a>
     <button class="element__remove"
             title="Remove {{ctrl.elementName}}{{element.count > 1 ? ' from all' : ''}}"
-            ng-click="ctrl.removeElement(element.data)">
+            ng-click="ctrl.removeElement(element.data)" aria-label="Remove {{ctrl.elementName}}">
         <gr-icon>close</gr-icon>
     </button>
 </li>

--- a/kahuna/public/js/edits/list-editor.js
+++ b/kahuna/public/js/edits/list-editor.js
@@ -150,7 +150,8 @@ listEditor.directive('uiListEditorCompact', [function() {
             disabled: '=',
             removeFromImages: '=',
             accessor: '=',
-            queryFilter: '@'
+            queryFilter: '@',
+          elementName: '@'
         },
         controller: 'ListEditorCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -1,11 +1,12 @@
-<gr-top-bar>
-    <gr-top-bar-nav>
-        <a class="top-bar-item side-padded clickable" ui-sref="search" title="Back to search">
+<gr-top-bar role="banner" aria-label="Top bar">
+    <gr-top-bar-nav role="navigation" aria-label="Primary">
+        <a class="top-bar-item side-padded clickable" ui-sref="search" title="Back to search"
+           aria-label="Go to image search">
             <gr-icon-label gr-icon="youtube_searched_for">Back to search</gr-icon-label>
         </a>
     </gr-top-bar-nav>
 
-    <gr-top-bar-actions>
+    <gr-top-bar-actions role="region" aria-label="User actions and secondary navigation">
         <gr-delete-image class="top-bar-item clickable"
                          ng-if="ctrl.canBeDeleted && !ctrl.isDeleted"
                          images="[ctrl.image]">
@@ -26,9 +27,9 @@
 </gr-top-bar>
 
 
-<div class="image-details image-details--crop">
+<div class="image-details image-details--crop" role="complementary" aria-label="Image original and crops select">
     <div class="image-info">
-        <div class="image-info__group">
+        <div class="image-info__group" role="region" aria-label="Original image">
             <dl>
                 <dt class="image-info__heading">Original <span class="image-info__file-size"> {{:: ctrl.image.data.source.size | asFileSize}}</span></dt>
                     <dd class="image-info__heading--crops">
@@ -36,7 +37,8 @@
                              ng-class="{'image-crop--selected': !ctrl.crop}">
                             <a draggable="true"
                                 ui-sref="{ crop: null }"
-                                ui-drag-data="ctrl.image | asImageDragData">
+                                ui-drag-data="ctrl.image | asImageDragData"
+                                aria-label="View original image">
                                 <img class="image-crop__image"
                                      alt="original image thumbnail"
                                      ng-src="{{:: ctrl.image.data.thumbnail | assetFile }}" />
@@ -50,7 +52,7 @@
                 </dt>
             </dl>
         </div>
-        <div ng-if="ctrl.hasFullCrop" class="image-info__group">
+        <div ng-if="ctrl.hasFullCrop" class="image-info__group" role="region" aria-label="Full frame">
             <dt class="image-info__heading">Full frame</dt>
             <dd>
                 <div class="image-crop"
@@ -93,7 +95,7 @@
                 </div>
             </dd>
         </div>
-        <div class="image-info__group" ng-if="ctrl.hasCrops">
+        <div class="image-info__group" ng-if="ctrl.hasCrops" role="region" aria-label="Image crops">
             <dl class="image-info__group--dl">
                 <dt class="image-info__heading">Crops</dt>
                 <dd class="image-info__heading--crops">
@@ -102,25 +104,29 @@
                             ng-repeat="crop in ctrl.crops"
                             ng-switch="ctrl.allowCropSelection(crop)"
                             ng-class="{'image-crop--selected': crop == ctrl.crop}">
-                            <a draggable="true"
-                               ng-init="extremeAssets = (crop | getExtremeAssets)"
-                               ng-switch-when="true"
-                               ng-click="ctrl.cropSelected(crop)"
-                               ui-sref="{crop: crop.id}"
-                               ui-drag-data="ctrl.image | asImageAndCropsDragData:crop"
-                               ui-drag-image="extremeAssets.smallest | assetFile">
+                            <div role="region"
+                                 aria-label="{{crop.master.dimensions.width}} pixels by {{crop.master.dimensions.height}} pixels crop">
+                                <a draggable="true"
+                                   ng-init="extremeAssets = (crop | getExtremeAssets)"
+                                   ng-switch-when="true"
+                                   ng-click="ctrl.cropSelected(crop)"
+                                   ui-sref="{crop: crop.id}"
+                                   ui-drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                                   ui-drag-image="extremeAssets.smallest | assetFile"
+                                   aria-label="Go to {{crop.master.dimensions.width}} pixels by {{crop.master.dimensions.height}} pixels crop">
 
-                              <ng-include src="'/assets/js/image/crop.html'"></ng-include>
-                            </a>
-                            <div
-                                class="image-crop--disabled"
-                                draggable="false"
-                                ng-init="extremeAssets = (crop | getExtremeAssets)"
-                                ng-switch-when="false"
-                                gr-tooltip="{{:: ctrl.capitalisedCropType}} crops only"
-                                gr-tooltip-position="top"
-                            >
-                              <ng-include src="'/assets/js/image/crop.html'"></ng-include>
+                                    <ng-include src="'/assets/js/image/crop.html'"></ng-include>
+                                </a>
+                                <div
+                                    class="image-crop--disabled"
+                                    draggable="false"
+                                    ng-init="extremeAssets = (crop | getExtremeAssets)"
+                                    ng-switch-when="false"
+                                    gr-tooltip="{{:: ctrl.capitalisedCropType}} crops only"
+                                    gr-tooltip-position="top"
+                                >
+                                    <ng-include src="'/assets/js/image/crop.html'"></ng-include>
+                                </div>
                             </div>
                         </li>
                     </ul>
@@ -135,7 +141,7 @@
             gr-on-delete="ctrl.onCropsDeleted()"></gr-delete-crops>
 </div>
 
-<div class="image-details image-details--full-image">
+<div class="image-details image-details--full-image" role="complementary" aria-label="Image information">
   <gr-metadata-validity gr-image="ctrl.image"></gr-metadata-validity>
   <gr-image-cost-message gr-image="ctrl.image"></gr-image-cost-message>
   <gr-radio-list gr-for="tabs" gr-options="ctrl.tabs" gr-selected-option="ctrl.selectedTab"></gr-radio-list>
@@ -149,7 +155,7 @@
   </div>
 </div>
 
-<div class="image-holder">
+<div class="image-holder" role="main" aria-label="Image view">
     <div class="easel">
         <div class="easel__canvas"
              ng-if="!ctrl.crop"

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -5,7 +5,8 @@
         ng-click="ctrl.editing = true"
         ng-if="ctrl.userCanEdit && !ctrl.receivingBatch"
         gr-tooltip="Add lease"
-        gr-tooltip-position="bottom">
+        gr-tooltip-position="bottom"
+        aria-label="Add lease to image">
 
     <gr-icon data-cy="it-add-lease-icon" ng-show="!ctrl.editing" ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
     <span>
@@ -17,12 +18,14 @@
         title="Apply these leases to all your current uploads"
         ng-if="!ctrl.confirmDelete"
         ng-click="ctrl.batchApplyLeases()"
+        aria-label="Apply these leases to all current uploads">
     >⇔</button>
 
     <button title="Remove ALL leases"
             class="button button--confirm-delete"
             ng-if="ctrl.confirmDelete"
-            ng-click="ctrl.batchRemoveLeases()">
+            ng-click="ctrl.batchRemoveLeases()"
+            aria-label="Remove all leases">
         <gr-icon>warning</gr-icon>Remove ALL leases in job?
     </button>
 </span>

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -8,7 +8,8 @@
                 type="button"
                 title="Clear query"
                 ng-show="searchQuery.filter.query"
-                ng-click="searchQuery.resetQuery()">
+                ng-click="searchQuery.resetQuery()"
+                aria-label="Clear search">
             <gr-icon>cancel</gr-icon>
         </button>
     </span>

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -16,7 +16,8 @@
     <button class="search__advanced-toggle"
             type="button"
             ng-click="searchInfo = !searchInfo"
-            gr-tooltip="Display advanced search information">
+            gr-tooltip="Display advanced search information"
+            aria-label="Display advanced search information">
         <gr-icon>info_outline</gr-icon>
     </button>
 
@@ -91,7 +92,8 @@
                            class="radio-list__circle"
                            name="sort-direction"
                            ng-value="undefined"
-                           ng-model="searchQuery.ordering.orderBy">
+                           ng-model="searchQuery.ordering.orderBy"
+                           aria-label="Order search results by newest first">
                     <label for="sort-direction__desc" class="radio-list__label"
                            ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === undefined}">
                         <div class="radio-list__selection-state"></div>
@@ -106,7 +108,8 @@
                            class="radio-list__circle"
                            name="sort-direction"
                            ng-value="'oldest'"
-                           ng-model="searchQuery.ordering.orderBy">
+                           ng-model="searchQuery.ordering.orderBy"
+                           aria-label="Order search results by oldest first">
                     <label for="sort-direction__asc" class="radio-list__label"
                            ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === 'oldest'}">
                         <div class="radio-list__selection-state"></div>

--- a/kahuna/public/js/search/view.html
+++ b/kahuna/public/js/search/view.html
@@ -1,33 +1,37 @@
 <!-- TODO: rename this file and split it into it's components -->
-<gr-top-bar fixed="true">
-    <gr-top-bar-nav>
-        <search-query></search-query>
+<gr-top-bar fixed="true" role="banner" aria-label="Top bar">
+    <gr-top-bar-nav role="region" aria-label="Primary navigation and image search">
+        <div role="region" aria-label="Image search and filters">
+            <search-query></search-query>
+        </div>
     </gr-top-bar-nav>
 
-    <gr-top-bar-actions>
+    <gr-top-bar-actions role="region" aria-label="User actions and secondary navigation">
         <a ng-if="ctrl.canUpload"
            ui-sref="upload"
            gr-track-click="Your recent uploads button"
            gr-track-click-data="{'Location': 'Search navigation'}"
            class="top-bar-item clickable side-padded"
-           title="my recent uploads">
+           title="my recent uploads"
+           aria-label="My recent uploads">
             <gr-icon-label gr-icon="photo_library">My recent uploads</gr-icon-label>
         </a>
         <file-uploader ng-if="ctrl.canUpload" class="top-bar-item side-padded"></file-uploader>
     </gr-top-bar-actions>
 </gr-top-bar>
 
-<gr-panels class="search-panels">
+<gr-panels class="search-panels" role="main" aria-label="Image search results">
     <gr-panel gr-left="true" gr-panel="ctrl.collectionsPanel" gr-icon="collections"
-              gr-remember-scroll="true">
+              gr-remember-scroll="true" role="region" aria-label="Collections">
         <ui-view name="collectionPanel"></ui-view>
     </gr-panel>
 
-    <gr-panel-content>
+    <gr-panel-content role="region" aria-label="Matched image search results">
         <ui-view name="results"></ui-view>
     </gr-panel-content>
 
-    <gr-panel gr-right="true" gr-panel="ctrl.metadataPanel" gr-icon="collections">
+    <gr-panel gr-right="true" gr-panel="ctrl.metadataPanel" gr-icon="collections"
+              role="region" aria-label="Image information">
         <ui-view name="infoPanel"></ui-view>
     </gr-panel>
 </gr-panels>

--- a/kahuna/public/js/upload/file-uploader.html
+++ b/kahuna/public/js/upload/file-uploader.html
@@ -1,4 +1,4 @@
-<form class="file-uploader">
+<form class="file-uploader" role="form" aria-label="Upload image">
     <!-- you cannot bind ng-model="files" nor use ng-change:
     https://github.com/angular/angular.js/issues/1375 -->
     <input class="file-uploader__file"
@@ -9,7 +9,8 @@
     <button data-cy="upload-button"
             class="file-uploader__select-files button"
             gr-track-click="Upload action"
-            gr-track-click-data="{ 'Action': 'Button click' }">
+            gr-track-click-data="{ 'Action': 'Button click' }"
+            aria-label="Select images to upload">
         <gr-icon-label gr-icon="file_upload">Upload</gr-icon-label>
     </button>
 </form>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -1,4 +1,6 @@
-<form class="job-editor" name="jobEditor" ng-submit="ctrl.save()" novalidate ng-class="{'job-editor__disabled': !ctrl.userCanEdit}">
+<form class="job-editor" name="jobEditor" ng-submit="ctrl.save()"
+      novalidate ng-class="{'job-editor__disabled': !ctrl.userCanEdit}"
+      aria-label="Image metadata">
     <div class="job-editor__inputs">
         <label class="job-info--editor__field flex-center">
             <div class="job-info--editor__label job-info--editor__label flex-center text-small">Description</div>

--- a/kahuna/public/js/upload/jobs/upload-jobs.html
+++ b/kahuna/public/js/upload/jobs/upload-jobs.html
@@ -1,12 +1,13 @@
 <div class="flex-container section-heading current-uploads">
     <h2 class="flex-spacer">Your current uploads <em ng-if="ctrl.remaining">({{ctrl.remaining}} remaining)</em></h2>
-    <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
+    <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})"
+       aria-label="View all your uploads">View all your uploads</a>
 </div>
 <ul>
     <li ng-repeat="job in ctrl.jobs | orderBy: 'name'"  class="upload-result">
 
         <div ng-if="!job.image"
-             class="job-uploading">
+             class="job-uploading" role="region" aria-label="{{job.name}} upload">
 
             <div class="result-editor__result">
                 <div>

--- a/kahuna/public/js/upload/recent/recent-uploads.html
+++ b/kahuna/public/js/upload/recent/recent-uploads.html
@@ -6,9 +6,11 @@
 </p>
 <ul ng-if="ctrl.myUploads.data.length > 0">
     <li ng-repeat="result in ctrl.myUploads.data track by result.data.id" class="upload-result">
-        <ui-image-editor image="result"></ui-image-editor>
-        <gr-delete-image class="flex-right"
-                         ng-if="ctrl.canBeDeleted(result)"
-                         images="[result]"></gr-delete-image>
+        <div role="region" aria-label="{{result.data.uploadInfo.filename}}">
+            <ui-image-editor image="result"></ui-image-editor>
+            <gr-delete-image class="flex-right"
+                             ng-if="ctrl.canBeDeleted(result)"
+                             images="[result]"></gr-delete-image>
+        </div>
     </li>
 </ul>

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -1,32 +1,31 @@
-<gr-top-bar>
-    <gr-top-bar-nav>
+<gr-top-bar role="banner" aria-label="Top bar">
+    <gr-top-bar-nav role="navigation" aria-label="Primary">
         <a class="top-bar-item side-padded"
-           ui-sref="search"><gr-icon>search</gr-icon>
+           ui-sref="search" role="link"
+           aria-label="Go to image search"><gr-icon>search</gr-icon>
            <span class="top-bar-item__label">Search</span></a>
     </gr-top-bar-nav>
     <gr-top-bar-actions></gr-top-bar-actions>
 </gr-top-bar>
 
-<div ng-if="ctrl.canUpload" class="page-wrapper">
-    <file-prompt class="section"></file-prompt>
+<div ng-if="ctrl.canUpload" class="page-wrapper" role="main" aria-label="Image uploads">
+    <file-prompt class="section" role="region" aria-label="File upload"></file-prompt>
 
-    <section class="section"
+    <section class="section" role="region" aria-label="Your current uploads"
              ng-if="ctrl.latestJob && ctrl.latestJob.length > 0">
-
-
-
         <ui-upload-jobs jobs="ctrl.latestJob"></ui-upload-jobs>
     </section>
 
-    <section class="section">
+    <section class="section" role="region" aria-label="Your past 50 uploads">
         <div class="flex-container section-heading">
             <h2 class="flex-spacer">Your past 50 uploads</h2>
-            <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})">View all your uploads</a>
+            <a ng-controller="SessionCtrl" class="coloured-link" ui-sref="search.results({uploadedBy: user.email, nonFree: true})"
+               aria-label="View all your uploads">View all your uploads</a>
         </div>
 
         <recent-uploads></recent-uploads>
     </section>
 </div>
-<div ng-if="ctrl.canUpload === false" class="unauthorised-message">You are not authorised to upload images. <a href="{{ctrl.supportEmailLink}}" class="coloured-link">Send an email to {{ctrl.systemName}} team</a> if you think this is incorrect.</div>
+<div ng-if="ctrl.canUpload === false" class="unauthorised-message" role="main">You are not authorised to upload images. <a href="{{ctrl.supportEmailLink}}" class="coloured-link">Send an email to {{ctrl.systemName}} team</a> if you think this is incorrect.</div>
 
 <dnd-uploader ng-if="ctrl.canUpload"></dnd-uploader>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -6,7 +6,8 @@
       aria-label="Image usage rights">
 
     <div class="ure__description">
-        <a rel="noopener" target="_blank" href="{{ctrl.usageRightsHelpLink}}">
+        <a rel="noopener" target="_blank" href="{{ctrl.usageRightsHelpLink}}"
+           aria-label="Usage rights guide">
             <gr-icon title="Rights Guide">
                 info_outline
             </gr-icon>
@@ -182,7 +183,8 @@
     </div>
     <div class="ure__bar">
         <button class="ure__action button-ico button-cancel" type="button" ng-click="ctrl.cancel()"
-                title="close usage rights overrides">
+                title="close usage rights overrides"
+                aria-label="Close usage rights form">
             <gr-icon-label gr-icon="close">Cancel</gr-icon-label>
         </button>
 
@@ -190,7 +192,8 @@
             class="ure__action button-ico button-save"
             type="submit"
             title="save usage rights overrides"
-            ng-disabled="ctrl.savingDisabled || !usageRights.$valid">
+            ng-disabled="ctrl.savingDisabled || !usageRights.$valid"
+            aria-label="Save usage rights">
             <gr-icon-label ng-if="!ctrl.saving" gr-icon="check">Save</gr-icon-label>
             <gr-icon ng-if="ctrl.saving">timelapse</gr-icon>
         </button>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -2,7 +2,8 @@
       novalidate
       name="usageRights"
       ng-class="{'ure__category-invalid': ctrl.categoryInvalid}"
-      ng-submit="usageRights.$valid && ctrl.save()">
+      ng-submit="usageRights.$valid && ctrl.save()"
+      aria-label="Image usage rights">
 
     <div class="ure__description">
         <a rel="noopener" target="_blank" href="{{ctrl.usageRightsHelpLink}}">


### PR DESCRIPTION
## What does this change?

Adds ARIA landmarks and labels to main sections, links and form elements to support screen readers and other assistive technologies. The landmarks convey structural information of the HTML pages and allows users to quickly jump to different sections of the HTML page while the labels describe HTML elements that screen readers can interact with e.g. links and form elements.

Pages with landmarks are:

- Images search - `kahuna/public/js/search/view.html`
- My uploads - `kahuna/public/js/upload/view.html`
- Image - `kahuna/public/js/image/view.html`
- Image crop - `kahuna/public/js/crop/view.html`


## How can success be measured?

Using VoiceOver (rotor) on Mac to jump to different sections of the HTML page and interact with HTML elements like links, buttons and form elements. 


## Screenshots

![Image - landmarks](https://user-images.githubusercontent.com/12212239/159779582-90303d5f-3013-421e-8934-9477ab5c86d4.png)

![Image crop - landmarks](https://user-images.githubusercontent.com/12212239/159779630-eee57a7d-3be5-47ae-b0af-5447590cb299.png)

![Image search - landmarks](https://user-images.githubusercontent.com/12212239/159779651-79a8bef7-5a2d-4cc1-86ee-373e6292e46c.png)

![My uploads - landmarks](https://user-images.githubusercontent.com/12212239/159779677-64f0b0a5-35ff-4b50-a3a5-22dd0c71f476.png)


## Who should look at this?

@guardian/digital-cms

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
