### PR TITLE
Don't syndicate an image if both allow and deny leases applied

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
@@ -59,7 +59,7 @@ case class Image(
 
         (allowSyndicationLease, denySyndicationLease) match {
           case (Some(_), None) => QueuedForSyndication
-          case (None, Some(_)) => BlockedForSyndication
+          case (_, Some(_)) => BlockedForSyndication
           case (_, _) => AwaitingReviewForSyndication
         }
       }


### PR DESCRIPTION
(Please ignore the panicked-sounding branch name; this is not as major a bug as I originally thought!)

## What does this change?

Don't syndicate an image if both allow and deny leases applied

## How should a reviewer test this change?

Apply an allow and deny lease to an image with syndication rights. Does the image get syndication status "queued" or "blocked"? (It should be "blocked")

## How can success be measured?


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
