### PR TITLE
Remove automatic rewrites for Peter Dejong

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/PhotographerRenamer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/PhotographerRenamer.scala
@@ -421,7 +421,6 @@ object PhotographerRenamer extends MetadataCleaner {
     "Pawel Wodzynski" -> "Paweł Wodzyński",
     "Pedro Fiuza" -> "Pedro Fiúza",
     "Petar Kujundzic" -> "Petar Kujundžić",
-    "Peter de Jong" -> "Peter Dejong",
     "Peter Komka" -> "Péter Komka",
     "Peter Lazar" -> "Peter Lázár",
     "Petras Malukas" -> "Petras Malūkas",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/PhotographerRenamer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/PhotographerRenamer.scala
@@ -421,7 +421,7 @@ object PhotographerRenamer extends MetadataCleaner {
     "Pawel Wodzynski" -> "Paweł Wodzyński",
     "Pedro Fiuza" -> "Pedro Fiúza",
     "Petar Kujundzic" -> "Petar Kujundžić",
-    "Peter Dejong" -> "Peter de Jong",
+    "Peter de Jong" -> "Peter Dejong",
     "Peter Komka" -> "Péter Komka",
     "Peter Lazar" -> "Peter Lázár",
     "Petras Malukas" -> "Petras Malūkas",


### PR DESCRIPTION
## What does this change?

We have been rewriting Peter Dejong's bylines to Peter de Jong. There are two photographers of note, of each spelling, so we shouldn't rewrite either to the other. 

Removes the rewrite rule

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
