### PR TITLE
Add some teal to represent successfully leased images

### DIFF
--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -11,27 +11,35 @@
             <li ng-repeat="cost in ctrl.selectedCosts | orderBy:'data'">
                 <div ng-switch="cost.data">
                     <div ng-switch-when="free"
-                         class="image-notice image-info__group status cost cost--free">
+                         class="image-notice image-info__group status cost cost--free"
+                    >
                         {{cost.count}} free
                     </div>
 
                     <div ng-switch-when="no_rights"
-                         class="image-notice image-info__group status cost cost--pay">
+                         class="image-notice image-info__group status cost cost--pay"
+                    >
                         {{cost.count}} no rights
                     </div>
 
                     <div ng-switch-when="pay"
-                         class="image-notice image-info__group status cost cost--pay">
+                         class="image-notice image-info__group status cost cost--pay"
+                         style="{{ctrl.stylePercentageLeased(cost)}}"
+                    >
                         {{cost.count}} paid
                     </div>
 
                     <div ng-switch-when="overquota"
-                         class="image-notice image-info__group status cost cost--pay">
+                         class="image-notice image-info__group status cost cost--pay"
+                         style="{{ctrl.stylePercentageLeased(cost)}}"
+                    >
                         {{cost.count}} over quota
                     </div>
 
                     <div ng-switch-when="conditional"
-                         class="image-notice image-info__group cost cost--conditional">
+                         class="image-notice image-info__group cost cost--conditional"
+                         style="{{ctrl.stylePercentageLeased(cost)}}"
+                    >
                         {{cost.count}} restricted
                     </div>
                 </div>
@@ -40,7 +48,7 @@
     </div>
 
     <div ng-if="ctrl.selectedImages.size > 0">
-        <gr-image-metadata 
+        <gr-image-metadata
             gr-images="ctrl.selectedImages"
             gr-user-can-edit="ctrl.userCanEdit"
         ></gr-image-metadata>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -59,16 +59,22 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
     inject$($scope, selectedImagesList$, ctrl, 'selectedImages');
 
     const selectedCosts$ = selectedImagesList$.
-    map(imageList.getCostState).
-    map(imageList.getOccurrences);
+      map(imageList.getCostState).
+      map(imageList.getOccurrences);
     inject$($scope, selectedCosts$, ctrl, 'selectedCosts');
 
     const selectionIsEditable$ = selectedImagesList$.
-    map(list => list.map(editsService.canUserEdit).toArray()).
-    map($q.all).
-    flatMap(Rx.Observable.fromPromise).
-    map(allEditable => allEditable.every(v => v === true));
+      map(list => list.map(editsService.canUserEdit).toArray()).
+      map($q.all).
+      flatMap(Rx.Observable.fromPromise).
+      map(allEditable => allEditable.every(v => v === true));
     inject$($scope, selectionIsEditable$, ctrl, 'userCanEdit');
+
+    ctrl.stylePercentageLeased = cost => {
+      const imageIsOfThisTypeAndIsLeased = (img) => img.data.cost === cost.data && img.data?.leases?.data?.leases?.some(lease => lease.access === 'allow-use' && lease.active);
+      const countLeased = ctrl.selectedImages.count(imageIsOfThisTypeAndIsLeased);
+      return `--pct-leased: ${Math.floor(100 * countLeased / cost.count)}`;
+    };
 
   }
 ]);

--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -28,7 +28,7 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
             cost,
             hasCrops: image.data.exports && image.data.exports.length > 0,
             hasRights,
-            costState: hasRights ? cost : "no_rights",
+            costState: hasRights && image.data.valid ? cost : "no_rights",
             isValid: image.data.valid,
             canDelete: imageLogic.canBeDeleted(image),
             canArchive: imageLogic.canBeArchived(image),

--- a/kahuna/public/js/leases/leases.css
+++ b/kahuna/public/js/leases/leases.css
@@ -62,11 +62,15 @@ gr-leases .metadata-line__key {
   margin-bottom: 10px
 }
 
-.allowed {
+.lease__access.lease__allow {
   background-color: #90ee90;
 }
 
-.denied {
+.lease__access.lease__allow.lease__use {
+  background-color: teal;
+}
+
+.lease__access.lease__deny {
   background-color: red;
 }
 
@@ -110,8 +114,7 @@ gr-leases .gu-date-range__display {
   background-color: inherit;
 }
 
-.lease__access,
-.lease__current {
+.lease__access {
   box-sizing: border-box;
   width: 100%;
   float: left;
@@ -122,16 +125,21 @@ gr-leases .gu-date-range__display {
   margin-bottom: 2px;
 }
 
-.lease__current {
-  padding: 2px;
-}
-
-.lease__current.current {
-  background-color: #00ADEE;
-}
-
-.current {
+.lease__wrapper {
   color: white;
+  border-top: 5px solid white;
+}
+
+.lease__wrapper.lease__inactive {
+  opacity: 0.5;
+}
+
+.lease__wrapper.lease__allow {
+  border-color: teal;
+}
+
+.lease__wrapper.lease__deny {
+  border-color: red;
 }
 
 gr-leases.leases-flex {

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -129,11 +129,7 @@
         class="lease__item"
         gr-tooltip-position="bottom">
 
-        <div class="lease__current" ng-class="ctrl.leaseStatus(lease).current" ng-if="ctrl.leaseStatus(lease).current"></div>
-
-        <div class="lease__access" ng-class="ctrl.leaseStatus(lease).access"></div>
-
-        <div class="lease__wrapper" ng-class="ctrl.leaseStatus(lease).current">
+        <div class="lease__wrapper" ng-class="ctrl.leaseClass(lease)">
           <div class="lease">
             <div class="lease__text">
               <div>{{ctrl.leaseName(lease)}}</div>

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -230,6 +230,11 @@ leases.controller('LeasesCtrl', [
 
         ctrl.isCurrent = (lease) => lease.active && lease.access.match(/-use/i);
 
+        ctrl.leaseClass = (lease) => {
+          const names = [...lease.access.split('-'), lease.active ? 'active' : 'inactive'];
+          return names.map(name => `lease__${name}`).join(' ');
+        };
+
         ctrl.leaseStatus = (lease) => {
             const active = lease.active ? 'active ' : ' ';
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -140,16 +140,18 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
                 </div>
 
                 <div ng-switch-when="overquota"
-                     class="cost cost--overquota"
-                     title="Quota for images from this supplier has been exceeded!">
+                     class="cost"
+                     ng-class="{'cost--overquota': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
+                     title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Quota for images from this supplier has been exceeded!">
 
                     <!-- material icons doesn't have a £ icon -->
                     <gr-icon>trending_up</gr-icon>
                 </div>
 
                 <div ng-switch-when="pay"
-                     class="cost cost--pay"
-                     title="Pay to use">
+                     class="cost"
+                     ng-class="{'cost--pay': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
+                     title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Pay to use">
 
                     <!-- material icons doesn't have a £ icon -->
                     <span>£</span>
@@ -157,8 +159,9 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
 
 
                 <div ng-switch-when="conditional"
-                     class="cost cost--conditional"
-                     title="{{ctrl.image.data.usageRights.restrictions}}">
+                     class="cost"
+                     ng-class="{'cost--conditional': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
+                     title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Restrictions: {{ctrl.image.data.usageRights.restrictions}}">
                      <!-- As `conditional` can only be set with usageRights, let's
                      just assume it's here. We might need to revisit this. -->
                     <gr-icon>flag</gr-icon>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -105,6 +105,7 @@ image.controller('uiPreviewImageCtrl', [
 
     ctrl.srefNonfree = () => storage.getJs("isNonFree", true) ? true : undefined;
 
+    ctrl.hasActiveAllowLease = ctrl.image.data.leases.data.leases.find(lease => lease.active && lease.access === 'allow-use');
 }]);
 
 image.directive('uiPreviewImage', function() {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -973,8 +973,23 @@ textarea.ng-invalid {
 .cost--conditional {
     background-color: orange;
 }
+.cost--leased {
+  background-color: teal;
+}
 .cost--free {
     background-color: green;
+}
+
+.image-notice {
+  --pct-leased: 0;
+}
+
+.image-notice.cost--pay {
+  background-image: linear-gradient(90deg, teal 0 calc(var(--pct-leased) * 1%), red calc(var(--pct-leased) * 1%) 100%);
+}
+
+.image-notice.cost--conditional {
+  background-image: linear-gradient(90deg, teal 0 calc(var(--pct-leased) * 1%), orange calc(var(--pct-leased) * 1%) 100%);
 }
 
 .costs li {


### PR DESCRIPTION
## What does this change?

Users have suggested that it would be useful to be able to see when an image has been leased more clearly. It is essentially visible on the image detail page (lease is large and visible, and the red danger banner goes yellow/warning once lease is added). But the flags on the search page and the status info boxes when multiple selecting could switch.

We've discussed colour and we are opposed to green (green should be reserved for free images only - paid/overquota/restricted images don't become free once leased) so we've picked *teal* `#008080` (positive but not *too* positive).

We've also removed the blue stripe on leases - it showed if a lease was active but no one knew what it meant. The lease now fades out when inactive.

Some pics:

![image](https://user-images.githubusercontent.com/10963046/188931029-a237c6eb-4f16-4a70-948a-6913ba933320.png)
![image](https://user-images.githubusercontent.com/10963046/188931133-7fdc3845-5398-4adc-aa78-876e00ec4aed.png)
![image](https://user-images.githubusercontent.com/10963046/188931305-99815dbe-e237-407e-94a3-c897f6af15d7.png)


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
