### PR TITLE
Skip counting the total hits for searches loading range of images

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -176,7 +176,7 @@ results.controller('SearchResultsCtrl', [
 
         ctrl.loadRange = function(start, end) {
             const length = end - start + 1;
-            search({offset: start, length: length}).then(images => {
+            search({offset: start, length: length, countAll: false}).then(images => {
                 // Update imagesAll with newly loaded images
                 images.data.forEach((image, index) => {
                     const position = index + start;
@@ -291,7 +291,7 @@ results.controller('SearchResultsCtrl', [
             return $stateParams.query || '*';
         }
 
-        function search({until, since, offset, length, orderBy} = {}) {
+        function search({until, since, offset, length, orderBy, countAll} = {}) {
             // FIXME: Think of a way to not have to add a param in a million places to add it
 
             /*
@@ -318,6 +318,9 @@ results.controller('SearchResultsCtrl', [
             if (angular.isUndefined(orderBy)) {
                 orderBy = $stateParams.orderBy;
             }
+            if (angular.isUndefined(countAll)) {
+              countAll = true;
+            }
 
             return mediaApi.search($stateParams.query, angular.extend({
                 ids:        $stateParams.ids,
@@ -337,7 +340,8 @@ results.controller('SearchResultsCtrl', [
                 orderBy:    orderBy,
                 hasRightsAcquired: $stateParams.hasRightsAcquired,
                 hasCrops: $stateParams.hasCrops,
-                syndicationStatus: $stateParams.syndicationStatus
+                syndicationStatus: $stateParams.syndicationStatus,
+                countAll
             }));
         }
 

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -17,7 +17,7 @@ mediaApi.factory('mediaApi',
                                  payType, uploadedBy, offset, length, orderBy,
                                  takenSince, takenUntil,
                                  modifiedSince, modifiedUntil, hasRightsAcquired, hasCrops,
-                                 syndicationStatus} = {}) {
+                                 syndicationStatus, countAll} = {}) {
         return root.follow('search', {
             q:          query,
             since:      since,
@@ -37,7 +37,8 @@ mediaApi.factory('mediaApi',
             orderBy:    getOrder(orderBy),
             hasRightsAcquired: maybeStringToBoolean(hasRightsAcquired),
             hasExports: maybeStringToBoolean(hasCrops), // Grid API calls crops exports...
-            syndicationStatus: syndicationStatus
+            syndicationStatus: syndicationStatus,
+            countAll
         }).get();
     }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -49,11 +49,34 @@ class MediaApi(
   val services: Services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   val gridClient: GridClient = GridClient(services)(ws)
 
-  private val searchParamList = List("q", "ids", "offset", "length", "orderBy",
-    "since", "until", "modifiedSince", "modifiedUntil", "takenSince", "takenUntil",
-    "uploadedBy", "archived", "valid", "free", "payType",
-    "hasExports", "hasIdentifier", "missingIdentifier", "hasMetadata",
-    "persisted", "usageStatus", "usagePlatform", "hasRightsAcquired", "syndicationStatus").mkString(",")
+  private val searchParamList = List(
+    "q",
+    "ids",
+    "offset",
+    "length",
+    "orderBy",
+    "since",
+    "until",
+    "modifiedSince",
+    "modifiedUntil",
+    "takenSince",
+    "takenUntil",
+    "uploadedBy",
+    "archived",
+    "valid",
+    "free",
+    "payType",
+    "hasExports",
+    "hasIdentifier",
+    "missingIdentifier",
+    "hasMetadata",
+    "persisted",
+    "usageStatus",
+    "usagePlatform",
+    "hasRightsAcquired",
+    "syndicationStatus",
+    "countAll"
+  ).mkString(",")
 
   private val searchLinkHref = s"${config.rootUri}/images{?$searchParamList}"
 

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -83,7 +83,8 @@ case class SearchParams(
                          usageStatus: List[UsageStatus] = List.empty,
                          usagePlatform: List[String] = List.empty,
                          tier: Tier,
-                         syndicationStatus: Option[SyndicationStatus] = None
+                         syndicationStatus: Option[SyndicationStatus] = None,
+  countAll: Option[Boolean] = None
                        )
 
 case class InvalidUriParams(message: String) extends Throwable
@@ -152,7 +153,8 @@ object SearchParams {
       commaSep("usageStatus").map(UsageStatus(_)),
       commaSep("usagePlatform"),
       request.user.accessor.tier,
-      request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus
+      request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus,
+      request.getQueryString("countAll") flatMap parseBooleanFromQuery,
     )
   }
 


### PR DESCRIPTION
This request doesnt care about an accurate count of total hits, only the initial search and the polling for new images do. I _think_ this is a source of how slow grid is to load images as we scroll (especially for empty searches) - if the hit count is entirely discarded, why even ask elasticsearch to calculate it? Hopefully this is a step towards tackling some of Grid's performance troubles.

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
