### PR TITLE
Remove useless `Reuters Photographer` byline

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -26,7 +26,9 @@ object RedundantTokenRemover extends MetadataCleaner {
     "uncredited",
     "XXSTRINGERXX xxxxx",
     "AFP Contributor",
-    "AFP Contributor#AFP"
+    "AFP Contributor#AFP",
+    "Reuters Photographer",
+    "REUTERS PHOTOGRAPHER"
   )
 
   override def clean(metadata: ImageMetadata): ImageMetadata = metadata.copy(


### PR DESCRIPTION
## What does this change?

Removes variously capitalised `Reuters Photographer` byline/credit token.

## How can success be measured?

Less useless metadata to cleanup manually.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
