### PR TITLE
Simpler OR queries for single text words

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -212,9 +212,9 @@ query.controller('SearchQueryCtrl', [
         }
 
         if (isNonFree === null) {
-          ctrl.filter.nonFree = session.user.permissions.showPaid ?
-            session.user.permissions.showPaid : undefined;
-            storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false);
+          ctrl.filter.nonFree = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
+
+          storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false);
         }
         else if (isNonFree === true || isNonFree === "true") {
             ctrl.filter.nonFree = true;

--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -46,6 +46,7 @@ export const filterFields = [
     'photoshoot',
     'leasedBy',
     'is',
+    'or',
     ... Object.keys(fieldAliases)
 ].sort();
 // TODO: add date fields

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -83,7 +83,7 @@ case class SearchParams(
                          usageStatus: List[UsageStatus] = List.empty,
                          usagePlatform: List[String] = List.empty,
                          tier: Tier,
-                         syndicationStatus: Option[SyndicationStatus] = None
+                         syndicationStatus: Option[SyndicationStatus] = None,
                        )
 
 case class InvalidUriParams(message: String) extends Throwable
@@ -152,7 +152,7 @@ object SearchParams {
       commaSep("usageStatus").map(UsageStatus(_)),
       commaSep("usagePlatform"),
       request.user.accessor.tier,
-      request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus
+      request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus,
     )
   }
 

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -31,6 +31,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   def Filter = rule {
     HasMatch ~> Match |
     IsMatch ~> Match |
+    OrMatch ~> Match |
     DateConstraintMatch |
     DateRangeMatch ~> Match | AtMatch |
     FileTypeMatch ~> Match |
@@ -47,6 +48,11 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   def IsMatchField = rule { capture(IsFieldName) ~> (_ => IsField) }
   def IsFieldName = rule { "is" }
   def IsMatchValue = rule { String ~> IsValue }
+
+  def OrMatch = rule { OrMatchField ~ ':' ~ OrMatchValue }
+  def OrMatchField = rule { capture(OrFieldName) ~> (_ => OrField) }
+  def OrFieldName = rule { "or" }
+  def OrMatchValue = rule { QuotedString ~> OrValue }
 
   def NestedMatch = rule { ParentField ~ "@" ~ NestedField ~ ':' ~ ExactMatchValue }
   def NestedDateMatch = rule { ParentField ~ "@" ~ DateConstraintMatch ~> (

--- a/media-api/app/lib/querysyntax/model.scala
+++ b/media-api/app/lib/querysyntax/model.scala
@@ -14,6 +14,7 @@ final case class SingleField(name: String) extends Field
 final case class MultipleField(names: List[String]) extends Field
 final case object HasField extends Field
 final case object IsField extends Field
+final case object OrField extends Field
 
 sealed trait Value
 final case class Words(string: String) extends Value
@@ -22,3 +23,4 @@ final case class Date(date: DateTime) extends Value
 final case class DateRange(startDate: DateTime, endDate: DateTime) extends Value
 final case class HasValue(string: String) extends Value
 final case class IsValue(string: String) extends Value
+final case class OrValue(string: String) extends Value


### PR DESCRIPTION
## What does this change?

Users should be able to search for a variety of terms, and view all images which match at least one of those terms.

Tried it before in #3516 to allow searches along the lines of `cat OR dog OR a flock of birds OR +by:squirrel`. That didn't really work well because of the current implementation of the search bar and the way chips interact, plus it didn't really mesh well with the query language.

This sidesteps the problem by restricting the terms that can be or-ed together by adding a new chip which accepts a list of words to OR together. `+or:"cat dog birds squirrel"`

This approach has limits - only single words can be ORed together and chips cannot be used. But it is cheap and provides some functionality until a bigger change is possible.

## How should a reviewer test this change?

Deploy to TEST. Can you query for different words and see all of the results for the different querywords in the same page?

![image](https://user-images.githubusercontent.com/10963046/170723267-52e5a23a-5497-4e76-a378-1964f20f53b7.png)


## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
