### PR TITLE
UI changes on the grid view/image preview tile

### DIFF
--- a/kahuna/public/js/components/gr-icon/gr-icon.css
+++ b/kahuna/public/js/components/gr-icon/gr-icon.css
@@ -37,6 +37,10 @@ gr-icon .gr-icon--small {
     font-size: 1.2rem;
 }
 
+.gr-icon--large {
+    font-size: 20px;
+}
+
 gr-icon-label .icon-label {
     vertical-align: middle;
 }

--- a/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
+++ b/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
@@ -1,5 +1,5 @@
 <div title="{{ ctrl.states.syndicationReason }}">
-    <gr-icon class="syndication-status--{{ ctrl.states.syndicationStatus }}">
+    <gr-icon style="font-size: 20px;" class="syndication-status--{{ ctrl.states.syndicationStatus }}">
         monetization_on
     </gr-icon>
 </div>

--- a/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
+++ b/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
@@ -1,5 +1,5 @@
 <div title="{{ ctrl.states.syndicationReason }}">
-    <gr-icon style="font-size: 20px;" class="syndication-status--{{ ctrl.states.syndicationStatus }}">
+    <gr-icon class="gr-icon--large" class="syndication-status--{{ ctrl.states.syndicationStatus }}">
         monetization_on
     </gr-icon>
 </div>

--- a/kahuna/public/js/preview/image-large.html
+++ b/kahuna/public/js/preview/image-large.html
@@ -99,7 +99,7 @@
         <div class="preview__bottom-bar bottom-bar preview__bottom-bar--large">
             <div class="bottom-bar__meta">
                 <span class="preview__upload-time">
-                    {{ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
+                    Uploaded: {{ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
                     {{ctrl.image.data.uploadTime | date:'HH:mm'}}
                 </span>
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -99,75 +99,69 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
             </span>
         </div>
     </div>
+    <div class="preview__bottom-icons">
+        <span class="bottom-bar__meta-item preview__has-crops"
+              title="this image has crops"
+              ng-if="ctrl.states.hasCrops">
+                <gr-icon style="font-size: 22px;">crop</gr-icon>
+        </span>
 
-    <div class="preview__info-flex">
-        <div class="preview__info-inline">
-            <span class="bottom-bar__meta-item preview__has-crops"
-                  title="this image has crops" ng-if="ctrl.states.hasCrops">
-                    <gr-icon style = "font-size: 22px;">crop</gr-icon>
-            </span>
+        <span class="bottom-bar__meta-item preview__has-print-usages"
+              title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
+              ng-if="ctrl.hasPrintUsages">
+                <gr-icon style="font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
+        </span>
 
-            <span class="bottom-bar__meta-item preview__has-print-usages"
-                  title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
-                  ng-if="ctrl.hasPrintUsages">
-                    <gr-icon style = "font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
-            </span>
+        <span class="bottom-bar__meta-item preview__has-web-usages"
+              title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
+              ng-if="ctrl.hasDigitalUsages">
+                <gr-icon style="font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
+        </span>
 
-            <span class="bottom-bar__meta-item preview__has-web-usages"
-                  title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
-                  ng-if="ctrl.hasDigitalUsages">
+        <span ng-switch="ctrl.flagState">
+            <div ng-switch-when="no_rights"
+                 class="cost cost--no_rights bottom-bar__action bottom-bar__action--cost preview__cost preview__bottom-icons-align-right"
+                 title="No current rights to use this image!">
 
-                    <gr-icon style = "font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
-            </span>
-        </div>
-
-        <div class="preview__info-inline">
-            <div class="bottom-bar__action bottom-bar__action--cost preview__cost align-right"
-
-                 ng-switch="ctrl.flagState">
-                <div ng-switch-when="no_rights"
-                     class="cost cost--no_rights"
-                     title="No current rights to use this image!">
-
-                    <!-- material icons doesn't have a £ icon -->
-                    <gr-icon>warning</gr-icon>
-                </div>
-
-                <div ng-switch-when="overquota"
-                     class="cost cost--overquota"
-                     title="Quota for images from this supplier has been exceeded!">
-
-                    <!-- material icons doesn't have a £ icon -->
-                    <gr-icon>trending_up</gr-icon>
-                </div>
-
-                <div ng-switch-when="pay"
-                     class="cost cost--pay"
-                     title="Pay to use">
-
-                    <!-- material icons doesn't have a £ icon -->
-                    <span>£</span>
-                </div>
-
-                <div
-                    class="cost cost--conditional"
-                    title="{{ctrl.image.data.usageRights.restrictions}}">
-                    <!-- As `conditional` can only be set with usageRights, let's
-                    just assume it's here. We might need to revisit this. -->
-                    <gr-icon>flag</gr-icon>
-                </div>
+                <!-- material icons doesn't have a £ icon -->
+                <gr-icon>warning</gr-icon>
             </div>
 
-            <div class="bottom-bar__action align-right" ng-if="ctrl.states.syndicationStatus !== 'unsuitable'">
-                <gr-syndication-icon image="ctrl.image"></gr-syndication-icon>
+            <div ng-switch-when="overquota"
+                 class="cost bottom-bar__action bottom-bar__action--cost preview__cost preview__bottom-icons-align-right"
+                 ng-class="{'cost--overquota': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
+                 title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Quota for images from this supplier has been exceeded!">
+
+                <!-- material icons doesn't have a £ icon -->
+                <gr-icon>trending_up</gr-icon>
             </div>
 
-            <gr-archiver-status class="bottom-bar__action align-right"
-                                image="ctrl.image"
-                                readonly="ctrl.selectionMode">
-            </gr-archiver-status>
+            <div ng-switch-when="pay"
+                 class="cost bottom-bar__action bottom-bar__action--cost preview__cost preview__bottom-icons-align-right"
+                 ng-class="{'cost--pay': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
+                 title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Pay to use">
 
+                <!-- material icons doesn't have a £ icon -->
+                <span>£</span>
+            </div>
+
+            <div ng-switch-when="conditional"
+                 class="cost bottom-bar__action bottom-bar__action--cost preview__cost preview__bottom-icons-align-right"
+                 ng-class="{'cost--conditional': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
+                 title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Restrictions: {{ctrl.image.data.usageRights.restrictions}}">
+                 <!-- As `conditional` can only be set with usageRights, let's
+                 just assume it's here. We might need to revisit this. -->
+                <gr-icon>flag</gr-icon>
+            </div>
+        </span>
+
+        <div class="bottom-bar__action preview__bottom-icons-align-right" ng-if="ctrl.states.syndicationStatus !== 'unsuitable'">
+            <gr-syndication-icon image="ctrl.image"></gr-syndication-icon>
         </div>
 
+        <gr-archiver-status class="bottom-bar__action preview__bottom-icons-align-right"
+                            image="ctrl.image"
+                            readonly="ctrl.selectionMode">
+        </gr-archiver-status>
     </div>
 </div>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -94,42 +94,36 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
         <div class="bottom-bar__meta">
             <span class="preview__upload-time" title="Uploaded: {{::ctrl.image.data.uploadTime | date:'d MMM yyyy, HH:mm'}}
       Taken: {{::(ctrl.image.data.metadata.dateTaken | date:'d MMM yyyy, HH:mm') || '[none]'}}">
-                {{::ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
+                Uploaded: {{::ctrl.image.data.uploadTime | date:'dd/MM/yy'}}
                 {{::ctrl.image.data.uploadTime | date:'HH:mm'}}
             </span>
+        </div>
+    </div>
 
+    <div class="preview__info-flex">
+        <div class="preview__info-inline">
             <span class="bottom-bar__meta-item preview__has-crops"
-                  title="this image has crops"
-                  ng-if="ctrl.states.hasCrops">
-
-                <gr-icon gr-small>crop</gr-icon>
+                  title="this image has crops" ng-if="ctrl.states.hasCrops">
+                    <gr-icon style = "font-size: 22px;">crop</gr-icon>
             </span>
 
             <span class="bottom-bar__meta-item preview__has-print-usages"
                   title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
                   ng-if="ctrl.hasPrintUsages">
-                <gr-icon gr-small ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
+                    <gr-icon style = "font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
             </span>
 
             <span class="bottom-bar__meta-item preview__has-web-usages"
                   title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
                   ng-if="ctrl.hasDigitalUsages">
 
-                <gr-icon gr-small ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
+                    <gr-icon style = "font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
             </span>
         </div>
-        <div>
-            <gr-archiver-status class="bottom-bar__action"
-                                image="ctrl.image"
-                                readonly="ctrl.selectionMode">
-            </gr-archiver-status>
 
-            <div class="bottom-bar__action" ng-if="ctrl.states.syndicationStatus !== 'unsuitable'">
-                <gr-syndication-icon image="ctrl.image"></gr-syndication-icon>
-            </div>
+        <div class="preview__info-inline">
+            <div class="bottom-bar__action bottom-bar__action--cost preview__cost align-right"
 
-            <div class="bottom-bar__action bottom-bar__action--cost preview__cost"
-                 ng-if="ctrl.flagState !== 'free'"
                  ng-switch="ctrl.flagState">
                 <div ng-switch-when="no_rights"
                      class="cost cost--no_rights"
@@ -140,33 +134,40 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
                 </div>
 
                 <div ng-switch-when="overquota"
-                     class="cost"
-                     ng-class="{'cost--overquota': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
-                     title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Quota for images from this supplier has been exceeded!">
+                     class="cost cost--overquota"
+                     title="Quota for images from this supplier has been exceeded!">
 
                     <!-- material icons doesn't have a £ icon -->
                     <gr-icon>trending_up</gr-icon>
                 </div>
 
                 <div ng-switch-when="pay"
-                     class="cost"
-                     ng-class="{'cost--pay': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
-                     title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Pay to use">
+                     class="cost cost--pay"
+                     title="Pay to use">
 
                     <!-- material icons doesn't have a £ icon -->
                     <span>£</span>
                 </div>
 
-
-                <div ng-switch-when="conditional"
-                     class="cost"
-                     ng-class="{'cost--conditional': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
-                     title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Restrictions: {{ctrl.image.data.usageRights.restrictions}}">
-                     <!-- As `conditional` can only be set with usageRights, let's
-                     just assume it's here. We might need to revisit this. -->
+                <div
+                    class="cost cost--conditional"
+                    title="{{ctrl.image.data.usageRights.restrictions}}">
+                    <!-- As `conditional` can only be set with usageRights, let's
+                    just assume it's here. We might need to revisit this. -->
                     <gr-icon>flag</gr-icon>
                 </div>
             </div>
+
+            <div class="bottom-bar__action align-right" ng-if="ctrl.states.syndicationStatus !== 'unsuitable'">
+                <gr-syndication-icon image="ctrl.image"></gr-syndication-icon>
+            </div>
+
+            <gr-archiver-status class="bottom-bar__action align-right"
+                                image="ctrl.image"
+                                readonly="ctrl.selectionMode">
+            </gr-archiver-status>
+
         </div>
+
     </div>
 </div>

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -103,19 +103,19 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
         <span class="bottom-bar__meta-item preview__has-crops"
               title="this image has crops"
               ng-if="ctrl.states.hasCrops">
-                <gr-icon style="font-size: 22px;">crop</gr-icon>
+                <gr-icon style="font-size: 20px;">crop</gr-icon>
         </span>
 
         <span class="bottom-bar__meta-item preview__has-print-usages"
               title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
               ng-if="ctrl.hasPrintUsages">
-                <gr-icon style="font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
+                <gr-icon style="font-size: 20px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
         </span>
 
         <span class="bottom-bar__meta-item preview__has-web-usages"
               title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
               ng-if="ctrl.hasDigitalUsages">
-                <gr-icon style="font-size: 22px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
+                <gr-icon style="font-size: 20px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
         </span>
 
         <span ng-switch="ctrl.flagState">

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -103,19 +103,19 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
         <span class="bottom-bar__meta-item preview__has-crops"
               title="this image has crops"
               ng-if="ctrl.states.hasCrops">
-                <gr-icon style="font-size: 20px;">crop</gr-icon>
+                <gr-icon class="gr-icon--large">crop</gr-icon>
         </span>
 
         <span class="bottom-bar__meta-item preview__has-print-usages"
               title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
               ng-if="ctrl.hasPrintUsages">
-                <gr-icon style="font-size: 20px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
+                <gr-icon class="gr-icon--large" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
         </span>
 
         <span class="bottom-bar__meta-item preview__has-web-usages"
               title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
               ng-if="ctrl.hasDigitalUsages">
-                <gr-icon style="font-size: 20px;" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
+                <gr-icon class="gr-icon--large" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
         </span>
 
         <span ng-switch="ctrl.flagState">

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -104,7 +104,7 @@
             ng-if="!ctrl.previewView"
             gu:lazy-table="ctrl.imagesAll"
             gu:lazy-table-cell-min-width="280"
-            gu:lazy-table-cell-height="333"
+            gu:lazy-table-cell-height="303"
             gu:lazy-table-preloaded-rows="4"
             gu:lazy-table-load-range="ctrl.loadRange($start, $end)"
             gu-lazy-table-shortcuts>

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -104,7 +104,7 @@
             ng-if="!ctrl.previewView"
             gu:lazy-table="ctrl.imagesAll"
             gu:lazy-table-cell-min-width="280"
-            gu:lazy-table-cell-height="292"
+            gu:lazy-table-cell-height="333"
             gu:lazy-table-preloaded-rows="4"
             gu:lazy-table-load-range="ctrl.loadRange($start, $end)"
             gu-lazy-table-shortcuts>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1196,6 +1196,20 @@ textarea.ng-invalid {
     padding-left: 10px;
     margin: 5px 0;
 }
+.preview__info-flex {
+    font-size: 1.3rem;
+    padding-left: 7px;
+    margin: 5px 0;
+    display: flex;
+}
+.preview__info-inline {
+    box-sizing: border-box;
+    width: 50%;
+    display: inline-block;
+}
+.align-right {
+    float: right;
+}
 
 .preview__info--large {
     font-size: 1.4rem;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1194,20 +1194,15 @@ textarea.ng-invalid {
 .preview__info {
     font-size: 1.3rem;
     padding-left: 10px;
-    margin: 5px 0;
+    margin: 10px 0;
 }
-.preview__info-flex {
+.preview__bottom-icons {
     font-size: 1.3rem;
     padding-left: 7px;
     margin: 5px 0;
-    display: flex;
+    display: inline;
 }
-.preview__info-inline {
-    box-sizing: border-box;
-    width: 50%;
-    display: inline-block;
-}
-.align-right {
+.preview__bottom-icons-align-right {
     float: right;
 }
 
@@ -1350,7 +1345,7 @@ FIXME: what to do with touch devices
 }
 
 .bottom-bar__action--cost {
-    width: 35px;
+    width: 20px;
 }
 /*
 .bottom-bar__action .allow {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1169,7 +1169,7 @@ textarea.ng-invalid {
 .preview__link,
 .preview__no-link {
     display: block;
-    height: 200px;
+    height: 190px;
 }
 
 .preview__link--large, .preview__no-link--large {
@@ -1181,7 +1181,7 @@ textarea.ng-invalid {
 .preview__image {
     display: block;
     max-width: 100%;
-    max-height: 100%;
+    max-height: 98%;
     margin: 0 auto;
     pointer-events: none;
 }
@@ -1194,7 +1194,7 @@ textarea.ng-invalid {
 .preview__info {
     font-size: 1.3rem;
     padding-left: 10px;
-    margin: 10px 0;
+    margin: 5px 0px 0px 0px;
 }
 .preview__bottom-icons {
     font-size: 1.3rem;
@@ -1296,7 +1296,7 @@ FIXME: what to do with touch devices
 
 .preview__bottom-bar {
     font-size: 1.4rem;
-    margin-top: 5px;
+    margin-top: 0px;
 }
 
 .preview__bottom-bar--large {


### PR DESCRIPTION
Change size and layout of icons inside an image preview tile. Add label "Uploaded:" before datetime

## What does this change?

No new or changed functionality, just minor UI related changes on the grid view image tile as per discussions during Grid Hour
- date time below an image preview was added with label "Uploaded:"
- warning and restriction icons are moved on the next row after the upload time label
- warning and restriction icons are slightly bigger (20px) than normal icons (16px was the normal icon size)

New Look
<img width="1008" alt="Screen Shot 2022-09-26 at 1 10 28 PM" src="https://user-images.githubusercontent.com/79340179/194814195-59118dfa-6bad-469d-afd0-e4dab66725b2.png">


Edit: Fixed layout issues (color changes are as per BBC custom config)
<img width="1374" alt="Screen Shot 2022-10-14 at 7 13 26 PM" src="https://user-images.githubusercontent.com/79340179/195881724-17718956-97ea-427b-8d1e-47926a6bf072.png">

Edit: Reduced the overall height of a preview tile by 30px from the last PR. Now it is only 10px taller than the original
<img width="1043" alt="Screen Shot 2022-10-28 at 1 28 25 PM" src="https://user-images.githubusercontent.com/79340179/198558132-bbf36ba7-50ae-4c0b-8ab3-2a3e6e14870c.png">

More can be seen from the third row, just like original
<img width="1509" alt="Screen Shot 2022-10-28 at 1 36 39 PM" src="https://user-images.githubusercontent.com/79340179/198558304-d425c11f-c4be-4e7c-8dc6-c360122a0943.png">


## How should a reviewer test this change?
Nothing to configure, just run and observe the label and new look of the icons

## How can success be measured?

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
