### PR TITLE
Remove `Chelsea FC` from list of Getty exclusions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -130,8 +130,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
 
   /* These are currently hardcoded */
   val payGettySourceList = List(
-    /* Chelsea possibly temporary, until Putin’s gone */
-    "Chelsea FC",
     "ABC News",
     "AFPTV",
     "Alinari",


### PR DESCRIPTION
## What does this change?

Ronseal. Not a Russian club any more.