### PR TITLE
Improve restrictions around sensible dateTaken values

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/ImageDataMerger.scala
@@ -147,8 +147,10 @@ class ImageDataMerger(gridClient: GridClient, services: Services, authFunction: 
 
   private def getFullMergedImageData(maybeImage: Option[Image])(implicit ec: ExecutionContext): Future[Option[Image]] = maybeImage match {
     case Some(image) =>
+      // time travel has not yet been invented, so we expect images to have been taken before they were uploaded
+      val latestAllowedDateTime = Some(image.uploadTime)
       // TODO I'm suspicious that we don't invoke the cleaners on this pass...
-      val imageWithMetadata = image.copy(originalMetadata = ImageMetadataConverter.fromFileMetadata(image.fileMetadata, latestAllowedDateTime = None))
+      val imageWithMetadata = image.copy(originalMetadata = ImageMetadataConverter.fromFileMetadata(image.fileMetadata, latestAllowedDateTime = latestAllowedDateTime))
       ImageDataMerger.aggregate(imageWithMetadata, gridClient, authFunction) map (i => Some(i))
     case None => Future.successful(None)
   }


### PR DESCRIPTION
## What does this change?

a couple of our images have very malformed datetakens, which place the value so far
in the future that we get integer overflow, and attempt to tell
elasticsearch that the images were taken over a hundred million years
ago. after some thinking we reckon it makes a reasonable amount of sense
to restrict dates to those in current calendar era (ie. in AD, ie. 1 AD -> uploadTime)

This PR also restricts datetakens during projection to be before upload time (there's little sense in an image where the dateTaken is after the uploadTime, at least until time travel is invented)

## How should a reviewer test this change?

Find some images with malformed (ie. future or pre-AD) datetakens / malform your own image's datetaken values, upload, project, etc. The malformed timestamps should be ignored.

eg. for image 4f304b65dde78b88823154d2607190b14d789f43, which has xmp field `"exif:DateTimeOriginal": "1008051601:00:00 00:00:"`:

Before:
```
"metadata": {
  "dateTaken": "-161056498-05-29T19:08:16.768Z",
  "description": "...",
  "credit": "...",
  "keywords": [
  ],
  "subjects": [
  ],
  "peopleInImage": [
  ]
},
```

After:
```
"metadata": {
  "description": "...",
  "credit": "...",
  "keywords": [
  ],
  "subjects": [
  ],
  "peopleInImage": [
  ]
},
```

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
