### PR TITLE
restore image draggability

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -145,8 +145,9 @@
                     </div>
 
                     <ui-preview-image image="image"
+                                      draggable="true"
                                       selection-mode="ctrl.inSelectionMode"
-                                      ng-class="{'preview__quick-select': ctrl.inSelectionMode}"
+                                      ng-class="{'preview__quick-select': ctrl.inSelectionMode, 'preview__select': !ctrl.inSelectionMode}"
                                       ng-click="ctrl.onImageClick(image, $event)">
                         <button class="mark-as-seen image-action"
                                 title="Mark all images until this point as seen"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1285,6 +1285,10 @@ FIXME: what to do with touch devices
     cursor: pointer;
 }
 
+.preview__select {
+  cursor: default;
+}
+
 .preview__fade {
     width: 100%;
     background: linear-gradient(to top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75));


### PR DESCRIPTION
A recent change to set images to `pointer-events:none` meant that the
images on the search page cannot be dragged, which breaks our support
for mass-dragging images into collections.

Instead of relying on the implicit draggability of images with css
pointer-events:auto, explicitly make the entire card draggable.
This may count as an improvement over the old behaviour as you can now
drag from anywhere inside the card, but you also cannot now select the
text in the card.

(Does this break anyone's workflow? You only get a few words here,
surely you would want to enter the full image before highlighting the
text?)

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [x] by @paperboyo 
- [ ] relevant documentation added or amended (if needed)
