### PR TITLE
Add script for reindexing usages

### DIFF
--- a/scripts/usage-reindex/reindex-usages.sh
+++ b/scripts/usage-reindex/reindex-usages.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+isFastForwarding=true
+
+touch lastQueriedId.txt
+lastQueriedId=$(cat lastQueriedId.txt)
+
+if [[ $lastQueriedId == "" ]]
+  then isFastForwarding=false
+fi
+
+while read line; do
+  id=$(echo "$line" | cut -d "," -f 1)
+  path=$(echo "$line" | cut -d "," -f 2)
+
+  if [[ $lastQueriedId == "$id" ]]
+    then isFastForwarding=false
+    continue
+  fi
+
+  if [[ $isFastForwarding == 'true' ]]
+    then continue
+  fi
+
+#  only gets to this if isFastForwarding is false
+  if curl "https://media-usage.test.dev-gutools.co.uk/usages/digital/content/$path/reindex" -H "X-Gu-Media-Key: $GRID_API_KEY" -f
+    then
+    echo "$id" > lastQueriedId.txt
+    echo "Reindexed id: $id, path: $path"
+  else
+    echo "$id" >> failedIds.txt
+    echo "Failed on id: $id, path: $path"
+  fi
+
+done < codeContentIdAndPath.csv

--- a/scripts/usage-reindex/reindex-usages.sh
+++ b/scripts/usage-reindex/reindex-usages.sh
@@ -28,7 +28,7 @@ while read line; do
     echo "$id" > lastQueriedId.txt
     echo "Reindexed id: $id, path: $path"
   else
-    echo "$id" >> failedIds.txt
+    echo "$id,$path" >> failedIds.txt
     echo "Failed on id: $id, path: $path"
   fi
 


### PR DESCRIPTION
## What does this change?

Worked on with @andrew-nowak and @rhystmills.

Adds a bash script to reindex usages from a `csv` of CAPI articles (of format `internal-composer-code,path`).

Has the ability to replay from the last reindexed ID if needed.

Also logs failed IDs.

## How should a reviewer test this change?

We are testing this on PROD. Once we have finished running this script, we will be confident of merging it into the codebase for future reference.

## How can success be measured?

Usages are successfully reindex for all CAPI articles in PROD.
