### PR TITLE
Set thrall projection parallelism from config

### DIFF
--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -53,7 +53,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val migrationSourceWithSender: MigrationSourceWithSender = MigrationSourceWithSender(materializer, auth.innerServiceCall, es, gridClient)
+  val migrationSourceWithSender: MigrationSourceWithSender = MigrationSourceWithSender(materializer, auth.innerServiceCall, es, gridClient, config.projectionParallelism)
 
   val thrallEventConsumer = new ThrallEventConsumer(
     es,

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -41,6 +41,8 @@ class ThrallConfig(resources: GridConfigResources) extends CommonConfigWithElast
 
   val isVersionedS3: Boolean = boolean("s3.image.versioned")
 
+  val projectionParallelism: Int = intDefault("thrall.projection.parallelism", 1)
+
   def kinesisConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisStream, rewindFrom, this)
   def kinesisLowPriorityConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)
 }

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -122,7 +122,8 @@ class ThrallStreamProcessorTest extends AnyFunSpec with BeforeAndAfterAll with M
       materializer,
       (req: WSRequest) => req,
       mockEs,
-      mockGrid
+      mockGrid,
+      projectionParallelism = 1
     )
 
     lazy val mockConsumer: ThrallEventConsumer = mock[ThrallEventConsumer]


### PR DESCRIPTION
## What does this change?

The current attempt to migrate is suffering errors. It's not immediately clear where the problem lies, but my suspicion is related to the quantity of simultaneously attempted projections overwhelming the projection instances. Rather than creating a PR every time we tweak this value, allow setting it from config.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

Better control over the amount of projections produced should let us run a smoother migration

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
