### PR TITLE
use a `mozilla/sbt` docker image built for `linux/amd64` for GHA ScalaBuild

### DIFF
--- a/.github/actions/sbt/Dockerfile
+++ b/.github/actions/sbt/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/sbt
+FROM mozilla/sbt:8u292_1.5.7
 
 RUN apt-get -y update
 


### PR DESCRIPTION
Scala GHA builds started failing (e.g. https://github.com/guardian/grid/runs/5726787902?check_suite_focus=true) due to a discrepancy in the `platform` of the runner vs the default in docker...
![image](https://user-images.githubusercontent.com/19289579/160596794-94499987-66d2-4676-afc4-642793c072b3.png)

It looks like [`mozilla/sbt` docker image](https://hub.docker.com/r/mozilla/sbt/tags) has stopped being built for `linux/amd64` (which is what the GHA runners are)...
![image](https://user-images.githubusercontent.com/19289579/160602477-07ca54d2-e506-42aa-91e8-e64b8d012211.png)

## What does this change?

... for the time being, use a hard coded image version (which was the last one built for `linux/amd64`) - since SBT will get the correct version of itself anyway. Longer term this isn't ideal.

## How can success be measured?
No failing builds.

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
