### PR TITLE
docs(concepts): initial commit

### DIFF
--- a/docs/08-concepts/README.md
+++ b/docs/08-concepts/README.md
@@ -1,0 +1,5 @@
+# Grid concepts
+
+This section of documentation is designed to act as a collection of descriptions of various concepts in the Grid.
+Discussion of implementation is intentionally kept to a minimum, as implementation of these concepts may change over
+time, while hopefully the ideas behind these concepts will last for a longer period of time.

--- a/docs/08-concepts/cost.md
+++ b/docs/08-concepts/cost.md
@@ -1,0 +1,12 @@
+# cost
+
+TODO
+
+## suppliers
+
+## usage rights
+
+## restrictions
+
+## validity
+

--- a/docs/08-concepts/crops.md
+++ b/docs/08-concepts/crops.md
@@ -1,0 +1,9 @@
+# Crops
+
+Grid is not an image manipulation tool; the only manipulation currently available to users is to [crop](https://en.wikipedia.org/wiki/Cropping_(image)) images. This will produce and store the cropped image into a specific S3 bucket. Multiple crops can be created for an image. Crops have all metadata stripped.
+
+The Guardian's deployment of Grid takes the opinion that only crops may be used in content. In other words, for a user to add an image to content from the grid, that image __must__ have been cropped, even if that "crop" does not remove any edges of the image (in fact the Grid UI will highlight such a "full frame crop"). This has the benefit of requiring users to very clearly mark the intention to use an image in content, which should help to prevent accidental deletion of images from the Grid (although this should usually be handled by the [usages system](./usages.md).
+
+Crops have identifiers in the format `{x}_{y}_{w}_{h}` , where `x` and `y` are the co-ordinates for the top-left corner of the crop, and `w` and `h` are the width and height of the crop.
+
+[^1]: An improvement currently under discussion would optionally add a "focal point" to a crop, which would provide some hints of the most important part of a crop to platforms displaying it, in the case they cannot display a crop at its given aspect ratio and need to trim further. Such crops may add a suffix to the id, in the format `_{fx}_{fy}`, where `fx` and `fy` are the coordinates of this focal point.

--- a/docs/08-concepts/images.md
+++ b/docs/08-concepts/images.md
@@ -1,0 +1,11 @@
+# Images
+
+Grid acts as a library for still digital images. Users can upload images, where the metadata stored on the image will be parsed and made visible and searchable.
+
+Grid currently supports uploads of [JPEG](https://en.wikipedia.org/wiki/JPEG), [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics) and [TIFF](https://en.wikipedia.org/wiki/TIFF) images. A curated selection of metadata for all of these will be parsed on ingest, and entered into the Elasticsearch document. Similar metadata fields will be rationalised into a single field (for example, Grid's "Description" field will be formed from the first available of the `xmp-dc:description`, `iptc:Caption/Abstract` and `exif:Image Description` fields; see [this code](https://github.com/guardian/grid/blob/a67c3acbfbdd562ff560e301a25402293d48ca76/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala#L57-L59)).
+
+While users can "edit" metadata in the Grid UI, this will only be reflected in the Grid and never applied to any image.
+
+Every image is assigned an ID on upload - this is the [SHA1 checksum](https://en.wikipedia.org/wiki/SHA-1) of the uploaded image. This usually prevents repeat uploads, but remember that any offline manipulation of the image _or its metadata_ will be treated by Grid as an entirely new image[^1].
+
+[^1]: A future improvement may be to mark images as related, or to allow revisions of an image to be uploaded.

--- a/docs/08-concepts/permissions.md
+++ b/docs/08-concepts/permissions.md
@@ -1,0 +1,3 @@
+# permissions
+
+TODO

--- a/docs/08-concepts/usages.md
+++ b/docs/08-concepts/usages.md
@@ -1,0 +1,5 @@
+# Usages
+
+The Grid can track where an image has been used in content. Generally, the consumer will need to call the Grid's Usages API to notify that the content has been used.
+
+This information powers some badges on the UI (eg. adds a warning when a given image was used in the past 7 days, which helps prevent repeated usage of an image in multiple pieces of content), and an active usage will prevent an image from being deleted. Users can also follow a backreference to the location of the usage.


### PR DESCRIPTION
## What does this change?

WIP:
Adds a new section to the documentation to store documents discussing the concepts represented in the grid. (eg. Images, Crops, Usages, etc.)

I've been trying to write some documentation around how some features in the Grid works, but as I did so I felt that a lot of words/time was spent describing the concepts behind those implementations and that a better first point might be committing some of these ideas (or at least my understanding of them) to "paper". A useful feature of this is that each concept can be described fairly briefly and independently, and these ideas are likely to last longer than any given implementation.

I've only got a couple written up so far, but would love some feedback on whether this approach looks useful, and on the style of the writing used (are the discussions too brief or too complex; too vague or too specific?, etc.)

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
