### PR TITLE
Query filter does not crash when fed undefined values

### DIFF
--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -16,6 +16,10 @@ export function maybeQuoted(value) {
 }
 
 export function fieldFilter(field, value) {
+    if (!value) {
+      return "";
+    }
+
     const cleanValue = stripDoubleQuotes(value);
     const valueMaybeQuoted = maybeQuoted(cleanValue);
     return `${field}:${valueMaybeQuoted}`;


### PR DESCRIPTION
## What does this change?

Adds a check to return an empty string, rather than throw an error, when `queryFilter` receives a key-value pair where the value is `undefined`.

This is very common – we currently have [315k errors in Sentry over the last 24hrs.](https://sentry.io/organizations/the-guardian/issues/2735185031/?project=35623&statsPeriod=14d)

Strangely, in AngularJS, [`filter` appears to behave like a `map`](https://docs.angularjs.org/api/ng/service/$filter), and we map over object k-v pairs in the UI [at least once](https://github.com/guardian/grid/blob/34e137821e17043302c974209ce266526ab26827/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html#L355) without checking that the value is a string, so we should probably be resilient to undefined values.

## How should a reviewer test this change?

[This image](https://media.test.dev-gutools.co.uk/images/26f76d8996ea757beba7f536df1e9168be2b71d2) throws errors in TEST. After this change, it shouldn't. The metadata panel should behave as before.

## How can success be measured?

Fewer errors in Sentry, with no affect on the user experience.
