### PR TITLE
FIX `Labels` should be editable by anyone in UI

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -867,7 +867,7 @@
         </dt>
         <dd class="labels">
             <ui-list-editor-info-panel
-                is-editable="ctrl.userCanEdit"
+                is-editable="true"
                 images="ctrl.selectedImages"
                 add-to-images="ctrl.addLabelToImages"
                 remove-from-images="ctrl.removeLabelFromImages"


### PR DESCRIPTION
tiny fix to #3908 to re-instate normal removable behaviour for labels in the UI