### PR TITLE
Fix WCAG contrast failed checks on image information panel

### DIFF
--- a/kahuna/public/js/edits/list-editor.css
+++ b/kahuna/public/js/edits/list-editor.css
@@ -117,7 +117,7 @@ element--partial is part of gr-panel.
 .image-info__keywords .element__remove,
 .image-info__keywords .element__add {
     background-color: #222;
-    color: #999;
+    color: #aaa;
     border-bottom: 0px;
 }
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1674,17 +1674,17 @@ FIXME: what to do with touch devices
 }
 
 .image-info__title {
-    color: #ccc;
+    color: #eee;
 }
 
 .image-info__file-size {
-    color: #ccc;
+    color: #eee;
     font-size: 1.2rem;
     font-weight: normal;
 }
 
 .image-info__heading {
-    color: #999;
+    color: #aaa;
     font-weight: bold;
     padding-bottom: 3px;
     display: flex;
@@ -1704,7 +1704,7 @@ FIXME: what to do with touch devices
 .image-info__special-instructions {
     /* respect newlines in text */
     white-space: pre-line;
-    color: #CCC;
+    color: #eee;
 }
 
 .image-info__description--options {
@@ -1720,7 +1720,7 @@ FIXME: what to do with touch devices
 .image-info__keyword li {
     display: inline-block;
     background-color: #222;
-    color: #999;
+    color: #aaa;
     border-radius: 8px;
     padding: 0 8px;
     margin-right: 5px;
@@ -1783,7 +1783,7 @@ FIXME: what to do with touch devices
 
 .image-info__wrap .editable-empty,
 .image-info__wrap .editable-empty:hover {
-    color: #999;
+    color: #aaa;
 }
 
 .image-info__wrap .editable-wrap .image-info__editor--error {
@@ -1827,7 +1827,7 @@ FIXME: what to do with touch devices
 }
 
 .metadata-line__info {
-    color: #ccc;
+    color: #eee;
     padding-bottom: 10px;
 }
 
@@ -1848,13 +1848,13 @@ FIXME: what to do with touch devices
 }
 .metadata-line__key {
     font-weight: bold;
-    color: #999;
+    color: #aaa;
     vertical-align: top;
     text-align: left;
 }
 
 .metadata-reveal {
-    color: #999;
+    color: #aaa;
     font-size: 1.4rem;
     font-family: inherit;
 }


### PR DESCRIPTION
## What does this change?

This PR changes the font color on the text-based UI elements on the information panel (`#333` background color) to pass WCAG contrast checks on the image view page (see failed contrast check screenshot). 

This change affects the following UI elements:
- Information panel section titles (`#999` to `#aaa`)
- Metadata field names (`#999` to `#aaa`)
- Metadata field values (`#ccc` to `#eee`)
- Image crop section title (`#999` to `#aaa`)

**Screenshot of failed contrast check**
![WCAG Color Contrast - FAIL](https://user-images.githubusercontent.com/12212239/189707887-ac0dc752-17a1-4e24-80b5-717fc82327ad.png)


**Screenshot of passed contrast check**
![WCAG Color Contrast - PASS](https://user-images.githubusercontent.com/12212239/189707874-1f8b1f47-df04-4b2f-b9e3-cc2cc4bec69d.png)


## How should a reviewer test this change?

1. Install [WCAG Contrast checker browser extension](https://chrome.google.com/webstore/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf?hl=en)
2. Run Contrast Level AA check

## How can success be measured?

All important information on the information panel should pass the WCAG AA contrast check.

## Who should look at this?

@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
