### PR TITLE
add a `--use-TEST` option to `start.sh` to run only `auth`, `kahuna` and `media-api` and to use `TEST` for everything else (including ElasticSearch)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,7 @@ lazy val root = project("grid", path = Some("."))
   )
 
 addCommandAlias("runAll", "all auth/run media-api/run thrall/run image-loader/run metadata-editor/run kahuna/run collections/run cropper/run usage/run leases/run admin-tools-dev/run")
+addCommandAlias("runMinimal", "all auth/run media-api/run kahuna/run")
 
 // Required to allow us to run more than four play projects in parallel from a single SBT shell
 Global / concurrentRestrictions := Seq(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -24,7 +24,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   override val awsRegion: String = stringDefault("aws.region", "eu-west-1")
 
-  override val awsLocalEndpoint: Option[String] = if(isDev) stringOpt("aws.local.endpoint") else None
+  override val awsLocalEndpoint: Option[String] = if(isDev) stringOpt("aws.local.endpoint").filter(_.nonEmpty) else None
 
   val useLocalAuth: Boolean = isDev && boolean("auth.useLocal")
 
@@ -44,6 +44,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   // Note: had to make these lazy to avoid init order problems ;_;
   val domainRoot: String = string("domain.root")
+  val domainRootOverride: Option[String] = stringOpt("domain.root-override")
   val rootAppName: String = stringDefault("app.name.root", "media")
   val serviceHosts = ServiceHosts(
     stringDefault("hosts.kahunaPrefix", s"$rootAppName."),
@@ -62,7 +63,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   val corsAllowedOrigins: Set[String] = getStringSet("security.cors.allowedOrigins")
 
-  val services = new Services(domainRoot, serviceHosts, corsAllowedOrigins)
+  val services = new Services(domainRoot, serviceHosts, corsAllowedOrigins, domainRootOverride)
 
   /**
    * Load in a list of domain metadata specifications from configuration. For example:

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigLoader.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigLoader.scala
@@ -34,7 +34,15 @@ object GridConfigLoader extends StrictLogging {
         // when in test mode never load any files
         Configuration.empty
       } else if (stageIdentifier.isDev) {
-        loadConfiguration(developerConfigFiles)
+        val overrides = Configuration(ConfigFactory.defaultOverrides())
+
+        val extraConfigFilepath = overrides.getOptional[String]("extraConfigDir")
+          .toList
+          .map(_ + s"/$appName.conf")
+
+        overrides.withFallback(
+          loadConfiguration(developerConfigFiles ++ extraConfigFilepath)
+        )
       } else {
         loadConfiguration(deployedConfigFiles)
       }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/Services.scala
@@ -38,19 +38,19 @@ object ServiceHosts {
   }
 }
 
-class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: Set[String]) {
+class Services(val domainRoot: String, hosts: ServiceHosts, corsAllowedOrigins: Set[String], domainRootOverride: Option[String] = None) {
   val kahunaHost: String      = s"${hosts.kahunaPrefix}$domainRoot"
   val apiHost: String         = s"${hosts.apiPrefix}$domainRoot"
-  val loaderHost: String      = s"${hosts.loaderPrefix}$domainRoot"
-  val cropperHost: String     = s"${hosts.cropperPrefix}$domainRoot"
-  val metadataHost: String    = s"${hosts.metadataPrefix}$domainRoot"
-  val imgopsHost: String      = s"${hosts.imgopsPrefix}$domainRoot"
-  val usageHost: String       = s"${hosts.usagePrefix}$domainRoot"
-  val collectionsHost: String = s"${hosts.collectionsPrefix}$domainRoot"
-  val leasesHost: String      = s"${hosts.leasesPrefix}$domainRoot"
+  val loaderHost: String      = s"${hosts.loaderPrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val cropperHost: String     = s"${hosts.cropperPrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val metadataHost: String    = s"${hosts.metadataPrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val imgopsHost: String      = s"${hosts.imgopsPrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val usageHost: String       = s"${hosts.usagePrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val collectionsHost: String = s"${hosts.collectionsPrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val leasesHost: String      = s"${hosts.leasesPrefix}${domainRootOverride.getOrElse(domainRoot)}"
   val authHost: String        = s"${hosts.authPrefix}$domainRoot"
-  val adminToolsHost: String  = s"${hosts.adminToolsPrefix}$domainRoot"
-  val projectionHost: String  = s"${hosts.projectionPrefix}$domainRoot"
+  val adminToolsHost: String  = s"${hosts.adminToolsPrefix}${domainRootOverride.getOrElse(domainRoot)}"
+  val projectionHost: String  = s"${hosts.projectionPrefix}${domainRootOverride.getOrElse(domainRoot)}"
 
   val kahunaBaseUri      = baseUri(kahunaHost)
   val apiBaseUri         = baseUri(apiHost)

--- a/dev/script/start.sh
+++ b/dev/script/start.sh
@@ -31,6 +31,10 @@ for arg in "$@"; do
     LOCAL_AUTH=true
     shift
   fi
+  if [ "$arg" == "--use-TEST" ]; then
+    USE_TEST=true
+    shift
+  fi
 done
 
 isInstalled() {
@@ -84,7 +88,26 @@ checkRequirements() {
 }
 
 startDockerContainers() {
-  docker-compose up -d
+  EXISTING_TUNNELS=$(ps -ef | grep ssh | grep 9200 | grep -v grep || true)
+  if [[ $USE_TEST == true ]]; then
+    docker-compose down
+    if [[ -n $EXISTING_TUNNELS ]]; then
+      echo "RE-USING EXISTING TUNNEL TO TEST ELASTICSEARCH (on port 9200)"
+    else
+      TUNNEL_OPTS="-o ExitOnForwardFailure=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=2"
+      SSH_COMMAND=$(ssm ssh --profile media-service -t elasticsearch-data,grid-elasticsearch,TEST --newest --raw)
+      eval $SSH_COMMAND -f -N $TUNNEL_OPTS -L 9200:localhost:9200
+      echo "TUNNEL ESTABLISHED TO TEST ELASTICSEARCH (on port 9200)"
+    fi
+  else
+    if [[ $EXISTING_TUNNELS ]]; then
+      echo "KILLING EXISTING TUNNEL TO TEST ELASTICSEARCH (on port 9200)"
+      # shellcheck disable=SC2046
+      kill $(echo $EXISTING_TUNNELS | awk '{print $2}')
+    fi
+    docker-compose up -d
+  fi
+
 }
 
 buildJs() {
@@ -101,9 +124,21 @@ startPlayApps() {
   echo "========================================================="
   pushd "$ROOT_DIR"
   if [ "$IS_DEBUG" == true ] ; then
-    sbt -jvm-debug 5005 runAll
+    SBT_OPTS="-jvm-debug 5005"
+  fi
+  if [[ $USE_TEST == true ]]; then
+
+    EXTRA_CONFIG_DIR=/tmp/grid-config-TEST
+    mkdir -p $EXTRA_CONFIG_DIR
+
+    aws s3 cp s3://grid-conf/TEST/media-api/media-api.conf $EXTRA_CONFIG_DIR/ --profile media-service
+    aws s3 cp s3://grid-conf/TEST/kahuna/kahuna.conf $EXTRA_CONFIG_DIR/ --profile media-service
+
+    SBT_OPTS="$SBT_OPTS -J-Daws.local.endpoint= -J-DextraConfigDir=$EXTRA_CONFIG_DIR -J-Ddomain.root-override=test.dev-gutools.co.uk"
+
+    sbt $SBT_OPTS runMinimal
   else
-    sbt runAll
+    sbt $SBT_OPTS runAll
   fi
   popd
 }

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -1,8 +1,10 @@
 package lib
 
+import com.amazonaws.services.cloudfront.util.SignerUtils
 import com.gu.mediaservice.lib.config.{CommonConfigWithElastic, GridConfigResources}
 import org.joda.time.DateTime
 
+import java.security.PrivateKey
 import scala.util.Try
 
 case class StoreConfig(
@@ -23,14 +25,10 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val imageBucket: String = string("s3.image.bucket")
   val thumbBucket: String = string("s3.thumb.bucket")
 
-  val cloudFrontPrivateKeyLocations: Seq[String] = Seq(
-    "/etc/grid/ssl/private/cloudfront.pem",
-    "/etc/gu/ssl/private/cloudfront.pem" // TODO - remove once migrated away from
-  )
-
-  val cloudFrontDomainImageBucket: Option[String] = stringOpt("cloudfront.domain.imagebucket")
-  val cloudFrontDomainThumbBucket: Option[String] = stringOpt("cloudfront.domain.thumbbucket")
-  val cloudFrontKeyPairId: Option[String]         = stringOpt("cloudfront.keypair.id")
+  val cloudFrontDomainThumbBucket: Option[String]   = stringOpt("cloudfront.domain.thumbbucket")
+  val cloudFrontPrivateKeyBucket: Option[String]    = stringOpt("cloudfront.private-key.bucket")
+  val cloudFrontPrivateKeyBucketKey: Option[String] = stringOpt("cloudfront.private-key.key")
+  val cloudFrontKeyPairId: Option[String]           = stringOpt("cloudfront.keypair.id")
 
  lazy val softDeletedMetadataTable: String = string("dynamo.table.softDelete.metadata")
 

--- a/media-api/app/lib/S3Client.scala
+++ b/media-api/app/lib/S3Client.scala
@@ -1,36 +1,51 @@
 package lib
 
+import com.amazonaws.auth.PEM
+
 import java.io.File
 import java.util.Date
-
 import com.amazonaws.services.cloudfront.CloudFrontUrlSigner
+import com.amazonaws.services.cloudfront.util.SignerUtils
 import com.amazonaws.services.cloudfront.util.SignerUtils.Protocol
+import com.amazonaws.services.s3.model.GetObjectRequest
 import com.gu.mediaservice.lib.aws.S3
 import org.joda.time.DateTime
 
+import java.security.PrivateKey
 import scala.util.Try
 
 trait CloudFrontDistributable {
-  val privateKeyLocations: Seq[String]
+  val privateKey: PrivateKey
   val keyPairId: Option[String]
 
   val protocol: Protocol = Protocol.https
   val validForMinutes: Int = 30
 
   private def expiresAt: Date = DateTime.now.plusMinutes(validForMinutes).toDate
-  private lazy val privateKeyFile: File =
-    privateKeyLocations.map { location =>
-      new File(location)
-    }.find(_.exists).get
 
   def signedCloudFrontUrl(cloudFrontDomain: String, s3ObjectPath: String): Option[String] = Try {
     CloudFrontUrlSigner.getSignedURLWithCannedPolicy(
-      protocol, cloudFrontDomain, privateKeyFile, s3ObjectPath, keyPairId.get, expiresAt)
+      SignerUtils.generateResourcePath(protocol, cloudFrontDomain, s3ObjectPath),
+      keyPairId.get,
+      privateKey,
+      expiresAt
+    )
   }.toOption
 }
 
 class S3Client(config: MediaApiConfig) extends S3(config) with CloudFrontDistributable {
-  lazy val privateKeyLocations: Seq[String] = config.cloudFrontPrivateKeyLocations
   lazy val keyPairId: Option[String] = config.cloudFrontKeyPairId
+  lazy val privateKey: PrivateKey = {
+    config.cloudFrontPrivateKeyBucket.flatMap(bucket => config.cloudFrontPrivateKeyBucketKey.map { key =>
+      val privateKeyStream = client.getObject(bucket, key).getObjectContent
+      try {
+        PEM.readPrivateKey(privateKeyStream)
+      }
+      finally {
+        privateKeyStream.close()
+      }
+    }).orElse(Try(SignerUtils.loadPrivateKey("/etc/grid/ssl/private/cloudfront.pem")).toOption)
+      .getOrElse(throw new RuntimeException("No private key found"))
+  }
 }
 


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 
Co-authored-by: @paperboyo 

Most of our development on the grid centres around `kahuna` (the UI) and `media-api` (the API) so it's a pain to...

1. have to spin-up docker with its 5 containers
2. upload images every time (including having to delete the containers between machine/docker restarts, since persistence in localstack is a paid-for feature)

... and for when you need to more than a handful of images (e.g. implementing search changes) it's super painful. SO, why don't we just connect to `TEST` for ElasticSearch and all the other micro-services (except auth, which we want to run locally too). That's what this PR does!

PLUS refactor loading of CloudFront private key to load from S3 once (using new config properties `cloudfront.private-key.bucket` and `cloudfront.private-key.key`)
