### PR TITLE
asset handle drag type

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -206,9 +206,6 @@ image.controller('ImageCtrl', [
       $state.go('image', {imageId: ctrl.image.data.id, crop: undefined}, {reload: true});
     };
 
-    ctrl.getEmbeddableUrl = (maybeCropId) =>
-      $state.href($state.current.name, { crop: maybeCropId || null }, { absolute: true });
-
     // TODO: move this to a more sensible place.
     function getCropDimensions() {
       return {

--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -19,6 +19,6 @@
     data-source="grid"
     data-source-type="crop"
     data-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
-    data-embeddable-url="{{ctrl.getEmbeddableUrl(crop.id)}}"
+    data-embeddable-url="{{:: ctrl.image.data.id | embeddableUrl:crop.id}}"
   ></asset-handle>
 </div>

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -70,7 +70,7 @@
                        ng-init="extremeAssets = (crop | getExtremeAssets)"
                        ng-click="ctrl.cropSelected(crop)"
                        ui-sref="{ crop: crop.id }"
-                       ui-drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                       ui-drag-data="ctrl.image | asImageAndCropDragData:crop"
                        ui-drag-image="extremeAssets.smallest | assetFile">
                         <img class="image-crop__image"
                              alt="full frame image thumbnail"
@@ -117,7 +117,7 @@
                                    ng-switch-when="true"
                                    ng-click="ctrl.cropSelected(crop)"
                                    ui-sref="{crop: crop.id}"
-                                   ui-drag-data="ctrl.image | asImageAndCropsDragData:crop"
+                                   ui-drag-data="ctrl.image | asImageAndCropDragData:crop"
                                    ui-drag-image="extremeAssets.smallest | assetFile"
                                    aria-label="Go to {{crop.master.dimensions.width}} pixels by {{crop.master.dimensions.height}} pixels crop">
 
@@ -178,7 +178,7 @@
         <!-- TODO: As this loads async, add a loader -->
         <div class="easel__canvas" ng-if="ctrl.crop"
              draggable="true"
-             ui-drag-data="ctrl.image | asImageAndCropsDragData:ctrl.crop"
+             ui-drag-data="ctrl.image | asImageAndCropDragData:ctrl.crop"
              ui-drag-image="extremeAssets.smallest | assetFile">
             <a class="easel__image-container"
                ng-init="extremeAssets = (ctrl.crop | getExtremeAssets)"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -50,7 +50,7 @@
                                     data-source="grid"
                                     data-source-type="original"
                                     data-thumbnail="{{:: ctrl.image.data.thumbnail | assetFile}}"
-                                    data-embeddable-url="{{ctrl.getEmbeddableUrl()}}"
+                                    data-embeddable-url="{{:: ctrl.image.data.id | embeddableUrl}}"
                                 ></asset-handle>
                             </a>
                         </div>
@@ -87,7 +87,7 @@
                             data-source="grid"
                             data-source-type="crop"
                             data-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
-                            data-embeddable-url="{{ctrl.getEmbeddableUrl(crop.id)}}"
+                            data-embeddable-url="{{:: ctrl.image.data.id | embeddableUrl:crop.id}}"
                         ></asset-handle>
                     </a>
                     <div ng-switch-when="false"

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -312,6 +312,11 @@ kahuna.controller('SessionCtrl',
     });
 }]);
 
+kahuna.filter("embeddableUrl", ['$state', function($state) {
+  return function(imageId, maybeCropId) {
+    return $state.href('image', {imageId: imageId, crop: maybeCropId}, { absolute: true });
+  }
+}]);
 
 kahuna.filter('getExtremeAssets', function() {
     return function(image) {

--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -53,7 +53,7 @@ var config = {
     vndMimeTypes: new Map([
         ['gridImageData',  'application/vnd.mediaservice.image+json'],
         ['gridImagesData', 'application/vnd.mediaservice.images+json'],
-        ['gridCropsData',  'application/vnd.mediaservice.crops+json'],
+        ['gridCropData',  'application/vnd.mediaservice.crops+json'], // this doesn't appear to hold multiple things, so shouldn't be plural, however too many usages outside this project e.g. https://github.com/search?q=org%3Aguardian+application%2Fvnd.mediaservice.crops%2Bjson&type=code
         ['kahunaUri',      'application/vnd.mediaservice.kahuna.uri'],
         ['assetHandle',    'application/vnd.asset-handle+json'],
         // These two are internal hacks to help us identify when we're dragging internal assets
@@ -376,11 +376,11 @@ kahuna.filter('asImageDragData', ['vndMimeTypes', '$filter', function(vndMimeTyp
 // Take an image and return a drag data map of mime-type -> value.
 // Note: the serialisation is expensive so make sure you only evaluate
 // this filter when necessary.
-kahuna.filter('asCropsDragData', ['vndMimeTypes', '$filter', function(vndMimeTypes, $filter) {
-    return function(image, crops) {
+kahuna.filter('asCropDragData', ['vndMimeTypes', '$filter', function(vndMimeTypes, $filter) {
+    return function(image, crop) {
       return {
-        [vndMimeTypes.get('gridCropsData')]: JSON.stringify(crops),
-        [vndMimeTypes.get('assetHandle')]: JSON.stringify(getAssetHandleDragData($filter, image, crops)),
+        [vndMimeTypes.get('gridCropData')]: JSON.stringify(crop),
+        [vndMimeTypes.get('assetHandle')]: JSON.stringify(getAssetHandleDragData($filter, image, crop)),
       };
     };
 }]);
@@ -388,15 +388,14 @@ kahuna.filter('asCropsDragData', ['vndMimeTypes', '$filter', function(vndMimeTyp
 // Take an image and return a drag data map of mime-type -> value.
 // Note: the serialisation is expensive so make sure you only evaluate
 // this filter when necessary.
-// TODO remove pluralisation from crops
-kahuna.filter('asImageAndCropsDragData', ['$filter',
+kahuna.filter('asImageAndCropDragData', ['$filter',
                                           function($filter) {
     var extend = angular.extend;
-    return function(image, crops) {
+    return function(image, crop) {
 
         return extend(
             $filter('asImageDragData')(image),
-            $filter('asCropsDragData')(image, crops));
+            $filter('asCropDragData')(image, crop));
     };
 }]);
 


### PR DESCRIPTION
# ACCIDENTALLY MERGED/RELEASED AS PART OF https://github.com/guardian/grid/pull/3740

Co-authored-by: @andrew-nowak 

## What does this change?
In https://github.com/guardian/grid/pull/3190 , https://github.com/guardian/grid/pull/3683 and https://github.com/guardian/grid/pull/3704 we keep the integration with [guardian/pinboard](https://github.com/guardian/pinboard) super light, by adding an `<asset-handle` HTML element (which is meaningless to the grid, but provides a means for pinboard to take over the rendering of that element and can use the data attributes.

In the sprit of the  `<asset-handle` this adds a new  `application/vnd.asset-handle+json` drag data, which contains the same fields to keep the grid logic in the grid and to keep the drop logic simple in https://github.com/guardian/pinboard/pull/125 (rather than it having to cobble together what it needs from the giant JSON objects already present in the `dataTransfer` of the drag event).

PLUS:
-  refactor `getEmbeddableUrl` on `ImageCtrl` (introduced in https://github.com/guardian/grid/pull/3190) to be a filter `embeddableUrl` at the top level, so it can be re-used in the new drag logic.
- corrected incorrect pluralisation of crops used in naming of various drag related logic

## How can success be measured?
In addition to the existing `Add to 📌` buttons, this provides an easy way for users to share images to pinboard, but doesn't affect the existing drag logic.

## Screenshots
TODO add GIF


## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
