### PR TITLE
Mass retry migration failures

### DIFF
--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -66,8 +66,7 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val thrallStreamProcessor = new ThrallStreamProcessor(
     uiSource,
     automationSource,
-    migrationSourceWithSender.manualSource,
-    migrationSourceWithSender.ongoingEsQuerySource,
+    migrationSourceWithSender.source,
     thrallEventConsumer,
     actorSystem
   )

--- a/thrall/app/lib/FailedMigrationDetails.scala
+++ b/thrall/app/lib/FailedMigrationDetails.scala
@@ -8,7 +8,8 @@ final case class FailedMigrationDetails(
   uploadedBy: String,
   uploadTime:String,
   sourceJson: String,
-  esDocAsImageValidationFailures: Option[String]
+  esDocAsImageValidationFailures: Option[String],
+  version: Long
 )
 
 final case class FailedMigrationSummary(totalFailed: Long, details: Seq[FailedMigrationDetails])

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -1,26 +1,25 @@
 package lib
 
 import akka.stream.scaladsl.Source
-import akka.stream.{Attributes, Materializer, OverflowStrategy, QueueOfferResult}
+import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
 import akka.{Done, NotUsed}
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.elasticsearch.{InProgress, Paused}
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.model.{MigrateImageMessage, MigrationMessage}
-import com.sksamuel.elastic4s.requests.searches.SearchHit
 import lib.elasticsearch.{ElasticSearch, ScrolledSearchResults}
 import play.api.libs.ws.WSRequest
 
-import java.time.{Instant, OffsetDateTime}
+import java.time.Instant
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
+case class MigrationRequest(imageId: String, version: Long)
 case class MigrationRecord(payload: MigrationMessage, approximateArrivalTimestamp: Instant)
 
 case class MigrationSourceWithSender(
-  send: MigrationMessage => Future[Boolean],
-  manualSource: Source[MigrationRecord, Future[Done]],
-  ongoingEsQuerySource: Source[MigrationRecord, Future[Done]]
+  send: MigrationRequest => Future[Boolean],
+  source: Source[MigrationRecord, Future[Done]],
 )
 
 object MigrationSourceWithSender extends GridLogging {
@@ -32,7 +31,9 @@ object MigrationSourceWithSender extends GridLogging {
     projectionParallelism: Int,
   )(implicit ec: ExecutionContext): MigrationSourceWithSender = {
 
-    val esQuerySource =
+    // scroll through elasticsearch, finding image ids and versions to migrate
+    // emits MigrationRequest
+    val scrollingIdsSource =
       Source.repeat(())
         .throttle(1, per = 1.second)
         .statefulMapConcat(() => {
@@ -84,42 +85,50 @@ object MigrationSourceWithSender extends GridLogging {
           if (searchHits.nonEmpty) {
             logger.info(s"Flattening ${searchHits.size} image ids to migrate")
           }
-          searchHits
+          searchHits.map(hit => MigrationRequest(hit.id, hit.version))
         })
         .filter(_ => es.migrationIsInProgress)
 
-    val projectedImageSource: Source[MigrationRecord, NotUsed] = esQuerySource.mapAsyncUnordered(projectionParallelism) { searchHit: SearchHit => {
-      val imageId = searchHit.id
-      val migrateImageMessageFuture = (
-        for {
-          maybeProjection <- gridClient.getImageLoaderProjection(mediaId = imageId, innerServiceCall)
-          maybeVersion = Some(searchHit.version)
-        } yield MigrateImageMessage(imageId, maybeProjection, maybeVersion)
-      ).recover {
-        case error => MigrateImageMessage(imageId, Left(error.toString))
-      }
-      migrateImageMessageFuture.map(message => MigrationRecord(message, java.time.Instant.now()))
-    }}
+    // receive MigrationRequests to migrate from a manual source (failures retry page, single image migration form, etc.)
+    val manualIdsSourceDeclaration = Source.queue[MigrationRequest](bufferSize = 2000, OverflowStrategy.dropNew)
+    val (manualIdsSourceMat, manualIdsSource) = manualIdsSourceDeclaration.preMaterialize()(materializer)
 
-    val manualSourceDeclaration = Source.queue[MigrationRecord](bufferSize = 2, OverflowStrategy.backpressure)
-    val (manualSourceMat, manualSource) = manualSourceDeclaration.preMaterialize()(materializer)
-    MigrationSourceWithSender(
-      send = (migrationMessage: MigrationMessage) => manualSourceMat.offer(MigrationRecord(
-        migrationMessage,
-        approximateArrivalTimestamp = OffsetDateTime.now().toInstant
-      )).map {
+    def submitIdForMigration(request: MigrationRequest) =
+      manualIdsSourceMat.offer(request).map {
         case QueueOfferResult.Enqueued => true
         case _ =>
-          logger.warn(s"Failed to add migration message to migration queue: ${migrationMessage}")
+          logger.warn(s"Failed to add migration message to migration queue: $request")
           false
-      }.recover{
+      }.recover {
         case error: Throwable =>
-          logger.error(s"Failed to add migration message to migration queue: ${migrationMessage}", error)
+          logger.error(s"Failed to add migration message to migration queue: $request", error)
           false
-      },
-      manualSource = manualSource.mapMaterializedValue(_ => Future.successful(Done)),
-      ongoingEsQuerySource = projectedImageSource.mapMaterializedValue(_ => Future.successful(Done)),
-    )
+      }
 
+    // merge both sources of MigrationRequest
+    // priority = false prefers manualIdsSource
+    val idsSource = manualIdsSource.mergePreferred(scrollingIdsSource, priority = false)
+
+    // project image from MigrationRequest, produce the MigrateImageMessage
+    val projectedImageSource: Source[MigrationRecord, NotUsed] = idsSource.mapAsyncUnordered(projectionParallelism) {
+      case MigrationRequest(imageId, version) =>
+        val migrateImageMessageFuture = (
+          for {
+            maybeProjection <- gridClient.getImageLoaderProjection(mediaId = imageId, innerServiceCall)
+            maybeVersion = Some(version)
+          } yield MigrateImageMessage(imageId, maybeProjection, maybeVersion)
+        ).recover {
+          case error => MigrateImageMessage(imageId, Left(error.toString))
+        }
+        migrateImageMessageFuture.map(message => MigrationRecord(
+          payload = message,
+          approximateArrivalTimestamp = java.time.Instant.now()
+        ))
+    }
+
+    MigrationSourceWithSender(
+      send = submitIdForMigration,
+      source = projectedImageSource.mapMaterializedValue(_ => Future.successful(Done)),
+    )
   }
 }

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -106,8 +106,8 @@ object MigrationSourceWithSender extends GridLogging {
       }
 
     // merge both sources of MigrationRequest
-    // priority = false prefers manualIdsSource
-    val idsSource = manualIdsSource.mergePreferred(scrollingIdsSource, priority = false)
+    // priority = true prefers manualIdsSource
+    val idsSource = manualIdsSource.mergePreferred(scrollingIdsSource, priority = true)
 
     // project image from MigrationRequest, produce the MigrateImageMessage
     val projectedImageSource: Source[MigrationRecord, NotUsed] = idsSource.mapAsyncUnordered(projectionParallelism) {

--- a/thrall/app/lib/Paging.scala
+++ b/thrall/app/lib/Paging.scala
@@ -1,0 +1,22 @@
+package lib
+
+import play.api.mvc.{Result, Results}
+
+import scala.concurrent.Future
+
+case class Paging(page: Int, from: Int, pageSize: Int)
+
+object Paging extends Results {
+  def withPaging(maybePage: Option[Int])(f: Paging => Future[Result]): Future[Result] = {
+    val pageSize = 250
+    // pages are indexed from 1
+    val page = maybePage.getOrElse(1)
+    val from = (page - 1) * pageSize
+
+    if (page < 1) {
+      Future.successful(BadRequest(s"Value for page parameter should be >= 1"))
+    } else {
+      f(Paging(page, from, pageSize))
+    }
+  }
+}

--- a/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
+++ b/thrall/app/lib/elasticsearch/ThrallMigrationClient.scala
@@ -147,7 +147,7 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
   def getMigrationFailures(
     currentIndexName: String, migrationIndexName: String, from: Int, pageSize: Int, filter: String
   )(implicit ec: ExecutionContext, logMarker: LogMarker = MarkerMap()): Future[FailedMigrationSummary] = {
-    val search = ElasticDsl.search(currentIndexName).trackTotalHits(true).from(from).size(pageSize) query must(
+    val search = ElasticDsl.search(currentIndexName).trackTotalHits(true).version(true).from(from).size(pageSize) query must(
       existsQuery(s"esInfo.migration.failures.$migrationIndexName"),
       termQuery(s"esInfo.migration.failures.$migrationIndexName.keyword", filter),
       not(matchQuery("esInfo.migration.migratedTo", migrationIndexName))
@@ -166,7 +166,8 @@ trait ThrallMigrationClient extends MigrationStatusProvider {
             uploadedBy = (sourceJson \ "uploadedBy").asOpt[String].getOrElse("-"),
             uploadTime = (sourceJson \ "uploadTime").asOpt[String].getOrElse("-"),
             sourceJson = Json.prettyPrint(sourceJson),
-            esDocAsImageValidationFailures = sourceJson.validate[Image].fold(failure => Some(failure.toString()), _ => None)
+            esDocAsImageValidationFailures = sourceJson.validate[Image].fold(failure => Some(failure.toString()), _ => None),
+            version = hit.version
           )
         }
 

--- a/thrall/app/views/migrationFailures.scala.html
+++ b/thrall/app/views/migrationFailures.scala.html
@@ -31,6 +31,11 @@
             Migration Failures - Page @(page) - <code>@filter</code>
         </h1>
         <p>@failures.totalFailed images failed with the above message!</p>
+        @if(shouldAllowReattempts) {
+            @form(action = routes.ThrallController.reattemptMigrationFailures(filter, page)){
+                <input type="submit" value="Reattempt all images on this page">
+            }
+        }
         @navigation
     </div>
 

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -5,13 +5,15 @@
 GET     /                                             controllers.ThrallController.index
 GET     /migrationFailuresOverview                    controllers.ThrallController.migrationFailuresOverview()
 GET     /migrationFailures                            controllers.ThrallController.migrationFailures(filter: String, page: Option[Int])
++nocsrf
+POST    /migrationFailures/reattempt                  controllers.ThrallController.reattemptMigrationFailures(filter: String, page: Int)
 
 +nocsrf
 POST    /startMigration                               controllers.ThrallController.startMigration
 +nocsrf
 POST    /pauseMigration                               controllers.ThrallController.pauseMigration
 +nocsrf
-POST    /resumeMigration                               controllers.ThrallController.resumeMigration
+POST    /resumeMigration                              controllers.ThrallController.resumeMigration
 +nocsrf
 POST    /migrate                                      controllers.ThrallController.migrateSingleImage
 +nocsrf

--- a/thrall/public/stylesheets/main.css
+++ b/thrall/public/stylesheets/main.css
@@ -30,5 +30,5 @@ body {
 }
 
 .headingRow {
-  top: 166px;
+  top: 190px;
 }


### PR DESCRIPTION
## What does this change?

<img width="406" alt="image" src="https://user-images.githubusercontent.com/10963046/177120391-43a31c7e-73cf-4075-8f32-6886b4a9e938.png">

Until now, retrying failed image migrations is an exercise in repeatedly clicking buttons, or making mass manual updates in ES - both undesirable. This PR adds a button that will retry failures a page at a time.

Caveat: manually enqueuing an image to be migrated now returns before a projection is attempted.
Pros: faster feedback for clicks, waiting for 250 images to be queued is much much faster than waiting for 250 images to be projected.
Cons: less feedback for images which fail to project due to problems internal to the image, a bigger and more confusing diff in this PR.

## How should a reviewer review this change?

Review commit-by-commit - I've done my best to split up the change from the prerequisite refactors, and each commit has a message describing the rationale.

## How should a reviewer test this change?

Deploy to TEST. There's currently a few thousand failed images there; feel free to try out the button. After clicking, return to the dashboard and do some refreshing. Does the number of failures go down? Go back to the main dashboard and resume the migration (or pause if running). Go back and do a batch retry again. Does it also work this time?

## How can success be measured?

Reduced chance of team members developing RSI

## Who should look at this?
 @guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
