### PR TITLE
replace git deps in package.json with npm/tarball dependencies

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -5435,8 +5435,9 @@
       "integrity": "sha512-yzcHpPMLQl0232nDzm5P4iAFTFQ9dMw0QgFLuKYbDj9M0xJ62z0oudYD/Lvh1pWfRsukiytP4Xj6BHOSrSXP8A=="
     },
     "angular-ui-router": {
-      "version": "git+ssh://git@github.com/angular-ui/ui-router.git#ef38bc78495ec7719dcd6876886cf5a27420f330",
-      "from": "angular-ui-router@angular-ui/ui-router#0.4.3",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.3.tgz",
+      "integrity": "sha512-EGBG7G7ArFVkJPM+ZIgPKuMYuT16UQrr3zj3BEiXHKwxss867bGt3u7QD9g4BxR+K2qQOSWok6JGvgTWXAko3A==",
       "requires": {
         "angular": "^1.0.8"
       }
@@ -17053,8 +17054,8 @@
       }
     },
     "titip": {
-      "version": "github:guardian/titip#9bafc18a91fe4e2eeaa841d1b582dab2ca6bf3c8",
-      "from": "github:guardian/titip#1.1.0"
+      "version": "https://github.com/guardian/titip/tarball/1.1.0",
+      "integrity": "sha512-5HovItHxUvCKIQZ0oE13mRxtKudvlrRv4edr4egkMgsszMk5F0FOz4n5kFgL77P6iRSskQ2EADe/saZqOVO31A=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -9,7 +9,7 @@
     "angular-hotkeys": "^1.7.0",
     "angular-messages": "1.6.10",
     "angular-ui-bootstrap": "^2.5.6",
-    "angular-ui-router": "angular-ui/ui-router#0.4.3",
+    "angular-ui-router": "0.4.3",
     "angular-xeditable": "^0.8.1",
     "any-http-angular": "^0.1.0",
     "any-promise-angular": "^0.1.1",
@@ -28,7 +28,7 @@
     "rx-dom": "^6.0.0",
     "theseus": "0.5.2",
     "theseus-angular": "^0.3.1",
-    "titip": "guardian/titip#1.1.0",
+    "titip": "https://github.com/guardian/titip/tarball/1.1.0",
     "ui-router-extras": "^0.1.3",
     "uri-templates": "0.1.5"
   },


### PR DESCRIPTION
## What does this change?

Speeds up the teamcity build :D 12-13 mins reduced back to the good old 5-6 mins
npm apparently doesn't like installing dependencies with the git protocol, so stop doing that.

angular-ui-router is available from npm registry, can't see a clear reason why we were installing from github 
our fork of titip is not published to npm registry, but you _can_ pass a link to the tarball that github generates for a tagged commit, which works really nicely!

buildtimes:

| before | after |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/10963046/195878595-dfb771a8-ecdd-4aa1-93f8-178528875d2b.png) | ![image](https://user-images.githubusercontent.com/10963046/195878667-872ccbdd-6c38-4bec-acef-ce9574a6b653.png) |

Tested on TEST, routing and tooltips packages seem to be imported and working correctly