### PR TITLE
add `asset-handle` html element to the 'Original' image

### DIFF
--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -46,6 +46,12 @@
                                     ng-class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
                                     {{::ctrl.image.data.source.dimensions.width}} &times; {{::ctrl.image.data.source.dimensions.height}}
                                 </div>
+                                <asset-handle
+                                    data-source="grid"
+                                    data-source-type="original"
+                                    data-thumbnail="{{:: ctrl.image.data.thumbnail | assetFile}}"
+                                    data-embeddable-url="{{ctrl.getEmbeddableUrl()}}"
+                                ></asset-handle>
                             </a>
                         </div>
                     </dd>


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 

## What does this change?
Similar to https://github.com/guardian/grid/pull/3190 and https://github.com/guardian/grid/pull/3683 this adds the `<asset-handle` HTML tag to the 'Original' image in grid, for the benefit of [guardian/pinboard](https://github.com/guardian/pinboard) (to take over them and add the `Add to 📌` button) - see https://github.com/guardian/pinboard/pull/126.

## How can success be measured?
This means pic eds can share pictures without needing to crop them first.

## Screenshots
![image](https://user-images.githubusercontent.com/19289579/162000136-33c633a4-5979-4157-9fa3-c6656c17794e.png)

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
