### PR TITLE
Guard against null mediaIDs, and include markers in logs

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/MediaUsage.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.model.usage
 
-import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 import org.joda.time.DateTime
 case class UsageId(id: String) {
   override def toString = id
@@ -27,13 +27,14 @@ case class MediaUsage(
   dateRemoved: Option[DateTime] = None
 ) extends GridLogging {
 
-  def isGridLikeId: Boolean = {
-    if (mediaId.startsWith("gu-image-") || mediaId.startsWith("gu-fc-")) {
-      // remove events from CAPI that represent images previous to Grid existing
-      logger.info(s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
+  def isGridLikeId(implicit logMarker: LogMarker): Boolean = {
+    // _no_ids - CAPI may sometimes(?) insert this in an element missing an id
+    if (mediaId == null || mediaId.trim.isEmpty || mediaId.trim == "_no_ids") {
+      logger.warn(logMarker, s"Unprocessable MediaUsage, mediaId is empty ${this.toString}")
       false
-    } else if (mediaId.trim.isEmpty) {
-      logger.warn("Unprocessable MediaUsage, mediaId is empty", this)
+    } else if (mediaId.startsWith("gu-image-") || mediaId.startsWith("gu-fc-")) {
+      // remove events from CAPI that represent images previous to Grid existing
+      logger.info(logMarker, s"MediaId $mediaId doesn't look like a Grid image. Ignoring usage $usageId.")
       false
     } else {
       true


### PR DESCRIPTION
## What does this change?

We have a couple of rows in the usage table that have null mediaIDs. They're usually not a problem, but the usages stream may throw NPEs when trying to process them (because they're null).

While I'm here, I've added logmarkers to the relevant log lines, and also added a check for "_no_ids" which I've come across in the table. It looks like CAPI can inject this where an element is missing an ID (https://github.com/guardian/content-api/blob/541a5b1c2fb18f5dad2110d5a00fe3ce7a53f04f/concierge/src/main/scala/com.gu.contentapi.concierge/processors/elementsgenerator/ElementsGenerator.scala#L129), though I don't know the specific trigger, and how it is different to the case that emits a null.

## How should a reviewer test this change?

With difficulty - it may be possible to contrive an example in TEST dynamodb and send updates from a matching composer piece if required