### PR TITLE
Upsert images into both indices

### DIFF
--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -61,9 +61,7 @@ class MessageProcessor(
   }
 
   private def indexImage(message: ImageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
-    Future.sequence(
-      es.migrationAwareIndexImage(message.id, message.image, message.lastModified)(ec, logMarker)
-    )
+    es.migrationAwareIndexImage(message.id, message.image, message.lastModified)(ec, logMarker)
 
   private def migrateImage(message: MigrateImageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) = {
     implicit val implicitLogMarker: LogMarker = logMarker ++ Map("imageId" -> message.id)

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -35,7 +35,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None).
             copy(userMetadata = userMetadata)
 
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(image.id))
 
@@ -52,7 +52,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
             rcsPublishDate = Some(now),
             lease = None, fileMetadata = Some(fileMetadata))
 
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, imageWithReallyLongMetadataField, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, imageWithReallyLongMetadataField, now), fiveSeconds)
 
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(imageWithReallyLongMetadataField.id))
 
@@ -65,7 +65,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           val id = UUID.randomUUID().toString
           val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
 
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
           val loadedImage = reloadedImage(id).get
           loadedImage.leases.lastModified shouldBe None
         }
@@ -73,9 +73,9 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         "updating an existing image should set the last modified date" in {
           val id = UUID.randomUUID().toString
           val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
           val lastModified = reloadedImage(id).get.lastModified
 
           lastModified.nonEmpty shouldBe true
@@ -113,7 +113,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           ES.migrationAwareIndexImage(id, image, now)
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(image.id))
 
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).get.metadata.title shouldBe Some("User supplied title"))
           reloadedImage(id).get.metadata.description shouldBe Some("My boring image")
@@ -169,7 +169,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         "can delete image" in {
           val id = UUID.randomUUID().toString
           val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(indexedImage(id).map(_.id) shouldBe Some(image.id))
 
           Await.result(Future.sequence(ES.deleteImage(id)), fiveSeconds)
@@ -180,7 +180,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         "failed deletes are indiciated with a failed future" in {
           val id = UUID.randomUUID().toString
           val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(image.id))
 
           val unknownImage = UUID.randomUUID().toString
@@ -193,7 +193,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         "should not delete images with usages" in {
           val id = UUID.randomUUID().toString
           val imageWithUsages = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None).copy(usages = List(usage()))
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, imageWithUsages, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, imageWithUsages, now), fiveSeconds)
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(imageWithUsages.id))
 
           whenReady(ES.deleteImage(id).head.failed) { ex =>
@@ -204,7 +204,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         "should not delete images with exports" in {
           val id = UUID.randomUUID().toString
           val imageWithExports = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None).copy(exports = List(crop))
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, imageWithExports, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, imageWithExports, now), fiveSeconds)
           eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(id).map(_.id) shouldBe Some(imageWithExports.id))
 
           whenReady(ES.deleteImage(id).head.failed) { ex =>
@@ -220,7 +220,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "can set image collections" in {
         val id = UUID.randomUUID().toString
         val imageWithExports = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None).copy(exports = List(crop))
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, imageWithExports, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, imageWithExports, now), fiveSeconds)
 
         val collection = Collection(path = List("/somewhere"), actionData = ActionData("Test author", DateTime.now), "A test collection")
         val anotherCollection = Collection(path = List("/somewhere-else"), actionData = ActionData("Test author", DateTime.now), "Another test collection")
@@ -239,7 +239,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "can add exports" in {
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
         reloadedImage(id).get.exports.isEmpty shouldBe true
         val exports = List(crop)
 
@@ -252,7 +252,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "can delete exports" in {
         val id = UUID.randomUUID().toString
         val imageWithExports = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None).copy(exports = List(crop))
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, imageWithExports, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, imageWithExports, now), fiveSeconds)
         reloadedImage(id).get.exports.nonEmpty shouldBe true
 
         Await.result(Future.sequence(ES.deleteImageExports(id, now)), fiveSeconds)
@@ -278,7 +278,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           Some(now),
           None,
           leasesLastModified = Some(timeBeforeEdit))
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
         reloadedImage(id).get.leases.leases.isEmpty shouldBe true
 
         val lease = model.leases.MediaLease(
@@ -300,7 +300,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         val lease = model.leases.MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("A test lease"), mediaId = UUID.randomUUID().toString)
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(id, true, Some(now), lease = Some(lease))
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
         reloadedImage(id).get.leases.leases.nonEmpty shouldBe true
 
         Await.result(Future.sequence(ES.removeImageLease(id, lease.id, now)), fiveSeconds)
@@ -327,7 +327,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           Some(now),
           lease = Some(lease)
         )
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
         reloadedImage(id).get.leases.leases.nonEmpty shouldBe true
 
         Await.result(Future.sequence(ES.removeImageLease(id, lease.id, now)), fiveSeconds)
@@ -348,7 +348,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           lease = Some(lease),
           leasesLastModified = Some(timeBeforeEdit)
         )
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
         val updatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("An updated lease"), mediaId = UUID.randomUUID().toString)
         val anotherUpdatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("Another updated lease"), mediaId = UUID.randomUUID().toString)
@@ -374,7 +374,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           lease = None,
           leasesLastModified = Some(timeBeforeEdit)
         ).copy(leases = LeasesByMedia.empty)
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
         val updatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("An updated lease"), mediaId = UUID.randomUUID().toString)
         val anotherUpdatedLease = MediaLease(id = Some(UUID.randomUUID().toString), leasedBy = None, notes = Some("Another updated lease"), mediaId = UUID.randomUUID().toString)
@@ -399,7 +399,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         val date = now.withSecondOfMinute(0)
 
         // Write  date
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, date)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, date), fiveSeconds)
 
         eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))( {
           val image = reloadedImage(id)
@@ -415,9 +415,9 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         val laterDate = earlierDate.withSecondOfMinute(30)  // Clearly thirty seconds later.
 
         // Write first date first
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, earlierDate)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, earlierDate), fiveSeconds)
         // Write second date second
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, laterDate)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, laterDate), fiveSeconds)
 
         eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))( {
           val image = reloadedImage(id)
@@ -433,7 +433,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
         val laterDate = earlierDate.withSecondOfMinute(30)  // Clearly thirty seconds later.
 
         // Write second date first
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, laterDate)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, laterDate), fiveSeconds)
 
         val updatedImage = eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))( {
           val image = reloadedImage(id)
@@ -443,7 +443,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           .copy(usageRights = StaffPhotographer("Dr. Pamela Lillian Isley", "Poison Ivy Inc."))
 
         // Write first date second
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, updatedImage, earlierDate)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, updatedImage, earlierDate), fiveSeconds)
 
         eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))( {
           val image =  reloadedImage(id)
@@ -466,7 +466,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "can delete all usages for an image" in {
         val id = UUID.randomUUID().toString
         val imageWithUsages = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None).copy(usages = List(usage()))
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, imageWithUsages, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, imageWithUsages, now), fiveSeconds)
 
         Await.result(Future.sequence(ES.deleteAllImageUsages(id, now)), fiveSeconds)
 
@@ -476,7 +476,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "can update usages" in {
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
         Await.result(Future.sequence(ES.updateImageUsages(id, List(usage()), now)), fiveSeconds)
 
@@ -486,7 +486,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "can update usages if the modification date of the update is new than the existing one" in {
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
         val existingUsage = usage(id = "existing")
         Await.result(Future.sequence(ES.updateImageUsages(id, List(existingUsage), now)), fiveSeconds)
@@ -502,7 +502,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
       "should ignore usage update requests when the proposed last modified date is older than the current" in {
         val id = UUID.randomUUID().toString
         val image = createImageForSyndication(id = UUID.randomUUID().toString, true, Some(now), None)
-        Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+        Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
         val mostRecentUsage = usage(id = "recent")
         Await.result(Future.sequence(ES.updateImageUsages(id, List(mostRecentUsage), now)), fiveSeconds)
@@ -743,7 +743,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           val id = UUID.randomUUID().toString
           val photog = StaffPhotographer("Tom Jenkins", "The Guardian")
           val image = createImage(id = UUID.randomUUID().toString, photog)
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
           val updateDoc = """
             |{
@@ -800,7 +800,7 @@ class ElasticSearchTest extends ElasticSearchTestBase {
           val id = UUID.randomUUID().toString
           val photog = StaffPhotographer("Tom Jenkins", "The Guardian")
           val image = createImage(id, photog)
-          Await.result(Future.sequence(ES.migrationAwareIndexImage(id, image, now)), fiveSeconds)
+          Await.result(ES.migrationAwareIndexImage(id, image, now), fiveSeconds)
 
 
           val updateDoc = """

--- a/thrall/test/lib/elasticsearch/GoodToGoCheckTest.scala
+++ b/thrall/test/lib/elasticsearch/GoodToGoCheckTest.scala
@@ -24,7 +24,7 @@ class GoodToGoCheckTest extends ElasticSearchTestBase {
       val testIds = List("first", "second", "third")
       "should delete old test images" in {
         // insert a few 'old' test images
-        Future.sequence(testIds.flatMap { id =>
+        Future.sequence(testIds.map { id =>
           ES.migrationAwareIndexImage(id, MappingTest.testImage.copy(id = id), old)
         }).futureValue
 
@@ -51,8 +51,8 @@ class GoodToGoCheckTest extends ElasticSearchTestBase {
         val notVeryOld = now.minus(Period.minutes(5))
         // insert one normal and a few others with an alternative uploader
         val eventualInserts: List[Future[ElasticSearchUpdateResponse]] =
-          ES.migrationAwareIndexImage("test", MappingTest.testImage.copy(id = "test"), old) :::
-          testIds.flatMap { id =>
+          ES.migrationAwareIndexImage("test", MappingTest.testImage.copy(id = "test"), old) ::
+          testIds.map { id =>
             ES.migrationAwareIndexImage(id, MappingTest.testImage.copy(id = id), notVeryOld)
           }
         Future.sequence(eventualInserts).futureValue
@@ -78,8 +78,8 @@ class GoodToGoCheckTest extends ElasticSearchTestBase {
 
       "should not delete images without the defined test uploader" in {
         val eventualInserts: List[Future[ElasticSearchUpdateResponse]] =
-          ES.migrationAwareIndexImage("old", MappingTest.testImage.copy(id = "old"), old) :::
-            testIds.flatMap { id =>
+          ES.migrationAwareIndexImage("old", MappingTest.testImage.copy(id = "old"), old) ::
+            testIds.map { id =>
               ES.migrationAwareIndexImage(id, MappingTest.testImage.copy(id = id, uploadedBy = "joe-bloggs"), old)
             }
         val eventualResponses = Future.sequence(eventualInserts).futureValue

--- a/thrall/test/lib/elasticsearch/ImageModelTest.scala
+++ b/thrall/test/lib/elasticsearch/ImageModelTest.scala
@@ -52,7 +52,7 @@ class ImageModelTest extends ElasticSearchTestBase {
        */
       val image = MappingTest.testImage
 
-      Await.result(Future.sequence(ES.migrationAwareIndexImage(image.id, image, image.lastModified.get)), fiveSeconds)
+      Await.result(ES.migrationAwareIndexImage(image.id, image, image.lastModified.get), fiveSeconds)
       eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(reloadedImage(image.id).map(_.id) shouldBe Some(image.id))
 
       val retrievedImage = reloadedImage(image.id).get


### PR DESCRIPTION
## What does this change?

Reuse the upsert logic when inserting into the migration index. This helps ensure that any changes made to an image are not hidden.

If a migration was running, and an image had been migrated, any changes made to the image would "disappear" on reuploading because the result of the upload pipeline would be directly inserted into the migration index. We should remember that the image may be a reupload, and safely merge the metadata into the index.

## How should a reviewer test this change?

Reupload an image, check that edits (and usage rights, crops, usages, etc.) stay visible in the UI.

## How can success be measured?

Migration is safer

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
