### PR TITLE
Limit the amount of file logs kept 

### DIFF
--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -14,9 +14,11 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOGS_LOCATION}/application.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOGS_LOCATION}/application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOGS_LOCATION}/application.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
             <maxHistory>7</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>


### PR DESCRIPTION
See also <https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy>

## What does this change?

This change is designed for Thrall, as a replacement for #3753 but will affect all services. In practice no service should be nearly as chatty as Thrall during a migration.

Limit the amount of space that can be consumed by Thrall application logs.

Since the migration to fluentbit, we store logs in 3 places - syslog, journald and the classic log files. We are using our infra to manage the rotation of syslog and journal files, we should also configure logback to do the same. We were already rotating logfiles once a day, storing compressed history for 7 days, but even that much can fill out an instance's disk space. This PR adds size based rolling, to rotate logfiles every day or 100MB, whichever comes first, storing 7 files' worth of history up to 500MB.

## How should a reviewer test this change?

Deploy to TEST, start a migration and wait. This may take a long time, so you may want to deploy a branch with smaller values for the purpose of testing the configuration.

## How can success be measured?

Logging continues even on a high-throughput process like a migration.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
