### PR TITLE
Remove `Hulton Archive` from the list of retired Getty collections

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -402,7 +402,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
     "Hoberman Collection UK RR",
     "Hola Images RM",
     "Hoxton",
-    "Hulton Archive",
     "I Love Images RF",
     "Iconic Images",
     "Iconica",


### PR DESCRIPTION
## What does this change?
Ronseal.

## How can success be measured?
Better.