### PR TITLE
Inline Box library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,6 @@ lazy val commonLib = project("common-lib").settings(
     "com.sksamuel.elastic4s" %% "elastic4s-core" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-domain" % elastic4sVersion,
-    "com.gu" %% "box" % "0.2.0",
     "com.gu" %% "thrift-serializer" % "4.0.0",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
     "org.im4java" % "im4java" % "1.4.0",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
@@ -2,7 +2,6 @@ package com.gu.mediaservice.lib
 
 import java.io.InputStream
 import akka.actor.{Cancellable, Scheduler}
-import com.gu.Box
 import com.gu.mediaservice.lib.aws.S3
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.GridLogging

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/Box.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/Box.scala
@@ -1,0 +1,37 @@
+package com.gu.mediaservice.lib
+
+import java.util.concurrent.atomic.AtomicReference
+
+abstract class Box[T] {
+  def get(): T
+  def apply(): T
+
+  def send(t: T): Unit
+  def send(f: T => T): Unit
+
+  def map[A](f: T => A): Box[A]
+  def flatMap[A](f: T => Box[A]): Box[A]
+}
+
+object Box {
+  def apply[T](initialValue: T): Box[T] = new AtomicRefBox[T](initialValue)
+}
+
+// Note the omission of modify and alter
+// (https://github.com/guardian/box/blob/master/src/main/scala/com/gu/Box.scala#L38).
+// These functions aren't used in grid and the modify function had not been
+// implemented correctly in the Box library.
+private class AtomicRefBox[T](initialValue: T) extends Box[T] {
+  // Note the name of this initial value. This has a different name those in
+  // the methods below to ensure the correct scope of named variables.
+  private val ref: AtomicReference[T] = new AtomicReference[T](initialValue)
+
+  def apply(): T = ref.get()
+  def get(): T = ref.get()
+
+  def send(t: T): Unit = ref.set(t)
+  def send(f: T => T): Unit = ref.updateAndGet(t => f(t))
+
+  def map[A](f: T => A): Box[A] = new AtomicRefBox[A](f(get()))
+  def flatMap[A](f: T => Box[A]): Box[A] = f(get())
+}


### PR DESCRIPTION
## What does this change?
The `frontend` project is updating to scala 2.13. As part of the update we found that [Box](https://github.com/guardian/box) is not compatible with 2.13 and that the lib also contained a bug. The advice we got was to deprecate the Box lib and inline the functionality in projects that are using it. The related `frontend` PR is here: https://github.com/guardian/frontend/pull/24768

In anticipation that `grid` might also update to scala 2.13 (at some point in the future), this commit removes Box as a dependency and inlines the functionality that `grid` requires.

## How can success be measured?
`com.gu.box` is no longer a dependency of this project, inlined Box class provides all necessary functionality.

## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
