### PR TITLE
Load some dummy quota config when running locally

### DIFF
--- a/dev/config/rcs-quota.json
+++ b/dev/config/rcs-quota.json
@@ -1,0 +1,14 @@
+[
+  {
+    "agency": "rex",
+    "count": 1600
+  },
+  {
+    "agency": "aap",
+    "count": 400
+  },
+  {
+    "agency": "getty",
+    "count": 1000000
+  }
+]

--- a/dev/config/usages.eml
+++ b/dev/config/usages.eml
@@ -1,0 +1,30 @@
+Return-Path: <mlemos@acm.org>
+To: Manuel Lemos <mlemos@linux.local>
+Subject: Testing Manuel Lemos' MIME E-mail composing and sending PHP class: HTML message
+From: mlemos <mlemos@acm.org>
+Reply-To: mlemos <mlemos@acm.org>
+Sender: mlemos@acm.org
+X-Mailer: http://www.phpclasses.org/mimemessage $Revision: 1.63 $ (mail)
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----_=_next_enterprise_message"
+Message-ID: <20050430192829.0489.mlemos@acm.org>
+Date: Sat, 30 Apr 2005 19:28:29 -0300
+
+------_=_next_enterprise_message
+
+This is a multi-part message in MIME format.
+------_=_next_enterprise_message
+Content-Type: text/plain;
+              charset="UTF-8"
+
+attached Usage by Supplier daily for 2022-08-01-01-00-04
+
+------_=_next_enterprise_message
+Content-Type: application/octet-stream; name="Usage by Supplier daily.csv"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="Usage by Supplier daily.csv"
+
+IkNwcm8gTmFtZSIsIklkIg0KIkFsYW15IEltYWdlcyBMdGQiLCIxMDY3Ig0KIkF1c3RyYWxpYW4gQXNzb2NpYXRlZCBQcmVz
+cyBMaW1pdGVkIiwiNjk1Ig0KIkdldHR5IEltYWdlcyBJbnRlcm5hdGlvbmFsIiwiNjA1MCINCiJSZXggRmVhdHVyZXMgTHRk
+IiwiMTM4MyINCg==
+------_=_next_enterprise_message--

--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -207,6 +207,34 @@ setupPhotographersConfiguration() {
   echo "  uploaded file to $configBucket"
 }
 
+setupQuotasConfiguration () {
+  echo "setting up quotas configuration"
+
+  configBucket=$(getStackResource "$CORE_STACK_NAME" ConfigBucket)
+
+  target="$ROOT_DIR/dev/config/rcs-quota.json"
+
+  aws s3 cp "$target" \
+    "s3://$configBucket/" \
+    --endpoint-url $LOCALSTACK_ENDPOINT
+
+  echo "  uploaded file to $configBucket"
+}
+
+setupUsagesData () {
+  echo "setting up usages data"
+
+  usageBucket=$(getStackResource "$CORE_STACK_NAME" UsageMailBucket)
+
+  target="$ROOT_DIR/dev/config/usages.eml"
+
+  aws s3 cp "$target" \
+    "s3://$usageBucket/" \
+    --endpoint-url $LOCALSTACK_ENDPOINT
+
+  echo "  uploaded file to $usageBucket"
+}
+
 setupUsageRightsConfiguration() {
   echo "setting up usage rights configuration"
 
@@ -337,6 +365,8 @@ main() {
   fi
 
   setupPhotographersConfiguration
+  setupQuotasConfiguration
+  setupUsagesData
   setupUsageRightsConfiguration
   setupDevNginx
   generateConfig

--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -67,7 +67,9 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
     usageQuota.usageStore.getUsageStatus()
       .map((s: StoreAccess) => respond(s))
       .recover {
-        case e => respondError(InternalServerError, "unknown-error", e.toString)
+        case e =>
+          logger.error("quota access failed", e)
+          respondError(InternalServerError, "unknown-error", e.toString)
       }
   }
 }

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -17,9 +17,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val quotaStoreKey: String = string("quota.store.key")
   val quotaStoreConfig: StoreConfig = StoreConfig(configBucket, quotaStoreKey)
 
-  // quota updates can only be turned off in DEV
-  val quotaUpdateEnabled: Boolean = if (isDev) boolean("quota.update.enabled") else true
-
   //Lazy allows this to be empty and not break things unless used somewhere
   lazy val imgPublishingBucket = string("publishing.image.bucket")
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -201,11 +201,7 @@ class QuotaStore(
   def getQuota: Future[Map[String, SupplierUsageQuota]] = Future.successful(store.get())
 
   def update() {
-    if (config.quotaUpdateEnabled) {
-      store.send(_ => fetchQuota)
-    } else {
-      logger.info("Quota store updates disabled. Set quota.update.enabled in media-api.properties to enable.")
-    }
+    store.send(_ => fetchQuota)
   }
 
   private def fetchQuota: Map[String, SupplierUsageQuota] = {


### PR DESCRIPTION
## What does this change?

Load some dummy quota config when running locally
Makes running the quotas page locally more meaningful and easier to hack on

## How should a reviewer test this change?

Clear all local config (delete the docker-compose stack), run setup script, then visit <https://media.local.dev-gutools.co.uk/quotas>. Are there some dummy values there?

## How can success be measured?

## Who should look at this?

@rhystmills 

## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
