### PR TITLE
Stop deduplicating usage notices

### DIFF
--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -43,11 +43,7 @@ class UsageRecorder(
 
   val notificationStream: Observable[UsageNotice] = getNotificationStream(dbUpdateStream)
 
-  val distinctNotificationStream: Observable[UsageNotice] = notificationStream.groupBy(_.mediaId).flatMap {
-    case (_, s) => s.distinctUntilChanged
-  }
-
-  val notifiedStream: Observable[Unit] = distinctNotificationStream.map(usageNotifier.send)
+  val notifiedStream: Observable[Unit] = notificationStream.map(usageNotifier.send)
 
   val finalObservable: Observable[Unit] = notifiedStream.retry((_, error) => {
     logger.error("UsageRecorder encountered an error.", error)


### PR DESCRIPTION
## What does this change?

This was dropping some usage notices going over the wire. I've only
noticed it on syndication usages where the image has exactly one usage
(images that also have a digital or print usage seem to be recording the
usage just fine).

Remaining q: have other usage types been impacted? We've not seen on print, and fronts and composer usages haven't been all that reliable recently.

## How should a reviewer test this change?

Deploy to TEST. 
Test other usage types (especially stream usages) - make changes in CODE composer, wait a few seconds and check that the usage gets updated correctly (none -> pending -> published -> taken down, etc.)

Send some syndication usages. Before this PR's changes, you should find that they will be processed without error, an entry in the DynamoDB created/updated, but (some/most/all) will not have the usage recorded in ES. This is bad as the image continues to seem queued for syndication despite having been already syndicated.

```sh
curl -H 'X-Gu-Media-Key: [YOUR API KEY HERE]' -H 'Content-Type: application/json' -d '{"data":{"mediaId":"[YOUR MEDIA ID HERE]","dateAdded":"2022-05-25T12:00:00.000Z","partnerName":"eyevine"}}' https://media-usage.test.dev-gutools.co.uk/usages/syndication
```

## How can success be measured?

When we syndicate an image, we know about it (and don't syndicate it again)

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
