### PR TITLE
Add a new filter showing reapable images

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -87,7 +87,8 @@ const isSearch = [
     `${staffPhotographerOrganisation}-owned-illustration`,
     `${staffPhotographerOrganisation}-owned`,
   'under-quota',
-  'deleted'
+  'deleted',
+  'reapable'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {

--- a/media-api/app/lib/elasticsearch/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/IsQueryFilter.scala
@@ -4,6 +4,8 @@ import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.model._
 import com.sksamuel.elastic4s.ElasticDsl.matchAllQuery
 import com.sksamuel.elastic4s.requests.searches.queries.Query
+import lib.MediaApiConfig
+import org.joda.time.DateTime
 import scalaz.syntax.std.list._
 
 sealed trait IsQueryFilter extends Query with ImageFields {
@@ -15,19 +17,21 @@ sealed trait IsQueryFilter extends Query with ImageFields {
     case IsOwnedImage(staffPhotographerOrg) => s"$staffPhotographerOrg-owned"
     case _: IsDeleted => "deleted"
     case _: IsUnderQuota => "under-quota"
+    case _: IsReapable => "reapable"
   }
 }
 
 object IsQueryFilter {
   // for readability, the client capitalises gnm, so `toLowerCase` it before matching
-  def apply(value: String, overQuotaAgencies: () => List[Agency], staffPhotographerOrganisation: String): Option[IsQueryFilter] = {
-   val organisation = staffPhotographerOrganisation.toLowerCase
+  def apply(value: String, overQuotaAgencies: () => List[Agency], config: MediaApiConfig): Option[IsQueryFilter] = {
+    val organisation = config.staffPhotographerOrganisation.toLowerCase
     value.toLowerCase match {
       case s if s == s"$organisation-owned-photo" => Some(IsOwnedPhotograph(organisation))
       case s if s == s"$organisation-owned-illustration" => Some(IsOwnedIllustration(organisation))
       case s if s == s"$organisation-owned" => Some(IsOwnedImage(organisation))
       case "under-quota" => Some(IsUnderQuota(overQuotaAgencies()))
       case "deleted" => Some(IsDeleted(true))
+      case "reapable" => Some(IsReapable(config.persistedRootCollections, config.persistenceIdentifier))
       case _ => None
     }
   }
@@ -60,5 +64,28 @@ case class IsUnderQuota(overQuotaAgencies: List[Agency]) extends IsQueryFilter {
 case class IsDeleted(isDeleted: Boolean) extends IsQueryFilter {
   override def query: Query = filters.or(
     (filters.existsOrMissing("softDeletedMetadata", _))(isDeleted)
+  )
+}
+
+case class IsReapable(persistedRootCollections: List[String], persistenceIdentifier: String) extends IsQueryFilter {
+  val moreThanTwentyDaysOld = filters.date("uploadTime", Some(new DateTime(0)), Some(DateTime.now().minusDays(20))).getOrElse(matchAllQuery())
+
+  val persistedQueries = filters.or(
+    PersistedQueries.hasCrops,
+    PersistedQueries.usedInContent,
+    PersistedQueries.addedToLibrary,
+    PersistedQueries.hasUserEditsToImageMetadata,
+    PersistedQueries.hasPhotographerUsageRights,
+    PersistedQueries.hasIllustratorUsageRights,
+    PersistedQueries.hasAgencyCommissionedUsageRights,
+    PersistedQueries.addedToPhotoshoot,
+    PersistedQueries.hasLabels,
+    PersistedQueries.hasLeases,
+    PersistedQueries.existedPreGrid(persistenceIdentifier),
+    PersistedQueries.addedGNMArchiveOrPersistedCollections(persistedRootCollections)
+  )
+  override def query: Query = filters.and(
+    moreThanTwentyDaysOld,
+    filters.not(persistedQueries)
   )
 }

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -54,7 +54,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies, config.staffPhotographerOrganisation) match {
+      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies, config) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           logger.info(s"Cannot perform IS query on ${condition.value}")


### PR DESCRIPTION
## What does this change?

This adds a search filter for 'reapable' images, Add this in the search bar with `+is:reapable`. Reapable images are older than 20 days and match none of the persistence criteria.

A follow-up PR can add this filter by default on the API end, so that users only see images that are not reapable.

## How should a reviewer test this change?

1. Deploy to TEST. 
2. Apply the search filter `+is:reapable`
3. Do you see the amount of images you would expect? Are any 'reapable' images less than 20 days old? (they shouldn't be)

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
