### PR TITLE
Bump pan-domain-auth-play to 1.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
     "com.gu" %% "editorial-permissions-client" % "2.14",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

Bumps the pan-domain-auth-play library to 1.0.6, to fix a few [high-priority](https://github.com/guardian/pan-domain-authentication/pull/87) [CVEs](https://github.com/guardian/pan-domain-authentication/pull/91).

## How should a reviewer test this change?

This should be a no-op. Run locally or deploy to TEST – authentication should continue to work as expected.

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
