### PR TITLE
Move date-sort to react

### DIFF
--- a/kahuna/.babelrc
+++ b/kahuna/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "@babel/preset-react",
     ["@babel/preset-env",{
       "exclude":["@babel/plugin-transform-regenerator"]
     }]

--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -252,11 +252,21 @@
         "@babel/types": "^7.8.3"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
       "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
       "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
@@ -423,6 +433,21 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+          "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+        }
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -710,6 +735,118 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
+      "integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+          "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+        }
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
+      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.19.0"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+          "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+          "requires": {
+            "@babel/types": "^7.18.6"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+          "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+          "requires": {
+            "@babel/types": "^7.18.6"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+          "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        },
+        "@babel/types": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+          "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+          "requires": {
+            "@babel/helper-string-parser": "^7.19.4",
+            "@babel/helper-validator-identifier": "^7.19.1",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.6.tgz",
+      "integrity": "sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+          "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
+          "requires": {
+            "@babel/types": "^7.18.6"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+          "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        },
+        "@babel/types": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+          "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+          "requires": {
+            "@babel/helper-string-parser": "^7.19.4",
+            "@babel/helper-validator-identifier": "^7.19.1",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.8.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
@@ -873,6 +1010,26 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz",
+      "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-react-display-name": "^7.18.6",
+        "@babel/plugin-transform-react-jsx": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-development": "^7.18.6",
+        "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.20.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+          "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
+        }
       }
     },
     "@babel/runtime": {
@@ -5045,6 +5202,11 @@
         "tslib": "^1.9.3"
       }
     },
+    "@types/angular": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.4.tgz",
+      "integrity": "sha512-wPS/ncJWhyxJsndsW1B6Ta8D4mi97x1yItSu+rkLDytU3oRIh2CFAjMuJceYwFAh9+DIohndWM0QBA9OU2Hv0g=="
+    },
     "@types/babel__core": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -5116,6 +5278,39 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.188",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
+      "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w=="
+    },
+    "@types/lodash.frompairs": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.frompairs/-/lodash.frompairs-4.0.7.tgz",
+      "integrity": "sha512-7UeH2+GF9yop4AqnPwae5/2TE+eY0WRDy0RRQtNGHjzIgdUhilRskMXvXqUcCSazvbkxasjqydXrIE1OB6bPKA==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/react": {
+      "version": "18.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
+      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -7431,6 +7626,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -13758,8 +13958,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -14073,8 +14272,12 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.frompairs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
+      "integrity": "sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -14086,7 +14289,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -14461,6 +14663,17 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "ngcomponent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ngcomponent/-/ngcomponent-4.1.0.tgz",
+      "integrity": "sha512-cGL3iVoqMWTpCfaIwgRKhdaGqiy2Z+CCG0cVfjlBvdqE8saj8xap9B4OTf+qwObxLVZmDTJPDgx3bN6Q/lZ7BQ==",
+      "requires": {
+        "@types/angular": "^1.6.39",
+        "@types/lodash": "^4.14.85",
+        "angular": ">=1.5.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -14643,8 +14856,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -15359,6 +15571,16 @@
         "sisteransi": "^1.0.4"
       }
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -15461,11 +15683,38 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react2angular": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/react2angular/-/react2angular-4.0.6.tgz",
+      "integrity": "sha512-MDl2WRoTyu7Gyh4+FAIlmsM2mxIa/DjSz6G/d90L1tK8ZRubqVEayKF6IPyAruC5DMhGDVJ7tlAIcu/gMNDjXg==",
+      "requires": {
+        "@types/lodash.frompairs": "^4.0.5",
+        "angular": ">=1.5",
+        "lodash.frompairs": "^4.0.1",
+        "ngcomponent": "^4.1.0"
+      }
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -16124,6 +16373,14 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "schema-utils": {
       "version": "2.6.5",
@@ -17081,8 +17338,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
+    "@babel/preset-react": "^7.18.6",
     "@sentry/browser": "^6.10.0",
     "@sentry/integrations": "^6.10.0",
+    "@types/react": "^18.0.25",
     "angular": "1.6.10",
     "angular-animate": "1.6.10",
     "angular-elastic": "^2.5.1 ",
@@ -23,6 +25,10 @@
     "pandular": "0.1.6",
     "pikaday": "^1.8.2",
     "pikaday-time": "^1.6.1",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react2angular": "^4.0.6",
     "rx": "^2.5.3",
     "rx-angular": "^1.1.3",
     "rx-dom": "^6.0.0",

--- a/kahuna/public/js/search/date-sort.js
+++ b/kahuna/public/js/search/date-sort.js
@@ -1,0 +1,70 @@
+// eslint-disable-next-line no-unused-vars
+import React, { useState } from 'react';
+
+export const DateSort = (props) => {
+  const [reactOrderState, setReactOrderState] = useState(props.initialOrder);
+
+  const setOrder = (value) => {
+    setReactOrderState(value);
+    props.setNgOrder(value);
+  };
+
+  return (
+    <div className="search__modifier order__option">
+        <div className="search__modifier-item radio-list">
+        <RadioOption
+          radioLabel="Order search results by newest first"
+          id="sort-direction__desc"
+          labelText="Newest first"
+          value={undefined}
+          order={reactOrderState}
+          setOrder={setOrder}
+        />
+        { props.collectionSearch ?
+          <RadioOption
+            radioLabel="Order search results by recently added first"
+            id="added-to-collection"
+            labelText="Recently Added First"
+            value="dateAddedToCollection"
+            order={reactOrderState}
+            setOrder={setOrder}
+          /> :
+          <RadioOption
+            radioLabel="Order search results by oldest first"
+            id="sort-direction__asc"
+            labelText="Oldest first"
+            value="oldest"
+            order={reactOrderState}
+            setOrder={setOrder}
+          />
+        }
+      </div>
+    </div>
+  );
+};
+
+// eslint-disable-next-line no-unused-vars
+const RadioOption = (props) => {
+  return (
+    <div className="radio-list__item">
+        <input
+          type="radio"
+          aria-hidden="false"
+          id={props.id}
+          className="radio-list__circle"
+          name="sort-direction"
+          aria-label={props.radioLabel}
+        />
+        <label
+          htmlFor={props.id}
+          className={`radio-list__label${props.value === props.order ? " radio-list--selected" : ""}`}
+          onClick={() => {
+            props.setOrder(props.value);
+          }}
+        >
+            <div className="radio-list__selection-state"></div>
+            <div className="radio-list__label-value">{props.labelText}</div>
+        </label>
+      </div>
+  );
+};

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -82,57 +82,12 @@
             <gr-icon class="search__modifier-toggle__icon">sort</gr-icon>
             <span class="search__modifier-toggle__text">Sort order</span>
         </button>
-
-        <ul class="search__modifier order__option"
-            ng-class="orderShown ? 'order__option--show' : 'order__option--hide'">
-            <li class="search__modifier-item radio-list">
-                <div class="radio-list__item">
-                    <input type="radio"
-                           aria-hidden="false"
-                           id="sort-direction__desc"
-                           class="radio-list__circle"
-                           name="sort-direction"
-                           ng-value="undefined"
-                           ng-model="searchQuery.ordering.orderBy"
-                           aria-label="Order search results by newest first">
-                    <label for="sort-direction__desc" class="radio-list__label"
-                           ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === undefined}">
-                        <div class="radio-list__selection-state"></div>
-                        <div class="radio-list__label-value">Newest first</div>
-                    </label>
-                </div>
-                <div ng-if="!searchQuery.collectionSearch"
-                     class="radio-list__item">
-                    <input type="radio"
-                           aria-hidden="false"
-                           id="sort-direction__asc"
-                           class="radio-list__circle"
-                           name="sort-direction"
-                           ng-value="'oldest'"
-                           ng-model="searchQuery.ordering.orderBy"
-                           aria-label="Order search results by oldest first">
-                    <label for="sort-direction__asc" class="radio-list__label"
-                           ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === 'oldest'}">
-                        <div class="radio-list__selection-state"></div>
-                        <div class="radio-list__label-value">Oldest first</div>
-                    </label>
-                </div>
-                <div ng-if="searchQuery.collectionSearch" class="radio-list__item">
-                    <input type="radio"
-                           id="sort-direction__added-to-collection"
-                           class="radio-list__circle"
-                           name="sort-direction"
-                           ng-value="'dateAddedToCollection'"
-                           ng-model="searchQuery.ordering.orderBy">
-                    <label for="sort-direction__added-to-collection" class="radio-list__label"
-                           ng-class="{'radio-list--selected': searchQuery.ordering.orderBy === 'dateAddedToCollection'}">
-                        <div class="radio-list__selection-state"></div>
-                        <div class="radio-list__label-value">Recently Added First</div>
-                    </label>
-                </div>
-            </li>
-        </ul>
-
+        <date-sort
+            collection-search="searchQuery.collectionSearch"
+            initial-order="searchQuery.ordering.orderBy"
+            set-ng-order="searchQuery.setOrdering"
+        >
+        </date-sort>
     </div>
 </form>
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -11,6 +11,8 @@ import {guDateRange} from '../components/gu-date-range/gu-date-range';
 import template from './query.html';
 import {syntax} from './syntax/syntax';
 import {grStructuredQuery} from './structured-query/structured-query';
+import { react2angular } from 'react2angular';
+import { DateSort } from './date-sort';
 
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
@@ -20,7 +22,8 @@ export var query = angular.module('kahuna.search.query', [
     syntax.name,
     grStructuredQuery.name,
     'util.storage'
-]);
+])
+.component('dateSort', react2angular(DateSort, ["initialOrder", "collectionSearch", "setNgOrder"],["$stateParams", "$state"]));
 
 query.controller('SearchQueryCtrl', [
   '$rootScope',
@@ -86,6 +89,8 @@ query.controller('SearchQueryCtrl', [
         {label: 'Date taken',    name: 'taken',        value: 'taken'},
         {label: 'Last modified', name: 'modified',     value: 'modified'}
     ];
+
+    ctrl.setOrdering = (ordering) => $state.go('search.results', {orderBy: ordering});
 
     const dateFilterParams = [
         'dateField', 'since', 'until', 'takenSince', 'takenUntil',


### PR DESCRIPTION
## What does this change?

Moves the date-sort from the top menu to React via `react2angular`. This acts as a proof of concept of moving a small part of the interface to React, and is also a step towards moving the search bar to React, in order to support testing of new search options.

I found it difficult for the React component to watch for changes to data in the AngularJS context - and ended up managing an internal state to represent the current sort order in addition to the external representation in AngularJS. Hopefully there is a better solution to watch for changes outside of the React context.

## How should a reviewer test this change?

1. Run Grid locally, according to the instructions in the readme. (`./dev/script/start.sh --use-TEST` is useful for testing UI changes).
2. Does the date sort work as expected? What about at smaller screen sizes?

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
