### PR TITLE
Embellish quotas page

### DIFF
--- a/kahuna/app/views/quotas.scala.html
+++ b/kahuna/app/views/quotas.scala.html
@@ -4,14 +4,40 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
-
+        <link rel="stylesheet" href="assets/stylesheets/main.css">
         <title>the grid - quotas</title>
         <link rel="media-api-uri" href="@mediaApiUri" />
     </head>
     <body>
-        <h1>Grid Quotas</h1>
-        <hr />
-        <div id="root"></div>
+        <style>
+            * {
+                box-sizing: border-box;
+            }
+            section, header {
+                padding: 12px;
+            }
+            header {
+                height: 50px;
+            }
+            h1 {
+                font-size: 2rem;
+                line-height: 2.6rem;
+            }
+            hr {
+                border: none;
+                border-bottom: 0.5px solid #565656;
+                margin: 0px;
+            }
+        </style>
+        <main>
+            <header>
+                <h1>Grid Quotas</h1>
+            </header>
+            <hr />
+            <section>
+                <div id="root"></div>
+            <section>
+        </main>
     </body>
     <script src="@routes.Assets.versioned("dist/quotas.js")"></script>
 </html>

--- a/kahuna/app/views/quotas.scala.html
+++ b/kahuna/app/views/quotas.scala.html
@@ -5,16 +5,26 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="assets/stylesheets/main.css">
-        <title>the grid - quotas</title>
+        <link rel="shortcut icon" type="image/svg+xml" href="/assets/images/grid-favicon.svg">
+        <title>quotas | the Grid</title>
         <link rel="media-api-uri" href="@mediaApiUri" />
     </head>
     <body>
         <style>
             * {
                 box-sizing: border-box;
+                text-align: left;
+                border-collapse: collapse;
             }
-            section, header {
+            section, h1 {
                 padding: 12px;
+            }
+            .usages {
+                padding: 24px;
+                margin: auto;
+                width: fit-content;
+                background-color: #333;
+                box-shadow: 0 1px 5px rgb(0 0 0 / 50%);
             }
             header {
                 height: 50px;
@@ -22,21 +32,46 @@
             h1 {
                 font-size: 2rem;
                 line-height: 2.6rem;
+                display: inline-block;
             }
             hr {
                 border: none;
                 border-bottom: 0.5px solid #565656;
                 margin: 0px;
             }
+            tr {
+                border-bottom: 1px solid #565656;
+            }
+            td {
+                color: #999;
+                font-size: 14px;
+                padding: 4px 12px 4px 4px;
+            }
+            th {
+                padding-top: 20px;
+            }
+            tr:first-child th {
+                padding-top: 0px;
+            }
+            meter {
+                width: 100px;
+                height: 16px;
+            }
+            .home-link {
+                border-right: 1px solid #565656;
+            }
         </style>
         <main>
             <header>
+                <a href="/search" class="home-link"></a>
                 <h1>Grid Quotas</h1>
             </header>
             <hr />
             <section>
-                <div id="root"></div>
-            <section>
+                <div class="usages">
+                    <table id="root"></table>
+                </div>
+            </section>
         </main>
     </body>
     <script src="@routes.Assets.versioned("dist/quotas.js")"></script>

--- a/kahuna/public/js/quotas.js
+++ b/kahuna/public/js/quotas.js
@@ -1,25 +1,37 @@
 const mediaApiUri = document.querySelector('link[rel="media-api-uri"').href;
 const usageUri = mediaApiUri + 'usage/quotas';
 
-function show(content) {
+const show = (content) => {
     document.getElementById("root").innerHTML = content;
-}
+};
 
-function renderSupplier(name, entry) {
-    const colour = entry.exceeded ? "red" : "green";
-
+const renderSupplier = (name, entry) => {
     const usage = entry.usage ? entry.usage.count : "unknown";
     const quota = entry.quota ? entry.quota.count : "unknown";
 
+    const warning = `– <span style="color: red"> quota exceeded</span>`;
+    const encouragement = `- <span style="color: green"> quota not full</span>`;
+    const meter = `<meter low="${quota - 2}" high="${quota - 1}" max="${quota}" value=${usage}>B</meter>`;
+
     return `
-        <li>
-            <h3 style="background-color: ${colour}">${name}</h3>
-            <small>
+        <tr>
+            <th colspan="3">
+                <h3>${name}  ${entry.exceeded ? warning : encouragement}</h3>
+            </th>
+        </tr>
+        <tr>
+            <td>
+                Usages:
+            </td>
+            <td>
                 ${usage}/${quota}
-            </small>
-        </li>
+            </td>
+            <td>
+                ${(typeof quota === "number" && typeof usage === "number") ? meter : ""}
+            </td>
+        </tr>
     `;
-}
+};
 
 fetch(usageUri, { credentials: "include" })
     .then(r => r.json())


### PR DESCRIPTION
## What does this change?

The quotas page looked a bit sad.

This PR makes the style more consistent with the rest of Grid, and attempts to communicate the usages more clearly with a meter.

| Before | After |
| --- | --- |
| ![Screenshot 2022-08-04 at 15 21 28](https://user-images.githubusercontent.com/34686302/182883272-eb8cce05-18bf-492e-bd2b-7dafdfb6c8a3.png)  | ![Screenshot 2022-08-04 at 16 11 15](https://user-images.githubusercontent.com/34686302/182883244-28896a1d-3568-4bc5-9f2e-e427864bfb84.png) |

It still looks a bit awkward as there's a small amount of information to display on quite a lot of screen space.

## How should a reviewer test this change?

1. Run Grid locally according to the instructions in the readme.
2. Visit the `quotas` page at https://media.local.dev-gutools.co.uk/quotas
3. Does everything look alright?


## Who should look at this?
Someone in @guardian/digital-cms

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
