### PR TITLE
reduce usage reindex capi query to MVQ

### DIFF
--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -105,8 +105,9 @@ class UsageApi(
     )
 
     val query = ItemQuery(contentId)
-      .showFields("all")
-      .showElements("all")
+      .showFields("firstPublicationDate,isLive,internalComposerCode")
+      .showElements("image")
+      .showAtoms("media")
 
     liveContentApi.getResponse(query).map{response =>
       response.content match {


### PR DESCRIPTION
minimal viable query

## What does this change?

We don't need all fields, elements, etc. Grid usage reingestion only needs media atoms, image elements, and a few fields. This makes the request much lighter for CAPI to process, allowing us to reprocess at a much higher rate!

## How should a reviewer test this change?

Deploy to TEST, build and publish an article with an image (and optionally a media atom with a thumbnail selected). Delete the usages out of Grid, then run a reindex request. Do the usages still get readded?

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
