### PR TITLE
do not write to logfiles

### DIFF
--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -2,48 +2,45 @@
 
     <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-    <if condition='property("STAGE").contains("DEV")'>
-        <then>
-            <property name="LOGS_LOCATION" value="${application.home}/logs" />
-        </then>
-        <else>
-            <property name="LOGS_LOCATION" value="logs" />
-        </else>
-    </if>
-
-    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOGS_LOCATION}/application.log</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOGS_LOCATION}/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
-
-        <encoder>
-            <pattern>%date - [%level] - from %logger in %thread markers=%marker %n%message%n%xException%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-      <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-      <appender-ref ref="STDOUT" />
-      <appender-ref ref="ASYNCSTDOUT"/>
-    </appender>
-
     <logger name="play" level="INFO" />
     <logger name="application" level="INFO" />
     <logger name="request" level="INFO" />
 
-    <root level="INFO">
-      <appender-ref ref="LOGFILE"/>
-      <if condition='!property("STAGE").contains("DEV")'>
-        <then>
+    <if condition='property("STAGE").contains("DEV")'>
+      <then>
+        <property name="LOGS_LOCATION" value="${application.home}/logs" />
+
+        <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+          <file>${LOGS_LOCATION}/application.log</file>
+
+          <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_LOCATION}/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+          </rollingPolicy>
+
+          <encoder>
+            <pattern>%date - [%level] - from %logger in %thread markers=%marker %n%message%n%xException%n</pattern>
+          </encoder>
+        </appender>
+
+        <root level="INFO">
+          <appender-ref ref="LOGFILE"/>
+        </root>
+      </then>
+      <else>
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+          <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+        </appender>
+
+        <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+          <appender-ref ref="STDOUT" />
           <appender-ref ref="ASYNCSTDOUT"/>
-        </then>
-      </if>
-    </root>
+        </appender>
+
+        <root level="INFO">
+          <appender-ref ref="ASYNCSTDOUT"/>
+        </root>
+      </else>
+    </if>
 
 </configuration>


### PR DESCRIPTION
stdout logs go to journald which are added to syslog; theres no need to store them in 2 files which can only overwhelm the disk

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
