### PR TITLE
Usages: log when processing usage event fails and fix retrievable content update

### DIFF
--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -104,10 +104,7 @@ class UsageApi(
       "contentId" -> contentId,
     )
 
-    val query = ItemQuery(contentId)
-      .showFields("firstPublicationDate,isLive,internalComposerCode")
-      .showElements("image")
-      .showAtoms("media")
+    val query = liveContentApi.usageQuery(contentId)
 
     liveContentApi.getResponse(query).map{response =>
       response.content match {

--- a/usage/app/lib/CrierEventProcessor.scala
+++ b/usage/app/lib/CrierEventProcessor.scala
@@ -124,6 +124,8 @@ abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGrou
             case Some(retrievableContent: EventPayload.RetrievableContent) =>
               val capiUrl = retrievableContent.retrievableContent.capiUrl
 
+              logger.info(logMarker, s"retrieving content event at $capiUrl")
+
               val query = ItemQuery(capiUrl, Map())
 
               liveCapi.getResponse(query).map(response => {

--- a/usage/app/lib/CrierEventProcessor.scala
+++ b/usage/app/lib/CrierEventProcessor.scala
@@ -69,7 +69,7 @@ abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGrou
 
   implicit val codec = Event
 
-  val liveCapi: GuardianContentClient
+  val liveCapi: LiveContentApi
 
   override def initialize(shardId: String): Unit = {
     logger.debug(s"Initialized an event processor for shard $shardId")
@@ -125,10 +125,7 @@ abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGrou
             case Some(retrievableContent: EventPayload.RetrievableContent) =>
               val capiUrl = retrievableContent.retrievableContent.capiUrl
 
-              val query = ItemQuery(retrievableContent.retrievableContent.id)
-                .showFields("firstPublicationDate,isLive,internalComposerCode")
-                .showElements("image")
-                .showAtoms("media")
+              val query = liveCapi.usageQuery(retrievableContent.retrievableContent.id)
 
               logger.info(logMarker, s"retrieving content event at $capiUrl parsed to id ${query.toString}")
 
@@ -159,7 +156,7 @@ private class CrierLiveEventProcessor(config: UsageConfig, usageGroupOps: UsageG
 
   def getContentItem(content: Content, date: DateTime): ContentContainer = LiveContentItem(content, date)
 
-  override val liveCapi: GuardianContentClient = new LiveContentApi(config)(ScheduledExecutor())
+  override val liveCapi: LiveContentApi = new LiveContentApi(config)(ScheduledExecutor())
 }
 
 private class CrierPreviewEventProcessor(config: UsageConfig, usageGroupOps: UsageGroupOps) extends CrierEventProcessor(config, usageGroupOps) {
@@ -167,5 +164,5 @@ private class CrierPreviewEventProcessor(config: UsageConfig, usageGroupOps: Usa
   def getContentItem(content: Content, date: DateTime): ContentContainer = PreviewContentItem(content, date)
 
   // FIXME - we should presumably be fetching from preview CAPI if the event came from preview Crier...
-  override val liveCapi: GuardianContentClient = new LiveContentApi(config)(ScheduledExecutor())
+  override val liveCapi: LiveContentApi = new LiveContentApi(config)(ScheduledExecutor())
 }

--- a/usage/app/lib/LiveContentApi.scala
+++ b/usage/app/lib/LiveContentApi.scala
@@ -1,5 +1,6 @@
 package lib
 
+import com.gu.contentapi.client.model.ItemQuery
 import com.gu.contentapi.client.{BackoffStrategy, GuardianContentClient, RetryableContentApiClient, ScheduledExecutor}
 
 import scala.concurrent.duration.DurationInt
@@ -9,4 +10,11 @@ class LiveContentApi(config: UsageConfig)(implicit val executor: ScheduledExecut
 {
   override val targetUrl: String = config.capiLiveUrl
   override val backoffStrategy: BackoffStrategy = BackoffStrategy.doublingStrategy(2.seconds, 4)
+
+  def usageQuery(contentId: String): ItemQuery = {
+    ItemQuery(contentId)
+      .showFields("firstPublicationDate,isLive,internalComposerCode")
+      .showElements("image")
+      .showAtoms("media")
+  }
 }


### PR DESCRIPTION
## What does this change?

Before, exceptions thrown during processing or deserialization of crier events for processing usages would be swallowed silently. Now, log an error.

Also, fix processing of retrievable content updates, by using the ID of the content instead of the URL, and taking the parameters needed as used in the reindex API.

## How should a reviewer test this change?

Add a new image to a very, very long liveblog (either restore one from PROD or DM me, I can link you to one that is long enough to trigger retrievablecontentupdate).

## How can success be measured?

The one remaining (known) hole in Composer usages is filled

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
