### PR TITLE
add pikaday-time dependency and update leases datepicker

### DIFF
--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -22,6 +22,7 @@
     "panda-session": "0.1.6",
     "pandular": "0.1.6",
     "pikaday": "^1.8.2",
+    "pikaday-time": "^1.6.1",
     "rx": "^2.5.3",
     "rx-angular": "^1.1.3",
     "rx-dom": "^6.0.0",

--- a/kahuna/public/js/components/gu-date/gu-date.html
+++ b/kahuna/public/js/components/gu-date/gu-date.html
@@ -17,6 +17,6 @@
 
     <div ng-show="showingOverlay" class="gu-date__container"></div>
 
-    <input type="text" class="gu-date__value--hidden" placeholder="DD-MM-YYYY HH:mm" ng-model="pikaValue">
+    <input ng-focus="showingOverlay = false" type="text" class="gu-date__value--hidden" placeholder="DD Mon YYYY HH:mm" ng-model="pikaValue">
 </div>
 

--- a/kahuna/public/js/components/gu-date/gu-date.html
+++ b/kahuna/public/js/components/gu-date/gu-date.html
@@ -17,6 +17,6 @@
 
     <div ng-show="showingOverlay" class="gu-date__container"></div>
 
-    <input type="text" class="gu-date__value--hidden" placeholder="DD-MM-YYYY" ng-model="pikaValue">
+    <input type="text" class="gu-date__value--hidden" placeholder="DD-MM-YYYY HH:mm" ng-model="pikaValue">
 </div>
 

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -1,13 +1,13 @@
 import angular from 'angular';
 import moment from 'moment';
-import Pikaday from 'pikaday';
+import Pikaday from 'pikaday-time';
 import 'pikaday/css/pikaday.css';
 
 import template from './gu-date.html';
 import rangeTemplate from './gu-date-range-x.html';
 import './gu-date.css';
 
-const DISPLAY_FORMAT = 'DD MMM YYYY';
+const DISPLAY_FORMAT = 'DD MMM YYYY HH:mm';
 const TEN_YEARS_MILLIS = (10 * 365 * 24 * 60 * 60 * 1000);
 const START_OF_WEEK = 1; // Monday
 
@@ -47,6 +47,14 @@ guDate.directive('guDate', [function () {
 
             const pika = new Pikaday({
                 field: input,
+                showTime: true,
+                showMinutes: true,
+                use24hour: false,
+                incrementHourBy: 1,
+                incrementMinuteBy: 1,
+                incrementSecondBy: 1,
+                autoClose: true,
+                timeLabel: null, // optional string added to left of time select
                 container: container,
                 bound: false,
                 minDate: $scope.minDate && new Date($scope.minDate),
@@ -65,7 +73,7 @@ guDate.directive('guDate', [function () {
             $scope.closeOverlay = () => $scope.showingOverlay = false;
 
             if (angular.isDefined($scope.minDate)) {
-                $scope.dateRounder = (date) => moment(date).endOf('day').toDate();
+                $scope.dateRounder = (date) => moment(date).toDate();
 
                 $scope.$watch('minDate', value => {
                     const dateValue = value ? new Date(value) : new Date();
@@ -74,7 +82,7 @@ guDate.directive('guDate', [function () {
             }
 
             if (angular.isDefined($scope.maxDate)) {
-                $scope.dateRounder = (date) => moment(date).startOf('day').toDate();
+                $scope.dateRounder = (date) => moment(date).toDate();
 
                 $scope.$watch('maxDate', value => {
                     const dateValue = value ? new Date(value) : new Date();

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -87,7 +87,6 @@ guDate.directive('guDate', [function () {
 
                 $scope.date = getDateISOString(date);
                 $scope.displayValue = getDisplayValue(date);
-                pika.setDate($scope.date);
             });
 
             $scope.$on('$destroy', () => pika.destroy);

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -43,16 +43,19 @@ guDate.directive('guDate', [function () {
 
             const root = el[0];
             const input = root.querySelector('input.gu-date__value--hidden');
+            const container = root.querySelector('.gu-date__container');
 
             const pika = new Pikaday({
                 field: input,
-                use24hour: true,
+                container: container,
+                bound: false,
                 minDate: $scope.minDate && new Date($scope.minDate),
                 maxDate: tenYearsFromNow,
                 yearRange: 100,
                 firstDay: START_OF_WEEK,
                 format: DISPLAY_FORMAT,
                 keyboardInput: false,
+                use24hour: true,
                 autoClose: false
             });
 
@@ -84,7 +87,7 @@ guDate.directive('guDate', [function () {
 
                 $scope.date = getDateISOString(date);
                 $scope.displayValue = getDisplayValue(date);
-                $scope.closeOverlay();
+                pika.setDate($scope.date);
             });
 
             $scope.$on('$destroy', () => pika.destroy);

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -49,7 +49,7 @@ guDate.directive('guDate', [function () {
                 field: input,
                 showTime: true,
                 showMinutes: true,
-                use24hour: false,
+                use24hour: true,
                 incrementHourBy: 1,
                 incrementMinuteBy: 1,
                 incrementSecondBy: 1,

--- a/kahuna/public/js/components/gu-date/gu-date.js
+++ b/kahuna/public/js/components/gu-date/gu-date.js
@@ -43,26 +43,17 @@ guDate.directive('guDate', [function () {
 
             const root = el[0];
             const input = root.querySelector('input.gu-date__value--hidden');
-            const container = root.querySelector('.gu-date__container');
 
             const pika = new Pikaday({
                 field: input,
-                showTime: true,
-                showMinutes: true,
                 use24hour: true,
-                incrementHourBy: 1,
-                incrementMinuteBy: 1,
-                incrementSecondBy: 1,
-                autoClose: true,
-                timeLabel: null, // optional string added to left of time select
-                container: container,
-                bound: false,
                 minDate: $scope.minDate && new Date($scope.minDate),
                 maxDate: tenYearsFromNow,
                 yearRange: 100,
                 firstDay: START_OF_WEEK,
                 format: DISPLAY_FORMAT,
-                keyboardInput: false
+                keyboardInput: false,
+                autoClose: false
             });
 
             $scope.clear = () => {
@@ -73,7 +64,6 @@ guDate.directive('guDate', [function () {
             $scope.closeOverlay = () => $scope.showingOverlay = false;
 
             if (angular.isDefined($scope.minDate)) {
-                $scope.dateRounder = (date) => moment(date).toDate();
 
                 $scope.$watch('minDate', value => {
                     const dateValue = value ? new Date(value) : new Date();
@@ -82,7 +72,6 @@ guDate.directive('guDate', [function () {
             }
 
             if (angular.isDefined($scope.maxDate)) {
-                $scope.dateRounder = (date) => moment(date).toDate();
 
                 $scope.$watch('maxDate', value => {
                     const dateValue = value ? new Date(value) : new Date();
@@ -91,11 +80,7 @@ guDate.directive('guDate', [function () {
             }
 
             $scope.$watch('pikaValue', value => {
-                const date = value === ""
-                    ? undefined
-                    : angular.isDefined($scope.dateRounder)
-                        ? $scope.dateRounder(value)
-                        : value;
+                const date = value === "" ? undefined : value;
 
                 $scope.date = getDateISOString(date);
                 $scope.displayValue = getDisplayValue(date);

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -88,6 +88,10 @@
         </div>
     </div>
     <div ng-switch-default>
+<!--        <span ng-if="ctrl.access">-->
+<!--            <input type="datetime-local" id="startDate" ng-model="ctrl.newLease.startDate">-->
+<!--            <input type="datetime-local" id="endDate" ng-model="ctrl.newLease.endDate">-->
+<!--        </span>-->
         <gu-date-range-x ng-if="ctrl.access"
                         start="ctrl.newLease.startDate"
                         end="ctrl.newLease.endDate">
@@ -107,7 +111,7 @@
     <button
         class="lease__form__buttons__button-save button-save"
         type="submit"
-        title="Save new label"
+        title="Save new lease"
         ng-disabled="ctrl.adding">
         <gr-icon-label data-cy="it-save-lease" gr-icon="check">
             <span ng-hide="ctrl.grSmall">Save</span>

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -88,10 +88,6 @@
         </div>
     </div>
     <div ng-switch-default>
-<!--        <span ng-if="ctrl.access">-->
-<!--            <input type="datetime-local" id="startDate" ng-model="ctrl.newLease.startDate">-->
-<!--            <input type="datetime-local" id="endDate" ng-model="ctrl.newLease.endDate">-->
-<!--        </span>-->
         <gu-date-range-x ng-if="ctrl.access"
                         start="ctrl.newLease.startDate"
                         end="ctrl.newLease.endDate">

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -273,7 +273,7 @@ leases.controller('LeasesCtrl', [
         });
 
         function getDefaultExpiryDate(leaseType) {
-            const inTwoDays = moment().add(2, 'days').startOf('day').toDate();
+            const inTwoDays = moment().add(2, 'days').endOf('day').toDate();
 
             return ['allow-use', 'deny-use'].includes(leaseType) ? inTwoDays : null;
         }


### PR DESCRIPTION


## What does this change?

add pikaday-time dependency and update **_gu-date_** datepicker Configuration to support time

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
when adding a lease the datepicker in the form of the leases should support the time
<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?
when adding a lease and changing the time from the datepicker in the form of the leases 
the lease time should be updated instead of being (start/end of the day) 

## Screenshots
![Screenshot from 2022-06-09 11-10-06](https://user-images.githubusercontent.com/33189781/172811558-5c819f20-1d56-4274-9958-e20b6a230d54.png)
![Screenshot from 2022-06-09 11-11-12](https://user-images.githubusercontent.com/33189781/172811728-7eb1662a-9d02-4896-8cb3-2dd3012b585e.png)


## Who should look at this?
@guardian/digital-cms
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
