### PR TITLE
ci: Deterministically install node dependencies

### DIFF
--- a/scripts/ci/grid.sh
+++ b/scripts/ci/grid.sh
@@ -29,7 +29,7 @@ buildKahuna() {
   # clear old packages first
   rm -rf node_modules
 
-  npm install
+  npm ci
   npm run undist
   npm test
   npm run dist
@@ -42,7 +42,7 @@ buildWatcher() {
   pushd ${SCRIPT_DIR}/../../s3watcher/lambda
 
   nvm use ${NODE_VERSION}
-  npm install
+  npm ci
   npm test
   npm run build
 


### PR DESCRIPTION
`npm ci` will strictly obey the lockfile and fail if any diff is created.

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
