### PR TITLE
add configuration for Shorten Download Filename

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -90,11 +90,10 @@ class S3(config: CommonConfig) extends GridLogging {
         // See http://docs.oracle.com/javase/6/docs/api/java/net/URLEncoder.html
         URLEncoder.encode(baseFilename, "UTF-8").replace("+", "%20")
       case characterSet => baseFilename.getBytes(characterSet).toString
-
     }
 
   private def getBaseFilename(image: Image, filenameSuffix: String): String = image.uploadInfo.filename match {
-    case Some(_) if config.shortenDownloadFilename => s"$filenameSuffix"
+    case Some(_) if config.shortenDownloadFilename => s"$filenameSuffix".filter(!"()".contains(_))
     case Some(f) => s"${removeExtension(f)} $filenameSuffix"
     case _ => filenameSuffix
   }
@@ -125,7 +124,7 @@ class S3(config: CommonConfig) extends GridLogging {
       case OptimisedPng => image.optimisedPng.getOrElse(image.source)
     }
     val extension: String = getExtension(image, asset)
-    val filenameSuffix: String = s"${image.id}$extension"
+    val filenameSuffix: String = s"(${image.id})$extension"
     val baseFilename = getBaseFilename(image, filenameSuffix)
 
     getContentDisposition(baseFilename)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -90,9 +90,11 @@ class S3(config: CommonConfig) extends GridLogging {
         // See http://docs.oracle.com/javase/6/docs/api/java/net/URLEncoder.html
         URLEncoder.encode(baseFilename, "UTF-8").replace("+", "%20")
       case characterSet => baseFilename.getBytes(characterSet).toString
+
     }
 
   private def getBaseFilename(image: Image, filenameSuffix: String): String = image.uploadInfo.filename match {
+    case Some(_) if config.shortenDownloadFilename => s"$filenameSuffix"
     case Some(f) => s"${removeExtension(f)} $filenameSuffix"
     case _ => filenameSuffix
   }
@@ -123,7 +125,7 @@ class S3(config: CommonConfig) extends GridLogging {
       case OptimisedPng => image.optimisedPng.getOrElse(image.source)
     }
     val extension: String = getExtension(image, asset)
-    val filenameSuffix: String = s"(${image.id})$extension"
+    val filenameSuffix: String = s"${image.id}$extension"
     val baseFilename = getBaseFilename(image, filenameSuffix)
 
     getContentDisposition(baseFilename)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -104,6 +104,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
   val fieldAliasConfigs: Seq[FieldAlias] = configuration.get[Seq[FieldAlias]]("field.aliases")
 
   val recordDownloadAsUsage: Boolean = boolean("image.record.download")
+  val shortenDownloadFilename: Boolean = boolean("image.download.shorten")
 
   /**
    * Load in a list of external staff photographers, internal staff photographers, contracted photographers,


### PR DESCRIPTION
## What does this change?

add configuration for Shorten Download Filename
if _` image.download.shorten`_ is set to true, the downloaded file name will be the image id only
else (default) it will be file name concatenated with image id

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
