### PR TITLE
Add telemetry to 'free only' and 'uploaded by me' filters

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -59,9 +59,6 @@ query.controller('SearchQueryCtrl', [
 
     ctrl.resetQuery = resetQuery;
 
-    const { nonFree, uploadedByMe } = ctrl.filter;
-    sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe);
-
     // Note that this correctly uses local datetime and returns
     // midnight for the local user
     const lastMidnight  = moment().startOf('day').toISOString();
@@ -236,6 +233,9 @@ query.controller('SearchQueryCtrl', [
     function resetQuery() {
         ctrl.filter.query = undefined;
     }
+
+    const { nonFree, uploadedByMe } = ctrl.filter;
+    sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe);
 }]);
 
 query.directive('searchQuery', [function() {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -186,6 +186,27 @@ query.controller('SearchQueryCtrl', [
         }
         const structuredQuery = structureQuery(ctrl.filter.query);
         const searchUuid = v4();
+        const { nonFree, uploadedByMe } = ctrl.filter;
+        // nonFree is unfortunately either a boolean, stringified boolean, or undefined
+        const freeToUseOnly = (!(nonFree === 'true' || nonFree === true));
+        const uploadedByMeOnly = (uploadedByMe);
+
+        const sendFilterTelemetryEvent = (key, value) => {
+            sendTelemetryEvent('GRID_FILTER', {
+                type: 'filter', 
+                filterType: 'inclusion',
+                key: key, 
+                value: value,
+                searchUuid
+            }, 1)
+        }
+        if (freeToUseOnly) {  
+            sendFilterTelemetryEvent('freeToUseOnly', 'true')
+        }
+        if (uploadedByMeOnly) {  
+            sendFilterTelemetryEvent('uploadedByMeOnly', 'true')
+        }
+
         structuredQuery.forEach(queryComponent => {
             // e.g. filter or search:
             // search > {type: 'text', value: 'my search'}
@@ -195,20 +216,16 @@ query.controller('SearchQueryCtrl', [
                 if (type === 'text') { return 'GRID_SEARCH'; }
                 if (type === 'filter') { return 'GRID_FILTER'; }
                 return `GRID_${type.toUpperCase()}`;
-            };
-            const { nonFree, uploadedByMe } = ctrl.filter;
-            // nonFree is unfortunately either a boolean, stringified boolean, or undefined
-            const freeToUseOnly = (!(nonFree === 'true' || nonFree === true)).toString();
-            const uploadedByMeOnly = (uploadedByMe).toString();
+            }
 
             // In case search is empty, as with a search containing only filters
             sendTelemetryEvent(formattedType(type), {
                 ...queryComponent, 
                 searchUuid: searchUuid,
-                freeToUseOnly,
-                uploadedByMe: uploadedByMeOnly
             }, 1);
         });
+
+        
 
         $state.go('search.results', filter);
     }));

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -11,11 +11,7 @@ import {guDateRange} from '../components/gu-date-range/gu-date-range';
 import template from './query.html';
 import {syntax} from './syntax/syntax';
 import {grStructuredQuery} from './structured-query/structured-query';
-import { v4 } from 'uuid';
-import { sendTelemetryEvent, sendTelemetryForQuery } from '../services/telemetry';
-import {structureQuery} from './structured-query/syntax';
-import { search } from '.';
-
+import { sendTelemetryForQuery } from '../services/telemetry';
 
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
@@ -64,7 +60,7 @@ query.controller('SearchQueryCtrl', [
     ctrl.resetQuery = resetQuery;
 
     const { nonFree, uploadedByMe } = ctrl.filter;
-    sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe)
+    sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe);
 
     // Note that this correctly uses local datetime and returns
     // midnight for the local user
@@ -187,9 +183,9 @@ query.controller('SearchQueryCtrl', [
           }
           Object.assign(filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
         }
+
         const { nonFree, uploadedByMe } = ctrl.filter;
-        sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe)
-        
+        sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe);
 
         $state.go('search.results', filter);
     }));

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import Rx from 'rx';
-import { v4 } from 'uuid';
 
 import './structured-query.css';
 
@@ -10,7 +9,6 @@ import {rxUtil} from '../../util/rx';
 
 import {querySuggestions, filterFields} from './query-suggestions';
 import {renderQuery, structureQuery} from './syntax';
-import { sendTelemetryEvent } from '../../services/telemetry';
 
 export const grStructuredQuery = angular.module('gr.structuredQuery', [
     rxUtil.name,
@@ -69,21 +67,6 @@ grStructuredQuery.directive('grStructuredQuery', ['subscribe$', function(subscri
 
             subscribe$(scope, ctrl.newQuery$, query => {
                 ngModelCtrl.$setViewValue(query);
-                const structuredQuery = structureQuery(query);
-                const searchUuid = v4();
-                structuredQuery.forEach(queryComponent => {
-                    // e.g. filter or search:
-                    // search > {type: 'text', value: 'my search'}
-                    // filter > {type: 'filter', filterType: 'inclusion', key: 'is', value: 'cool'}
-                    const { type } = queryComponent;
-                    const formattedType = (type) => {
-                        if (type === 'text') { return 'GRID_SEARCH'; }
-                        if (type === 'filter') { return 'GRID_FILTER'; }
-                        return `GRID_${type.toUpperCase()}`;
-                    };
-                    // In case search is empty, as with a search containing only filters
-                    sendTelemetryEvent(formattedType(type), {...queryComponent, searchUuid: searchUuid}, 1);
-                });
             });
         }
     };


### PR DESCRIPTION
## What does this change?

This adds telemetry to the 'Free only' and 'Uploaded by me' checkboxes.

## How should a reviewer test this change?

Run the grid locally. Change the checkboxes. Does a network request go out (shortly afterwards) to the telemetry `event` endpoint with a suitably payload?

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
