### PR TITLE
support the persisted query param

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -162,7 +162,8 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             'modifiedUntil',
             'hasRightsAcquired',
             'hasCrops',
-            'syndicationStatus'
+            'syndicationStatus',
+            'persisted'
         ].join('&'),
         // Non-URL parameters
         params: {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -341,6 +341,7 @@ results.controller('SearchResultsCtrl', [
                 hasRightsAcquired: $stateParams.hasRightsAcquired,
                 hasCrops: $stateParams.hasCrops,
                 syndicationStatus: $stateParams.syndicationStatus,
+                persisted: $stateParams.persisted,
                 countAll
             }));
         }

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -17,7 +17,7 @@ mediaApi.factory('mediaApi',
                                  payType, uploadedBy, offset, length, orderBy,
                                  takenSince, takenUntil,
                                  modifiedSince, modifiedUntil, hasRightsAcquired, hasCrops,
-                                 syndicationStatus, countAll} = {}) {
+                                 syndicationStatus, countAll, persisted} = {}) {
         return root.follow('search', {
             q:          query,
             since:      since,
@@ -38,7 +38,8 @@ mediaApi.factory('mediaApi',
             hasRightsAcquired: maybeStringToBoolean(hasRightsAcquired),
             hasExports: maybeStringToBoolean(hasCrops), // Grid API calls crops exports...
             syndicationStatus: syndicationStatus,
-            countAll
+            countAll,
+            persisted
         }).get();
     }
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -75,7 +75,8 @@ class MediaApi(
     "usagePlatform",
     "hasRightsAcquired",
     "syndicationStatus",
-    "countAll"
+    "countAll",
+    "persisted"
   ).mkString(",")
 
   private val searchLinkHref = s"${config.rootUri}/images{?$searchParamList}"


### PR DESCRIPTION
## What does this change?

Allow to do search for reapable images by adding `persisted=false` (or `true`) in address bar
(I did briefly look at adding to chips, but is definitely harder than query-param :( )

## How should a reviewer test this change?

Deploy to TEST, add the param, see the results be filtered accordingly

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
