### PR TITLE
Restore /quotas routing

### DIFF
--- a/kahuna/conf/routes
+++ b/kahuna/conf/routes
@@ -7,6 +7,7 @@ GET     /images/$id<[0-9a-z]+>                        controllers.KahunaControll
 GET     /images/$id<[0-9a-z]+>/crop                   controllers.KahunaController.index(id: String)
 GET     /search                                       controllers.KahunaController.index(ignored="")
 GET     /upload                                       controllers.KahunaController.index(ignored="")
+GET     /quotas                                       controllers.KahunaController.quotas
 
 # Empty page to return to the same domain as the app
 GET     /ok                                           controllers.KahunaController.ok


### PR DESCRIPTION
## What does this change?

Restores the /quotas page, which the routing was removed as some point previously

## How can success be measured?

See the /quotas page in all its barely-styled glory

## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
