### PR TITLE
Process duplicate usages

### DIFF
--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -114,6 +114,7 @@ class UsageRecorder(
 
       Observable.from(markAsRemovedOps ++ updateOps ++ createOps)
         .flatten[JsObject]
+        .toSeq // observable emits exactly once, when all ops complete and have been emitted, or immediately if there are 0 ops
         .map(_ => mediaIdsImplicatedInDBUpdates)
     })
   }

--- a/usage/app/lib/UsageRecorder.scala
+++ b/usage/app/lib/UsageRecorder.scala
@@ -43,11 +43,7 @@ class UsageRecorder(
 
   val notificationStream: Observable[UsageNotice] = getNotificationStream(dbUpdateStream)
 
-  val distinctNotificationStream: Observable[UsageNotice] = notificationStream.groupBy(_.mediaId).flatMap {
-    case (_, s) => s.distinctUntilChanged
-  }
-
-  val notifiedStream: Observable[Unit] = distinctNotificationStream.map(usageNotifier.send)
+  val notifiedStream: Observable[Unit] = notificationStream.map(usageNotifier.send)
 
   val finalObservable: Observable[Unit] = notifiedStream.retry((_, error) => {
     logger.error("UsageRecorder encountered an error.", error)


### PR DESCRIPTION
## What does this change?

We currently have some logic that avoids sending usage notices through to thrall to be set into ES if there is "nothing to do", which is inferred when the dynamodb table matches the constructed usage notice. This probably saves quite a bit of work on the ES cluster, eg. when a writer edits body copy in Composer, we don't need to send a usage notice for all of the images in the (potentially long) piece. But there is currently a bug somewhere which means that the usage notice may be dropped after insertion into the db but before landing in the ES which we've not yet been able to crack - this means that even if the usage is sent again, it will never be inserted into the ES. Eg. syndications, where some images will be retried every run unless there is manual intervention.

We do this by changing the list of media IDs affected by the usage update, making it be emitted exactly once per received event (previously it would be emitted once per creation/update/removal in the db; meaning it could be emitted 0 times so no continuation of the stream, or many times meaning lots of duplicates in the stream), and then removing the deduplication of notices, taken from #3758.

## How should a reviewer test this change?

Send a usage notice, delete from ES and then try to resend it. This si quite involved as we don't have a reproduction for the underlying bug - pair with me and I can help.

## How can success be measured?

Resent usages will be retried.

## Risks

This will cause an increase in usages sent via composer, if the volume is especially high this may cause issues for the thrall queue/ES? I think best way is to deploy and roll back if it does cause issues (we might be able to scope some of the deduplicating logic to composer usage types).

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
