### PR TITLE
make the location field editable

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -5,3 +5,22 @@
 .image-info--editor__input-preview {
   border: 1px solid #ffbc01;
 }
+
+.edit-Location-form{
+    display: table;
+}
+
+.edit-Location-form-row{
+    display: table-row;
+}
+
+.edit-Location-form-cell{
+    display: table-cell; }
+
+.edit-Location-form-cell:first-child {
+    width: 77px;
+}
+
+.edit-Location-form .editable-buttons {
+    padding-top: 7px;
+}

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -25,3 +25,10 @@
     padding-top: 7px;
     padding-bottom: 7px;
 }
+
+.inactiveLink {
+   pointer-events: none;
+   cursor: default;
+   text-decoration: none;
+   border-bottom: none !important;
+}

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -23,4 +23,5 @@
 
 .edit-Location-form .editable-buttons {
     padding-top: 7px;
+    padding-bottom: 7px;
 }

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -317,7 +317,7 @@
 
                 <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']"
                       >
-                        <span class="metadata-line__info">
+                        <span>
                             <a
                                ui-sref="{{ ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) ? '' : 'search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})'}}"
                                ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop]),
@@ -331,7 +331,7 @@
                         </span>
 
                 </span>
-                <span ng-hide="locationEditForm.$visible" class="metadata-line__info"
+                <span ng-hide="locationEditForm.$visible" class="editable-empty"
                       ng-if="!ctrl.hasLocationInformation() &&
                             ctrl.userCanEdit &&
                             (!ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) &&

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -316,7 +316,12 @@
                         ng-click="locationEditForm.$show()"
                         ng-hide="locationEditForm.$visible">✎</button>
 
-                <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
+                <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']"
+                      ng-if="ctrl.metadata[prop] &&
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) &&
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.city) &&
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.state) &&
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.country)">
                         <span class="metadata-line__info">
                             <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
                                aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
@@ -329,6 +334,12 @@
 
                 </span>
                 <span ng-hide="locationEditForm.$visible" class="metadata-line__info" ng-if="!ctrl.hasLocationInformation() && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                <span ng-hide="locationEditForm.$visible" class="metadata-line__info"
+                      ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) ||
+                            ctrl.hasMultipleValues(ctrl.rawMetadata.city) ||
+                            ctrl.hasMultipleValues(ctrl.rawMetadata.state) ||
+                            ctrl.hasMultipleValues(ctrl.rawMetadata.country)"
+                      >Multiple Location (click ✎ to edit <strong>all</strong>)</span>
             </dd>
 
             <div ng-hide="!locationEditForm.$visible" data-cy="metadata-location" class="image-info__wrap">
@@ -343,6 +354,7 @@
                                 editable-text="ctrl.metadata.subLocation"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="subLocation"
+                                e-placeholder="Multiple subLocations"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': locationEditForm.$waiting,
@@ -360,6 +372,7 @@
                                 editable-text="ctrl.metadata.city"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="city"
+                                e-placeholder="Multiple cities"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': locationEditForm.$waiting,
@@ -377,6 +390,7 @@
                                 editable-text="ctrl.metadata.state"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="state"
+                                e-placeholder="Multiple states"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': locationEditForm.$waiting,
@@ -390,10 +404,10 @@
                         <dd class="edit-Location-form-cell">
                             <div
                                 class="metadata-line__info"
-                                ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
                                 editable-text="ctrl.metadata.country"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="country"
+                                e-placeholder="Multiple countries"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                           'image-info__editor--saving': locationEditForm.$waiting,

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -319,12 +319,16 @@
                       >
                         <span>
                             <a
-                               ui-sref="{{ ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) ? '' : 'search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})'}}"
-                               ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop]),
-                                          'inactiveLink': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}"
-                               aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
-                                 {{ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) ? '(Multiple ' + ctrl.locationFieldPluralMap[prop] + ')' : ctrl.metadata[prop] }}
+                                ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
+                                ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
+                                aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
+                                 {{ctrl.metadata[prop]}}
                             </a>
+                            <span
+                                ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
+                                ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}">
+                                {{'(Multiple ' + ctrl.locationFieldPluralMap[prop] + ')'}}
+                            </span>
                         </span>
                         <span ng-if="! $last && ( ctrl.metadata[prop] || ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) )">
                             ,

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -213,7 +213,6 @@
             <dt class="metadata-line image-info__wrap metadata-line__key image-info__group--dl__key--panel" ng-if="ctrl.metadata.dateTaken">Taken on</dt>
             <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel" ng-if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
 
-
             <dt ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
             <dd data-cy="metadata-byline" ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">
                 <span ng-if="ctrl.metadataUpdatedByTemplate.includes('byline')">
@@ -319,8 +318,10 @@
                 <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']"
                       >
                         <span class="metadata-line__info">
-                            <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
-                               ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}"
+                            <a
+                               ui-sref="{{ ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) ? '' : 'search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})'}}"
+                               ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop]),
+                                          'inactiveLink': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}"
                                aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
                                  {{ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) ? '(Multiple ' + ctrl.locationFieldPluralMap[prop] + ')' : ctrl.metadata[prop] }}
                             </a>
@@ -333,9 +334,9 @@
                 <span ng-hide="locationEditForm.$visible" class="metadata-line__info"
                       ng-if="!ctrl.hasLocationInformation() &&
                             ctrl.userCanEdit &&
-                            (!ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) ||
-                            !ctrl.hasMultipleValues(ctrl.rawMetadata.city) ||
-                            !ctrl.hasMultipleValues(ctrl.rawMetadata.state) ||
+                            (!ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) &&
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.city) &&
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.state) &&
                             !ctrl.hasMultipleValues(ctrl.rawMetadata.country))">Unknown (click ✎ to add)</span>
             </dd>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -317,29 +317,26 @@
                         ng-hide="locationEditForm.$visible">✎</button>
 
                 <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']"
-                      ng-if="ctrl.metadata[prop] &&
-                            !ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) &&
-                            !ctrl.hasMultipleValues(ctrl.rawMetadata.city) &&
-                            !ctrl.hasMultipleValues(ctrl.rawMetadata.state) &&
-                            !ctrl.hasMultipleValues(ctrl.rawMetadata.country)">
+                      >
                         <span class="metadata-line__info">
                             <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
+                               ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}"
                                aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
-                                {{ctrl.metadata[prop]}}
+                                 {{ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) ? '(Multiple ' + ctrl.locationFieldPluralMap[prop] + ')' : ctrl.metadata[prop] }}
                             </a>
                         </span>
-                        <span ng-if="! $last">
+                        <span ng-if="! $last && ( ctrl.metadata[prop] || ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) )">
                             ,
                         </span>
 
                 </span>
-                <span ng-hide="locationEditForm.$visible" class="metadata-line__info" ng-if="!ctrl.hasLocationInformation() && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
                 <span ng-hide="locationEditForm.$visible" class="metadata-line__info"
-                      ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) ||
-                            ctrl.hasMultipleValues(ctrl.rawMetadata.city) ||
-                            ctrl.hasMultipleValues(ctrl.rawMetadata.state) ||
-                            ctrl.hasMultipleValues(ctrl.rawMetadata.country)"
-                      >Multiple Location (click ✎ to edit <strong>all</strong>)</span>
+                      ng-if="!ctrl.hasLocationInformation() &&
+                            ctrl.userCanEdit &&
+                            (!ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) ||
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.city) ||
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.state) ||
+                            !ctrl.hasMultipleValues(ctrl.rawMetadata.country))">Unknown (click ✎ to add)</span>
             </dd>
 
             <div ng-hide="!locationEditForm.$visible" data-cy="metadata-location" class="image-info__wrap">
@@ -354,7 +351,7 @@
                                 editable-text="ctrl.metadata.subLocation"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="subLocation"
-                                e-placeholder="Multiple subLocations"
+                                e-placeholder="{{ctrl.hasMultipleValues(ctrl.rawMetadata.subLocation) ? 'Multiple sublocations' : 'sublocation' }}"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': locationEditForm.$waiting,
@@ -372,7 +369,7 @@
                                 editable-text="ctrl.metadata.city"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="city"
-                                e-placeholder="Multiple cities"
+                                e-placeholder="{{ctrl.hasMultipleValues(ctrl.rawMetadata.city) ? 'Multiple cities' : 'city' }}"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': locationEditForm.$waiting,
@@ -390,7 +387,7 @@
                                 editable-text="ctrl.metadata.state"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="state"
-                                e-placeholder="Multiple states"
+                                e-placeholder="{{ctrl.hasMultipleValues(ctrl.rawMetadata.state) ? 'Multiple states' : 'state' }}"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                       'image-info__editor--saving': locationEditForm.$waiting,
@@ -407,7 +404,7 @@
                                 editable-text="ctrl.metadata.country"
                                 ng-hide="locationEditForm.$visible"
                                 e-name="country"
-                                e-placeholder="Multiple countries"
+                                e-placeholder="{{ctrl.hasMultipleValues(ctrl.rawMetadata.country) ? 'Multiple countries' : 'country' }}"
                                 e:msd-elastic
                                 e:ng-class="{'image-info__editor--error': $error,
                                           'image-info__editor--saving': locationEditForm.$waiting,

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -308,22 +308,110 @@
 
             </dd>
 
+            <dt ng-hide="locationEditForm.$visible" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Location</dt>
+            <dd class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                <button data-cy="it-edit-loc-button"
+                        class="image-info__edit"
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="locationEditForm.$show()"
+                        ng-hide="locationEditForm.$visible">✎</button>
 
-            <dt ng-if="ctrl.hasLocationInformation()" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Location</dt>
-            <dd ng-if="ctrl.hasLocationInformation()" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                <span ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
-                    <span class="metadata-line__info">
-                        <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
-                           aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
-                            {{ctrl.metadata[prop]}}
-                        </a>
-                    </span>
-                    <span ng-if="! $last">
-                        ,
-                    </span>
+                <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']" ng-if="ctrl.metadata[prop]">
+                        <span class="metadata-line__info">
+                            <a ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
+                               aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
+                                {{ctrl.metadata[prop]}}
+                            </a>
+                        </span>
+                        <span ng-if="! $last">
+                            ,
+                        </span>
+
                 </span>
+                <span ng-hide="locationEditForm.$visible" class="metadata-line__info" ng-if="!ctrl.hasLocationInformation() && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
             </dd>
 
+            <div ng-hide="!locationEditForm.$visible" data-cy="metadata-location" class="image-info__wrap">
+                <form  class="edit-Location-form" editable-form name="locationEditForm" onbeforesave="ctrl.updateLocationField('Location', $data)">
+
+                    <div class="edit-Location-form-row">
+                        <dt  ng-hide="!locationEditForm.$visible" class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Sub location</dt>
+                        <dd class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                            <div
+                                class="metadata-line__info"
+
+                                editable-text="ctrl.metadata.subLocation"
+                                ng-hide="locationEditForm.$visible"
+                                e-name="subLocation"
+                                e:msd-elastic
+                                e:ng-class="{'image-info__editor--error': $error,
+                                      'image-info__editor--saving': locationEditForm.$waiting,
+                                      'text-input': true}">
+                            </div>
+                        </dd>
+                    </div>
+
+                    <div class="edit-Location-form-row">
+                        <dt  ng-hide="!locationEditForm.$visible" class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">City</dt>
+                        <dd class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                            <div
+                                class="metadata-line__info"
+
+                                editable-text="ctrl.metadata.city"
+                                ng-hide="locationEditForm.$visible"
+                                e-name="city"
+                                e:msd-elastic
+                                e:ng-class="{'image-info__editor--error': $error,
+                                      'image-info__editor--saving': locationEditForm.$waiting,
+                                      'text-input': true}">
+                            </div>
+                        </dd>
+                    </div>
+
+                    <div class="edit-Location-form-row">
+                        <dt  ng-hide="!locationEditForm.$visible" class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">State</dt>
+                        <dd class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                            <div
+                                class="metadata-line__info"
+
+                                editable-text="ctrl.metadata.state"
+                                ng-hide="locationEditForm.$visible"
+                                e-name="state"
+                                e:msd-elastic
+                                e:ng-class="{'image-info__editor--error': $error,
+                                      'image-info__editor--saving': locationEditForm.$waiting,
+                                      'text-input': true}">
+                            </div>
+                        </dd>
+                    </div>
+
+                    <div class="edit-Location-form-row">
+                        <dt ng-hide="!locationEditForm.$visible" class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Country</dt>
+                        <dd class="edit-Location-form-cell">
+                            <div
+                                class="metadata-line__info"
+                                ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}"
+                                editable-text="ctrl.metadata.country"
+                                ng-hide="locationEditForm.$visible"
+                                e-name="country"
+                                e:msd-elastic
+                                e:ng-class="{'image-info__editor--error': $error,
+                                          'image-info__editor--saving': locationEditForm.$waiting,
+                                          'text-input': true}">
+                            </div>
+                            <div ng-if="ctrl.userCanEdit && locationEditForm.$visible" class="editable-buttons">
+                                <button class="button-cancel" type="button" ng-click="locationEditForm.$cancel()">
+                                    <gr-icon-label gr-icon="close">Cancel</gr-icon-label>
+                                </button>
+
+                                <button class="button-save" type="submit">
+                                    <gr-icon-label gr-icon="check">Save</gr-icon-label>
+                                </button>
+                            </div>
+                        <dd/>
+                    </div>
+                </form>
+            </div>
 
             <dt ng-if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Copyright</dt>
             <dd data-cy="metadata-copyright" ng-if="ctrl.rawMetadata.copyright || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -335,7 +335,7 @@
                 <form  class="edit-Location-form" editable-form name="locationEditForm" onbeforesave="ctrl.updateLocationField('Location', $data)">
 
                     <div class="edit-Location-form-row">
-                        <dt  ng-hide="!locationEditForm.$visible" class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Sub location</dt>
+                        <dt  ng-hide="!locationEditForm.$visible" class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Sublocation</dt>
                         <dd class="edit-Location-form-cell image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                             <div
                                 class="metadata-line__info"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -311,7 +311,7 @@
             <dd class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <button data-cy="it-edit-loc-button"
                         class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
+                        ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                         ng-click="locationEditForm.$show()"
                         ng-hide="locationEditForm.$visible">✎</button>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -99,6 +99,11 @@ module.controller('grImageMetadataCtrl', [
     };
 
     ctrl.updateLocationField = function(data, value) {
+      Object.keys(value).forEach(key => {
+        if (value[key] === undefined) {
+          delete value[key];
+        }
+      });
       ctrl.updateMetadataField('location', value);
     };
 
@@ -372,6 +377,13 @@ module.controller('grImageMetadataCtrl', [
       'city': 'city',
       'state': 'state',
       'country': 'country'
+    };
+
+    ctrl.locationFieldPluralMap = {
+      'subLocation': 'subLocations',
+      'city': 'cities',
+      'state': 'states',
+      'country': 'countries'
     };
 
     ctrl.fieldAliases = $window._clientConfig.fieldAliases;

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -98,6 +98,10 @@ module.controller('grImageMetadataCtrl', [
       ctrl.updateMetadataField('description', ctrl.metadata.description);
     };
 
+    ctrl.updateLocationField = function(data, value) {
+      ctrl.updateMetadataField('location', value);
+    };
+
     ctrl.updateMetadataField = function (field, value) {
       var imageArray = Array.from(ctrl.selectedImages);
       if (field === 'peopleInImage') {

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -282,6 +282,10 @@ service.factory('editsService',
 
         var changed = getMetadataDiff(image, proposedMetadata);
 
+         if (field === 'location') {
+            Object.assign(changed, value);
+          }
+
         return update(image.data.userMetadata.data.metadata, changed, image, inBatch)
           .then(() => image.get());
     }


### PR DESCRIPTION
## What does this change?

Make the location field editable in the metadata section in the right info panel

Location value is a concatenation of City, State, Country, Sub Location.
Edit Location Form appears when clicking on the edit location button
to add remove and update any of the Location fields

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->
![Screenshot from 2022-04-05 18-05-29](https://user-images.githubusercontent.com/33189781/161852353-0fe09b29-1c1f-46fd-bba8-8b06e1f5772b.png)
![Screenshot from 2022-04-05 18-06-10](https://user-images.githubusercontent.com/33189781/161852513-10e9568a-4d71-4f30-8e53-35b539cca004.png)
![Screenshot from 2022-04-05 18-16-57](https://user-images.githubusercontent.com/33189781/161852660-e3ec1879-143f-4362-963b-adf765d385ad.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
