### PR TITLE
get local auth running again

### DIFF
--- a/dev/oidc-provider/app.js
+++ b/dev/oidc-provider/app.js
@@ -55,6 +55,9 @@ const oidc = new Provider(issuer, {
     openid: [ "sub", "email", "email_verified", "given_name", "family_name", "name" ]
   },
   proxy: true,
+  pkce: {
+    required: () => false
+  },
   findAccount
 });
 

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -198,7 +198,7 @@ function getGridProdConfig(config) {
   return stripMargin`
     |auth.useLocal=true
     |panda.userDomain="${config.EMAIL_DOMAIN}"
-    |panda.bucketName="${config.authStackProps.PanDomainBucket}"
+    |authentication.providers.user.config.panda.bucketName="${config.authStackProps.PanDomainBucket}"
     |permissions.bucket="${config.authStackProps.PermissionsBucket}"
     |`;
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -16,7 +16,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
   extends AuthorisationProvider with StrictLogging {
 
   def config: CommonConfig = resources.commonConfig
-  def permissionsBucket: String = configuration.getOptional[String]("permissions.bucket").getOrElse("permissions-cache")
+  def permissionsBucket: String = config.configuration.getOptional[String]("permissions.bucket").getOrElse("permissions-cache")
 
   private val permissions: PermissionsProvider = config.awsLocalEndpoint match {
     case Some(_) if config.isDev && config.useLocalAuth =>


### PR DESCRIPTION
## What does this change?

A couple of places were looking for config on the wrong object / under the wrong key, and oidc-provider seems to now need PKCE disabling to work with grid locally. 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
