### PR TITLE
customizing warnings and restrictions messages

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -51,28 +51,15 @@ class KahunaController(
     val costFilterLabel = config.costFilterLabel.getOrElse("Free to use only")
     val costFilterChargeable = config.costFilterChargeable.getOrElse(false)
     Ok(views.html.main(
-      config.mediaApiUri,
-      config.authUri,
       s"${config.authUri}/login?redirectUri=$returnUri",
-      config.sentryDsn,
-      config.sessionId,
-      config.googleTrackingId,
-      config.feedbackFormLink,
-      config.usageRightsHelpLink,
-      config.invalidSessionHelpLink,
-      config.supportEmail,
       fieldAliases,
       scriptsToLoad,
-      config.staffPhotographerOrganisation,
-      config.homeLinkHtml,
-      config.systemName,
-      config.canDownloadCrop,
       domainMetadataSpecs,
-      config.recordDownloadAsUsage,
       metadataTemplates,
       additionalNavigationLinks,
       costFilterLabel,
-      costFilterChargeable
+      costFilterChargeable,
+      config
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -51,5 +51,9 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
 
   val metadataTemplates: Seq[MetadataTemplate] = configuration.get[Seq[MetadataTemplate]]("metadata.templates")
 
+  //BBC custom warning text
+  val warningTextPrefix: String = configuration.getOptional[String]("warningText.prefix").getOrElse("")
+  val warningTextPrefixNoRights: String = configuration.getOptional[String]("warningText.prefixNoRights").getOrElse("")
+  val unusableTextPrefix: String = configuration.getOptional[String]("warningText.unusablePrefix").getOrElse("")
 }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -52,8 +52,11 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val metadataTemplates: Seq[MetadataTemplate] = configuration.get[Seq[MetadataTemplate]]("metadata.templates")
 
   //BBC custom warning text
-  val warningTextPrefix: String = configuration.getOptional[String]("warningText.prefix").getOrElse("")
-  val warningTextPrefixNoRights: String = configuration.getOptional[String]("warningText.prefixNoRights").getOrElse("")
-  val unusableTextPrefix: String = configuration.getOptional[String]("warningText.unusablePrefix").getOrElse("")
+  val warningTextHeader: String = configuration.getOptional[String]("warningText.header")
+    .getOrElse("This image can be used, but has warnings:")
+  val warningTextHeaderNoRights: String = configuration.getOptional[String]("warningText.headerNoRights")
+    .getOrElse("This image can be used, but has warnings:")
+  val unusableTextHeader: String = configuration.getOptional[String]("warningText.unusableHeader")
+    .getOrElse("Unusable image")
 }
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -1,50 +1,39 @@
 @import lib.ScriptToLoad
 
-@(mediaApiUri: String,
-  authApiUri: String,
+@import lib.KahunaConfig
+@(
   reauthUri: String,
-  sentryDsn: Option[String],
-  sessionId: String,
-  googleTrackingId: Option[String],
-  feedbackFormLink: Option[String],
-  usageRightsHelpLink: Option[String],
-  invalidSessionHelpLink: Option[String],
-  supportEmail: Option[String],
   fieldAliases: String,
   scriptsToLoad: List[ScriptToLoad],
-  staffPhotographerOrganisation: String,
-  homeLinkHtml: Option[String],
-  systemName: String,
-  canDownloadCrop: Boolean,
   domainMetadataSpecs: String,
-  recordDownloadAsUsage: Boolean,
   metadataTemplates: String,
   additionalNavigationLinks: String,
   costFilterLabel: String,
-  costFilterChargeable: Boolean
+  costFilterChargeable: Boolean,
+  kahunaConfig: KahunaConfig
 )
 <!DOCTYPE html>
 <html>
-  <head>
+<head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title ui-title ui-title-suffix="@systemName">@systemName</title>
+    <title ui-title ui-title-suffix="@kahunaConfig.systemName">@kahunaConfig.systemName</title>
     <!-- htmllint line-ending-style="false" -->
 
 
     <!-- preconnect to core APIs ahead of JS making the requests -->
-    <link rel="preconnect" href="@mediaApiUri"/>
-    <link rel="preconnect" href="@authApiUri"/>
+    <link rel="preconnect" href="@kahunaConfig.mediaApiUri"/>
+    <link rel="preconnect" href="@kahunaConfig.authUri"/>
 
     <link rel="shortcut icon" type="image/svg+xml" href="@routes.Assets.versioned("images/grid-favicon.svg")"/>
     <link rel="alternate shortcut icon" type="image/png" href="@routes.Assets.versioned("images/grid-favicon-32.png")"/>
     <link rel="assets" href="@routes.Assets.versioned("")"/>
-    <link rel="media-api-uri" href="@mediaApiUri" />
+    <link rel="media-api-uri" href="@kahunaConfig.mediaApiUri" />
     <link rel="reauth-uri" href="@reauthUri" />
-    <link rel="auth-uri" href="@authApiUri" />
+    <link rel="auth-uri" href="@kahunaConfig.authUri" />
 
-    @sentryDsn.map { dsn => <link rel="sentry-dsn" href="@dsn" /> }
+    @kahunaConfig.sentryDsn.map { dsn => <link rel="sentry-dsn" href="@dsn" /> }
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 
     <style>
@@ -53,46 +42,50 @@
 
     <script>
         this._clientConfig = {
-          sessionId: "@Html(sessionId)",
-          googleTrackingId: "@Html(googleTrackingId.getOrElse(""))",
-          feedbackFormLink: "@Html(feedbackFormLink.getOrElse(""))",
-          usageRightsHelpLink: "@Html(usageRightsHelpLink.getOrElse(""))",
-          invalidSessionHelpLink: "@Html(invalidSessionHelpLink.getOrElse(""))",
-          supportEmail: "@Html(supportEmail.getOrElse(""))",
-          staffPhotographerOrganisation: "@Html(staffPhotographerOrganisation)",
+          sessionId: "@Html(kahunaConfig.sessionId)",
+          googleTrackingId: "@Html(kahunaConfig.googleTrackingId.getOrElse(""))",
+          feedbackFormLink: "@Html(kahunaConfig.feedbackFormLink.getOrElse(""))",
+          usageRightsHelpLink: "@Html(kahunaConfig.usageRightsHelpLink.getOrElse(""))",
+          invalidSessionHelpLink: "@Html(kahunaConfig.invalidSessionHelpLink.getOrElse(""))",
+          supportEmail: "@Html(kahunaConfig.supportEmail.getOrElse(""))",
+          staffPhotographerOrganisation: "@Html(kahunaConfig.staffPhotographerOrganisation)",
           fieldAliases: @Html(fieldAliases),
-          homeLinkHtml: '@Html(homeLinkHtml.getOrElse(""))',
-          systemName: "@Html(systemName)",
-          canDownloadCrop: @canDownloadCrop,
+          homeLinkHtml: '@Html(kahunaConfig.homeLinkHtml.getOrElse(""))',
+          systemName: "@Html(kahunaConfig.systemName)",
+          canDownloadCrop: @kahunaConfig.canDownloadCrop,
           domainMetadataSpecs: @Html(domainMetadataSpecs),
-          recordDownloadAsUsage: @recordDownloadAsUsage,
+          recordDownloadAsUsage: @kahunaConfig.recordDownloadAsUsage,
           metadataTemplates: @Html(metadataTemplates),
           additionalNavigationLinks: @Html(additionalNavigationLinks),
           costFilterLabel: "@Html(costFilterLabel)",
-          costFilterChargeable: @costFilterChargeable
+          costFilterChargeable: @costFilterChargeable,
+          restrictDownload: @kahunaConfig.restrictDownload.getOrElse(false),
+          warningTextPrefix: "@Html(kahunaConfig.warningTextPrefix)",
+          warningTextPrefixNoRights: "@Html(kahunaConfig.warningTextPrefixNoRights)",
+          unusableTextPrefix: "@Html(kahunaConfig.unusableTextPrefix)"
         }
     </script>
 
-  </head>
-  <body>
-    <p class="loader" ng-hide="true">Loading @systemName…</p>
+</head>
+<body>
+<p class="loader" ng-hide="true">Loading @kahunaConfig.systemName…</p>
 
-    <div ui-view></div>
+<div ui-view></div>
 
-    <ui-global-errors></ui-global-errors>
+<ui-global-errors></ui-global-errors>
 
-    @googleTrackingId.map { id =>
-      <script>
+@kahunaConfig.googleTrackingId.map { id =>
+<script>
         window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       </script>
-      <script async src='https://www.google-analytics.com/analytics.js'></script>
-    }
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+}
 
-    <script src="@routes.Assets.versioned("dist/build.js")"></script>
+<script src="@routes.Assets.versioned("dist/build.js")"></script>
 
-    @scriptsToLoad.map { scriptDetail =>
-      <script async="@scriptDetail.async" src="@scriptDetail.host/@scriptDetail.path"></script>
-    }
+@scriptsToLoad.map { scriptDetail =>
+<script async="@scriptDetail.async" src="@scriptDetail.host/@scriptDetail.path"></script>
+}
 
-  </body>
+</body>
 </html>

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -60,9 +60,9 @@
           costFilterLabel: "@Html(costFilterLabel)",
           costFilterChargeable: @costFilterChargeable,
           restrictDownload: @kahunaConfig.restrictDownload.getOrElse(false),
-          warningTextPrefix: "@Html(kahunaConfig.warningTextPrefix)",
-          warningTextPrefixNoRights: "@Html(kahunaConfig.warningTextPrefixNoRights)",
-          unusableTextPrefix: "@Html(kahunaConfig.unusableTextPrefix)"
+          warningTextHeader: "@Html(kahunaConfig.warningTextHeader)",
+          warningTextHeaderNoRights: "@Html(kahunaConfig.warningTextHeaderNoRights)",
+          unusableTextHeader: "@Html(kahunaConfig.unusableTextHeader)"
         }
     </script>
 

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -3,15 +3,15 @@
     class="image-notice image-info__group validity validity--invalid validity--point-up"
     ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning}"
 >
-    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">Unusable Image
+    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">{{ctrl.unusableTextPrefix}}
         <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
     </strong>
     <strong ng-if="ctrl.isOverridden && !ctrl.isDeleted">
-        This image can be used, but has warnings:
+        {{ctrl.warningTextPrefix}}
         <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon>
     </strong>
     <strong ng-if="ctrl.isDeleted">
-        Unusable Image
+        {{ctrl.unusableTextPrefix}}
         <gr-icon title="This image cannot normally be used in content - image has been deleted">help</gr-icon>
     </strong>
     <ul ng-if="!ctrl.isDeleted">

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -3,15 +3,15 @@
     class="image-notice image-info__group validity validity--invalid validity--point-up"
     ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning}"
 >
-    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">{{ctrl.unusableTextPrefix}}
+    <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">{{ctrl.unusableTextHeader}}
         <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
     </strong>
     <strong ng-if="ctrl.isOverridden && !ctrl.isDeleted">
-        {{ctrl.warningTextPrefix}}
+        {{ctrl.warningTextHeader}}
         <gr-icon title="This image cannot normally be used in content - either this image has been given a valid lease or you are a lease granter.">help</gr-icon>
     </strong>
     <strong ng-if="ctrl.isDeleted">
-        {{ctrl.unusableTextPrefix}}
+        {{ctrl.unusableTextHeader}}
         <gr-icon title="This image cannot normally be used in content - image has been deleted">help</gr-icon>
     </strong>
     <ul ng-if="!ctrl.isDeleted">

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -5,7 +5,7 @@ import './gr-metadata-validity.css';
 
 export const module = angular.module('gr.metadataValidity', []);
 
-module.controller('grMetadataValidityCtrl', [ '$rootScope', function ($rootScope) {
+module.controller('grMetadataValidityCtrl', [ '$rootScope', '$window', function ($rootScope, $window) {
     let ctrl = this;
 
     function updateState() {
@@ -15,6 +15,17 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', function ($rootScope
             ctrl.invalidReasons = image.data.invalidReasons;
             ctrl.isOverridden = ctrl.showInvalidReasons && image.data.valid;
             ctrl.isStrongWarning = ctrl.isDeleted || !ctrl.isOverridden || image.data.cost === "pay";
+
+            ctrl.warningTextPrefix = "This image can be used, but has warnings:";
+            const hasUsageRights = Object.keys(image.data.usageRights).length > 0;
+            const hasCustomWarningText = $window._clientConfig.warningTextPrefixNoRights.trim() !== "";
+            if (!hasUsageRights && hasCustomWarningText) {
+              ctrl.warningTextPrefix = $window._clientConfig.warningTextPrefixNoRights;
+            } else if (hasUsageRights && hasCustomWarningText) {
+              ctrl.warningTextPrefix = $window._clientConfig.warningTextPrefix;
+            }
+            const customUnusableText = $window._clientConfig.unusableTextPrefix;
+            ctrl.unusableTextPrefix = customUnusableText.trim() !== "" ? customUnusableText : "Unusable image";
         });
     }
 

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -16,16 +16,13 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', '$window', function 
             ctrl.isOverridden = ctrl.showInvalidReasons && image.data.valid;
             ctrl.isStrongWarning = ctrl.isDeleted || !ctrl.isOverridden || image.data.cost === "pay";
 
-            ctrl.warningTextPrefix = "This image can be used, but has warnings:";
             const hasUsageRights = Object.keys(image.data.usageRights).length > 0;
-            const hasCustomWarningText = $window._clientConfig.warningTextPrefixNoRights.trim() !== "";
-            if (!hasUsageRights && hasCustomWarningText) {
-              ctrl.warningTextPrefix = $window._clientConfig.warningTextPrefixNoRights;
-            } else if (hasUsageRights && hasCustomWarningText) {
-              ctrl.warningTextPrefix = $window._clientConfig.warningTextPrefix;
+            if (!hasUsageRights) {
+              ctrl.warningTextHeader = $window._clientConfig.warningTextHeaderNoRights;
+            } else {
+              ctrl.warningTextHeader = $window._clientConfig.warningTextHeader;
             }
-            const customUnusableText = $window._clientConfig.unusableTextPrefix;
-            ctrl.unusableTextPrefix = customUnusableText.trim() !== "" ? customUnusableText : "Unusable image";
+            ctrl.unusableTextHeader = $window._clientConfig.unusableTextHeader;
         });
     }
 

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -58,9 +58,9 @@ object ImageExtras {
     )
   }
 
-  def invalidReasons(validityMap: ValidMap) = validityMap
+  def invalidReasons(validityMap: ValidMap, customValidityDesc: Map[String, String] = Map.empty) = validityMap
     .filter { case (_, v) => v.invalid }
-    .map { case (id, _) => id -> validityDescription.get(id) }
+    .map { case (id, _) => id -> customValidityDesc.get(id).orElse(validityDescription.get(id)) }
     .map {
       case (id, Some(reason)) => id -> reason
       case (id, None) => id -> s"Validity error: $id"

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -84,7 +84,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 
     val validityMap = ImageExtras.validityMap(image, withWritePermission)
     val valid = ImageExtras.isValid(validityMap)
-    val invalidReasons = ImageExtras.invalidReasons(validityMap)
+    val invalidReasons = ImageExtras.invalidReasons(validityMap, config.customValidityDescription)
 
     val persistenceReasons = imagePersistenceReasons(image)
     val isPersisted = persistenceReasons.nonEmpty

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -65,4 +65,7 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   }.toOption.flatten
   val useRuntimeFieldsToFixSyndicationReviewQueueQuery = boolean("syndication.review.useRuntimeFieldsFix")
 
+  //BBC custom validity description messages
+  val customValidityDescription: Map[String, String] =
+    configuration.getOptional[Map[String, String]]("warningText.validityDescription").getOrElse(Map.empty)
 }


### PR DESCRIPTION
add configuration to customize warning and restriction text for labels and messages

## What does this change?

BBC wants to change the default warning messages for its users. This PR adds configuration to change the warning text and messages displayed on the metadata panel when an image is selected. **FYI The change of colors shown in the screenshot is a BBC only configuration and is not included in this PR**

<img width="324" alt="Screen Shot 2022-10-06 at 4 11 25 PM" src="https://user-images.githubusercontent.com/79340179/194309603-2a5975fa-5a43-4409-919e-99735bbc5518.png">

<img width="323" alt="Screen Shot 2022-10-06 at 4 10 11 PM" src="https://user-images.githubusercontent.com/79340179/194309622-401ca46b-1262-40d4-bc49-90628064aa5a.png">

<img width="334" alt="Screen Shot 2022-10-06 at 5 53 19 PM" src="https://user-images.githubusercontent.com/79340179/194331411-414ff635-11e6-4a16-a5a1-de0427127995.png">


## How should a reviewer test this change?

In application.conf, add the following configuration

> warningText {
>     prefix = "This image has warnings attached."
>     prefixNoRights = "Do not use this image."
>     unusablePrefix = "Do not use this image."
>     validityDescription {
>         no_rights = "No rights to use. Contact your appropriate rights management team to check rights status."
>         missing_credit = "This image requires credit information."
>         missing_description = "This image requires a description."
>         paid_image = "This image is a payable image. There are no rights to use unless an allow lease has been set. See lease information below. If there is no lease or the lease has expired, contact your appropriate rights management team to negotiate a licence to use."
>         over_quota = "The image quota downloaded for this organisation has been exceeded."
>         conditional_paid = "This image has a restriction applied to it, read more in the restricted use section."
>         current_deny_lease = "This image has been denied a lease and cannot be used. See further details in the lease section below."
>     }
> }

Select any image with warnings (ex. no rights, missing description). The custom messages from the above configuration should appear instead of the default.

Without this configuration, the default warning messages will stay the same.

## How can success be measured?

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
