### PR TITLE
introduce `--no-auth` flag for `setup.sh` and `start.sh` scripts for easier local development

### DIFF
--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -10,6 +10,7 @@ function getCorsAllowedOriginString(config) {
 }
 
 function getCommonConfig(config) {
+  const isNoAuth = process.env.NO_AUTH === "true";
   return `domain.root="${config.DOMAIN}"
         |authentication.providers.machine.config.authKeyStoreBucket="${config.coreStackProps.KeyBucket}"
         |aws.local.endpoint="https://localstack.media.${config.DOMAIN}"
@@ -18,6 +19,8 @@ function getCommonConfig(config) {
         |es.index.aliases.current="Images_Current"
         |es.index.aliases.migration="Images_Migration"
         |image.record.download=false
+        ${isNoAuth ? '|authentication.providers.user="com.gu.mediaservice.lib.auth.provider.LocalAuthenticationProvider"' : ''}
+        ${isNoAuth ? '|authorisation.provider="com.gu.mediaservice.lib.auth.provider.LocalAuthorisationProvider"' : ''}
         |`;
 }
 

--- a/dev/script/start.sh
+++ b/dev/script/start.sh
@@ -27,6 +27,10 @@ for arg in "$@"; do
     LOCAL_AUTH=true
     shift
   fi
+  if [ "$arg" == "--no-auth" ]; then
+    LOCAL_AUTH=true
+    shift
+  fi
 done
 
 isInstalled() {

--- a/docs/01-setup/03-running-setup.md
+++ b/docs/01-setup/03-running-setup.md
@@ -19,7 +19,7 @@ From the project root, run:
 
 This process will take a little while to complete.
 
-If you see an error message similar to `nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size`, follow [these instructions](https://github.com/guardian/dev-nginx/blob/main/TROUBLESHOOTING.md#hash-bucket-size-emerg) and then run the setup script again. 
+If you see an error message similar to `nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size`, follow [these instructions](https://github.com/guardian/dev-nginx/blob/main/TROUBLESHOOTING.md#hash-bucket-size-emerg) and then run the setup script again.
 
 ### Available flags
 There are a few options available for `setup.sh`.
@@ -35,3 +35,6 @@ Adding the `--with-local-auth` flag will result in:
 - the generation of pan-domain-authentication settings and a number of [users](../../dev/config/users.json)
 
 Using this flag is encouraged if you're outside the Guardian and want to run Grid locally without setting up pan-domain-authentication for real.
+
+#### `--no-auth`
+Adding this flag will result in effectively no auth, you'll be signed in automatically as John Doe (with no oauth flow) and will have ALL permissions.

--- a/docs/02-running/01-running-locally.md
+++ b/docs/02-running/01-running-locally.md
@@ -27,7 +27,7 @@ or your favourite IDE.
 Adding the `--ship-logs` flag will ship logs to a [local elk](https://github.com/guardian/local-elk) stack over tcp on port `5000`.
 You'll need to be sure `local-elk` is running beforehand to sure port `5000` is open.
 
-#### `--with-local-auth`
+#### `--with-local-auth` or `--no-auth`
 If you previously ran `setup.sh` using this flag, you'll also need to use it in `start.sh`.
 
 ## `the_pingler.sh`
@@ -53,6 +53,8 @@ This is the [oidc-provider](../../dev/oidc-provider) and we can login to Grid us
 [`users.json`](../../dev/config/users.json), for example `grid-demo-account@guardian.co.uk`. There isn't a password, so enter any value.
 
 If you haven't used the `--with-local-auth` flag, you'll begin a Google authentication flow.
+
+If you have used the `--no-auth` flag you'll be signed in automatically as John Doe (with no oauth flow) and will have ALL permissions.
 
 ## Cerebro
 


### PR DESCRIPTION
https://trello.com/c/9qsSL3Am

https://github.com/guardian/grid/pull/3226 was quite confusing and undocumented, here we introduce a new flag `--no-auth` for the `setup.sh` and `start.sh` scripts (which replaces $LOCAL_SIMPLE_AUTH_PROVIDER and better describes the behaviour) and it now changes the auth providers in the generated config rather than re-writing the `application.conf` file (since that could easily get committed).

_NOTE: The `--with-local-auth` is still potentially broken (I couldn't get it working, and other users outside Guardian have reported problems) - I've created https://trello.com/c/3cF1guts/2825-fix-improve-with-local-auth-option-in-grid-setup-start to revisit this. **EDIT:** this looks to have been picked up in https://github.com/guardian/grid/pull/3865_
