### PR TITLE
Filtering download links from media-api image response where user does not have permission

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -110,4 +110,4 @@ metadata.templates = []
 #  chargeable: true
 # }
 
-restrictDownload = false # This is overridden in common.conf
+restrictDownload = false #This is overridden in common.conf

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -110,4 +110,4 @@ metadata.templates = []
 #  chargeable: true
 # }
 
-restrictDownload = false
+restrictDownload = true

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -110,4 +110,4 @@ metadata.templates = []
 #  chargeable: true
 # }
 
-restrictDownload = false #This is overridden in common.conf
+restrictDownload = false # This is overridden in common.conf

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -110,4 +110,4 @@ metadata.templates = []
 #  chargeable: true
 # }
 
-restrictDownload = true
+restrictDownload = false #This is overridden in common.conf

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.css
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.css
@@ -9,10 +9,11 @@ button .download:hover {
 .download-warning {
   color: yellow;
   padding-left: 5px;
+  margin-left: -6px;
 }
 
 gr-icon-label.download-icon-label {
-  padding: 0;
+  padding: 0 5px 0 0;
 }
 
 .download-button {

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -12,7 +12,7 @@
     </button>
     <button type="button"
             class="download-button"
-            title="Download images"
+            aria-label="Download images"
             ng-disabled="ctrl.downloading"
             gr-tooltip="Not all selected images are available to download"
             ng-if="ctrl.multipleSelectedSomeValid"

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -69,8 +69,7 @@
         </a>
     </button>
     <span ng-if="ctrl.multipleSelectedNoneValid || ctrl.singleSelectedInvalid"
-          aria-label="Cannot download"
-          gr-tooltip="Selected image(s) not available for download">
+          aria-label="Cannot download">
         <gr-icon-label gr-icon="file_download" class="download-icon-label">
             Cannot download
         </gr-icon-label>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.html
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.html
@@ -70,7 +70,11 @@
     </button>
     <span ng-if="ctrl.multipleSelectedNoneValid || ctrl.singleSelectedInvalid"
           aria-label="Cannot download">
-        <gr-icon-label gr-icon="file_download" class="download-icon-label">
+        <gr-icon-label
+            gr-icon="file_download"
+            class="download-icon-label"
+            gr-tooltip="Downloading non-free images requires a lease"
+        >
             Cannot download
         </gr-icon-label>
     </span>

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -78,7 +78,7 @@ downloader.controller('DownloaderCtrl', [
             };
             createDownload();
             ctrl.downloading = false;
-            $scope.$apply()
+            $scope.$apply();
           });
         },
         (e) => {

--- a/kahuna/public/js/components/gr-downloader/gr-downloader.js
+++ b/kahuna/public/js/components/gr-downloader/gr-downloader.js
@@ -7,22 +7,6 @@ export const downloader = angular.module('gr.downloader', [
   'gr.image-downloads.service'
 ]);
 
-// blob URLs have a max size of 500MB - https://github.com/eligrey/FileSaver.js/#supported-browsers
-const maxBlobSize = 500 * 1024 * 1024;
-
-const bytesToSize = (bytes) => {
-  if (bytes === 0) {
-    return '0 Bytes';
-  }
-
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-
-  return i === 0 ?
-    `${bytes} ${sizes[i]}` :
-    `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`;
-};
-
 downloader.controller('DownloaderCtrl', [
   '$window',
   '$q',
@@ -37,12 +21,14 @@ downloader.controller('DownloaderCtrl', [
     ctrl.canDownloadCrop = $window._clientConfig.canDownloadCrop;
     const restrictDownload = $window._clientConfig.restrictDownload;
 
-
     ctrl.imagesArray = () => Array.isArray(ctrl.images) ?
       ctrl.images : Array.from(ctrl.images.values());
     ctrl.imageCount = () => ctrl.imagesArray().length;
 
-    ctrl.downloadableImagesArray = () => restrictDownload ? ctrl.imagesArray().filter(({data}) => data.userCanEdit && data.softDeletedMetadata === undefined) : ctrl.imagesArray();
+    ctrl.downloadableImagesArray = () => restrictDownload ?
+      ctrl.imagesArray().filter(({data, links}) =>
+        links?.some(({rel}) => rel === 'download') && data.softDeletedMetadata === undefined) :
+      ctrl.imagesArray();
 
     $scope.$watch('ctrl.images', function () {
       ctrl.singleImageSelected = ctrl.imageCount() === 1;
@@ -50,11 +36,14 @@ downloader.controller('DownloaderCtrl', [
 
       if (restrictDownload) {
         const totalSelectedImages = ctrl.imageCount();
-        const selectedNonDownloadableImages = ctrl.imagesArray().filter(({ data }) => !data.userCanEdit || data.softDeletedMetadata !== undefined);
+        const selectedNonDownloadableImages = ctrl.imagesArray().filter(({data, links}) =>
+          !links?.some(({rel}) => rel === 'download') || data.softDeletedMetadata !== undefined);
         const singleImageSelected = totalSelectedImages === 1;
         const multipleImagesSelected = totalSelectedImages > 1;
 
-        ctrl.singleImageSelected = singleImageSelected && ctrl.imagesArray()[0].data.userCanEdit && ctrl.imagesArray()[0].data.softDeletedMetadata === undefined;
+        ctrl.singleImageSelected = singleImageSelected && ctrl.imagesArray()[0].links?.some(({rel}) => rel === 'download')
+          && ctrl.imagesArray()[0].data.softDeletedMetadata === undefined;
+
         ctrl.singleSelectedInvalid = singleImageSelected && selectedNonDownloadableImages.length === 1;
 
         ctrl.multipleSelectedAllValid = multipleImagesSelected && selectedNonDownloadableImages.length < 1;
@@ -64,6 +53,7 @@ downloader.controller('DownloaderCtrl', [
     });
 
     ctrl.isDeleted = ctrl.singleImageSelected && ctrl.images[0].data.softDeletedMetadata !== undefined;
+
     const uris$ = imageDownloadsService.getDownloads(ctrl.imagesArray()[0]);
 
     inject$($scope, uris$, ctrl, 'firstImageUris');
@@ -81,36 +71,14 @@ downloader.controller('DownloaderCtrl', [
           zip.generateAsync({type: 'uint8array'}).then(file => {
             const blob = new Blob([file], {type: 'application/zip'});
 
-            // const isTooBig = blob.size > maxBlobSize;
-            const isTooBig = false;
-
             const createDownload = () => {
               const url = $window.URL.createObjectURL(blob);
               $window.location = url;
               $window.URL.revokeObjectURL(url);
             };
-
-            const refuseDownload = () => {
-              const maxSize = bytesToSize(maxBlobSize);
-              const blobSize = bytesToSize(blob.size);
-
-              // the things we do for a happy linter...
-              const message = [
-                'Download is too big!',
-                `Max file size: ${maxSize}. Your download: ${blobSize}.`,
-                'Consider downloading smaller batches.'
-              ].join('\n');
-
-              $window.alert(message);
-            };
-
-            if (isTooBig) {
-              refuseDownload();
-            } else {
-              createDownload();
-            }
-
+            createDownload();
             ctrl.downloading = false;
+            $scope.$apply()
           });
         },
         (e) => {
@@ -124,7 +92,6 @@ downloader.controller('DownloaderCtrl', [
           throw e;
         });
     };
-
   }]);
 
 downloader.directive('grDownloader', function () {

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -182,15 +182,14 @@ leases.controller('LeasesCtrl', [
         };
 
         ctrl.toolTip = (lease) => {
-            const  leasedBy = Boolean(lease.leasedBy) ? `leased by: ${lease.leasedBy}` : ``;
-            return leasedBy;
+          return Boolean(lease.leasedBy) ? `leased by: ${lease.leasedBy}` : ``;
         };
 
         ctrl.inactiveLeases = (leases) => {
-            leases.leases.filter((l) => !ctrl.isCurrent(l)).length;
+          leases ? leases.leases.filter((l) => !ctrl.isCurrent(l)).length : 0;
         };
         ctrl.activeLeases = (leases) => {
-            leases.leases.filter((l) => ctrl.isCurrent(l)).length;
+          leases ? leases.leases.filter((l) => ctrl.isCurrent(l)).length : 0;
         };
 
         ctrl.resetLeaseForm = () => {

--- a/kahuna/public/js/services/image/downloads.js
+++ b/kahuna/public/js/services/image/downloads.js
@@ -41,6 +41,10 @@ imageDownloadsService.factory('imageDownloadsService', ['imgops', '$http', funct
     }
 
     function getDownloads(imageResource) {
+      const hasDownloadLinks = imageResource.links.some(({rel}) => rel === 'download');
+      if (!hasDownloadLinks) {
+        return Rx.Observable.empty();
+      }
         const image$ = Rx.Observable.fromPromise(imageResource.getData());
 
         const originalName$   = image$.map((image) => imageName(image));

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -39,7 +39,8 @@ object ImageExtras {
   def hasCurrentDenyLease(leases: LeasesByMedia): Boolean = leases.leases.exists(lease => lease.access == DenyUseLease && isCurrent(lease))
 
   private def validationMap(image: Image, withWritePermission: Boolean, isImageValidation: Boolean)(
-    implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
+    implicit cost: CostCalculator, quotas: UsageQuota
+  ): ValidMap = {
 
     val shouldOverride = validityOverrides(image, withWritePermission).exists(_._2 == true)
 
@@ -65,12 +66,14 @@ object ImageExtras {
   }
 
   def validityMap(image: Image, withWritePermission: Boolean)(
-    implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
+    implicit cost: CostCalculator, quotas: UsageQuota
+  ): ValidMap = {
     validationMap(image, withWritePermission, isImageValidation = true)
   }
 
   def downloadableMap(image: Image, withWritePermission: Boolean)(
-    implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
+    implicit cost: CostCalculator, quotas: UsageQuota
+  ): ValidMap = {
     validationMap(image, withWritePermission, isImageValidation = false)
   }
 

--- a/media-api/app/lib/ImageExtras.scala
+++ b/media-api/app/lib/ImageExtras.scala
@@ -38,7 +38,7 @@ object ImageExtras {
 
   def hasCurrentDenyLease(leases: LeasesByMedia): Boolean = leases.leases.exists(lease => lease.access == DenyUseLease && isCurrent(lease))
 
-  def validityMap(image: Image, withWritePermission: Boolean)(
+  private def validationMap(image: Image, withWritePermission: Boolean, isImageValidation: Boolean)(
     implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
 
     val shouldOverride = validityOverrides(image, withWritePermission).exists(_._2 == true)
@@ -46,19 +46,35 @@ object ImageExtras {
     def createCheck(validCheck: Boolean, overrideable: Boolean = true) =
       ValidityCheck(validCheck, overrideable, shouldOverride)
 
-    Map(
-      "paid_image"           -> createCheck(cost.isPay(image.usageRights)),
-      "conditional_paid"     -> createCheck(cost.isConditional(image.usageRights)),
-      "no_rights"            -> createCheck(!hasRights(image.usageRights)),
-      "missing_credit"       -> createCheck(!hasCredit(image.metadata), overrideable = false),
-      "missing_description"  -> createCheck(!hasDescription(image.metadata), overrideable = false),
-      "current_deny_lease"   -> createCheck(hasCurrentDenyLease(image.leases)),
-      "over_quota"           -> createCheck(quotas.isOverQuota(image.usageRights)),
-      "tass_agency_image"    -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS") | image.originalMetadata.byline.exists(_ == "ITAR-TASS News Agency"), overrideable = true, shouldOverride = true)
+    val baseValidationMap = Map(
+      "paid_image" -> createCheck(cost.isPay(image.usageRights)),
+      "conditional_paid" -> createCheck(cost.isConditional(image.usageRights)),
+      "no_rights" -> createCheck(!hasRights(image.usageRights)),
+      "current_deny_lease" -> createCheck(hasCurrentDenyLease(image.leases)),
+      "over_quota" -> createCheck(quotas.isOverQuota(image.usageRights)),
+      "tass_agency_image" -> ValidityCheck(image.metadata.source.exists(_.toUpperCase == "TASS") | image.originalMetadata.byline.exists(_ == "ITAR-TASS News Agency"), overrideable = true, shouldOverride = true)
     )
+    if (isImageValidation) {
+      baseValidationMap ++ Map(
+        "missing_credit" -> createCheck(!hasCredit(image.metadata), overrideable = false),
+        "missing_description" -> createCheck(!hasDescription(image.metadata), overrideable = false),
+      )
+    } else {
+      baseValidationMap
+    }
   }
 
-  def invalidReasons(validityMap: ValidMap) = validityMap
+  def validityMap(image: Image, withWritePermission: Boolean)(
+    implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
+    validationMap(image, withWritePermission, isImageValidation = true)
+  }
+
+  def downloadableMap(image: Image, withWritePermission: Boolean)(
+    implicit cost: CostCalculator, quotas: UsageQuota): ValidMap = {
+    validationMap(image, withWritePermission, isImageValidation = false)
+  }
+
+  def invalidReasons(validityMap: ValidMap): Map[String, String] = validityMap
     .filter { case (_, v) => v.invalid }
     .map { case (id, _) => id -> validityDescription.get(id) }
     .map {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -112,7 +112,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 
     val links: List[Link] = tier match {
       case Internal => imageLinks(id, imageUrl, pngUrl, withWritePermission, valid) ++ getDownloadLinks(id, isDownloadable)
-      case _ => List(downloadLink(id), downloadOptimisedLink(id)) //Todo: ascertain whether filtering is required for non-internal users
+      case _ => List(downloadLink(id), downloadOptimisedLink(id))
     }
 
     val isDeletable = canBeDeleted(image) && withDeleteImagePermission

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -65,4 +65,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   }.toOption.flatten
   val useRuntimeFieldsToFixSyndicationReviewQueueQuery = boolean("syndication.review.useRuntimeFieldsFix")
 
+  val restrictDownload: Boolean = boolean("restrictDownload")
+
 }

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -12,11 +12,11 @@ import org.scalatestplus.mockito.MockitoSugar
 
 class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
 
-  val Quota = mock[UsageQuota]
+  private val Quota = mock[UsageQuota]
 
   object Costing extends CostCalculator {
-    val quotas = Quota
-    override def getOverQuota(usageRights: UsageRights) = None
+    val quotas: UsageQuota = Quota
+    override def getOverQuota(usageRights: UsageRights): Option[Nothing] = None
     override val freeSuppliers: List[String] = GuardianUsageRightsConfig.freeSuppliers
     override val suppliersCollectionExcl: Map[String, List[String]] = GuardianUsageRightsConfig.suppliersCollectionExcl
   }
@@ -24,7 +24,7 @@ class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
   implicit val cost: CostCalculator = Costing
   implicit val quotas: UsageQuota = Quota
 
-  val baseImage = Image(
+  private val baseImage = Image(
     id = "id",
     uploadTime = new DateTime(),
     uploadedBy = "uploadedBy",
@@ -48,15 +48,13 @@ class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
     originalUsageRights = NoRights
   )
 
-  val validImageMetadata = ImageMetadata(
+  private  val validImageMetadata = ImageMetadata(
     credit = Some("credit"),
     description = Some("description")
   )
 
-  val baseValidityMap = Map(
+  private val baseMappings = Map(
     "paid_image" -> ValidityCheck(invalid = true,overrideable = true,shouldOverride = false),
-    "missing_description" -> ValidityCheck(invalid = true,overrideable = false,shouldOverride = false),
-    "missing_credit" -> ValidityCheck(invalid = true,overrideable = false,shouldOverride = false),
     "over_quota" -> ValidityCheck(invalid = false,overrideable = true,shouldOverride = false),
     "current_deny_lease" -> ValidityCheck(invalid = false,overrideable = true,shouldOverride = false),
     "no_rights" -> ValidityCheck(invalid = true,overrideable = true,shouldOverride = false),
@@ -64,29 +62,83 @@ class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
     "tass_agency_image" -> ValidityCheck(invalid = false, overrideable = true, shouldOverride = true)
   )
 
+  private val imageValidityMappings = Map(
+    "missing_description" -> ValidityCheck(invalid = true, overrideable = false, shouldOverride = false),
+    "missing_credit" -> ValidityCheck(invalid = true, overrideable = false, shouldOverride = false)
+  )
+
+  private val baseValidityMap = baseMappings ++ imageValidityMappings
+
+  describe("non-downloadable Image") {
+
+    it("should generate downloadable validity map") {
+      baseMappings should be(ImageExtras.downloadableMap(baseImage, withWritePermission = false))
+    }
+
+    it("should report validity") {
+      val validityMap = ImageExtras.validityMap(baseImage, withWritePermission = false)
+      val validity = ImageExtras.isValid(baseMappings)
+
+      validity should be(false)
+    }
+
+    it("should report overridden validity") {
+      val validityMap = ImageExtras.downloadableMap(baseImage, withWritePermission = true)
+      val validity = ImageExtras.isValid(validityMap)
+
+      validity should be(true)
+    }
+
+    it("should report all non-downloadable reasons") {
+      val validityMap = ImageExtras.downloadableMap(baseImage, withWritePermission = false)
+      val invalidReasons = ImageExtras.invalidReasons(validityMap)
+      val expectedInvalidReasons = Map(
+        "paid_image" -> "Paid imagery requires a lease",
+        "no_rights" -> "No rights to use this image"
+      )
+
+      expectedInvalidReasons should be(invalidReasons)
+    }
+
+    it("should report all non-downloadbable reasons if write permissions are true") {
+      val validityMap = ImageExtras.downloadableMap(baseImage, withWritePermission = true)
+      val invalidReasons = ImageExtras.invalidReasons(validityMap)
+      val expectedInvalidReasons = Map(
+        "paid_image" -> "Paid imagery requires a lease",
+        "no_rights" -> "No rights to use this image"
+      )
+
+      expectedInvalidReasons should be(invalidReasons)
+    }
+  }
+
   describe("Invalid Images") {
     it("should generate validityMaps") {
       baseValidityMap should be(ImageExtras.validityMap(baseImage, withWritePermission = false))
     }
+
     it("should report validity") {
       val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = false)
       val validity = ImageExtras.isValid(validityMap)
 
       validity should be(false)
     }
-    it("should report overriden validity") {
+
+    it("should report overridden validity") {
       val overrideableImage = baseImage.copy(metadata = validImageMetadata)
       val validityMap  = ImageExtras.validityMap(overrideableImage, withWritePermission = true)
       val validity = ImageExtras.isValid(validityMap)
 
       validity should be(true)
     }
-    it("should report invalid when fields cannot be overriden") {
+
+    it("should report invalid when fields cannot be overridden") {
       val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = true)
       val validity = ImageExtras.isValid(validityMap)
 
       validity should be(false)
     }
+
     it("should report all invalid reasons") {
       val validityMap  = ImageExtras.validityMap(baseImage, withWritePermission = false)
       val invalidReasons = ImageExtras.invalidReasons(validityMap)


### PR DESCRIPTION
This update filters download links from media-api response where users should not have access to the download for that image. UI interprets the absence of download links to programmatically determine downloadability. 

Co-authored-by: Ara Cho  <aracho1@users.noreply.github.com>

## What does this change?
No changes to the UI. Media-api response now filters based on user permissions.
Prior to this update, `restrictDownload` was set in `kanuna.config`, this now needs to be moved up to `common.conf` as it configs behaviour both in media-api and the client.

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
`restrictDownload` config should be set to true in `common.conf`, this enables filtering on download responses from media-api required by the UI to determine whether an image should be downloadable. 
<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
