### PR TITLE
set GHA to run on ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Grid CI
 on: [pull_request]
 jobs:
   JSBuild:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [12.16.1]
@@ -33,7 +33,7 @@ jobs:
           npm install
           npm run riffraff-artefact
   ScalaBuild:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2


### PR DESCRIPTION


## What does this change?

18.04 is deprecated and slated for decomm soonish

see https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

## How should a reviewer test this change?

See the actions runs succeed