### PR TITLE
handle NonFree Filter and keep it in Sync with NonFree stateParam

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -29,7 +29,7 @@
         <a data-cy="collection-child-link"
            ng-if="! ctrl.hasCustomSelect"
            class="node__name flex-spacer"
-           ui-sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId)})">
+           ui-sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId), nonFree: ctrl.srefNonfree()})">
             {{:: node.data.data.description}}
         </a>
 

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -7,7 +7,7 @@ import {collectionsApi} from '../../services/api/collections-api';
 import {mediaApi}       from '../../services/api/media-api';
 import '../../directives/gr-auto-focus';
 import '../../util/eq';
-
+import '../../util/storage';
 import './gr-collections-panel.css';
 import {getCollection} from '../../search-query/query-syntax';
 import nodeTemplate from './gr-collections-panel-node.html';
@@ -19,7 +19,8 @@ export var grCollectionsPanel = angular.module('grCollectionsPanel', [
     mediaApi.name,
     'util.rx',
     'util.eq',
-    'gr.autoFocus'
+    'gr.autoFocus',
+    'util.storage'
 ]);
 
 grCollectionsPanel.factory('collectionsTreeState', ['$window', function($window) {
@@ -88,8 +89,8 @@ grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
 }]);
 
 grCollectionsPanel.controller('GrNodeCtrl',
-    ['$scope', 'collections', 'subscribe$', 'inject$', 'onValChange', 'collectionsTreeState',
-    function($scope, collections, subscribe$, inject$, onValChange, collectionsTreeState) {
+    ['$scope', 'collections', 'subscribe$', 'inject$', 'onValChange', 'collectionsTreeState', 'storage',
+    function($scope, collections, subscribe$, inject$, onValChange, collectionsTreeState, storage) {
 
     const ctrl = this;
 
@@ -175,6 +176,9 @@ grCollectionsPanel.controller('GrNodeCtrl',
         ctrl.select = () => {
             grCollectionTreeCtrl.onSelect({$collection: ctrl.node.data.data.path});
         };
+
+        ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
+
 
     };
 }]);

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -280,7 +280,7 @@
 
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
                             <span ng-if="ctrl.metadata.byline">
-                                <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by')})"
+                                <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by'), nonFree: ctrl.srefNonfree()})"
                                    aria-label="Search images by {{ctrl.metadata.byline}} byline">{{ctrl.metadata.byline}}</a>
                             </span>
 
@@ -328,7 +328,7 @@
 
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
                             <span ng-if="ctrl.metadata.credit">
-                                <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit')})"
+                                <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit'), nonFree: ctrl.srefNonfree()})"
                                    aria-label="Search images by {{ctrl.metadata.credit}} credit">{{ctrl.metadata.credit}}</a>
                             </span>
 
@@ -351,7 +351,7 @@
                     <span ng-if="ctrl.metadata[prop] || ctrl.hasMultipleValues(ctrl.rawMetadata[prop])">
                         <a
                             ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
-                            ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop])})"
+                            ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop]), nonFree: ctrl.srefNonfree()})"
                             aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}"
                         >
                             {{ctrl.metadata[prop]}}
@@ -497,7 +497,7 @@
 
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
                             <span ng-if="ctrl.metadata.copyright">
-                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright')})"
+                                <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright'), nonFree: ctrl.srefNonfree()})"
                                    aria-label="Search images by {{ctrl.metadata.copyright}} copyright">{{ctrl.metadata.copyright}}</a>
                             </span>
 
@@ -518,7 +518,7 @@
             <dt ng-if="!ctrl.hasMultipleValues(ctrl.extraInfo.uploadedBy)" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">Uploader</dt>
             <dd ng-if="!ctrl.hasMultipleValues(ctrl.extraInfo.uploadedBy)" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <span class="metadata-line__info">
-                    <a ui-sref="search.results({query: (ctrl.extraInfo.uploadedBy | queryFilter:'uploader')})"
+                    <a ui-sref="search.results({query: (ctrl.extraInfo.uploadedBy | queryFilter:'uploader'), nonFree: ctrl.srefNonfree()})"
                        aria-label="Search images uploaded by {{ctrl.extraInfo.uploadedBy}}">{{ctrl.extraInfo.uploadedBy | stripEmailDomain}}</a>
                 </span>
             </dd>
@@ -538,7 +538,7 @@
                 class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <span class="metadata-line__info">
                     <span ng-repeat="subject in ctrl.metadata.subjects">
-                        <a ui-sref="search.results({query: (subject | queryFilter:'subject')})"
+                        <a ui-sref="search.results({query: (subject | queryFilter:'subject'), nonFree: ctrl.srefNonfree()})"
                            aria-label="Search images by {{subject}} subject">
                             {{subject}}
                         </a>
@@ -771,7 +771,7 @@
         </dt>
         <dd class="metadata-line__info flex-container"
             ng-repeat="collection in ctrl.singleImage.data.collections">
-            <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+            <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter), nonFree: ctrl.srefNonfree()})"
                aria-label="Search images by {{collection.data.description}} collection">
                 {{collection.data.path.join(' ▸ ')}}
             </a>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -294,6 +294,8 @@ module.controller('grImageMetadataCtrl', [
       return storage.getJs(generateStoreName(key)).hidden;
     };
 
+    ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
+
     function isUsefulMetadata(metadataKey) {
       return ignoredMetadata.indexOf(metadataKey) === -1;
     }

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.html
@@ -21,7 +21,7 @@
 
         <span ng-if="ctrl.hasPhotoshootData">
             <span ng-if="ctrl.hasSinglePhotoshoot">
-                <a ui-sref="search.results({query: (ctrl.photoshootData.title | queryFilter:'photoshoot')})">
+                <a ui-sref="search.results({query: (ctrl.photoshootData.title | queryFilter:'photoshoot'), nonFree: ctrl.srefNonfree()})">
                     {{ctrl.photoshootData.title}}
                 </a>
             </span>

--- a/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
+++ b/kahuna/public/js/components/gr-photoshoot/gr-photoshoot.js
@@ -6,11 +6,13 @@ import template from './gr-photoshoot.html';
 import '../../image/service';
 import '../../services/photoshoot';
 import '../../services/image-accessor';
+import '../../util/storage';
 
 export const photoshoot = angular.module('gr.photoshoot', [
     'gr.image.service',
     'kahuna.services.image-accessor',
-    'kahuna.services.photoshoot'
+    'kahuna.services.photoshoot',
+    'util.storage'
 ]);
 
 photoshoot.controller('GrPhotoshootCtrl', [
@@ -20,8 +22,9 @@ photoshoot.controller('GrPhotoshootCtrl', [
     'mediaApi',
     'imageAccessor',
     'photoshootService',
+    'storage',
 
-    function($rootScope, $scope, imageService, mediaApi, imageAccessor, photoshootService) {
+    function($rootScope, $scope, imageService, mediaApi, imageAccessor, photoshootService, storage) {
         const ctrl = this;
 
         function refreshForOne() {
@@ -72,6 +75,8 @@ photoshoot.controller('GrPhotoshootCtrl', [
         ctrl.remove = () => {
             return photoshootService.batchRemove({ images: ctrl.images });
         };
+
+        ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
 
         if (Boolean(ctrl.withBatch)) {
             const batchApplyEvent = 'events:batch-apply:photoshoot';

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.html
@@ -3,7 +3,7 @@
         ng-if="ctrl.presetLabels.length > 0">
         <li class="preset-label"
             ng-repeat="label in ctrl.presetLabels">
-            <a ui-sref="search.results({query: (label | queryLabelFilter)})"
+            <a ui-sref="search.results({query: (label | queryLabelFilter), nonFree: ctrl.srefNonfree()})"
                class="preset-label__value preset-label__link"
                aria-label="Search images by {{label}} label">{{label}}</a>
 

--- a/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
+++ b/kahuna/public/js/components/gr-preset-labels/gr-preset-labels.js
@@ -9,15 +9,18 @@ import {mediaApi} from '../../services/api/media-api';
 
 import strings from '../../strings.json';
 
+import '../../util/storage';
+
 export var presetLabels = angular.module('gr.presetLabels', [
     'gr.autoFocus',
     'kahuna.services.presetLabel',
-    mediaApi.name
+    mediaApi.name,
+    'util.storage'
 ]);
 
 presetLabels.controller('GrPresetLabelsCtrl', [
-    '$window', 'presetLabelService', 'mediaApi',
-    function ($window, presetLabelService, mediaApi) {
+    '$window', 'presetLabelService', 'mediaApi', 'storage',
+    function ($window, presetLabelService, mediaApi, storage) {
 
         let ctrl = this;
 
@@ -58,6 +61,8 @@ presetLabels.controller('GrPresetLabelsCtrl', [
             ctrl.active = false;
             ctrl.newLabel = '';
         }
+
+        ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
 
     }
 ]);

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -222,7 +222,7 @@
                             ng-repeat="collection in ctrl.image.data.collections track by collection.data.pathId">
                             <a gr-tooltip="Click to open collection: {{::collection.data.path.join(' ▸ ')}}"
                                gr-tooltip-position="top"
-                               ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                               ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter), nonFree: ctrl.srefNonfree()})"
                                ng-attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                                class="preview__collections__collection__value">
                                 {{::collection.data.description}}

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -12,6 +12,7 @@ import {leases} from '../leases/leases';
 import {archiver} from '../components/gr-archiver-status/gr-archiver-status';
 import {collectionsApi} from '../services/api/collections-api';
 import {rememberScrollTop} from '../directives/gr-remember-scroll-top';
+import '../util/storage';
 
 export var imageEditor = angular.module('kahuna.edits.imageEditor', [
     service.name,
@@ -23,7 +24,8 @@ export var imageEditor = angular.module('kahuna.edits.imageEditor', [
     collectionsApi.name,
     rememberScrollTop.name,
     leases.name,
-    metadataTemplates.name
+    metadataTemplates.name,
+    'util.storage'
 ]);
 
 imageEditor.controller('ImageEditorCtrl', [
@@ -37,6 +39,7 @@ imageEditor.controller('ImageEditorCtrl', [
     'imageAccessor',
     'collections',
     'mediaApi',
+    'storage',
 
     function($rootScope,
              $scope,
@@ -47,7 +50,8 @@ imageEditor.controller('ImageEditorCtrl', [
              labelService,
              imageAccessor,
              collections,
-             mediaApi) {
+             mediaApi,
+             storage) {
 
     var ctrl = this;
     ctrl.canUndelete = false;
@@ -275,6 +279,9 @@ imageEditor.controller('ImageEditorCtrl', [
             ctrl.canUndelete = ctrl.isDeleted = false
         );
     }
+
+    ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
+
 }]);
 
 

--- a/kahuna/public/js/edits/list-editor-compact.html
+++ b/kahuna/public/js/edits/list-editor-compact.html
@@ -7,7 +7,7 @@
 
             <a class="element__value element__value--compact element__link"
                ng-if="!ctrl.disabled"
-               ui-sref="search.results({query: (element | {{ctrl.queryFilter}})})"
+               ui-sref="search.results({query: (element | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})"
                aria-label="Search images by {{element}} {{ctrl.elementName}}">
                 {{element}}
             </a>

--- a/kahuna/public/js/edits/list-editor-info-panel.html
+++ b/kahuna/public/js/edits/list-editor-info-panel.html
@@ -7,7 +7,7 @@
             ng-click="ctrl.addElements([element.data])">
         <gr-icon>library_add</gr-icon>
     </button>
-    <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}})})" class="element__value"
+    <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})" class="element__value"
        aria-label="Search images by {{element.data}} {{ctrl.elementName}}">{{element.data}}</a>
     <button class="element__remove"
             title="Remove {{ctrl.elementName}}{{element.count > 1 ? ' from all' : ''}}"

--- a/kahuna/public/js/edits/list-editor-upload.html
+++ b/kahuna/public/js/edits/list-editor-upload.html
@@ -18,7 +18,7 @@
         <li class="element"
             ng-repeat="element in ctrl.plainList"
             ng-class="{'element--removing': ctrl.elementsBeingRemoved.has(element)}">
-            <a ui-sref="search.results({query: (element | {{ctrl.queryFilter}})})"
+            <a ui-sref="search.results({query: (element | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})"
                class="element__value element__link">{{element}}</a>
 
             <button data-cy="it-remove-element-button"

--- a/kahuna/public/js/edits/list-editor.js
+++ b/kahuna/public/js/edits/list-editor.js
@@ -4,12 +4,14 @@ import templateCompact from './list-editor-compact.html';
 import templateInfoPanel from './list-editor-info-panel.html';
 import './list-editor.css';
 import '../services/image-list';
+import '../util/storage';
 
 import '../search/query-filter';
 
 export var listEditor = angular.module('kahuna.edits.listEditor', [
     'kahuna.search.filters.query',
-    'kahuna.services.image-logic'
+    'kahuna.services.image-logic',
+    'util.storage'
 ]);
 
 listEditor.controller('ListEditorCtrl', [
@@ -19,12 +21,14 @@ listEditor.controller('ListEditorCtrl', [
     '$timeout',
     'imageLogic',
     'imageList',
+    'storage',
     function($rootScope,
             $scope,
             $window,
             $timeout,
             imageLogic,
-            imageList) {
+            imageList,
+            storage) {
     var ctrl = this;
 
     const retrieveElementsWithOccurrences = (images) => imageList.getOccurrences(images.flatMap(img => ctrl.accessor(img)));
@@ -85,6 +89,8 @@ listEditor.controller('ListEditorCtrl', [
     ctrl.removeAll = () => {
         ctrl.plainList.forEach(element => ctrl.removeFromImages(ctrl.images, element));
     };
+
+    ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
 
     const batchAddEvent = 'events:batch-apply:add-all';
     const batchRemoveEvent = 'events:batch-apply:remove-all';

--- a/kahuna/public/js/preview/image-large.html
+++ b/kahuna/public/js/preview/image-large.html
@@ -62,7 +62,7 @@
                         ng-repeat="collection in ctrl.image.data.collections"
                         gr-tooltip="Click to open collection: {{collection.data.path.join(' ▸ ')}}"
                         gr-tooltip-position="top">
-                        <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                        <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter), nonFree: ctrl.srefNonfree()})"
                            ng-attr-style="{{ctrl.getCollectionStyle(collection)}}"
                            class="preview__collections__collection__value">
                             {{collection.data.description}}

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -54,7 +54,7 @@
                     ng-repeat="collection in ctrl.image.data.collections"
                     gr-tooltip="Click to open collection: {{::collection.data.path.join(' ▸ ')}}"
                     gr-tooltip-position="top">
-                    <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter)})"
+                    <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter), nonFree: ctrl.srefNonfree()})"
                        ng-attr-style="{{::ctrl.getCollectionStyle(collection)}}"
                        class="preview__collections__collection__value">
                         {{::collection.data.description}}

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import Rx from 'rx';
 
 import '../util/rx';
+import '../util/storage';
+
 
 import template from './image.html';
 import templateLarge from './image-large.html';
@@ -24,7 +26,8 @@ export var image = angular.module('kahuna.preview.image', [
     'gr.archiverStatus',
     'gr.syndicationIcon',
     'util.rx',
-    'kahuna.imgops'
+    'kahuna.imgops',
+    'util.storage'
 ]);
 
 image.controller('uiPreviewImageCtrl', [
@@ -36,6 +39,7 @@ image.controller('uiPreviewImageCtrl', [
     'imageUsagesService',
     'labelService',
     'imageAccessor',
+    'storage',
     function (
         $scope,
         inject$,
@@ -44,7 +48,8 @@ image.controller('uiPreviewImageCtrl', [
         imageService,
         imageUsagesService,
         labelService,
-        imageAccessor) {
+        imageAccessor,
+        storage) {
       var ctrl = this;
 
       $scope.$watch(() => ctrl.image, (newImage) => {
@@ -97,6 +102,9 @@ image.controller('uiPreviewImageCtrl', [
     ctrl.getCollectionStyle = collection => {
         return collection.data.cssColour && `background-color: ${collection.data.cssColour}`;
     };
+
+    ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
+
 }]);
 
 image.directive('uiPreviewImage', function() {

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -104,6 +104,12 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
               });
             };
 
+            if ($state.current.name === 'search') {
+              mediaApi.getSession().then(session => {
+                storage.setJs('isNonFree', session.user.permissions.showPaid, true);
+              });
+            }
+
             ctrl.collectionsPanel = panels.collectionsPanel;
             ctrl.metadataPanel = panels.metadataPanel;
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -221,9 +221,9 @@ query.controller('SearchQueryCtrl', [
             storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false, true);
         }
         else if (isNonFree === true || isNonFree === "true") {
-            ctrl.filter.nonFree = "true";
+            ctrl.filter.nonFree =  $stateParams.nonFree;
         } else {
-          ctrl.filter.nonFree = undefined;
+          ctrl.filter.nonFree = $stateParams.nonFree;
         }
     });
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -216,9 +216,8 @@ query.controller('SearchQueryCtrl', [
         }
 
         if (isNonFree === null) {
-          ctrl.filter.nonFree = session.user.permissions.showPaid ?
-            session.user.permissions.showPaid : undefined;
-            storage.setJs("isNonFree", session.user.permissions.showPaid ? session.user.permissions.showPaid : false, true);
+          ctrl.filter.nonFree = $stateParams.nonFree;
+          storage.setJs("isNonFree", ctrl.filter.nonFree ? ctrl.filter.nonFree : false, true);
         }
         else if (isNonFree === true || isNonFree === "true") {
             ctrl.filter.nonFree =  $stateParams.nonFree;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -220,9 +220,9 @@ query.controller('SearchQueryCtrl', [
           storage.setJs("isNonFree", ctrl.filter.nonFree ? ctrl.filter.nonFree : false, true);
         }
         else if (isNonFree === true || isNonFree === "true") {
-            ctrl.filter.nonFree =  $stateParams.nonFree;
+            ctrl.filter.nonFree = "true";
         } else {
-          ctrl.filter.nonFree = $stateParams.nonFree;
+          ctrl.filter.nonFree = undefined;
         }
     });
 


### PR DESCRIPTION
## What does this change?

The only place in kahuna which should pay attention to the showPaid
permission should be the state for the root (ie. '/'), which after
finding the permission and setting the nonFree state param will
insert that to session storage and then transition to /search.
If we are on the /search state and do not have nonFree in session
storage, then the user has followed a link directly to a search - in
that case, we should respect the current state of the URL (ie.
stateParams.nonFree)

and update outgoing search links eg. underline byline to include NonFree value from the storage

This Fixes https://github.com/guardian/grid/issues/3780. Closes #3782.

credit goes to @andrew-nowak  https://github.com/guardian/grid/pull/3782/commits/02bdf52846f338b27063a0af4e8276dd57eaa678 , https://github.com/guardian/grid/commit/78982025c2de41419e8cca8df04994ac21a5e03f 



<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
