### PR TITLE
Upgrade to panda v1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
     "com.gu" %% "editorial-permissions-client" % "2.14",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

Switched Google API method used to check membership of mfa group from
groups.list(userKey) to members.hasMember.

See <https://github.com/guardian/pan-domain-authentication/releases/tag/v1.2.0>

This will unblock our user whose group memberships cannot be listed (due to a presumed google bug), but their membership of the MFA group can be tested directly.

## How should a reviewer test this change?

Check that you are able to sign in using this new method.
Already tested on TEST with the user in question.


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
