### PR TITLE
Do not show invalid images as no_rights in costState

### DIFF
--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -28,7 +28,7 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
             cost,
             hasCrops: image.data.exports && image.data.exports.length > 0,
             hasRights,
-            costState: hasRights && image.data.valid ? cost : "no_rights",
+            costState: hasRights ? cost : "no_rights",
             isValid: image.data.valid,
             canDelete: imageLogic.canBeDeleted(image),
             canArchive: imageLogic.canBeArchived(image),


### PR DESCRIPTION
## What does this change?

I did this in #3854 to try and override all other costs when an image is
missing credit or description (one definition of "valid"). Instead it
overrides all other costs whenever an image is uncroppable (restricted,
overquota, etc., the other definition of "valid").

costState is used to determine both which flags to show on the search
results page, and also the warnings/error messages on the image page,
which means that this change hid the restriction text from ALL
unpermissioned users! So revert this logic now, and commit to finding a
better way of applying the invalid flag in the future.


## How should a reviewer test this change?

Look at an image with restrictions while without the edit_metadata permission. Can you see the restriction text? If you view the image in the search results page, you will unfortunately see only a yellow "restricted" flag, rather than a more descriptive red "!" flag.
