### PR TITLE
Update the API key docs

### DIFF
--- a/dev/script/mkapikey.sh
+++ b/dev/script/mkapikey.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 <name>"
+  echo "  where <name> is the name of user or application which will use this key"
+  exit 1
+fi
+
+GRID_USER_NAME="$1"
+GRID_KEY_NAME="$(echo $GRID_USER_NAME | tr ' ' '_' | tr '[:upper:]' '[:lower:]')-$(openssl rand -base64 450 | tr -d '\n' | tr -d '/' | tr -d '+' | cut -c1-48)"
+
+echo "$GRID_USER_NAME" > "$GRID_KEY_NAME"
+echo "created key: $GRID_KEY_NAME"
+

--- a/get-stack-resource.sh
+++ b/get-stack-resource.sh
@@ -17,7 +17,7 @@ fi
 
 JQ_FILTER="jq '.StackResources[] | select(.LogicalResourceId == \"$STACK_RESOURCE\") | .PhysicalResourceId'"
 
-aws cloudformation describe-stack-resources \
+AWS_REGION="${AWS_REGION:-eu-west-1}" aws cloudformation describe-stack-resources \
     --stack-name ${STACK_NAME} \
     --profile media-service \
     | eval ${JQ_FILTER} \


### PR DESCRIPTION
## What does this change?

Ronseal.
Also includes update to get-stack-resource script to ensure running, and a new script mkapikey to replace the command in the docs, which generates longer, securer api keys
