### PR TITLE
Updated config doc to add `restrictDownload` definition

### DIFF
--- a/docs/06-objects-of-interest/02-config.md
+++ b/docs/06-objects-of-interest/02-config.md
@@ -75,6 +75,12 @@ Service-specific configs. These will override all other config files.
     <td>boolean</td>
     <td></td>
   </tr>
+  <tr>
+    <td><code>restrictDownload</code><br>Restrict download of images to users with edit_metadata permission where that user is not the image uploader</td>
+    <td>True</td>
+    <td>boolean</td>
+    <td>false</td>
+  </tr>
 </tbody>
 </table>
 
@@ -731,7 +737,7 @@ Service-specific configs. These will override all other config files.
     <td></td>
   </tr>
   <tr>
-    <td<code>aws.region</code></td>
+    <td><code>aws.region</code></td>
     <td></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
## What does this change?

Config Doc

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

Visually

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

Doc now has a. reference to the `restrictDownload` config item

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
