### PR TITLE
tweaks to the imgops image to run on m1

### DIFF
--- a/dev/imgops/Dockerfile
+++ b/dev/imgops/Dockerfile
@@ -1,6 +1,7 @@
-FROM debian:jessie
+FROM ubuntu:focal
 MAINTAINER The Guardian
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get --yes update && apt-get --yes install \
     nginx \
     nginx-extras

--- a/dev/imgops/nginx.conf
+++ b/dev/imgops/nginx.conf
@@ -1,3 +1,4 @@
+load_module /usr/lib/nginx/modules/ngx_http_image_filter_module.so;
 events {
   worker_connections  1024;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     ports:
       - "9200:9200"
   imgops:
-    platform: 'linux/x86_64'
     build:
       context: ./dev/imgops
     ports:


### PR DESCRIPTION

## What does this change?

- switch from debian to ubuntu (slightly more modern nginx, docker
  images are built natively for arm64)
- set DEBIAN_FRONTEND=noninteractive (prevents images getting stuck
  waiting for input during an apt-get)
- explicitly load the nginx image filter
- allow docker to run the container on the same cpu architecture as the
  host

## How should a reviewer test this change?

Run grid locally. Does the imgops docker container spin up and work correctly?

## How can success be measured?

Local development is fully supported on both amd64 and arm64 hosts.