### PR TITLE
make `font-src` (of Content-Security-Policy) configurable via a new config property `security.fontSources`

### DIFF
--- a/docs/06-objects-of-interest/02-config.md
+++ b/docs/06-objects-of-interest/02-config.md
@@ -665,6 +665,14 @@ Service-specific configs. These will override all other config files.
     <td><code>string[]</code></td>
     <td></td>
   </tr>
+  <tr>
+    <td><code>security.fontSources</code><br/>
+      Additional entries to be added to the <code>font-src</code> section of the <code>Content-Security-Policy</code>
+    </td>
+    <td>true</td>
+    <td><code>string[]</code></td>
+    <td></td>
+  </tr>
 </tbody>
 </table>
 

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -56,7 +56,7 @@ object KahunaSecurityConfig {
       "'self'"
     ).mkString(" ")}"
 
-    val fontSources = s"font-src data: 'self'"
+    val fontSources = s"font-src data: 'self' ${config.fontSources.mkString(" ")}"
 
     val scriptSources = s"script-src 'self' 'unsafe-inline' $gaHost ${config.scriptsToLoad.map(_.host).mkString(" ")}"
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -41,6 +41,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources")
+  val fontSources: Set[String] = getStringSet("security.fontSources")
 
   val scriptsToLoad: List[ScriptToLoad] = getConfigList("scriptsToLoad").map(entry => ScriptToLoad(
     host = entry.getString("host"),


### PR DESCRIPTION
Co-authored-by: @aracho1 
Co-authored-by: @phillipbarron 

https://trello.com/c/am4GCw1H/946-load-agate-fonts-in-pinboard

Following https://github.com/guardian/grid/pull/3893 grid no longer loads `Guardian Agate Sans`... however, they're required for pinboard, so in order to allow pinboard to load that font from outside the grid (see https://github.com/guardian/pinboard/pull/212) we need the `font-src` (of Content-Security-Policy) to be configurable - which is done in this PR with `security.fontSources` (much like we have for other parts of the Content-Security-Policy).