### PR TITLE
try to fix bootstrapping of nonFree query param

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -104,6 +104,12 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
               });
             };
 
+            if ($state.current.name === 'search') {
+              mediaApi.getSession().then(session => {
+                storage.setJs('isNonFree', session.user.permissions.showPaid, true);
+              });
+            }
+
             ctrl.collectionsPanel = panels.collectionsPanel;
             ctrl.metadataPanel = panels.metadataPanel;
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -216,9 +216,8 @@ query.controller('SearchQueryCtrl', [
         }
 
         if (isNonFree === null) {
-          ctrl.filter.nonFree = session.user.permissions.showPaid ?
-            session.user.permissions.showPaid : undefined;
-            storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false, true);
+          ctrl.filter.nonFree = $stateParams.nonFree;
+          storage.setJs("isNonFree", ctrl.filter.nonFree ? ctrl.filter.nonFree : false, true);
         }
         else if (isNonFree === true || isNonFree === "true") {
             ctrl.filter.nonFree = "true";


### PR DESCRIPTION
The only place in kahuna which should pay attention to the showPaid
permission should be the state for the root (ie. '/'), which after
finding the permission and setting the nonFree state param will
insert that to session storage ang then transition to /search.
If we are on the /search state and do not have nonFree in session
storage, then the user has followed a link directly to a search - in
that case we should respect the current state of the URL (ie.
stateParams.nonFree)

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
