### PR TITLE
make the dateTaken field editable

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -26,12 +26,6 @@
     padding-bottom: 7px;
 }
 
-.inactiveLink {
-   pointer-events: none;
-   cursor: default;
-   text-decoration: none;
-   border-bottom: none !important;
-
 .image-info__dateTaken form input {
      padding-right: 5px;
      letter-spacing: -1px;

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -31,4 +31,9 @@
    cursor: default;
    text-decoration: none;
    border-bottom: none !important;
+
+.image-info__dateTaken form input {
+     padding-right: 5px;
+     letter-spacing: -1px;
+     margin-bottom: 3px;
 }

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -210,8 +210,29 @@
 
     <div class="image-info__group" role="region" aria-label="Image metadata">
         <dl class="image-info__group--dl metadata-line">
-            <dt class="metadata-line image-info__wrap metadata-line__key image-info__group--dl__key--panel" ng-if="ctrl.metadata.dateTaken">Taken on</dt>
-            <dd class="image-info__wrap metadata-line image-info__credit metadata-line__info image-info__group--dl__value--panel" ng-if="ctrl.metadata.dateTaken">{{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}</dd>
+            <dt class="metadata-line image-info__wrap metadata-line__key image-info__group--dl__key--panel">Taken on</dt>
+            <dd class="image-info__wrap metadata-line
+             image-info__credit metadata-line__info image-info__group--dl__value--panel"
+            >
+                <button data-cy="it-edit-dateTaken-button"
+                        class="image-info__edit"
+                        ng-if="ctrl.userCanEdit"
+                        ng-click="takenEditForm.$show()"
+                        ng-hide="takenEditForm.$visible"
+                >✎</button>
+
+                <span editable-date="ctrl.metadata.dateTaken"
+                      ng-hide="takenEditForm.$visible"
+                      onbeforesave="ctrl.updateMetadataField('dateTaken', $data)"
+                      e:form="takenEditForm"
+                      e:ng-class="{'image-info__editor--error': $error,
+                                   'image-info__editor--saving': takenEditForm.$waiting,
+                                   'text-input': true}">
+
+                {{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}
+                </span>
+                <span class="editable-empty" ng-if="!ctrl.metadata.dateTaken && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+            </dd>
 
             <dt ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>
             <dd data-cy="metadata-byline" ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__info image-info__group--dl__value--panel">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -211,9 +211,7 @@
     <div class="image-info__group" role="region" aria-label="Image metadata">
         <dl class="image-info__group--dl metadata-line">
             <dt class="metadata-line image-info__wrap metadata-line__key image-info__group--dl__key--panel">Taken on</dt>
-            <dd class="image-info__wrap metadata-line
-             image-info__credit metadata-line__info image-info__group--dl__value--panel"
-            >
+            <dd class="image-info__wrap metadata-line image-info__dateTaken metadata-line__info image-info__group--dl__value--panel">
                 <button data-cy="it-edit-dateTaken-button"
                         class="image-info__edit"
                         ng-if="ctrl.userCanEdit"
@@ -245,9 +243,6 @@
                         <span class="editable-empty" ng-if="!ctrl.metadata.dateTaken && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
                     </span>
                 </span>
-
-
-
             </dd>
 
             <dt ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -221,7 +221,7 @@
                         ng-hide="takenEditForm.$visible"
                 >✎</button>
 
-                <span editable-date="ctrl.metadata.dateTaken"
+                <span editable-datetime-local="ctrl.metadata.dateTaken"
                       ng-hide="takenEditForm.$visible"
                       onbeforesave="ctrl.updateMetadataField('dateTaken', $data)"
                       e:form="takenEditForm"
@@ -229,9 +229,25 @@
                                    'image-info__editor--saving': takenEditForm.$waiting,
                                    'text-input': true}">
 
-                {{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}
+                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.dateTaken) && ctrl.userCanEdit">
+                        Multiple date (click ✎ to edit <strong>all</strong>)
+                    </span>
+
+                    <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.dateTaken) && !ctrl.userCanEdit">
+                        Multiple date
+                    </span>
+
+                    <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.dateTaken)">
+                        <span ng-if="ctrl.metadata.dateTaken">
+                            {{ctrl.metadata.dateTaken | date:'d MMM yyyy, HH:mm'}}
+                        </span>
+
+                        <span class="editable-empty" ng-if="!ctrl.metadata.dateTaken && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+                    </span>
                 </span>
-                <span class="editable-empty" ng-if="!ctrl.metadata.dateTaken && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
+
+
+
             </dd>
 
             <dt ng-if="ctrl.rawMetadata.byline || ctrl.userCanEdit" class="image-info__wrap metadata-line image-info__byline metadata-line__key image-info__group--dl__key--panel">By</dt>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -228,11 +228,11 @@
                                    'text-input': true}">
 
                     <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.dateTaken) && ctrl.userCanEdit">
-                        Multiple date (click ✎ to edit <strong>all</strong>)
+                        Multiple dates (click ✎ to edit <strong>all</strong>)
                     </span>
 
                     <span class="metadata-line__info" ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.dateTaken) && !ctrl.userCanEdit">
-                        Multiple date
+                        Multiple dates
                     </span>
 
                     <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.dateTaken)">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -214,7 +214,7 @@
             <dd class="image-info__wrap metadata-line image-info__dateTaken metadata-line__info image-info__group--dl__value--panel">
                 <button data-cy="it-edit-dateTaken-button"
                         class="image-info__edit"
-                        ng-if="ctrl.userCanEdit"
+                        ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                         ng-click="takenEditForm.$show()"
                         ng-hide="takenEditForm.$visible"
                 >✎</button>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -63,6 +63,7 @@ module.controller('grImageMetadataCtrl', [
       inject$($scope, Rx.Observable.fromPromise(selectedUsageCategory(ctrl.usageRights)), ctrl, 'usageCategory');
       ctrl.rawMetadata = rawMetadata();
       ctrl.metadata = displayMetadata();
+      ctrl.metadata.dateTaken =  ctrl.metadata.dateTaken ? new Date(ctrl.metadata.dateTaken) : undefined;
       ctrl.newPeopleInImage = "";
       ctrl.extraInfo = extraInfo();
       if (ctrl.singleImage) {
@@ -109,6 +110,9 @@ module.controller('grImageMetadataCtrl', [
 
     ctrl.updateMetadataField = function (field, value) {
       var imageArray = Array.from(ctrl.selectedImages);
+      if (field === 'dateTaken') {
+          value = value.toISOString()
+      }
       if (field === 'peopleInImage') {
         ctrl.addPersonToImages(imageArray, value);
         return;

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -83,7 +83,7 @@ module.controller('grImageMetadataCtrl', [
 
     ctrl.displayDateTakenMetadata = function() {
       let dateTaken = ctrl.metadata.dateTaken ? new Date(ctrl.metadata.dateTaken) : undefined;
-      if (dateTaken) dateTaken.setSeconds(0, 0);
+      if (dateTaken) { dateTaken.setSeconds(0, 0); }
       return dateTaken;
     };
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -63,7 +63,7 @@ module.controller('grImageMetadataCtrl', [
       inject$($scope, Rx.Observable.fromPromise(selectedUsageCategory(ctrl.usageRights)), ctrl, 'usageCategory');
       ctrl.rawMetadata = rawMetadata();
       ctrl.metadata = displayMetadata();
-      ctrl.metadata.dateTaken =  ctrl.metadata.dateTaken ? new Date(ctrl.metadata.dateTaken) : undefined;
+      ctrl.metadata.dateTaken =  ctrl.displayDateTakenMetadata();
       ctrl.newPeopleInImage = "";
       ctrl.extraInfo = extraInfo();
       if (ctrl.singleImage) {
@@ -80,6 +80,12 @@ module.controller('grImageMetadataCtrl', [
     };
 
     ctrl.hasMultipleValues = (val) => Array.isArray(val) && val.length > 1;
+
+    ctrl.displayDateTakenMetadata = function() {
+      let dateTaken = ctrl.metadata.dateTaken ? new Date(ctrl.metadata.dateTaken) : undefined;
+      if (dateTaken) dateTaken.setSeconds(0, 0);
+      return dateTaken;
+    };
 
     ctrl.credits = function(searchText) {
       return ctrl.metadataSearch('credit', searchText);

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -111,7 +111,7 @@ module.controller('grImageMetadataCtrl', [
     ctrl.updateMetadataField = function (field, value) {
       var imageArray = Array.from(ctrl.selectedImages);
       if (field === 'dateTaken') {
-          value = value.toISOString()
+          value = value.toISOString();
       }
       if (field === 'peopleInImage') {
         ctrl.addPersonToImages(imageArray, value);


### PR DESCRIPTION
## What does this change?

Make the date taken field editable in the metadata section in the right info panel

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->

![Screenshot from 2022-04-14 02-52-58](https://user-images.githubusercontent.com/33189781/163293235-81b2d922-6a74-4fd5-be27-0f569d500815.png)
![Screenshot from 2022-04-14 02-53-05](https://user-images.githubusercontent.com/33189781/163293400-df223a94-627c-457f-915c-ac1cb4552d20.png)
![Screenshot from 2022-04-14 02-53-38](https://user-images.githubusercontent.com/33189781/163293481-516e663b-f7be-4a8a-af3b-1c564d125ae0.png)
![Screenshot from 2022-04-14 02-53-50](https://user-images.githubusercontent.com/33189781/163293558-f78ab8d3-fd43-4d10-8e04-770fca44a216.png)
![Screenshot from 2022-04-14 02-54-06](https://user-images.githubusercontent.com/33189781/163293611-ced4c89d-fd69-4d72-b3bc-412dac42fc07.png)
![Screenshot from 2022-04-14 02-54-19](https://user-images.githubusercontent.com/33189781/163293668-388908a5-5d8c-4a38-823f-fa14d1cd8fab.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
