### PR TITLE
Don't render missing location fields

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -347,26 +347,27 @@
                         ng-click="locationEditForm.$show()"
                         ng-hide="locationEditForm.$visible">✎</button>
 
-                <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']"
-                      >
-                        <span>
-                            <a
-                                ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
-                                ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
-                                aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}">
-                                 {{ctrl.metadata[prop]}}
-                            </a>
-                            <span
-                                ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
-                                ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}">
-                                {{'(Multiple ' + ctrl.locationFieldPluralMap[prop] + ')'}}
-                            </span>
+                <span ng-hide="locationEditForm.$visible" ng-repeat="prop in ['subLocation', 'city', 'state', 'country']">
+                    <span ng-if="ctrl.metadata[prop] || ctrl.hasMultipleValues(ctrl.rawMetadata[prop])">
+                        <a
+                            ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
+                            ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
+                            aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}"
+                        >
+                            {{ctrl.metadata[prop]}}
+                        </a>
+                        <span
+                            ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
+                            ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata[prop])}"
+                        >
+                            {{'(Multiple ' + ctrl.locationFieldPluralMap[prop] + ')'}}
                         </span>
-                        <span ng-if="! $last && ( ctrl.metadata[prop] || ctrl.hasMultipleValues(ctrl.rawMetadata[prop]) )">
+                        <span ng-if="! $last">
                             ,
                         </span>
-
+                    </span>
                 </span>
+
                 <span ng-hide="locationEditForm.$visible" class="editable-empty"
                       ng-if="!ctrl.hasLocationInformation() &&
                             ctrl.userCanEdit &&


### PR DESCRIPTION
## What does this change?

Some location fields may be null - previously we still rendered them with a null anchor, which threw errors as seen in #3781 

## How should a reviewer test this change?

Without this PR, open almost any image with less than 4 location fields, there should be stack traces in the browser console. Then open the same image with this PR - there should not be stack traces.

Without this PR, there will be anchors with no content for the null location fields, eg. 
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/10963046/172676213-06820292-11d6-4258-82b7-f800979ad51e.png">
With this PR, these should all be gone.

## How can success be measured?

Big reduction in errors in Sentry.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
