### PR TITLE
Make Title never loose underline

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.css
@@ -31,4 +31,5 @@
 gr-image-metadata dd {
     overflow: hidden;
     word-break: break-word;
+    display: inline;
 }


### PR DESCRIPTION
## What does this change?

It was observed that metadata values with an underline loose it on some zoom levels in Firefox for the last line (sometimes the last line is also the first one):

![sdfsdfsdfsdf](https://user-images.githubusercontent.com/6032869/203321405-a18a18e9-19a5-4917-9def-4a3497739db3.gif)

This fixes it.

## How should a reviewer test this change?

Change zoom levels in Firefox looking at the Info panel of any image with a Title.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
