### PR TITLE
Apply -is:reapable filter by default on API end

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -87,7 +87,8 @@ const isSearch = [
     `${staffPhotographerOrganisation}-owned-illustration`,
     `${staffPhotographerOrganisation}-owned`,
   'under-quota',
-  'deleted'
+  'deleted',
+  'reapable'
 ];
 
 querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(mediaApi, editsApi) {

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -54,7 +54,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
       case _ => throw InvalidQuery(s"Cannot perform has field on ${condition.value}")
     }
     case IsField => condition.value match {
-      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies, config.staffPhotographerOrganisation) match {
+      case IsValue(value) => IsQueryFilter.apply(value, overQuotaAgencies, config) match {
         case Some(isQuery) => isQuery.query
         case _ => {
           logger.info(s"Cannot perform IS query on ${condition.value}")

--- a/media-api/app/lib/querysyntax/Parser.scala
+++ b/media-api/app/lib/querysyntax/Parser.scala
@@ -5,12 +5,22 @@ object Parser {
   def run(input: String): List[Condition] = {
     normalise(
       parse(
-        if(input.contains("is:deleted")) input
-        else input.concat(" -is:deleted").trim
+        addDefaultFilters(input)
       )
     )
   }
+  def addDefaultFilters(input: String): String = {
+    val DeletedAndReapablePattern = "(?=is:deleted)(?=is:toBeReaped)".r
+    val ReapablePattern = "(.*is:reapable.*)".r
+    val DeletedPattern = "(.*is:deleted.*)".r
 
+    input match {
+      case DeletedAndReapablePattern(input) => input
+      case ReapablePattern(input) => input.concat(" -is:deleted").trim
+      case DeletedPattern(input) => input.concat(" -is:reapable").trim
+      case _ => input.concat(" -is:deleted -is:reapable").trim
+    }
+  }
   def parse(input: String): List[Condition] =
     new QuerySyntax(input.trim).Query.run().map(_.toList) getOrElse List()
 

--- a/media-api/app/lib/querysyntax/Parser.scala
+++ b/media-api/app/lib/querysyntax/Parser.scala
@@ -10,7 +10,7 @@ object Parser {
     )
   }
   def addDefaultFilters(input: String): String = {
-    val DeletedAndReapablePattern = "(?=is:deleted)(?=is:toBeReaped)".r
+    val DeletedAndReapablePattern = "(?=is:deleted)(?=is:reapable)".r
     val ReapablePattern = "(.*is:reapable.*)".r
     val DeletedPattern = "(.*is:deleted.*)".r
 

--- a/media-api/test/scala/lib/querysyntax/ParserTest.scala
+++ b/media-api/test/scala/lib/querysyntax/ParserTest.scala
@@ -12,49 +12,51 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
   val bylineField     = SingleField(getFieldPath("byline"))
   val labelsField     = SingleField(getFieldPath("labels"))
   val uploadTimeField = SingleField(getFieldPath("uploadTime"))
+  val deleteNegation = Negation(Match(IsField,IsValue("deleted")))
+  val reapableNegation = Negation(Match(IsField,IsValue("reapable")))
 
   describe("text") {
     it("should match single terms") {
-      Parser.run("cats") should be (List(Match(AnyField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("cats") should be (List(Match(AnyField, Words("cats")), deleteNegation, reapableNegation))
     }
 
     it("should match single terms with accents") {
-      Parser.run("séb") should be (List(Match(AnyField,Words("séb")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("séb") should be (List(Match(AnyField,Words("séb")), deleteNegation, reapableNegation))
     }
     it("should match single terms with curly apostrophe") {
-      Parser.run("l’apostrophe") should be (List(Match(AnyField, Words("l’apostrophe")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("l’apostrophe") should be (List(Match(AnyField, Words("l’apostrophe")), deleteNegation, reapableNegation))
     }
 
     it("should ignore surrounding whitespace") {
-      Parser.run(" cats ") should be (List(Match(AnyField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run(" cats ") should be (List(Match(AnyField, Words("cats")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms") {
-      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats dogs")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("cats dogs") should be (List(Match(AnyField, Words("cats dogs")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms separated by multiple whitespace") {
-      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats dogs")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("cats  dogs") should be (List(Match(AnyField, Words("cats dogs")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms including 'in'") {
-      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats in dogs")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("cats in dogs") should be (List(Match(AnyField, Words("cats in dogs")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms including 'by'") {
-      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats by dogs")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("cats by dogs") should be (List(Match(AnyField, Words("cats by dogs")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms including apostrophes") {
-      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's a cat")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("it's a cat") should be (List(Match(AnyField, Words("it's a cat")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms including commas") {
-      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats, dogs")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("cats, dogs") should be (List(Match(AnyField, Words("cats, dogs")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple terms including single double quotes") {
-      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\" cats")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("5\" cats") should be (List(Match(AnyField, Words("5\" cats")), deleteNegation, reapableNegation))
     }
 
     // it("should match multiple terms including '#' character") {
@@ -63,18 +65,18 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
     // }
 
     it("should match a quoted phrase") {
-      Parser.run(""""cats dogs"""") should be (List(Match(AnyField, Phrase("cats dogs")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run(""""cats dogs"""") should be (List(Match(AnyField, Phrase("cats dogs")), deleteNegation, reapableNegation))
     }
 
     it("should match faceted terms") {
-      Parser.run("credit:cats") should be (List(Match(creditField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("credit:cats") should be (List(Match(creditField, Words("cats")), deleteNegation, reapableNegation))
     }
 
     it("should match multiple faceted terms on the same facet") {
       Parser.run("label:cats label:dogs") should be (List(
         Match(labelsField, Words("cats")),
         Match(labelsField, Words("dogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -82,7 +84,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("credit:cats label:dogs") should be (List(
         Match(creditField, Words("cats")),
         Match(labelsField, Words("dogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
   }
@@ -100,7 +102,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-12-31T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -112,7 +114,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-31T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -124,7 +126,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-31T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -136,7 +138,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -148,7 +150,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -160,7 +162,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -172,7 +174,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -184,7 +186,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -196,7 +198,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -224,7 +226,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2000-01-02T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -236,7 +238,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2000-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -257,7 +259,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
             SingleField("usages.status"),
             Phrase("pending")
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -271,7 +273,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
             )),
             Phrase("foo")
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -285,7 +287,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
             )),
             Phrase("https://generic.cms/1234")
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
     }
@@ -300,7 +302,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2012-01-01T00:00:00.000Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -314,7 +316,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
                 new DateTime("2012-01-01T00:00:00.000Z")
               )
             ),
-            Negation(Match(IsField,IsValue("deleted"))))
+            deleteNegation, reapableNegation)
           )
         }
 
@@ -332,7 +334,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -344,7 +346,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -356,7 +358,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
               new DateTime("2014-01-01T23:59:59.999Z")
             )
           ),
-          Negation(Match(IsField,IsValue("deleted"))))
+          deleteNegation, reapableNegation)
         )
       }
 
@@ -369,7 +371,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       it("should ignore an invalid date argument") {
         Parser.run("date:NAZGUL") should be (List(
           Match(SingleField("date"), Words("NAZGUL")),
-          Negation(Match(IsField,IsValue("deleted")))
+          deleteNegation, reapableNegation
         ))
       }
 
@@ -380,11 +382,11 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
   describe("negation") {
 
     it("should match negated single terms") {
-      Parser.run("-cats") should be (List(Negation(Match(AnyField, Words("cats"))), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("-cats") should be (List(Negation(Match(AnyField, Words("cats"))), deleteNegation, reapableNegation))
     }
 
     it("should match negated quoted terms") {
-      Parser.run("""-"cats dogs"""") should be (List(Negation(Match(AnyField, Phrase("cats dogs"))), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("""-"cats dogs"""") should be (List(Negation(Match(AnyField, Phrase("cats dogs"))), deleteNegation, reapableNegation))
     }
 
   }
@@ -393,16 +395,16 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
   describe("aliases") {
 
     it("should match aliases to a single canonical field") {
-      Parser.run("by:cats") should be (List(Match(bylineField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("by:cats") should be (List(Match(bylineField, Words("cats")), deleteNegation, reapableNegation))
     }
 
     it("should match aliases to multiple fields") {
       Parser.run("in:berlin") should be (List(Match(MultipleField(List("subLocation", "city", "state", "country").map(getFieldPath)),
-        Words("berlin")), Negation(Match(IsField,IsValue("deleted")))))
+        Words("berlin")), deleteNegation, reapableNegation))
     }
 
     it("should match #terms as labels") {
-      Parser.run("#cats") should be (List(Match(labelsField, Words("cats")), Negation(Match(IsField,IsValue("deleted")))))
+      Parser.run("#cats") should be (List(Match(labelsField, Words("cats")), deleteNegation, reapableNegation))
     }
 
   }
@@ -414,7 +416,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("""-credit:cats dogs""") should be (List(
         Negation(Match(creditField, Words("cats"))),
         Match(AnyField, Words("dogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -422,7 +424,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("""-credit:"cats dogs" unicorns""") should be (List(
         Negation(Match(creditField, Phrase("cats dogs"))),
         Match(AnyField, Words("unicorns")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -430,7 +432,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("""cats dogs #unicorns""") should be (List(
         Match(AnyField, Words("cats dogs")),
         Match(labelsField, Words("unicorns")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -439,7 +441,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
         Match(AnyField, Words("cats")),
         Match(labelsField, Words("unicorns")),
         Match(AnyField, Words("dogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -447,7 +449,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("""-cats dogs""") should be (List(
         Negation(Match(AnyField, Words("cats"))),
         Match(AnyField, Words("dogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -457,7 +459,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
     it("should find images with crops") {
       Parser.run("has:crops") should be (List(
         Match(HasField, HasValue("crops")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -465,14 +467,14 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("cats dogs has:rightsSyndication") should be (List(
         Match(AnyField, Words("cats dogs")),
         Match(HasField, HasValue("rightsSyndication")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should match negated has queries") {
       Parser.run("-has:foo") should be (List(
         Negation(Match(HasField, HasValue("foo"))),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -480,7 +482,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("by:cats has:paws") should be (List(
         Match(bylineField, Words("cats")),
         Match(HasField, HasValue("paws")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
   }
@@ -489,28 +491,28 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
     it("should find jpegs images") {
       Parser.run("fileType:jpeg") should be (List(
         Match(SingleField(getFieldPath("mimeType")), Words("image/jpeg")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should find png images") {
       Parser.run("fileType:png") should be (List(
         Match(SingleField(getFieldPath("mimeType")), Words("image/png")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should find tiff images when searching for file type 'tif'") {
       Parser.run("fileType:tif") should be (List(
         Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should find tiff images when searching for file type 'tiff'") {
       Parser.run("fileType:tiff") should be (List(
         Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -518,14 +520,14 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("fileType:tiff cats dogs") should be (List(
         Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
         Match(AnyField, Words("cats dogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should match negated fileType queries") {
       Parser.run("-fileType:jpeg") should be (List(
         Negation(Match(SingleField(getFieldPath("mimeType")), Words("image/jpeg"))),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -533,14 +535,14 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("by:cats fileType:tiff") should be (List(
         Match(bylineField, Words("cats")),
         Match(SingleField(getFieldPath("mimeType")), Words("image/tiff")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should not match unrelated file types") {
       Parser.run("fileType:catsdogs") should be (List(
         Match(SingleField("fileType"), Words("catsdogs")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
   }
@@ -549,28 +551,28 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
     it("should match a quoted field search") {
       Parser.run(""""fieldDogs":cats""") should be (List(
         Match(SingleField("fieldDogs"), Words("cats")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should match a quoted field search with  colons") {
       Parser.run(""""fieldDogs:dinosaur:lemur":cats""") should be (List(
         Match(SingleField("fieldDogs:dinosaur:lemur"), Words("cats")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should match a quoted field search colons, and a search term with quotes and colons") {
       Parser.run(""""fieldDogs":"cats:are:fun"""") should be (List(
         Match(SingleField("fieldDogs"), Phrase("cats:are:fun")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
     it("should match a quoted field search with colons and spaces") {
       Parser.run(""""fieldDogs: dinosaur:lemur":cats""") should be (List(
         Match(SingleField("fieldDogs: dinosaur:lemur"), Words("cats")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -578,7 +580,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("fieldDogs : dinosaur:lemur:cats") should be (List(
         Match(AnyField,Words("fieldDogs :")),
         Match(SingleField("dinosaur"),Words("lemur:cats")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
 
@@ -586,7 +588,7 @@ class ParserTest extends AnyFunSpec with Matchers with BeforeAndAfter with Image
       Parser.run("fieldDogs:dinosaur lemur:cats") should be (List(
         Match(SingleField("fieldDogs"),Words("dinosaur")),
         Match(SingleField("lemur"),Words("cats")),
-        Negation(Match(IsField,IsValue("deleted")))
+        deleteNegation, reapableNegation
       ))
     }
   }


### PR DESCRIPTION
## What does this change?

Apply the `-is:reapable` filter by default on the API end.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
