### PR TITLE
Use pills for subjects

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -578,24 +578,23 @@
                     title="{{ctrl.extraInfo.filename}}">{{ctrl.extraInfo.filename}}</span>
             </dd>
 
-            <dt ng-if="ctrl.metadata.subjects.length > 0"
+            <dt ng-if="((ctrl.metadata.subjects.length > 0) || ctrl.hasMultipleValues(ctrl.rawMetadata.subjects))"
                 class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">
                 Subjects
             </dt>
-            <dd ng-if="ctrl.metadata.subjects.length > 0"
-                class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
-                <span class="metadata-line__info">
-                    <span ng-repeat="subject in ctrl.metadata.subjects">
-                        <a ui-sref="search.results({query: (subject | queryFilter:'subject'), nonFree: ctrl.srefNonfree()})"
-                           aria-label="Search images by {{subject}} subject">
-                            {{subject}}
-                        </a>
-                    </span>
-                </span>
+            <dd ng-if="((ctrl.metadata.subjects.length > 0) || ctrl.hasMultipleValues(ctrl.rawMetadata.subjects))"
+                class="image-info__pills image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+                <ui-list-editor-info-panel
+                   is-editable="false"
+                   images="ctrl.selectedImages"
+                   accessor="ctrl.subjectsAccessor"
+                   query-filter="queryFilter:'subject'"
+                   element-name="subject">
+                </ui-list-editor-info-panel>
             </dd>
 
             <dt class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">People</dt>
-            <dd class="image-info__people image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+            <dd class="image-info__pills image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <button data-cy="it-edit-people-button"
                         class="metadata-plus__button"
                         ng-class="{'small': ctrl.grSmall}"
@@ -921,7 +920,7 @@
                 </span>
             </button>
         </dt>
-        <dd class="image-info__keywords">
+        <dd class="image-info__pills">
             <span ng-class="{'image-info--multiple': ctrl.selectedImages.size > 0}"
                   editable-text="ctrl.newKeywords"
                   ng-hide="keywordsEditForm.$visible"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -578,11 +578,11 @@
                     title="{{ctrl.extraInfo.filename}}">{{ctrl.extraInfo.filename}}</span>
             </dd>
 
-            <dt ng-if="((ctrl.metadata.subjects.length > 0) || ctrl.hasMultipleValues(ctrl.rawMetadata.subjects))"
+            <dt ng-if="ctrl.selectedImagesHasAny(ctrl.subjectsAccessor)"
                 class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">
                 Subjects
             </dt>
-            <dd ng-if="((ctrl.metadata.subjects.length > 0) || ctrl.hasMultipleValues(ctrl.rawMetadata.subjects))"
+            <dd ng-if="ctrl.selectedImagesHasAny(ctrl.subjectsAccessor)"
                 class="image-info__pills image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <ui-list-editor-info-panel
                    is-editable="false"
@@ -592,9 +592,10 @@
                    element-name="subject">
                 </ui-list-editor-info-panel>
             </dd>
-
-            <dt class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">People</dt>
-            <dd class="image-info__pills image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
+            <dt ng-if="ctrl.userCanEdit || ctrl.selectedImagesHasAny(ctrl.peopleAccessor)"
+                class="image-info__wrap metadata-line metadata-line__key image-info__group--dl__key--panel">People</dt>
+            <dd ng-if="ctrl.userCanEdit || ctrl.selectedImagesHasAny(ctrl.peopleAccessor)"
+                class="image-info__pills image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <button data-cy="it-edit-people-button"
                         class="metadata-plus__button"
                         ng-class="{'small': ctrl.grSmall}"
@@ -617,7 +618,7 @@
                       e:form="peopleInImageEditForm"
                       e:ng-class="{'image-info__editor--error': $error,
                                    'image-info__editor--saving': peopleInImageEditForm.$waiting,
-                                   'text-input': true}">
+                                   'text-input': true}"></span>
 
                     <ui-list-editor-info-panel
                         is-editable="ctrl.userCanEdit"
@@ -900,7 +901,8 @@
     </div>
 </div>
 
-<div class="image-info" role="region" aria-label="Keywords">
+<div ng-if="ctrl.userCanEdit || ctrl.selectedImagesHasAny(ctrl.keywordAccessor)"
+     class="image-info" role="region" aria-label="Keywords" >
     <dl class="image-info__group image-info__wrap">
         <dt class="image-info__heading image-info__wrap">
             Keywords

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -218,6 +218,10 @@ module.controller('grImageMetadataCtrl', [
 
     ctrl.subjectsAccessor = (image) => imageAccessor.readMetadata(image).subjects;
 
+    ctrl.selectedImagesHasAny = (accessor) => ctrl.selectedImages.find(
+      (image) => Object.keys(accessor(image)).length > 0
+    );
+
     const ignoredMetadata = [
       'title', 'description', 'copyright', 'keywords', 'byline',
       'credit', 'subLocation', 'city', 'state', 'country',

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -216,6 +216,8 @@ module.controller('grImageMetadataCtrl', [
     ctrl.removeKeywordFromImages = removeXFromImages('keywords', ctrl.keywordAccessor);
     ctrl.addKeywordToImages = addXToImages('keywords', ctrl.keywordAccessor);
 
+    ctrl.subjectsAccessor = (image) => imageAccessor.readMetadata(image).subjects;
+
     const ignoredMetadata = [
       'title', 'description', 'copyright', 'keywords', 'byline',
       'credit', 'subLocation', 'city', 'state', 'country',

--- a/kahuna/public/js/edits/list-editor.css
+++ b/kahuna/public/js/edits/list-editor.css
@@ -99,44 +99,33 @@ element--partial is part of gr-panel.
     background-color: #222;
 }
 
-.image-info__people  .element--partial .element__value,
-.image-info__people .element--partial .element__right-bit,
-.image-info__people .element--partial .element__add,
-.image-info__keywords  .element--partial .element__value,
-.image-info__keywords .element--partial .element__right-bit,
-.image-info__keywords .element--partial .element__add{
+.image-info__pills  .element--partial .element__value,
+.image-info__pills .element--partial .element__right-bit,
+.image-info__pills .element--partial .element__add{
     background-color: white;
     color: #222;
     border-bottom: 0px;
 }
 
-.image-info__people .element__value,
-.image-info__people .element__right-bit,
-.image-info__people .element__add,
-.image-info__keywords .element__value,
-.image-info__keywords .element__right-bit,
-.image-info__keywords .element__add {
+.image-info__pills .element__value,
+.image-info__pills .element__right-bit,
+.image-info__pills .element__add {
     background-color: #222;
     color: #aaa;
     border-bottom: 0px;
 }
 
-.image-info__people .element__value:hover,
-.image-info__people .element__link:hover,
-.image-info__people .element__right-bit:hover,
-.image-info__keywords .element__value:hover,
-.image-info__keywords .element__link:hover,
-.image-info__keywords .element__right-bit:hover {
-    color: #222;
+.image-info__pills .element__value:hover,
+.image-info__pills .element__link:hover,
+.image-info__pills .element__right-bit:hover {
+    color: #717171;
     background-color: white;
 }
 
-.image-info__people .element--partial .element__add:hover gr-icon,
-.image-info__keywords .element--partial .element__add:hover gr-icon {
+.image-info__pills .element--partial .element__add:hover gr-icon {
     color: #717171;
 }
 
-.image-info__people .element--partial .element__right-bit:hover gr-icon,
-.image-info__keywords .element--partial .element__right-bit:hover gr-icon {
+.image-info__pills .element--partial .element__right-bit:hover gr-icon {
     color: #717171;
 }

--- a/kahuna/public/js/edits/list-editor.css
+++ b/kahuna/public/js/edits/list-editor.css
@@ -52,10 +52,7 @@ element--partial is part of gr-panel.
 .element__value {
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
-}
-
-.element--partial .element__value {
-    border-radius: 0px;
+    margin-left: -1.4px;
 }
 
 .element__value {
@@ -99,7 +96,7 @@ element--partial is part of gr-panel.
     background-color: #222;
 }
 
-.image-info__pills  .element--partial .element__value,
+.image-info__pills .element--partial .element__value,
 .image-info__pills .element--partial .element__right-bit,
 .image-info__pills .element--partial .element__add{
     background-color: white;


### PR DESCRIPTION
_co-authored by: @twrichards_

## What does this change?

It annoyed me that subjects were presented in a broken way. When multiple, they looked like one long link, even though it worked correctly when hovered. They also didn’t work for multiple selections.

This PR switches them to use pills. I haven’t made them editable, because for this we need a UI pattern of editing pills from a set of values (no arbitrary subjects are allowed).

| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/6032869/204059016-f5608529-edd4-4d3c-b21b-6a0b6af97b54.png) | ![image](https://user-images.githubusercontent.com/6032869/204059493-d93c8d5d-cb59-43e6-872e-c118eb2239ca.png) |

[this is four subjects on the left]

This also fixes pills view of common but uneditable pills to retain rounded corners by blindly editing/deleting some CSS code. It’s not perfect (remove button is further away from the value than the add one), but it’s better:

| Before      | After |
| ----------- | ----------- |
|   ![image](https://user-images.githubusercontent.com/6032869/204059828-dcdf9df4-ffbd-4209-b578-3860a99e9806.png)   |   ![image](https://user-images.githubusercontent.com/6032869/204059786-b9124363-9792-4bb8-9041-66eb7e506f24.png)    |

It also makes value highlight on hover like on the add and remove buttons:

| Before      | After |
| ----------- | ----------- |
|   ![sdfsdfsdfsdf](https://user-images.githubusercontent.com/6032869/204059353-f0cd17e6-921c-4825-aff8-65eadd313473.gif)    |    ![sdfsdfsdfsdf](https://user-images.githubusercontent.com/6032869/204059411-17292dbc-7b4a-4f9e-8cde-53c64d7671c0.gif)   |

## How should a reviewer test this change?

Choose some images with commmon and uncommon subjects and have a play.

## How can success be measured?

Less confusing UI. Subjects show up for multiple selections.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
