### PR TITLE
usage-stream fixes!

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -6,6 +6,10 @@ case class UsageId(id: String) {
   override def toString = id
 }
 
+case class MediaUsageKey(
+  usageId: UsageId,
+  grouping: String,
+)
 case class MediaUsage(
   usageId: UsageId,
   grouping: String,
@@ -41,15 +45,6 @@ case class MediaUsage(
     removed <- dateRemoved
   } yield !removed.isBefore(added)).getOrElse(false)
 
-  // Used in set comparison of UsageGroups
-  override def equals(other: Any): Boolean = other match {
-    case otherMediaUsage: MediaUsage => {
-      usageId == otherMediaUsage.usageId &&
-        grouping == otherMediaUsage.grouping &&
-        dateRemoved == otherMediaUsage.dateRemoved
-    } // TODO: This will work for checking if new items have been added/removed
-    case _ => false
-  }
-
-  override def hashCode(): Int = List(usageId, grouping, dateRemoved.isEmpty).mkString("_").hashCode()
+  def key: MediaUsageKey = MediaUsageKey(usageId = usageId, grouping = grouping)
+  def entry: (MediaUsageKey, MediaUsage) = key -> this
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -47,4 +47,35 @@ case class MediaUsage(
 
   def key: MediaUsageKey = MediaUsageKey(usageId = usageId, grouping = grouping)
   def entry: (MediaUsageKey, MediaUsage) = key -> this
+
+  override def equals(other: Any): Boolean = other match {
+    case otherUsage: MediaUsage =>
+      usageId == otherUsage.usageId &&
+      grouping == otherUsage.grouping &&
+      mediaId == otherUsage.mediaId &&
+      usageType == otherUsage.usageType &&
+      mediaType == otherUsage.mediaType &&
+      status == otherUsage.status &&
+      printUsageMetadata == otherUsage.printUsageMetadata &&
+      digitalUsageMetadata == otherUsage.digitalUsageMetadata &&
+      syndicationUsageMetadata == otherUsage.syndicationUsageMetadata &&
+      frontUsageMetadata == otherUsage.frontUsageMetadata &&
+      downloadUsageMetadata == otherUsage.downloadUsageMetadata
+      // NOTE that we don't compare any date fields
+    case _ => false
+  }
+
+  override def hashCode(): Int = List(
+    usageId,
+    grouping,
+    mediaId,
+    usageType,
+    mediaType,
+    status,
+    printUsageMetadata,
+    digitalUsageMetadata,
+    syndicationUsageMetadata,
+    frontUsageMetadata,
+    downloadUsageMetadata
+  ).mkString("_").hashCode
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -48,24 +48,7 @@ case class MediaUsage(
   def key: MediaUsageKey = MediaUsageKey(usageId = usageId, grouping = grouping)
   def entry: (MediaUsageKey, MediaUsage) = key -> this
 
-  override def equals(other: Any): Boolean = other match {
-    case otherUsage: MediaUsage =>
-      usageId == otherUsage.usageId &&
-      grouping == otherUsage.grouping &&
-      mediaId == otherUsage.mediaId &&
-      usageType == otherUsage.usageType &&
-      mediaType == otherUsage.mediaType &&
-      status == otherUsage.status &&
-      printUsageMetadata == otherUsage.printUsageMetadata &&
-      digitalUsageMetadata == otherUsage.digitalUsageMetadata &&
-      syndicationUsageMetadata == otherUsage.syndicationUsageMetadata &&
-      frontUsageMetadata == otherUsage.frontUsageMetadata &&
-      downloadUsageMetadata == otherUsage.downloadUsageMetadata
-      // NOTE that we don't compare any date fields
-    case _ => false
-  }
-
-  override def hashCode(): Int = (
+  private def asEqualityTuple = (
     usageId,
     grouping,
     mediaId,
@@ -77,5 +60,14 @@ case class MediaUsage(
     syndicationUsageMetadata,
     frontUsageMetadata,
     downloadUsageMetadata
-  ).##
+    // NOTE that we don't compare any date fields
+  )
+
+  override def equals(other: Any): Boolean = other match {
+    case otherUsage: MediaUsage => asEqualityTuple == otherUsage.asEqualityTuple
+    case _ => false
+  }
+
+  override def hashCode(): Int = asEqualityTuple.##
+
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -48,7 +48,7 @@ case class MediaUsage(
   def key: MediaUsageKey = MediaUsageKey(usageId = usageId, grouping = grouping)
   def entry: (MediaUsageKey, MediaUsage) = key -> this
 
-  private def asEqualityTuple = (
+  private lazy val asEqualityTuple = (
     usageId,
     grouping,
     mediaId,

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -65,7 +65,7 @@ case class MediaUsage(
     case _ => false
   }
 
-  override def hashCode(): Int = List(
+  override def hashCode(): Int = (
     usageId,
     grouping,
     mediaId,
@@ -77,5 +77,5 @@ case class MediaUsage(
     syndicationUsageMetadata,
     frontUsageMetadata,
     downloadUsageMetadata
-  ).mkString("_").hashCode
+  ).##
 }

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -102,9 +102,9 @@ class UsageRecorder(
         .flatMap(streamUsageMap.get)
       val createOps = toCreate.map(performAndLogDBOperation(usageTable.create, "create"))
 
-      // TODO add a filter to only bother with these updates when there are meaningful changes to the DB record (possibly via the .equals method)
       val toUpdate = (if (usageGroup.isReindex) Set() else streamUsageKeys intersect dbUsageKeys)
         .flatMap(streamUsageMap.get)
+        .diff(dbUsages) // to avoid updating to exactly the same data that's already in the DB
       val updateOps = toUpdate.map(performAndLogDBOperation(usageTable.update, "update"))
 
       val mediaIdsImplicatedInDBUpdates =

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -92,8 +92,6 @@ class UsageRecorder(
         result
       }
 
-      // FIXME exponential number of DB operations likely related to the content status (derived from preview vs live stream)
-
       val toMarkAsRemoved = (dbUsageKeys diff streamUsageKeys).flatMap(dbUsageMap.get)
       val markAsRemovedOps = toMarkAsRemoved
         .map(performAndLogDBOperation(usageTable.markAsRemoved, "markAsRemoved"))

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -83,13 +83,15 @@ class UsageRecorder(
       })
 
       def performAndLogDBOperation(func: MediaUsage => Observable[JsObject], opName: String)(mediaUsage: MediaUsage) = {
-        val result = func(mediaUsage)
-        logger.info(
-          logMarker,
-          s"'$opName' DB Operation for ${mediaUsage.grouping} - on mediaID: ${mediaUsage.mediaId} with result: $result"
-        )
-        usageMetrics.incrementUpdated
-        result
+        val resultObservable = func(mediaUsage)
+        resultObservable.foreach(result => {
+          logger.info(
+            logMarker,
+            s"'$opName' DB Operation for ${mediaUsage.grouping} - on mediaID: ${mediaUsage.mediaId} with result: $result"
+          )
+          usageMetrics.incrementUpdated
+        })
+        resultObservable
       }
 
       val markAsRemovedOps = dbUsageKeys.diff(streamUsageKeys)

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -13,7 +13,8 @@ case class UsageGroup(
   usages: Set[MediaUsage],
   grouping: String,
   lastModified: DateTime,
-  isReindex: Boolean = false
+  isReindex: Boolean = false,
+  maybeStatus: Option[UsageStatus] = None
 )
 class UsageGroupOps(config: UsageConfig, liveContentApi: LiveContentApi, mediaWrapperOps: MediaWrapperOps)
   extends GridLogging {
@@ -52,7 +53,7 @@ class UsageGroupOps(config: UsageConfig, liveContentApi: LiveContentApi, mediaWr
     ContentWrapper.build(content, status, lastModified).map(contentWrapper => {
       val usages = createUsages(contentWrapper, isReindex)
       logger.info(s"Built UsageGroup: ${contentWrapper.id}")
-      UsageGroup(usages.toSet, contentWrapper.id, lastModified, isReindex)
+      UsageGroup(usages.toSet, contentWrapper.id, lastModified, isReindex, maybeStatus = Some(status))
     })
 
   def build(printUsageRecords: List[PrintUsageRecord]) =


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 

Related: https://github.com/guardian/grid/pull/3652

Lately `usage-stream` boxes have been falling over with `OutOfMemory` errors, typically when large pieces with many pictures were being updated frequently (election live blogs for example). From the stack traces this appeared to stem from the Kinesis library, however when considered in conjunction with the excessive amount of DB operations, particularly `markAsRemoved` which were occurring (despite no pictures actually being removed from the pieces), we realised that the processing of the preview stream (i.e. status='pending') was inadvertently but repeatedly marking as removed usages which came in via the live stream (i.e. status='published'). Not only did this result in incorrect status (taken down rather than published) on many usages (essentially a race condition) we also think the number of DB writes (and the time and resources they take) was causing the `OutOfMemory` errors 🤞 .

## What does this change?

- When comparing incoming usages (from either preview or live stream) with DB usages, we filter the DB usages for only those records with the same status (pending vs published) as this incoming usages, so that when we perform the set comparisons we don't inadvertently update the wrong records.
- Finally improved/fixed the `.equals` and `.hashCode` overrides on `MediaUsage` to no longer consider any date fields (since incoming usages have no meaningful notion/value for any of the date fields [lastModified, dateAdded, dateRemoved] ) but instead to compare all the other fields for truer equality - which means fewer/no unnecessary DB operations.
- we now detect composer pieces which are 'taken down' (via update event on the preview stream, unfortunately no update event on the live stream and the delete event from capi doesn't have composer id) and ensure all pictures are marked as removed (i.e. show as taken down)

## How can success be measured?
Greater stability and accuracy of our 'digital' usages (although we really need to do a full re-index of everything in CAPI before we can start really relying on usages [for things such as safely deleting images with reaperV2] - FYI @paperboyo - but it would make sense to do https://trello.com/c/rxesTmr0/2582-capture-additional-usages-not-currently-captured so we have image usages from interactives etc.).

## How to test?
With this branch deployed to TEST, create a CODE composer article...

- add a picture - shortly after look at the Usages tab (right sidebar) of that image in TEST grid, notice the `Pending` usage
- publish the piece - shortly after notice the `Published` usage in TEST grid
- remove the image, Save & Launch - shortly after notice the `Taken Down` usage in TEST grid

... all the while, observe in the logs `"DB Operation for composer/COMPOSER_ID"` where you replace `COMPOSER_ID` with the id of your CODE composer piece.

Note that if you change some text in the article there should be no `'update' DB Operation for composer/COMPOSER_ID`, but when you change the headline for example you should see `'update' DB Operation for composer/COMPOSER_ID` in the logs.

Lastly, try adding a different image (ensuring that's launched), then take the piece down, see that image gets marked as Taken Down, and for completeness add a further image whilst in taken down state to see that image only appears as Pending.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
