### PR TITLE
Add API to get single collection

### DIFF
--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -101,6 +101,16 @@ def uri(u: String) = URI.create(u)
       (collection) => collection.description)
   }
 
+  def getCollection(collectionPathId: String) = authenticated.async {
+    store.get(uriToPath(collectionPathId)).map {
+      case Some(collection) =>
+        val node = Node(collection.path.last, Nil, collection.path, collection.path, Some(collection))
+        respond(node, actions = getActions(node))
+      case None =>
+        respondNotFound("Collection not found")
+    }
+  }
+
   def getCollections = authenticated.async { req =>
     allCollections.map { tree =>
       respond(

--- a/collections/app/controllers/CollectionsController.scala
+++ b/collections/app/controllers/CollectionsController.scala
@@ -108,6 +108,8 @@ def uri(u: String) = URI.create(u)
         respond(node, actions = getActions(node))
       case None =>
         respondNotFound("Collection not found")
+    } recover {
+      case e: CollectionsStoreError => storeError(e.message)
     }
   }
 

--- a/collections/app/store/CollectionsStore.scala
+++ b/collections/app/store/CollectionsStore.scala
@@ -24,6 +24,13 @@ class CollectionsStore(config: CollectionsConfig) {
     case e => throw CollectionsStoreError(e)
   }
 
+  def get(collectionPath: List[String]): Future[Option[Collection]] = {
+    val path = CollectionsManager.pathToPathId(collectionPath)
+    dynamo.get(path).map(json => (json \ "collection").asOpt[Collection])
+  } recover {
+    case e => throw CollectionsStoreError(e)
+  }
+
   def remove(collectionPath: List[String]): Future[Unit] = {
     val path = CollectionsManager.pathToPathId(collectionPath)
     dynamo.deleteItem(path)

--- a/collections/app/store/CollectionsStore.scala
+++ b/collections/app/store/CollectionsStore.scala
@@ -1,6 +1,6 @@
 package store
 
-import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.mediaservice.lib.aws.{DynamoDB, NoItemFound}
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.model.Collection
 import lib.CollectionsConfig
@@ -28,6 +28,7 @@ class CollectionsStore(config: CollectionsConfig) {
     val path = CollectionsManager.pathToPathId(collectionPath)
     dynamo.get(path).map(json => (json \ "collection").asOpt[Collection])
   } recover {
+    case NoItemFound => None
     case e => throw CollectionsStoreError(e)
   }
 

--- a/collections/conf/routes
+++ b/collections/conf/routes
@@ -7,6 +7,7 @@ DELETE  /images/:imageId/*collection                    controllers.ImageCollect
 
 # Collections
 GET     /collections                                    controllers.CollectionsController.getCollections
+GET     /collections/*collection                        controllers.CollectionsController.getCollection(collection: String)
 POST    /collections                                    controllers.CollectionsController.addChildToRoot
 POST    /collections/*collection                        controllers.CollectionsController.addChildToCollection(collection: String)
 DELETE  /collections/*collection                        controllers.CollectionsController.removeCollection(collection: String)


### PR DESCRIPTION
## What does this change?

Adds an API to get a single collection.
The collections API contains hrefs to APIs which look as though they would fetch data for a single collection, but no such API existed. Fortunately most of the required logic exists in other APIs which I was able to collate quite quickly.

Caveats: This doesn't fetch the child collection(s) - I think we'd need to scan the whole db to get them which would make this not much better than getting all the collections

## How can success be measured?

We can get data for a single collection without fetching the entire collections tree out of Dynamo (quite slow).

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)

Tested with guardian/pinboard#127
