### PR TITLE
Add telemetry to search and filters (chips)

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -32,6 +32,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)
   val invalidSessionHelpLink: Option[String]= stringOpt("links.invalidSessionHelp").filterNot(_.isEmpty)
   val supportEmail: Option[String]= stringOpt("links.supportEmail").filterNot(_.isEmpty)
+  val telemetryUri: Option[String] = stringOpt("links.telemetryUri").filterNot(_.isEmpty)
 
   val homeLinkHtml: Option[String] = stringOpt("branding.homeLinkHtml").filterNot(_.isEmpty)
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -70,7 +70,7 @@
           imagePreviewFlagLeaseAttachedCopy: "@Html(kahunaConfig.imagePreviewFlagLeaseAttachedCopy)",
           useReaper: @kahunaConfig.useReaper.getOrElse(false),
           featureSwitches: @Html(featureSwitches),
-          telemetryUri: "@kahunaConfig.telemetryUri.getOrElse("")",
+          telemetryUri: '@kahunaConfig.telemetryUri.getOrElse("")'
         }
     </script>
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -69,7 +69,8 @@
           imagePreviewFlagWarningCopy: "@Html(kahunaConfig.imagePreviewFlagWarningCopy)",
           imagePreviewFlagLeaseAttachedCopy: "@Html(kahunaConfig.imagePreviewFlagLeaseAttachedCopy)",
           useReaper: @kahunaConfig.useReaper.getOrElse(false),
-          featureSwitches: @Html(featureSwitches)
+          featureSwitches: @Html(featureSwitches),
+          telemetryUri: "@kahunaConfig.telemetryUri.getOrElse("")",
         }
     </script>
 

--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -1038,6 +1038,14 @@
         }
       }
     },
+    "@guardian/user-telemetry-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@guardian/user-telemetry-client/-/user-telemetry-client-1.1.0.tgz",
+      "integrity": "sha512-3jb0rN/+i2jcvqmDuSs4aSiaVVBuXg3rqjWyT2PSpW+o19zjSUgLzFAZCtZUt95ORuzIKfT4Xqr3c2PvuW8cmw==",
+      "requires": {
+        "lodash": "^4.17.20"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
@@ -14273,7 +14281,7 @@
     "lodash.frompairs": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
-      "integrity": "sha1-vE5SB/onV8E25XNhTpZkUGsrG9I="
+      "integrity": "sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -5434,6 +5434,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
@@ -15900,6 +15906,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "request-promise-core": {
@@ -17477,10 +17491,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
+    "@guardian/user-telemetry-client": "^1.1.0",
     "@sentry/browser": "^6.10.0",
     "@sentry/integrations": "^6.10.0",
     "angular": "1.6.10",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -35,7 +35,8 @@
     "theseus-angular": "^0.3.1",
     "titip": "https://github.com/guardian/titip/tarball/1.1.0",
     "ui-router-extras": "^0.1.3",
-    "uri-templates": "0.1.5"
+    "uri-templates": "0.1.5",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
@@ -44,6 +45,7 @@
     "@types/angular": "^1.8.4",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
+    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
     "babel-jest": "^25.2.1",

--- a/kahuna/public/js/components/gr-feature-switch-panel/gr-feature-switch-panel.tsx
+++ b/kahuna/public/js/components/gr-feature-switch-panel/gr-feature-switch-panel.tsx
@@ -7,19 +7,11 @@ import styles from "./gr-feature-switch-panel.module.css";
 
 type KeydownHandler = (e: KeyboardEvent) => void
 
-type FeatureSwitchData = {
+export type FeatureSwitchData = {
   key: string,
   title: string,
   value: 'true' | 'false'
  }
-
-declare global {
-  interface Window {
-    _clientConfig: {
-      featureSwitches: Array<FeatureSwitchData>
-    }
-  }
-}
 
 export const getFeatureSwitchActive = (key: string): boolean => {
   const match = document.cookie.match(new RegExp("(^| )" + "feature-switch-" + key + "=([^;]+)"));

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -9,9 +9,7 @@ import {rxUtil} from '../../util/rx';
 
 import {querySuggestions, filterFields} from './query-suggestions';
 import {renderQuery, structureQuery} from './syntax';
-import { search } from '..';
 import { sendTelemetryEvent } from '../../services/telemetry';
-import { setTags } from '@sentry/browser';
 
 export const grStructuredQuery = angular.module('gr.structuredQuery', [
     rxUtil.name,
@@ -77,15 +75,15 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
                     // filter > {type: 'filter', filterType: 'inclusion', key: 'is', value: 'cool'}
                     const { type } = queryComponent;
                     const formattedType = (type) => {
-                        if (type === 'text') return 'GRID_SEARCH'
-                        if (type === 'filter') return 'GRID_FILTER'
-                        return `GRID_${type.toUpperCase()}`
-                    }
+                        if (type === 'text') { return 'GRID_SEARCH'; }
+                        if (type === 'filter') { return 'GRID_FILTER'; }
+                        return `GRID_${type.toUpperCase()}`;
+                    };
                     if (queryComponent.value){
                         // In case search is empty, as with a search containing only filters
                         sendTelemetryEvent(formattedType(type), queryComponent, 1);
-                    }
-                })
+                    };
+                });
             });
         }
     };

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -24,6 +24,7 @@ grStructuredQuery.controller('grStructuredQueryCtrl',
                              ['querySuggestions',
                               function(querySuggestions) {
     const ctrl = this;
+    
     const structuredQueryUpdates$ = Rx.Observable.create(observer => {
         ctrl.structuredQueryChanged = function(structuredQuery) {
             observer.onNext(structuredQuery);
@@ -44,7 +45,6 @@ grStructuredQuery.controller('grStructuredQueryCtrl',
         // Watch out for `false`, but we know it's a string here..
         return str ? str : undefined;
     }
-
 }]);
 
 

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -24,7 +24,7 @@ grStructuredQuery.controller('grStructuredQueryCtrl',
                              ['querySuggestions',
                               function(querySuggestions) {
     const ctrl = this;
-    
+
     const structuredQueryUpdates$ = Rx.Observable.create(observer => {
         ctrl.structuredQueryChanged = function(structuredQuery) {
             observer.onNext(structuredQuery);

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -80,10 +80,8 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
                         if (type === 'filter') { return 'GRID_FILTER'; }
                         return `GRID_${type.toUpperCase()}`;
                     };
-                    if (queryComponent.value){
-                        // In case search is empty, as with a search containing only filters
-                        sendTelemetryEvent(formattedType(type), {...queryComponent, searchId: searchId}, 1);
-                    };
+                    // In case search is empty, as with a search containing only filters
+                    sendTelemetryEvent(formattedType(type), {...queryComponent, searchId: searchId}, 1);
                 });
             });
         }

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import Rx from 'rx';
+import { v4 } from 'uuid';
 
 import './structured-query.css';
 
@@ -69,7 +70,7 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
             subscribe$(scope, ctrl.newQuery$, query => {
                 ngModelCtrl.$setViewValue(query);
                 const structuredQuery = structureQuery(query);
-                const searchId = generateId();
+                const searchUuid = v4();
                 structuredQuery.forEach(queryComponent => {
                     // e.g. filter or search:
                     // search > {type: 'text', value: 'my search'}
@@ -81,7 +82,7 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
                         return `GRID_${type.toUpperCase()}`;
                     };
                     // In case search is empty, as with a search containing only filters
-                    sendTelemetryEvent(formattedType(type), {...queryComponent, searchId: searchId}, 1);
+                    sendTelemetryEvent(formattedType(type), {...queryComponent, searchUuid: searchUuid}, 1);
                 });
             });
         }

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -10,7 +10,7 @@ import {rxUtil} from '../../util/rx';
 
 import {querySuggestions, filterFields} from './query-suggestions';
 import {renderQuery, structureQuery} from './syntax';
-import { generateId, sendTelemetryEvent } from '../../services/telemetry';
+import { sendTelemetryEvent } from '../../services/telemetry';
 
 export const grStructuredQuery = angular.module('gr.structuredQuery', [
     rxUtil.name,

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -9,7 +9,7 @@ import {rxUtil} from '../../util/rx';
 
 import {querySuggestions, filterFields} from './query-suggestions';
 import {renderQuery, structureQuery} from './syntax';
-import { sendTelemetryEvent } from '../../services/telemetry';
+import { generateId, sendTelemetryEvent } from '../../services/telemetry';
 
 export const grStructuredQuery = angular.module('gr.structuredQuery', [
     rxUtil.name,
@@ -69,6 +69,7 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
             subscribe$(scope, ctrl.newQuery$, query => {
                 ngModelCtrl.$setViewValue(query);
                 const structuredQuery = structureQuery(query);
+                const searchId = generateId();
                 structuredQuery.forEach(queryComponent => {
                     // e.g. filter or search:
                     // search > {type: 'text', value: 'my search'}
@@ -81,7 +82,7 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
                     };
                     if (queryComponent.value){
                         // In case search is empty, as with a search containing only filters
-                        sendTelemetryEvent(formattedType(type), queryComponent, 1);
+                        sendTelemetryEvent(formattedType(type), {...queryComponent, searchId: searchId}, 1);
                     };
                 });
             });

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -8,9 +8,10 @@ const parserRe = /(-?)(?:(?:([a-zA-Z@><]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^'
 const falsyValuesToEmptyString = (value) => {
     if (!value){
         return '';
+    } else {
+        return value.toString();
     }
-    else return value.toString();
-}
+};
 // TODO: expose the server-side query parser via an API instead of
 // replicating it poorly here
 export function structureQuery(query) {

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -5,6 +5,12 @@ import {getLabel, getCollection} from '../../search-query/query-syntax';
 /*eslint-disable max-len */
 const parserRe = /(-?)(?:(?:([a-zA-Z@><]+):|(#)|(~))(?:([^ "']+)|"([^"]+)"|'([^']+)')|([a-zA-Z0-9]+)|"([^"]*)"|'([^']*)')/g;
 /*eslint-enable max-len */
+const falsyValuesToEmptyString = (value) => {
+    if (!value){
+        return '';
+    }
+    else return value.toString();
+}
 // TODO: expose the server-side query parser via an API instead of
 // replicating it poorly here
 export function structureQuery(query) {
@@ -37,7 +43,7 @@ export function structureQuery(query) {
 
             struct.push({
                 type: 'text',
-                value: prepend + text
+                value: prepend + falsyValuesToEmptyString(text)
             });
         }
     }

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -1,21 +1,20 @@
 import {UserTelemetryEventSender, IUserTelemetryEvent} from '@guardian/user-telemetry-client';
-
-export const generateId = () => (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
+import { v4 } from 'uuid';
 
 const getStoredId = (storage: Storage, key: string) => {
     const maybeId = storage.getItem(key);
     if (maybeId) {
         return Number(maybeId);
     } else {
-        const id = generateId();
+        const id = v4();
         storage.setItem(key, id.toString());
         return id;
     }
 };
 
-const getBrowserId = () => getStoredId(localStorage, 'browserId');
+const getBrowserId = () => getStoredId(localStorage, 'browserUuid');
 
-const getSessionId = () => getStoredId(localStorage, 'sessionId');
+const getSessionId = () => getStoredId(localStorage, 'sessionUuid');
 
 const getEnv = () => {
     const url = window.location.hostname;

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -8,6 +8,23 @@ declare global {
     }
 }
 
+export const generateId = () => (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
+
+const getStoredId = (storage: Storage, key: string) => {
+    const maybeId = storage.getItem(key);
+    if (maybeId) {
+        return Number(maybeId);
+    } else {
+        const id = generateId();
+        storage.setItem(key, id.toString());
+        return id;
+    }
+};
+
+const getBrowserId = () => getStoredId(localStorage, 'browserId');
+
+const getSessionId = () => getStoredId(localStorage, 'sessionId');
+
 const getEnv = () => {
     const url = window.location.hostname;
     if (url.includes("local.dev-gutools.co.uk")) {return "LOCAL";}
@@ -26,6 +43,6 @@ export const sendTelemetryEvent = (type: string, tags?: IUserTelemetryEvent["tag
         eventTime: new Date().toISOString(),
         type,
         value,
-        tags
+        tags: {...tags, browserId: getBrowserId(), sessionId: getSessionId()}
     });
 };

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -14,7 +14,7 @@ const getStoredId = (storage: Storage, key: string): string => {
 
 const getBrowserId = () => getStoredId(localStorage, 'browserUuid');
 
-const getSessionId = () => getStoredId(localStorage, 'sessionUuid');
+const getSessionId = () => getStoredId(sessionStorage, 'sessionUuid');
 
 const getEnv = () => {
     const url = window.location.hostname;

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -1,10 +1,10 @@
 import {UserTelemetryEventSender, IUserTelemetryEvent} from '@guardian/user-telemetry-client';
 import { v4 } from 'uuid';
 
-const getStoredId = (storage: Storage, key: string) => {
+const getStoredId = (storage: Storage, key: string): string => {
     const maybeId = storage.getItem(key);
     if (maybeId) {
-        return Number(maybeId);
+        return maybeId;
     } else {
         const id = v4();
         storage.setItem(key, id.toString());
@@ -34,6 +34,6 @@ export const sendTelemetryEvent = (type: string, tags?: IUserTelemetryEvent["tag
         eventTime: new Date().toISOString(),
         type,
         value,
-        tags: {...tags, browserId: getBrowserId(), sessionId: getSessionId()}
+        tags: {...tags, browserUuid: getBrowserId(), sessionUuid: getSessionId()}
     });
 };

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -1,0 +1,31 @@
+import {UserTelemetryEventSender, IUserTelemetryEvent} from '@guardian/user-telemetry-client';
+
+declare global {
+    interface Window {
+        _clientConfig: {
+            telemetryUri: string | undefined
+        }
+    }
+}
+
+const getEnv = () => {
+    const url = window.location.hostname;
+    if (url.includes("local.dev-gutools.co.uk")) {return "LOCAL";}
+    if (url.includes("test.dev-gutools.co.uk")) {return "TEST";}
+    if (url.includes(".gutools.co.uk")) {return "PROD";}
+};
+
+const telemetryUri = window._clientConfig.telemetryUri;
+
+export const telemetrySender = telemetryUri ? new UserTelemetryEventSender(telemetryUri) : undefined;
+
+export const sendTelemetryEvent = (type: string, tags?: IUserTelemetryEvent["tags"], value: boolean | number = true): void => {
+    telemetrySender?.addEvent({
+        app: "grid",
+        stage: getEnv(),
+        eventTime: new Date().toISOString(),
+        type,
+        value,
+        tags
+    });
+};

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -1,13 +1,5 @@
 import {UserTelemetryEventSender, IUserTelemetryEvent} from '@guardian/user-telemetry-client';
 
-declare global {
-    interface Window {
-        _clientConfig: {
-            telemetryUri: string | undefined
-        }
-    }
-}
-
 export const generateId = () => (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
 
 const getStoredId = (storage: Storage, key: string) => {

--- a/kahuna/public/js/window.ts
+++ b/kahuna/public/js/window.ts
@@ -1,0 +1,10 @@
+import { FeatureSwitchData } from "./components/gr-feature-switch-panel/gr-feature-switch-panel";
+
+declare global {
+    interface Window {
+      _clientConfig: {
+        telemetryUri: string;
+        featureSwitches: Array<FeatureSwitchData>
+      }
+    }
+  }


### PR DESCRIPTION
## What does this change?

Adds telemetry to filters and searches (only those done via the search bar - not the checkboxes for my uploads and free only).

These are applied when the search is updated, which is debounced after the user stops typing for >500ms.

I'm interested in how we think we can make this more configurable for different organisations, who would have their own telemetry/analytics setups - they would have their own endpoints that would expect the data in a certain shape and therefore would need to reshape the data. How can we make this work for the BBC (and possibly Telex)? How could we make it work if we had 10 organisations using the Grid? 



## How should a reviewer test this change?

Run locally or on `TEST`, ensuring that the telemetryUri is available from config, i.e. `links.telemetryUri="https://user-telemetry.code.dev-gutools.co.uk"` in kahuna config locally.

Make a search with filters. Check kibana for the logs ([relevant search here](https://logs.gutools.co.uk/s/editorial-tools/goto/b65d6850-6ffc-11ed-8ffd-9129a5724241)).

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
