### PR TITLE
Removes params

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -128,6 +128,5 @@ deployments:
   media-service-fluentbit:
     type: aws-s3
     parameters:
-      bucket: media-service-dist
       cacheControl: private
       publicReadAcl: false


### PR DESCRIPTION
Removes params since bucket ssm look up is set to true by default and to remove any riffraff deprecation warnings (where applicable for the repo)

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
