### PR TITLE
Use new riffraff option to lookup deployment bucket from ssm

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -128,5 +128,6 @@ deployments:
   media-service-fluentbit:
     type: aws-s3
     parameters:
+      bucket: media-service-dist
       cacheControl: private
       publicReadAcl: false

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,7 +12,6 @@ templates:
   autoscaling:
     type: autoscaling
     parameters:
-      bucket: media-service-dist
     dependencies:
       - app-ami-update
       - media-service-fluentbit
@@ -22,7 +21,6 @@ templates:
     app: usage
     contentDirectory: usage
     parameters:
-      bucket: media-service-dist
     dependencies:
       - app-ami-update
       - media-service-fluentbit
@@ -119,7 +117,6 @@ deployments:
   s3watcher:
     type: aws-lambda
     parameters:
-      bucket: media-service-dist
       functions:
         TEST:
           filename: s3watcher.zip
@@ -131,6 +128,5 @@ deployments:
   media-service-fluentbit:
     type: aws-s3
     parameters:
-      bucket: media-service-dist
       cacheControl: private
       publicReadAcl: false


### PR DESCRIPTION

## What does this change?

Remove hard-coded deployment artifact bucket, riff-raff now defaults to locating bucket from account parameter store.
Less red ink on our deploys due to using deprecated options!

(aws-s3 does not yet have bucketSsmLookup so the hard-coded bucket name must remain there :( )