### PR TITLE
Configure additional navigation links in user actions dropdown menu

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -44,6 +44,7 @@ class KahunaController(
     val okPath = routes.KahunaController.ok.url
     // If the auth is successful, we redirect to the kahuna domain so the iframe
     // is on the same domain and can be read by the JS
+    val additionalNavigationLinks: String = Json.toJson(config.additionalLinks).toString()
     val domainMetadataSpecs: String = Json.toJson(config.domainMetadataSpecs).toString()
     val fieldAliases: String = Json.toJson(config.fieldAliasConfigs).toString()
     val metadataTemplates: String = Json.toJson(config.metadataTemplates).toString()
@@ -67,7 +68,8 @@ class KahunaController(
       config.canDownloadCrop,
       domainMetadataSpecs,
       config.recordDownloadAsUsage,
-      metadataTemplates
+      metadataTemplates,
+      additionalNavigationLinks
     ))
   }
 

--- a/kahuna/app/lib/AdditionalLinksConfig.scala
+++ b/kahuna/app/lib/AdditionalLinksConfig.scala
@@ -1,0 +1,31 @@
+package lib
+
+import play.api.ConfigLoader
+import play.api.libs.json.{Json, Writes}
+
+import scala.collection.JavaConverters._
+
+object LinkTarget extends Enumeration {
+  val blank = Value("_blank")
+  val self = Value("_self")
+  val parent = Value("_parent")
+  val top = Value("_top")
+}
+
+case class AdditionalLink(name: String, url: String, target: LinkTarget.Value = LinkTarget.blank)
+
+object AdditionalLink {
+  implicit val writes: Writes[AdditionalLink] = Json.writes[AdditionalLink]
+
+  implicit val configLoader: ConfigLoader[Seq[AdditionalLink]] =
+    ConfigLoader(_.getConfigList).map(
+      _.asScala.map(config => {
+        val linkTarget = if (config.hasPath("target")) LinkTarget.withName(config.getString("target")) else LinkTarget.blank
+
+        AdditionalLink(
+          config.getString("name"),
+          config.getString("url"),
+          linkTarget
+        )
+      }))
+}

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -25,6 +25,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val imageOrigin: String = string("origin.images")
   val googleTrackingId: Option[String] = stringOpt("google.tracking.id").filterNot(_.isEmpty)
 
+  val additionalLinks: Seq[AdditionalLink] = configuration.getOptional[Seq[AdditionalLink]]("links.additional").getOrElse(Seq.empty)
   val feedbackFormLink: Option[String]= stringOpt("links.feedbackForm").filterNot(_.isEmpty)
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)
   val invalidSessionHelpLink: Option[String]= stringOpt("links.invalidSessionHelp").filterNot(_.isEmpty)

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -18,7 +18,8 @@
   canDownloadCrop: Boolean,
   domainMetadataSpecs: String,
   recordDownloadAsUsage: Boolean,
-  metadataTemplates: String
+  metadataTemplates: String,
+  additionalNavigationLinks: String
 )
 <!DOCTYPE html>
 <html>
@@ -63,7 +64,8 @@
           canDownloadCrop: @canDownloadCrop,
           domainMetadataSpecs: @Html(domainMetadataSpecs),
           recordDownloadAsUsage: @recordDownloadAsUsage,
-          metadataTemplates: @Html(metadataTemplates)
+          metadataTemplates: @Html(metadataTemplates),
+          additionalNavigationLinks: @Html(additionalNavigationLinks)
         }
     </script>
 

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -5,9 +5,22 @@
             aria-label="Secondary navigation menu">
         <gr-icon>more_vert</gr-icon>
     </button>
-    <ul class="drop-menu__items drop-menu__items--right" ng-if="showUserActions">
-        <li><a class="drop-menu__items__quotas" href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
-        <li><a class="drop-menu__items__feedback" href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
-        <li><a class="drop-menu__items__logout" href="{{ctrl.logoutUri}}" target="_self">Logout</a></li>
-    </ul>
+    <div class="drop-menu__items drop-menu__items--right" ng-if="showUserActions">
+        <ul class="drop-menu__items__separator">
+            <li><a class="drop-menu__items__quotas" href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
+            <li ng-repeat="additionalLink in ctrl.additionalLinks">
+                <a class="drop-menu__items__quotas"
+                   href="{{additionalLink.url}}"
+                   rel="noopener"
+                   target={{additionalLink.target}}>
+                    {{additionalLink.name}}
+                </a>
+            </li>
+            <li><a class="drop-menu__items__feedback" href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
+        </ul>
+        <ul>
+            <li><a class="drop-menu__items__logout" href="{{ctrl.logoutUri}}" target="_self">Logout</a></li>
+        </ul>
+    </div>
+
 </nav>

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -15,10 +15,10 @@
                     {{additionalLink.name}}
                 </a>
             </li>
-            <li><a class="drop-menu__items__feedback" href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
+            <li><a class="drop-menu__items__feedback" ng-href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
         </ul>
         <ul>
-            <li><a class="drop-menu__items__logout" href="{{ctrl.logoutUri}}" target="_self">Logout</a></li>
+            <li><a class="drop-menu__items__logout" ng-href="{{ctrl.logoutUri}}" target="_self">Logout</a></li>
         </ul>
     </div>
 

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -9,10 +9,9 @@
         <ul class="drop-menu__items__separator">
             <li><a class="drop-menu__items__quotas" href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
             <li ng-repeat="additionalLink in ctrl.additionalLinks">
-                <a class="drop-menu__items__quotas"
-                   href="{{additionalLink.url}}"
+                <a ng-href="{{additionalLink.url}}"
                    rel="noopener"
-                   target={{additionalLink.target}}>
+                   target="{{additionalLink.target}}">
                     {{additionalLink.name}}
                 </a>
             </li>

--- a/kahuna/public/js/common/user-actions.js
+++ b/kahuna/public/js/common/user-actions.js
@@ -9,6 +9,7 @@ userActions.controller('userActionCtrl',
             var ctrl = this;
             ctrl.feedbackFormLink = window._clientConfig.feedbackFormLink;
             ctrl.logoutUri = document.querySelector('link[rel="auth-uri"]').href + "logout";
+            ctrl.additionalLinks = window._clientConfig.additionalNavigationLinks;
         }]);
 
 userActions.directive('uiUserActions', [function() {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2219,6 +2219,11 @@ FIXME: what to do with touch devices
     background-color: grey;
 }
 
+.drop-menu__items__separator {
+    border-bottom: 1px solid #565656;
+    margin-bottom: 5px;
+    padding-bottom: 5px;
+}
 
 /* ==========================================================================
    Dropdown menu e.g. autocomplete

--- a/kahuna/test/lib/AdditionalLinksConfigTest.scala
+++ b/kahuna/test/lib/AdditionalLinksConfigTest.scala
@@ -1,0 +1,62 @@
+package lib
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.Configuration
+
+class AdditionalLinksConfigTest extends AnyFreeSpec with Matchers {
+
+  "The config loader" - {
+    val configuration = Configuration.from(Map(
+      "links.additional" -> List(
+        Map(
+          "name" -> "A",
+          "target" -> "_blank",
+          "url" -> "https://a.com"
+        ),
+        Map(
+          "name" -> "C",
+          "target" -> "_self",
+          "url" -> "/c"
+        ),
+        Map(
+          "name" -> "D",
+          "target" -> "_parent",
+          "url" -> "https://d.com"
+        ),
+        Map(
+          "name" -> "F",
+          "target" -> "_top",
+          "url" -> "https://f.com"
+        ),
+        Map(
+          "name" -> "E",
+          "url" -> "https://e.com"
+        ),
+      )
+    ))
+
+    val additionalLinks: Seq[AdditionalLink] = configuration
+      .getOptional[Seq[AdditionalLink]]("links.additional").getOrElse(Seq.empty)
+
+    "should return a list of links when links.additional is configured" in {
+      additionalLinks.nonEmpty shouldBe true
+      additionalLinks.length shouldBe 5
+    }
+
+    "should return a link with name A, with blank target and https://a.com url" in {
+      additionalLinks.headOption.nonEmpty shouldBe true
+      val link = additionalLinks.head
+      link.name shouldBe "A"
+      link.target shouldBe LinkTarget.blank
+      link.url shouldBe "https://a.com"
+    }
+
+    "should return a link with default blank target" in {
+      val link = additionalLinks.last
+      link.name shouldBe "E"
+      link.target shouldBe LinkTarget.blank
+    }
+  }
+
+}


### PR DESCRIPTION
## What does this change?

In addition to the `Quotas`, `Feedback` and `Logout` links in the secondary navigation menu, there's a need from BBC to add additional external links that users can use to navigate to user guides, external systems and tools. 

At the moment, adding arbitrary deployment-specific links to the secondary navigation menu will require a change in the [user-actions.html](https://github.com/guardian/grid/blob/main/kahuna/public/js/common/user-actions.html) component and shared codebase PR review ceremonies; which is not ideal for deployment-specific changes / customizations. 

This PR introduces the ability to configure additional navigation links which are deployment-specific in a deployment-agnostic way via configuration.


## How can success be measured?

Additional links should be rendered in the user-action menu when `links.additional` configuration is defined in `kahuna.conf`.

Sample configuration:

```hocon
links.additional = [
  {
    name: "Reports" # Link text
    target: "_blank" # Optional; defaults to _blank. Accepted values _blank, _parent, _self, _top
    url: "https://reports.com" # URL of the page the link goes to
  },
  {
    name: "User Guides"
    target: "_blank"
    url: "https://userguides.com"
  }
]
```

See screenshot below

## Screenshots

![With additional links and separator](https://user-images.githubusercontent.com/12212239/166968984-4d92442b-c18d-4934-aee7-232725fbdfa9.png)


## Who should look at this?
@guardian/digital-cms


## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
