### PR TITLE
Remove doubly closed tag

### DIFF
--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -18,7 +18,7 @@
         title="Apply these leases to all your current uploads"
         ng-if="!ctrl.confirmDelete"
         ng-click="ctrl.batchApplyLeases()"
-        aria-label="Apply these leases to all current uploads">
+        aria-label="Apply these leases to all current uploads"
     >⇔</button>
 
     <button title="Remove ALL leases"


### PR DESCRIPTION
## What does this change?

This HTML tag was accidentally closed twice

![image](https://user-images.githubusercontent.com/10963046/167106791-aaf50d2c-5477-422e-8a4c-79ad625a8352.png)


## How can success be measured?



## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
