### PR TITLE
Add restriction for PA images based in restriction message

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -407,12 +407,22 @@ object PaParser extends ImageProcessor {
     "Press Association Images"
   ).map(_.toLowerCase)
 
+  val restrictionMessage: String =
+    """
+      |This handout photo may only be used in for editorial reporting purposes for the contemporaneous
+      |illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture
+      |may require further permission from the copyright holder.
+      |""".stripMargin.replace('\n', ' ').trim
+
   def apply(image: Image): Image = {
     val isPa = List(image.metadata.credit, image.metadata.source).flatten.exists { creditOrSource =>
       paCredits.contains(creditOrSource.toLowerCase)
     }
     if (isPa) {
-      image.copy(usageRights = Agency("PA"))
+      val restrictions = if (image.metadata.description.exists(_.contains(restrictionMessage))) {
+        Some(restrictionMessage)
+      } else None
+      image.copy(usageRights = Agency("PA", restrictions = restrictions))
     } else image
   }
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -411,14 +411,16 @@ object PaParser extends ImageProcessor {
     "Press Association Images"
   ).map(_.toLowerCase)
 
-  val restrictionText: String =
+  private val restrictionText =
     """
       |This handout photo may only be used in for editorial reporting purposes for the contemporaneous
       |illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture
       |may require further permission from the copyright holder.
       |""".stripMargin.replace('\n', ' ').trim
 
-  val restrictionNotice = s"NOTE TO EDITORS: $restrictionText"
+  private val fixedRestrictionText = restrictionText.replace("used in for", "used in")
+
+  private val restrictionNotice = s"NOTE TO EDITORS: $restrictionText"
 
   def apply(image: Image): Image = {
     val isPa = List(image.metadata.credit, image.metadata.source).flatten.exists { creditOrSource =>
@@ -446,7 +448,7 @@ object PaParser extends ImageProcessor {
       )
       image.copy(
         metadata = metadata,
-        usageRights = Agency("PA", restrictions = Some(restrictionText)),
+        usageRights = Agency("PA", restrictions = Some(fixedRestrictionText)),
         leases = firstLease,
       )
     } else if (isPa) {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -4,6 +4,8 @@ import akka.actor.ActorSystem
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import com.gu.mediaservice.lib.guardian.GuardianUsageRightsConfig
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.leases.AllowUseLease
+import org.joda.time.DateTime
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.inject.ApplicationLifecycle
@@ -473,7 +475,11 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
         "This handout photo may only be used in for editorial reporting purposes for the contemporaneous illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture may require further permission from the copyright holder."
       val image = createImageFromMetadata("credit" -> "PA", "description" -> s"text text text\nNOTE TO EDITORS: $restrictionText")
       val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("PA", restrictions = Some(restrictionText)))
+      processedImage.usageRights should be (Agency("PA", restrictions = Some(restrictionText)))
+      processedImage.leases.leases.head.access shouldBe AllowUseLease
+
+      processedImage.leases.leases.head.startDate should be (Some(processedImage.uploadTime))
+      processedImage.leases.leases.head.endDate should be (Some(processedImage.uploadTime.plusMonths(1)))
     }
   }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -471,11 +471,12 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
     }
 
     it("should restrict images with PA restriction text") {
-      val restrictionText = PaParser.restrictionText
-      val image = createImageFromMetadata("credit" -> "PA", "description" -> s"text text text\nNOTE TO EDITORS: $restrictionText")
+      val inputRestrictionText = "This handout photo may only be used in for editorial reporting purposes for the contemporaneous illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture may require further permission from the copyright holder."
+      val outputRestrictionText = "This handout photo may only be used in editorial reporting purposes for the contemporaneous illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture may require further permission from the copyright holder."
+      val image = createImageFromMetadata("credit" -> "PA", "description" -> s"text text text\nNOTE TO EDITORS: $inputRestrictionText")
       val processedImage = applyProcessors(image)
 
-      processedImage.usageRights should be (Agency("PA", restrictions = Some(restrictionText)))
+      processedImage.usageRights should be (Agency("PA", restrictions = Some(outputRestrictionText)))
       processedImage.metadata.description shouldBe Some("text text text")
 
       processedImage.leases.leases.head.access shouldBe AllowUseLease

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -467,6 +467,14 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       val processedImage = applyProcessors(image)
       processedImage.usageRights should be(Agency("PA"))
     }
+
+    it("should restrict images with PA restriction text") {
+      val restrictionText =
+        "This handout photo may only be used in for editorial reporting purposes for the contemporaneous illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture may require further permission from the copyright holder."
+      val image = createImageFromMetadata("credit" -> "PA", "description" -> s"text text text\nNOTE TO EDITORS: $restrictionText")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("PA", restrictions = Some(restrictionText)))
+    }
   }
 
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -4,8 +4,6 @@ import akka.actor.ActorSystem
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import com.gu.mediaservice.lib.guardian.GuardianUsageRightsConfig
 import com.gu.mediaservice.model._
-import com.gu.mediaservice.model.leases.AllowUseLease
-import org.joda.time.DateTime
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.inject.ApplicationLifecycle
@@ -478,10 +476,6 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
 
       processedImage.usageRights should be (Agency("PA", restrictions = Some(outputRestrictionText)))
       processedImage.metadata.description shouldBe Some("text text text")
-
-      processedImage.leases.leases.head.access shouldBe AllowUseLease
-      processedImage.leases.leases.head.startDate should be (Some(processedImage.uploadTime))
-      processedImage.leases.leases.head.endDate should be (Some(processedImage.uploadTime.plusMonths(1)))
     }
   }
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -471,13 +471,14 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
     }
 
     it("should restrict images with PA restriction text") {
-      val restrictionText =
-        "This handout photo may only be used in for editorial reporting purposes for the contemporaneous illustration of events, things or the people in the image or facts mentioned in the caption. Reuse of the picture may require further permission from the copyright holder."
+      val restrictionText = PaParser.restrictionText
       val image = createImageFromMetadata("credit" -> "PA", "description" -> s"text text text\nNOTE TO EDITORS: $restrictionText")
       val processedImage = applyProcessors(image)
-      processedImage.usageRights should be (Agency("PA", restrictions = Some(restrictionText)))
-      processedImage.leases.leases.head.access shouldBe AllowUseLease
 
+      processedImage.usageRights should be (Agency("PA", restrictions = Some(restrictionText)))
+      processedImage.metadata.description shouldBe Some("text text text")
+
+      processedImage.leases.leases.head.access shouldBe AllowUseLease
       processedImage.leases.leases.head.startDate should be (Some(processedImage.uploadTime))
       processedImage.leases.leases.head.endDate should be (Some(processedImage.uploadTime.plusMonths(1)))
     }


### PR DESCRIPTION
## What does this change?

Recognise and apply PA (Press Association) restriction comment as a usage restriction, which PA supplies in the description of the image.

Applying to our back catalogue can be completed with a migration.

We attempted automatically adding a 1 month lease on processing, but that doesn't work well. Adding to ES but not Dynamo is against our data storage model, and makes the lease uneditable. The supplier processors can't call out to the leases API to add the lease as the image hasn't yet been uploaded to ES, meaning that thrall would attempt to process an AddLease message _before_ the IndexImage message, which won't end well. To do this, image-loader _could_ make the api call after sending off the IndexImage message (even if Thrall picks up the message asynchronously, the messages will be processed in order), but this loses the encapsulation of the SupplierProcessors. More thinking/work is needed for that functionality.

## How can success be measured?


## Screenshots
<!--  If applicable, otherwise delete the header.
      i.e. this is a visible frontend change -->


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
