### PR TITLE
make keywords editable in UI

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -35,7 +35,7 @@ object MappingTest {
     suppliersReference = Some("ASDFFF"),
     source = Some("bill-withers"),
     specialInstructions = Some("This is really important."),
-    keywords = Some(List("sunset", "loveliness", "distance")),
+    keywords = Some(Set("sunset", "loveliness", "distance")),
     subLocation = Some("Downtown"),
     city = Some("LA"),
     state = Some("California"),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -42,13 +42,13 @@ object ImageMetadataConverter extends GridLogging {
     Some((xmpIptcPeople ++ xmpGettyPeople).toSet)
   }
 
-  private def extractKeywords(fileMetadata: FileMetadata): Option[List[String]] = {
-    val fromXMP =  extractXMPArrayStrings("dc:subject", fileMetadata).toList
-    val fromIPTC= fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toList) getOrElse Nil
+  private def extractKeywords(fileMetadata: FileMetadata): Option[Set[String]] = {
+    val fromXMP  = extractXMPArrayStrings("dc:subject", fileMetadata).toSet
+    val fromIPTC = fileMetadata.iptc.get("Keywords") map (_.split(Array(';', ',')).distinct.map(_.trim).toSet) getOrElse Set.empty
     Some((fromXMP, fromIPTC) match {
       case (xmp, _)  if xmp.nonEmpty  => xmp
       case (_, iptc) if iptc.nonEmpty => iptc
-      case _ => Nil
+      case _ => Set.empty
     })
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -19,7 +19,7 @@ case class ImageMetadata(
   suppliersReference:  Option[String]   = None,
   source:              Option[String]   = None,
   specialInstructions: Option[String]   = None,
-  keywords:            Option[List[String]] = None,
+  keywords:            Option[Set[String]] = None,
   subLocation:         Option[String]   = None,
   city:                Option[String]   = None,
   state:               Option[String]   = None,
@@ -67,7 +67,7 @@ object ImageMetadata {
       (__ \ "suppliersReference").readNullable[String] ~
       (__ \ "source").readNullable[String] ~
       (__ \ "specialInstructions").readNullable[String] ~
-      (__ \ "keywords").readNullable[List[String]] ~
+      (__ \ "keywords").readNullable[Set[String]] ~
       (__ \ "subLocation").readNullable[String] ~
       (__ \ "city").readNullable[String] ~
       (__ \ "state").readNullable[String] ~
@@ -89,7 +89,7 @@ object ImageMetadata {
       (__ \ "suppliersReference").writeNullable[String] ~
       (__ \ "source").writeNullable[String] ~
       (__ \ "specialInstructions").writeNullable[String] ~
-      (__ \ "keywords").writeNullable[List[String]] ~
+      (__ \ "keywords").writeNullable[Set[String]] ~
       (__ \ "subLocation").writeNullable[String] ~
       (__ \ "city").writeNullable[String] ~
       (__ \ "state").writeNullable[String] ~

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverterTest.scala
@@ -22,7 +22,7 @@ class ImageMetadataConverterTest extends AnyFunSpec with Matchers {
     imageMetadata.suppliersReference should be ('empty)
     imageMetadata.source should be ('empty)
     imageMetadata.specialInstructions should be ('empty)
-    imageMetadata.keywords should be (Some(Nil))
+    imageMetadata.keywords should be (Some(Set.empty))
     imageMetadata.subLocation should be ('empty)
     imageMetadata.city should be ('empty)
     imageMetadata.state should be ('empty)
@@ -306,13 +306,13 @@ class ImageMetadataConverterTest extends AnyFunSpec with Matchers {
   it("should populate keywords field of ImageMetadata from comma-separated list of keywords") {
     val fileMetadata = FileMetadata(Map("Keywords" -> "Foo,Bar, Baz"), Map(), Map(), Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.keywords should be(Some(List("Foo", "Bar", "Baz")))
+    imageMetadata.keywords should be(Some(Set("Foo", "Bar", "Baz")))
   }
 
   it("should populate keywords field of ImageMetadata from semi-colon-separated list of keywords") {
     val fileMetadata = FileMetadata(Map("Keywords" -> "Foo;Bar; Baz"), Map(), Map(), Map())
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.keywords should be(Some(List("Foo", "Bar", "Baz")))
+    imageMetadata.keywords should be(Some(Set("Foo", "Bar", "Baz")))
   }
 
   it("should populate keywords field of ImageMetadata from dc-subjects") {
@@ -322,7 +322,7 @@ class ImageMetadataConverterTest extends AnyFunSpec with Matchers {
       exifSub = Map(),
       xmp = Map("dc:subject"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.keywords should be(Some(List("Foo", "Bar", "Baz")))
+    imageMetadata.keywords should be(Some(Set("Foo", "Bar", "Baz")))
   }
 
   it("should populate keywords field of ImageMetadata from dc-subjectsin preference to keywords") {
@@ -331,7 +331,7 @@ class ImageMetadataConverterTest extends AnyFunSpec with Matchers {
       exif = Map(), exifSub = Map(),
       xmp = Map("dc:subject"-> JsArray(Seq(JsString("Foo"), JsString("Bar"), JsString("Baz")))))
     val imageMetadata = ImageMetadataConverter.fromFileMetadata(fileMetadata)
-    imageMetadata.keywords should be(Some(List("Foo", "Bar", "Baz")))
+    imageMetadata.keywords should be(Some(Set("Foo", "Bar", "Baz")))
   }
 
   it("should leave non-dates alone") {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -1,4 +1,4 @@
-.metadata-people__button {
+.metadata-plus__button {
   float: right;
 }
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -619,6 +619,7 @@
                                    'text-input': true}">
 
                     <ui-list-editor-info-panel
+                        is-editable="ctrl.userCanEdit"
                         images="ctrl.selectedImages"
                         add-to-images="ctrl.addPersonToImages"
                         remove-from-images="ctrl.removePersonFromImages"
@@ -867,6 +868,7 @@
         </dt>
         <dd class="labels">
             <ui-list-editor-info-panel
+                is-editable="ctrl.userCanEdit"
                 images="ctrl.selectedImages"
                 add-to-images="ctrl.addLabelToImages"
                 remove-from-images="ctrl.removeLabelFromImages"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -592,10 +592,10 @@
                 </span>
             </dd>
 
-            <dt ng-if="ctrl.rawMetadata.peopleInImage.length > 0 || ctrl.userCanEdit" class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">People</dt>
-            <dd ng-if="ctrl.rawMetadata.peopleInImage.length > 0 || ctrl.userCanEdit" class="image-info__people image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+            <dt class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">People</dt>
+            <dd class="image-info__people image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <button data-cy="it-edit-people-button"
-                        class="metadata-people__button"
+                        class="metadata-plus__button"
                         ng-class="{'small': ctrl.grSmall}"
                         ng-click="peopleInImageEditForm.$show()"
                         ng-hide="peopleInImageEditForm.$visible"
@@ -627,7 +627,6 @@
                         query-filter="queryFilter:'person'"
                         element-name="person">
                     </ui-list-editor-info-panel>
-                </span>
             </dd>
     </dl>
     </div>
@@ -900,18 +899,47 @@
     </div>
 </div>
 
-<div ng-if="ctrl.singleImage" class="image-info" role="region" aria-label="Keywords">
-    <dl class="image-info__group image-info__wrap" ng-if="ctrl.metadata.keywords.length > 0">
-        <dt class="image-info__heading image-info__wrap">Keywords</dt>
+<div class="image-info" role="region" aria-label="Keywords">
+    <dl class="image-info__group image-info__wrap">
+        <dt class="image-info__heading image-info__wrap">
+            Keywords
+            <button data-cy="it-edit-keywords-button"
+                    class="metadata-plus__button"
+                    ng-class="{'small': ctrl.grSmall}"
+                    ng-click="keywordsEditForm.$show()"
+                    ng-hide="keywordsEditForm.$visible"
+                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
+                    gr-tooltip="Add Keyword"
+                    gr-tooltip-position="left"
+                    aria-label="Add keyword to image">
+
+                <gr-icon ng-class="{'spin': ctrl.adding}">add_box</gr-icon>
+                <span>
+                    <span ng-show="ctrl.adding">Adding...</span>
+                </span>
+            </button>
+        </dt>
         <dd class="image-info__keywords">
-            <ul>
-                <ui-list-editor-compact
+            <span ng-class="{'image-info--multiple': ctrl.selectedImages.size > 0}"
+                  editable-text="ctrl.newKeywords"
+                  ng-hide="keywordsEditForm.$visible"
+                  onbeforesave="ctrl.updateMetadataField('keywords', $data)"
+                  e:form="keywordsEditForm"
+                  e:ng-class="{'image-info__editor--error': $error,
+                                       'image-info__editor--saving': keywordsEditForm.$waiting,
+                                       'text-input': true}">
+
+                <ui-list-editor-info-panel
+                    is-editable="ctrl.userCanEdit"
                     images="ctrl.selectedImages"
+                    add-to-images="ctrl.addKeywordToImages"
+                    remove-from-images="ctrl.removeKeywordFromImages"
                     accessor="ctrl.keywordAccessor"
                     query-filter="queryFilter:'keyword'"
                     element-name="keyword">
-                </ui-list-editor-compact>
-            </ul>
+                </ui-list-editor-info-panel>
+
+            </span>
         </dd>
     </dl>
 </div>

--- a/kahuna/public/js/edits/list-editor-info-panel.html
+++ b/kahuna/public/js/edits/list-editor-info-panel.html
@@ -10,6 +10,7 @@
     <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})" class="element__value"
        aria-label="Search images by {{element.data}} {{ctrl.elementName}}">{{element.data}}</a>
     <button class="element__remove"
+            ng-if="ctrl.isEditable"
             title="Remove {{ctrl.elementName}}{{element.count > 1 ? ' from all' : ''}}"
             ng-click="ctrl.removeElement(element.data)" aria-label="Remove {{ctrl.elementName}}">
         <gr-icon>close</gr-icon>

--- a/kahuna/public/js/edits/list-editor-info-panel.html
+++ b/kahuna/public/js/edits/list-editor-info-panel.html
@@ -1,15 +1,19 @@
 <li class="element"
     ng-repeat="element in ctrl.listWithOccurrences"
     ng-class="{'element--partial': element.count < ctrl.images.size}">
-    <button ng-if="element.count < ctrl.images.size"
+    <button ng-if="ctrl.isEditable && element.count < ctrl.images.size"
             class="element__add"
             title="Apply {{ctrl.elementName}} to all"
             ng-click="ctrl.addElements([element.data])">
         <gr-icon>library_add</gr-icon>
     </button>
     <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})" class="element__value"
-       aria-label="Search images by {{element.data}} {{ctrl.elementName}}">{{element.data}}</a>
-    <button class="element__remove"
+       aria-label="Search images by {{element.data}} {{ctrl.elementName}}"
+       ng-class="{'element__right-bit': !ctrl.isEditable}"
+    >
+        {{element.data}}
+    </a>
+    <button class="element__right-bit"
             ng-if="ctrl.isEditable"
             title="Remove {{ctrl.elementName}}{{element.count > 1 ? ' from all' : ''}}"
             ng-click="ctrl.removeElement(element.data)" aria-label="Remove {{ctrl.elementName}}">

--- a/kahuna/public/js/edits/list-editor-upload.html
+++ b/kahuna/public/js/edits/list-editor-upload.html
@@ -22,7 +22,7 @@
                class="element__value element__link">{{element}}</a>
 
             <button data-cy="it-remove-element-button"
-                    class="element__remove"
+                    class="element__right-bit"
                     title="Remove {{ctrl.elementName}}"
                     ng-click="ctrl.removeElement(element)">
                 <gr-icon>close</gr-icon>

--- a/kahuna/public/js/edits/list-editor.css
+++ b/kahuna/public/js/edits/list-editor.css
@@ -24,25 +24,25 @@ element--partial is part of gr-panel.
 */
 .element--partial .element__value,
 .element--partial .element__add,
-.element--partial .element__remove {
+.element--partial .element__right-bit {
     background-color: white;
     color: #00adee;
 }
 
 .element__value,
-.element__remove {
+.element__right-bit {
     color: white;
     background-color: #00adee;
     font-style: normal;
 }
 
 .element__link:hover,
-.element__remove:hover {
+.element__right-bit:hover {
     color: #00adee;
     background-color: white;
 }
 
-.image-info .element__remove:hover,
+.image-info .element__right-bit:hover,
 .image-info .element__value:hover {
     color: #00adee;
     background-color: white;
@@ -66,7 +66,7 @@ element--partial is part of gr-panel.
     border-radius: 2px;
 }
 
-.element__remove {
+.element__right-bit {
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
 }
@@ -100,10 +100,10 @@ element--partial is part of gr-panel.
 }
 
 .image-info__people  .element--partial .element__value,
-.image-info__people .element--partial .element__remove,
+.image-info__people .element--partial .element__right-bit,
 .image-info__people .element--partial .element__add,
 .image-info__keywords  .element--partial .element__value,
-.image-info__keywords .element--partial .element__remove,
+.image-info__keywords .element--partial .element__right-bit,
 .image-info__keywords .element--partial .element__add{
     background-color: white;
     color: #222;
@@ -111,10 +111,10 @@ element--partial is part of gr-panel.
 }
 
 .image-info__people .element__value,
-.image-info__people .element__remove,
+.image-info__people .element__right-bit,
 .image-info__people .element__add,
 .image-info__keywords .element__value,
-.image-info__keywords .element__remove,
+.image-info__keywords .element__right-bit,
 .image-info__keywords .element__add {
     background-color: #222;
     color: #aaa;
@@ -123,10 +123,10 @@ element--partial is part of gr-panel.
 
 .image-info__people .element__value:hover,
 .image-info__people .element__link:hover,
-.image-info__people .element__remove:hover,
+.image-info__people .element__right-bit:hover,
 .image-info__keywords .element__value:hover,
 .image-info__keywords .element__link:hover,
-.image-info__keywords .element__remove:hover {
+.image-info__keywords .element__right-bit:hover {
     color: #222;
     background-color: white;
 }
@@ -136,7 +136,7 @@ element--partial is part of gr-panel.
     color: #717171;
 }
 
-.image-info__people .element--partial .element__remove:hover gr-icon,
-.image-info__keywords .element--partial .element__remove:hover gr-icon {
+.image-info__people .element--partial .element__right-bit:hover gr-icon,
+.image-info__keywords .element--partial .element__right-bit:hover gr-icon {
     color: #717171;
 }

--- a/kahuna/public/js/edits/list-editor.js
+++ b/kahuna/public/js/edits/list-editor.js
@@ -177,6 +177,7 @@ listEditor.directive('uiListEditorInfoPanel', [function() {
             addToImages: '<',
             removeFromImages: '<',
             accessor: '<',
+            isEditable: '<',
             queryFilter: '@',
             elementName: '@'
         },

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -74,7 +74,7 @@ trait Fixtures {
       optimisedPng = None,
       fileMetadata = fileMetadata.getOrElse(FileMetadata()),
       userMetadata = None,
-      metadata = ImageMetadata(dateTaken = None, title = Some(s"Test image $id"), keywords = Some(List("test", "es"))),
+      metadata = ImageMetadata(dateTaken = None, title = Some(s"Test image $id"), keywords = Some(Set("test", "es"))),
       originalMetadata = ImageMetadata(),
       usageRights = usageRights,
       originalUsageRights = usageRights,

--- a/thrall/test/helpers/Fixtures.scala
+++ b/thrall/test/helpers/Fixtures.scala
@@ -42,7 +42,7 @@ trait Fixtures {
      optimisedPng = None,
      fileMetadata = fileMetadata.getOrElse(FileMetadata()),
      userMetadata = optPhotoshoot.map(_ => Edits(metadata = ImageMetadata(), photoshoot = optPhotoshoot)),
-     metadata = ImageMetadata(dateTaken = None, title = Some(s"Test image $id"), keywords = Some(List("test", "es"))),
+     metadata = ImageMetadata(dateTaken = None, title = Some(s"Test image $id"), keywords = Some(Set("test", "es"))),
      originalMetadata = ImageMetadata(),
      usageRights = usageRights,
      originalUsageRights = usageRights,


### PR DESCRIPTION
Previously keywords were readonly (despite the fact metadata service technically supports them being edited).

In the PR we re-use the pattern & components used for the `People` field, for keywords - to make them editable.

| Before | After |
| --- | --- |
| <img width="272" alt="image" src="https://user-images.githubusercontent.com/19289579/198596960-ca2382f8-6917-4a32-b496-95f9543f4470.png"> | <img width="276" alt="image" src="https://user-images.githubusercontent.com/19289579/198597165-7fd6a766-13ba-4c22-9084-e1a645d1c461.png"> |

This involved a little refactoring to make the add/remove logic generic to avoid repetition (UI parts could probably be wrapped in their own directive).

PLUS made sure that the remove button beside editable pills is not visible if the user cannot edit (i.e. they're not the uploader or they don't have `EditMetadata` permission) - to avoid it just breaking when clicked by users who cannot edit.

| Before | After |
| --- | --- |
| <img width="280" alt="image" src="https://user-images.githubusercontent.com/19289579/198599088-db166e50-1821-4680-a1e5-fba8d23b895b.png"> | <img width="279" alt="image" src="https://user-images.githubusercontent.com/19289579/198598914-9ec72e2b-e5d7-407c-b3c7-62e79428781a.png"> |
