### PR TITLE
remove double scrollbar from image page

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -30,5 +30,5 @@
 
 gr-image-metadata dd {
     overflow: hidden;
-    text-overflow: ellipsis;
+    word-break: break-word;
 }

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -27,3 +27,8 @@
      letter-spacing: -1px;
      margin-bottom: 3px;
 }
+
+gr-image-metadata dd {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -28,7 +28,7 @@
 
 
 <div class="image-details image-details--crop" role="complementary" aria-label="Image original and crops select">
-    <div class="image-info">
+    <div class="image-info image-details--scroll">
         <div class="image-info__group" role="region" aria-label="Original image">
             <dl>
                 <dt class="image-info__heading">Original <span class="image-info__file-size"> {{:: ctrl.image.data.source.size | asFileSize}}</span></dt>

--- a/kahuna/public/js/leases/leases.css
+++ b/kahuna/public/js/leases/leases.css
@@ -87,7 +87,6 @@ gr-leases .gu-date-range__display {
   width: 100%;
 }
 
-.image-details--full-image,
 .image-info__wrap {
   overflow: visible;
 }

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -5,7 +5,7 @@
         ng-click="ctrl.editing = true"
         ng-if="ctrl.userCanEdit && !ctrl.receivingBatch"
         gr-tooltip="Add lease"
-        gr-tooltip-position="bottom"
+        gr-tooltip-position="left"
         aria-label="Add lease to image">
 
     <gr-icon data-cy="it-add-lease-icon" ng-show="!ctrl.editing" ng-class="{'spin': ctrl.adding}">add_box</gr-icon>

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -324,6 +324,7 @@ z-index
 }
 
 html {
+    overflow-x: hidden;
     font: 62.5%/1.5 "Open Sans", sans-serif;
 }
 
@@ -1906,7 +1907,7 @@ FIXME: what to do with touch devices
 }
 
 .image-details--scroll {
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
 }
 
@@ -1917,11 +1918,11 @@ FIXME: what to do with touch devices
     border-left: none;
     position: relative;
     height: calc(100vh - 50px); /* viewport - top-bar */
+    display: flex;
+    flex-direction: column;
 }
 
 .image-details__delete-crops {
-    position: absolute;
-    bottom: 0;
     width: 100%;
 }
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1901,11 +1901,13 @@ FIXME: what to do with touch devices
     height: calc(100vh - 50px); /* viewport - top-bar */
     width: 300px;
     border-left: 1px solid #565656;
+    display: flex;
+    flex-direction: column;
 }
 
 .image-details--scroll {
-    height: calc(100vh - 50px - 35px); /* viewport - top-bar - tab-bar */
     overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .image-details--crop {


### PR DESCRIPTION
## What does this change?

Before:
![image](https://user-images.githubusercontent.com/10963046/199688119-6bc6a975-0eaa-4512-b83d-96aaaf3ac6ae.png)
After:
<img width="323" alt="image" src="https://user-images.githubusercontent.com/10963046/199986201-3a3e7dcf-121e-47ac-89cf-0bad45cbd8ea.png">
<img width="133" alt="image" src="https://user-images.githubusercontent.com/10963046/199986246-7b54f3de-0b90-4fc8-a515-dc11706fdb3d.png">


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
