### PR TITLE
Get Grid running on M1 machines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - "9200:9200"
   imgops:
+    platform: 'linux/x86_64'
     build:
       context: ./dev/imgops
     ports:
@@ -19,6 +20,7 @@ services:
       - "9090:9000"
   localstack:
     image: localstack/localstack:0.12.3
+    platform: 'linux/x86_64'
     ports:
       - "4566:4566" # localstack's service proxy endpoint
       - "4572:4572" # localstack's direct S3 endpoint, needed for image and image-origin buckets (see nginx-mappings.yml)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.6.2


### PR DESCRIPTION
Co-authored by @andrew-nowak and @paperboyo 

## What does this change?

I had some trouble running Grid locally on my M1 Macbook. This PR makes some changes to get it running, specifically:
- Specifying a platform in `docker-compose.yaml`
- Bumping `sbt` to `1.6.2`. ( `1.7.1` introduced a separate issue so I used a smaller version bump)

## How should a reviewer test this change?

Run the grid locally on your machine following the instructions in the readme.

- Does it run on an M1 machine? (👍  it does for me)
- Does it run on a non-M1 machine? (👍 lgtm on my intel - @andrew-nowak )

## Tested? Documented?
- [X] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
