### PR TITLE
make cost filter checkbox label configurable

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -104,3 +104,8 @@ usageRightsConfigProvider = {
 domainMetadata.specifications = []
 
 metadata.templates = []
+
+# costFilter {
+#  label: "chargeable",
+#  chargeable: true
+# }

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -40,7 +40,6 @@ class KahunaController(
     val scriptsToLoad = config.scriptsToLoad
       .filter(_.shouldLoadWhenIFramed.contains(true) || !isIFramed)
       .filter(_.permission.map(authorisation.hasPermissionTo).fold(true)(maybeUser.exists))
-
     val okPath = routes.KahunaController.ok.url
     // If the auth is successful, we redirect to the kahuna domain so the iframe
     // is on the same domain and can be read by the JS
@@ -49,6 +48,8 @@ class KahunaController(
     val fieldAliases: String = Json.toJson(config.fieldAliasConfigs).toString()
     val metadataTemplates: String = Json.toJson(config.metadataTemplates).toString()
     val returnUri = config.rootUri + okPath
+    val costFilterLabel = config.costFilterLabel.getOrElse("Free to use only")
+    val costFilterChargeable = config.costFilterChargeable.getOrElse(false)
     Ok(views.html.main(
       config.mediaApiUri,
       config.authUri,
@@ -69,7 +70,9 @@ class KahunaController(
       domainMetadataSpecs,
       config.recordDownloadAsUsage,
       metadataTemplates,
-      additionalNavigationLinks
+      additionalNavigationLinks,
+      costFilterLabel,
+      costFilterChargeable
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -25,6 +25,8 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val imageOrigin: String = string("origin.images")
   val googleTrackingId: Option[String] = stringOpt("google.tracking.id").filterNot(_.isEmpty)
 
+  val costFilterLabel: Option[String] = stringOpt("costFilter.label")
+  val costFilterChargeable: Option[Boolean] = booleanOpt("costFilter.chargeable")
   val additionalLinks: Seq[AdditionalLink] = configuration.getOptional[Seq[AdditionalLink]]("links.additional").getOrElse(Seq.empty)
   val feedbackFormLink: Option[String]= stringOpt("links.feedbackForm").filterNot(_.isEmpty)
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -19,7 +19,9 @@
   domainMetadataSpecs: String,
   recordDownloadAsUsage: Boolean,
   metadataTemplates: String,
-  additionalNavigationLinks: String
+  additionalNavigationLinks: String,
+  costFilterLabel: String,
+  costFilterChargeable: Boolean
 )
 <!DOCTYPE html>
 <html>
@@ -65,7 +67,9 @@
           domainMetadataSpecs: @Html(domainMetadataSpecs),
           recordDownloadAsUsage: @recordDownloadAsUsage,
           metadataTemplates: @Html(metadataTemplates),
-          additionalNavigationLinks: @Html(additionalNavigationLinks)
+          additionalNavigationLinks: @Html(additionalNavigationLinks),
+          costFilterLabel: "@Html(costFilterLabel)",
+          costFilterChargeable: @costFilterChargeable
         }
     </script>
 

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -37,9 +37,9 @@
                             when the option is off -->
                 <input type="checkbox"
                     ng-model="searchQuery.filter.nonFree"
-                    ng-true-value="undefined"
-                    ng-false-value="'true'" />
-                Free to use only
+                    ng-true-value="{{searchQuery.costFilterTrueValue}}"
+                    ng-false-value="{{searchQuery.costFilterFalseValue}}" />
+                {{ searchQuery.costFilterLabel }}
 
                 <!-- TODO: Decide on correct cost filter model -->
                 <!--

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -33,6 +33,10 @@ query.controller('SearchQueryCtrl', [
   function($rootScope, $scope, $state, $stateParams, onValChange, storage, mediaApi) {
 
     const ctrl = this;
+    ctrl.costFilterLabel = window._clientConfig.costFilterLabel;
+    ctrl.costFilterChargeable = window._clientConfig.costFilterChargeable;
+    ctrl.costFilterFalseValue =  ctrl.costFilterChargeable ? undefined : "'true'";
+    ctrl.costFilterTrueValue =  ctrl.costFilterChargeable ? "'true'" : undefined;
 
     ctrl.canUpload = false;
 
@@ -214,10 +218,10 @@ query.controller('SearchQueryCtrl', [
         if (isNonFree === null) {
           ctrl.filter.nonFree = session.user.permissions.showPaid ?
             session.user.permissions.showPaid : undefined;
-            storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false);
+            storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false, true);
         }
         else if (isNonFree === true || isNonFree === "true") {
-            ctrl.filter.nonFree = true;
+            ctrl.filter.nonFree = "true";
         } else {
           ctrl.filter.nonFree = undefined;
         }


### PR DESCRIPTION
## What does this change?
Add configuration For **_cost filter_** checkbox (Free to use only checkbox)
eg:
```
costFilter {
 label: "chargeable",
 chargeable: true
}
```
`costFilter.label` responsible for checkbox label, it will be **"_Free to use only_"** by default if the config doesn't present
`costFilter.chargeable` responsible for checkbox behavior it will be **_false_**  by default if the config doesn't present

if the `costFilter.label` value equals any synonyms of _**chargeable**_ eg ('chargeable', 'paid', ...etc) the `costFilter.chargeable` should set to **_true_** to make checkbox getting paid images when been ticked

if the `costFilter.label` value equals any synonyms of **_Free_** eg ('Free to use', 'non paid', 'gratis' ...etc) the `costFilter.chargeable` should set to **_false_** to make checkbox getting Free images when been ticked



<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
without `costFilter` configuration or with `costFilter.chargeable = false` 
it should behave in the same behavior

with `costFilter.chargeable = true`
- users with `showPaid` permission 
   **_cost filter_** checkbox is ticked by default
- users without `showPaid` permission 
   **_cost filter_** checkbox is unticked by default

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?
 if the  `costFilter` configuration doesn't present or `costFilter.chargeable` set to false
 **_cost filter_** checkbox (Free to use only checkbox) should be the same experience
 if the  `costFilter` configuration present and `costFilter.chargeable` set to true
 - users with `showPaid` permission should see **_cost filter_** checkbox is ticked by default
- users without `showPaid` permission should see  **_cost filter_** checkbox is unticked by default
 
## Screenshots
without `costFilter` configuration or with `costFilter.chargeable = false` and users with `showPaid` permission
![Screenshot from 2022-05-26 03-43-21](https://user-images.githubusercontent.com/33189781/170445782-d1b24ec2-8cf4-4404-9b92-fe451473100a.png)
without `costFilter` configuration or with `costFilter.chargeable = false` and users without `showPaid` permission
![Screenshot from 2022-05-26 03-43-35](https://user-images.githubusercontent.com/33189781/170445777-c6d0b28a-a23b-4307-ad39-0b319127ba8b.png)

with `costFilter.chargeable = true` and users with `showPaid` permission
![Screenshot from 2022-05-26 03-42-14](https://user-images.githubusercontent.com/33189781/170445791-9d2be9d6-8cfa-40b4-abcb-ace42e849d2c.png)
with `costFilter.chargeable = true` and users without `showPaid` permission
![Screenshot from 2022-05-26 03-42-32](https://user-images.githubusercontent.com/33189781/170445785-77003628-1b20-4a9c-9acd-be71ca583aeb.png)


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
