### PR TITLE
Upgrade CAPI scala client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val thrall = playProject("thrall", 9002).settings(
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "18.0.1",
+    "com.gu" %% "content-api-client-default" % "19.0.4",
     "io.reactivex" %% "rxscala" % "0.26.5",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val thrall = playProject("thrall", 9002).settings(
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "14.2",
+    "com.gu" %% "content-api-client-default" % "14.3",
     "io.reactivex" %% "rxscala" % "0.26.5",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val thrall = playProject("thrall", 9002).settings(
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "17.25.2",
+    "com.gu" %% "content-api-client-default" % "18.0.1",
     "io.reactivex" %% "rxscala" % "0.26.5",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val thrall = playProject("thrall", 9002).settings(
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "14.3",
+    "com.gu" %% "content-api-client-default" % "17.25.2",
     "io.reactivex" %% "rxscala" % "0.26.5",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10"
   )

--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -1,3 +1,4 @@
+import com.gu.contentapi.client.ScheduledExecutor
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.UsageApi
@@ -14,7 +15,7 @@ class UsageComponents(context: Context) extends GridComponents(context, new Usag
 
   val usageMetadataBuilder = new UsageMetadataBuilder(config)
   val mediaWrapper = new MediaWrapperOps(usageMetadataBuilder)
-  val liveContentApi = new LiveContentApi(config)
+  val liveContentApi = new LiveContentApi(config)(ScheduledExecutor())
   val usageGroupOps = new UsageGroupOps(config, mediaWrapper)
   val usageTable = new UsageTable(config)
   val usageMetrics = new UsageMetrics(config)

--- a/usage/app/lib/ContentHelpers.scala
+++ b/usage/app/lib/ContentHelpers.scala
@@ -1,6 +1,5 @@
 package lib
 
-import com.gu.contentapi.client.GuardianContentClient
 import com.gu.contentapi.client.model.v1.Content
 import org.joda.time.{DateTime, DateTimeZone}
 
@@ -11,10 +10,3 @@ object ContentHelpers {
     date = new DateTime(firstPublicationDate.iso8601, DateTimeZone.UTC)
   } yield date
 }
-
-class LiveContentApi(config: UsageConfig) extends ContentApiRequestBuilder(config) {
-  override val targetUrl = config.capiLiveUrl
-}
-
-class ContentApiRequestBuilder(config: UsageConfig) extends GuardianContentClient(apiKey = config.capiApiKey)
-

--- a/usage/app/lib/LiveContentApi.scala
+++ b/usage/app/lib/LiveContentApi.scala
@@ -1,0 +1,12 @@
+package lib
+
+import com.gu.contentapi.client.{BackoffStrategy, GuardianContentClient, RetryableContentApiClient, ScheduledExecutor}
+
+import scala.concurrent.duration.DurationInt
+
+class LiveContentApi(config: UsageConfig)(implicit val executor: ScheduledExecutor)
+  extends GuardianContentClient(apiKey = config.capiApiKey) with RetryableContentApiClient
+{
+  override val targetUrl: String = config.capiLiveUrl
+  override val backoffStrategy: BackoffStrategy = BackoffStrategy.exponentialStrategy(2.seconds, 15)
+}

--- a/usage/app/lib/LiveContentApi.scala
+++ b/usage/app/lib/LiveContentApi.scala
@@ -8,5 +8,5 @@ class LiveContentApi(config: UsageConfig)(implicit val executor: ScheduledExecut
   extends GuardianContentClient(apiKey = config.capiApiKey) with RetryableContentApiClient
 {
   override val targetUrl: String = config.capiLiveUrl
-  override val backoffStrategy: BackoffStrategy = BackoffStrategy.exponentialStrategy(2.seconds, 15)
+  override val backoffStrategy: BackoffStrategy = BackoffStrategy.doublingStrategy(2.seconds, 4)
 }


### PR DESCRIPTION
## What does this change?

Upgrades the CAPI scala client to the latest version, which includes the latest content models and a client that implements automatic retries with backoff. I've plucked an initial retry policy out of thin air - we should probably come up with better timings

## How should a reviewer test this change?

Deploy to TEST and try the usage reindex endpoint (`/usages/digital/content/<content path>/reindex`), and see if the usages for the images gets backfilled

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
