### PR TITLE
Update basic image to Focal

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -91,7 +91,7 @@ deployments:
         AmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: editorial-tools-bionic-java8
+          Recipe: editorial-tools-focal-java8
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?

Moves the "basic" instances (ones which don't require imagemagick, elasticsearch, etc.) to Ubuntu Focal. grid-imaging is already on focal, and the others will be moved in follow-up PRs.

## How should a reviewer test this change?

Deploy to TEST, sense check that instances continue to function correctly.