### PR TITLE
[IMAGEDAM-927] visibility of Programmes/Archives metadata submenu

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -585,7 +585,7 @@
     </dl>
     </div>
 
-    <div ng-if="ctrl.singleImage && (ctrl.metadata.length > 0 || ctrl.additionalMetadata.length > 0 || ctrl.identifiers.length > 0)" class="image-info__group image-info__group--full-metadata" role="region" aria-label="Additional metadata">
+    <div ng-if="ctrl.singleImage && !ctrl.isAdditionalMetadataEmpty()" class="image-info__group image-info__group--full-metadata" role="region" aria-label="Additional metadata">
         <button class="metadata-reveal"
                 ng-click="ctrl.showMetadataSection('additionalMetadata')"
                 aria-label="{{ctrl.isMetadataSectionHidden('additionalMetadata') ? 'Show' : 'Hide'}} additional metadata section">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -584,8 +584,8 @@
             </dd>
     </dl>
     </div>
-    <!-- FIXME: iff has useful metadata -->
-    <div ng-if="ctrl.singleImage" class="image-info__group image-info__group--full-metadata" role="region" aria-label="Additional metadata">
+
+    <div ng-if="ctrl.singleImage && (ctrl.metadata.length > 0 || ctrl.additionalMetadata.length > 0 || ctrl.identifiers.length > 0)" class="image-info__group image-info__group--full-metadata" role="region" aria-label="Additional metadata">
         <button class="metadata-reveal"
                 ng-click="ctrl.showMetadataSection('additionalMetadata')"
                 aria-label="{{ctrl.isMetadataSectionHidden('additionalMetadata') ? 'Show' : 'Hide'}} additional metadata section">
@@ -612,7 +612,7 @@
         </div>
     </div>
 
-    <div ng-if="ctrl.singleImage" ng-repeat="spec in ctrl.domainMetadata" class="image-info__group image-info__group--full-domain-metadata"
+    <div ng-if="(ctrl.singleImage && ctrl.userCanEdit) || (ctrl.singleImage && !ctrl.userCanEdit && !ctrl.isDomainMetadataEmpty(spec.name))" ng-repeat="spec in ctrl.domainMetadata" class="image-info__group image-info__group--full-domain-metadata"
          role="region" aria-label="Domain metadata">
         <button class="metadata-reveal" ng-click="ctrl.showMetadataSection(spec.name)"
                 aria-label="{{ctrl.isMetadataSectionHidden(spec.name) ? 'Show' : 'Hide'}} {{spec.label}} domain metadata section">
@@ -625,8 +625,8 @@
             <span class="metadata__description" ng-if="spec.description">{{spec.description}}</span>
 
             <dl ng-repeat="specField in spec.fields" class="metadata__body image-info__group--dl">
-                <dt class="image-info__{{specField.name}} image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng-if="ctrl.userCanEdit">{{specField.label}}</dt>
-                <dd data-cy="metadata-{{specField.name}}" class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="ctrl.userCanEdit">
+                <dt class="image-info__{{specField.name}} image-info__wrap metadata-line image-info__group--dl__key metadata-line__key" ng-if="specField.value || ctrl.userCanEdit">{{specField.label}}</dt>
+                <dd data-cy="metadata-{{specField.name}}" class="image-info__wrap image-info__group--dl__value metadata-line__info" ng-if="specField.value || ctrl.userCanEdit">
 
                     <div ng-switch="specField.fieldType">
                         <span ng-switch-when="string">
@@ -648,7 +648,7 @@
                                 <span ng-if="specField.value">
                                     {{specField.value}}
                                 </span>
-                                <span class="editable-empty" ng-if="! specField.value">
+                                <span class="editable-empty" ng-if="! specField.value && ctrl.userCanEdit">
                                     Unknown (click ✎ to add)
                                 </span>
                             </span>
@@ -673,7 +673,7 @@
                                 <span ng-if="specField.value">
                                     {{specField.value | date:'d MMM yyyy, HH:mm'}}
                                 </span>
-                                <span class="editable-empty" ng-if="! specField.value">
+                                <span class="editable-empty" ng-if="! specField.value && ctrl.userCanEdit">
                                     Unknown (click ✎ to add)
                                 </span>
                             </span>
@@ -699,7 +699,7 @@
                                 <span ng-if="specField.value">
                                     {{specField.value}}
                                 </span>
-                                <span class="editable-empty" ng-if="! specField.value">
+                                <span class="editable-empty" ng-if="! specField.value && ctrl.userCanEdit">
                                     Unknown (click ✎ to add)
                                 </span>
                             </span>
@@ -725,7 +725,7 @@
                                 <span ng-if="specField.value">
                                     {{specField.value}}
                                 </span>
-                                <span class="editable-empty" ng-if="! specField.value">
+                                <span class="editable-empty" ng-if="! specField.value && ctrl.userCanEdit">
                                     Unknown (click ✎ to add)
                                 </span>
                             </span>
@@ -750,7 +750,7 @@
                                 <span ng-if="specField.value">
                                     {{specField.value}}
                                 </span>
-                                <span class="editable-empty" ng-if="! specField.value">
+                                <span class="editable-empty" ng-if="! specField.value && ctrl.userCanEdit">
                                     Unknown (click ✎ to add)
                                 </span>
                             </span>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -450,7 +450,7 @@ module.controller('grImageMetadataCtrl', [
     };
 
     ctrl.isAdditionalMetadataEmpty = () => {
-      var totalAdditionalMetadataCount = Object.keys(ctrl.metadata).filter(key=> { ctrl.isUsefulMetadata(key); }).length +
+      const totalAdditionalMetadataCount = Object.keys(ctrl.metadata).filter(key => ctrl.isUsefulMetadata(key)).length +
       Object.keys(ctrl.additionalMetadata).length +
       Object.keys(ctrl.identifiers).length;
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -448,6 +448,14 @@ module.controller('grImageMetadataCtrl', [
     ctrl.isDomainMetadataEmpty = (key) => {
       return ctrl.domainMetadata.find(obj => obj.name === key ).fields.every(field => field.value === undefined );
     };
+
+    ctrl.isAdditionalMetadataEmpty = () => {
+      var totalAdditionalMetadataCount = Object.keys(ctrl.metadata).filter(key=> { ctrl.isUsefulMetadata(key); }).length +
+      Object.keys(ctrl.additionalMetadata).length +
+      Object.keys(ctrl.identifiers).length;
+
+      return totalAdditionalMetadataCount == 0;
+    };
 }
 ]);
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -444,6 +444,10 @@ module.controller('grImageMetadataCtrl', [
       ctrl.metadata = metadata;
       ctrl.usageRights.first().data = usageRights;
     };
+
+    ctrl.isDomainMetadataEmpty = (key) => {
+      return ctrl.domainMetadata.find(obj => obj.name === key ).fields.every(field => field.value === undefined );
+    };
 }
 ]);
 


### PR DESCRIPTION
## What does this change?

This changes the visibility behavior of Hide/Show Programmes metadata and Hide/Show Archives metadata submenus. Given a user who cannot edit metadata and when selected image has no Programmes/Archives metadata to show anyway, then do not show the UI submenus "Hide/Show Programmes/Archives metadata" for this user

## How should a reviewer test this change?

1. Add the configuration below in common-lib/src/main/resources/application.conf
```

domainMetadata.specifications = [
{
    name = "programmes"
    label = "Programmes"
    description = "Model used for Programmes"
    fields = [
      {
        name = "originalTxDate"
        label = "Original TX Date"
        type = "datetime"
      }
      {
        name = "channels"
        label = "Channels"
        type = "string"
      }
      {
        name = "seriesNumber"
        label = "Series Number"
        type = "string"
      }
    ]
  },
  {
    name = "archives"
    label = "Archives"
    description = "Model used for Archives"
    fields = [
      {
        name = "hard_copy_ref_number"
        label = "Hard Copy Ref Number"
        type = "string"
      }
      {
        name = "original_filename"
        label = "Original Filename"
        type = "string"
      }
    ]
  }
]

```

The above configuration will display for the selected image, Programmes metadata submenu with three fields under it (Original TX Date, Channels, Series Number) as well as Archives metadata submenus also with three fields under it (Hard Copy Ref Number, Original Filename)
2. Log in as a user who cannot add or edit metadata
3. Search an image with no values for all the fields under Programmes metadata and/or Archives metadata (**might be easier to upload a new image with empty metadata rather than search an existing one**)
4. Select that image then in the Metadata tab to the right, the Hide/Show Programmes metadata and Hide/Show Archives metadata submenu should not be displayed
5. Log in as a user who can edit metadata
6. Search any image with metadata for Programmes metadata and Archives metadata
7. Select the image then in the Metadata tab to the right, the Hide/Show Programmes metadata and/or Hide/Show Archives metadata submenu should still be visible regardless if some fields have value, all fields have value or no fields have value

## How can success be measured?
Given the domainMetadata.specifications config shown above, a user with no edit rights can view and interact with the Hide/Show Programmes metadata and Hide/Show Archives metadata only if there are metadata present in these submenu. Otherwise, these UI components will be invisible to the user.

## Screenshots

User can edit. Programmes and Archives metadata are not empty (both panels visible)
<img width="1329" alt="Screen Shot 2022-07-05 at 1 15 10 AM" src="https://user-images.githubusercontent.com/79340179/177311128-2cf27f95-c7ef-4de5-880a-3401573f88a9.png">

User cannot edit. Programmes metadata is not empty (panel visible but empty items hidden). Archives metadata is empty (panel hidden)
<img width="1334" alt="Screen Shot 2022-07-05 at 1 40 20 AM" src="https://user-images.githubusercontent.com/79340179/177311159-905cfc88-68cf-448b-ba5d-89f4b7dcd4e8.png">


## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
