### PR TITLE
Add checkbox for org-owned images only

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -55,6 +55,9 @@ class KahunaController(
     val returnUri = config.rootUri + okPath
     val costFilterLabel = config.costFilterLabel.getOrElse("Free to use only")
     val costFilterChargeable = config.costFilterChargeable.getOrElse(false)
+    val orgOwnedLabel = config.orgOwnedLabel.getOrElse("Owned by us")
+    val orgOwnedValue = config.orgOwnedValue.getOrElse("")
+
     Ok(views.html.main(
       s"${config.authUri}/login?redirectUri=$returnUri",
       fieldAliases,
@@ -64,6 +67,8 @@ class KahunaController(
       additionalNavigationLinks,
       costFilterLabel,
       costFilterChargeable,
+      orgOwnedLabel,
+      orgOwnedValue,
       config,
       featureSwitchesJson
     ))

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -27,6 +27,8 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
 
   val costFilterLabel: Option[String] = stringOpt("costFilter.label")
   val costFilterChargeable: Option[Boolean] = booleanOpt("costFilter.chargeable")
+  val orgOwnedLabel: Option[String] = stringOpt("orgOwned.label")
+  val orgOwnedValue: Option[String] = stringOpt("orgOwned.value")
   val additionalLinks: Seq[AdditionalLink] = configuration.getOptional[Seq[AdditionalLink]]("links.additional").getOrElse(Seq.empty)
   val feedbackFormLink: Option[String]= stringOpt("links.feedbackForm").filterNot(_.isEmpty)
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -10,6 +10,8 @@
   additionalNavigationLinks: String,
   costFilterLabel: String,
   costFilterChargeable: Boolean,
+  orgOwnedLabel: String,
+  orgOwnedValue: String,
   kahunaConfig: KahunaConfig,
   featureSwitches: String,
 )
@@ -61,6 +63,8 @@
           additionalNavigationLinks: @Html(additionalNavigationLinks),
           costFilterLabel: "@Html(costFilterLabel)",
           costFilterChargeable: @costFilterChargeable,
+          orgOwnedLabel: "@orgOwnedLabel",
+          orgOwnedValue: "@orgOwnedValue",
           restrictDownload: @kahunaConfig.restrictDownload.getOrElse(false),
           warningTextHeader: "@Html(kahunaConfig.warningTextHeader)",
           warningTextHeaderNoRights: "@Html(kahunaConfig.warningTextHeaderNoRights)",

--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
@@ -16,6 +16,7 @@ gr-top-bar-actions {
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+    min-width: 278px;
 }
 
 

--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -61,6 +61,15 @@
                 </label>
             </li>
 
+            <li ng-if="searchQuery.orgOwnedValue" id="org-owned-checkbox" class="search__modifier-item search__modifier-checkbox">
+                <label>
+                    <input type="checkbox"
+                        ng-model="searchQuery.filter.orgOwned" />
+                    {{ searchQuery.orgOwnedLabel }}
+                </label>
+            </li>
+
+
             <li class="search__modifier-item">
                 <gu-date-range class="search__date"
                                gu:start-date="searchQuery.dateFilter.since"

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -172,6 +172,18 @@ query.controller('SearchQueryCtrl', [
 
         ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
 
+        const defaultNonFreeFilter = storage.getJs("defaultNonFreeFilter", true);
+        if (defaultNonFreeFilter && defaultNonFreeFilter.isDefault === true){
+          let newNonFree = defaultNonFreeFilter.isNonFree ? "true" : undefined;
+          if (newNonFree !== filter.nonFree){
+            storage.setJs("isNonFree", newNonFree ? newNonFree : false, true);
+            storage.setJs("isUploadedByMe", false, true);
+            storage.setJs("defaultNonFreeFilter", {isDefault: false, isNonFree: false}, true);
+            ctrl.filter.orgOwned = false;
+          }
+          Object.assign(filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
+        }
+
         if (filter.orgOwned){
             // If the checkbox is ticked, add the chip to the serach bar
             const structuredQuery = structureQuery(ctrl.filter.query);
@@ -193,17 +205,6 @@ query.controller('SearchQueryCtrl', [
                 structuredQuery.splice(indexToDelete, 1);
                 ctrl.filter.query = renderQuery(structuredQuery);
             }
-        }
-
-        const defaultNonFreeFilter = storage.getJs("defaultNonFreeFilter", true);
-        if (defaultNonFreeFilter && defaultNonFreeFilter.isDefault === true){
-          let newNonFree = defaultNonFreeFilter.isNonFree ? "true" : undefined;
-          if (newNonFree !== filter.nonFree){
-                storage.setJs("isNonFree", newNonFree ? newNonFree : false, true);
-                storage.setJs("isUploadedByMe", false, true);
-                storage.setJs("defaultNonFreeFilter", {isDefault: false, isNonFree: false}, true);
-          }
-          Object.assign(filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
         }
 
         const { nonFree, uploadedByMe } = ctrl.filter;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -173,6 +173,7 @@ query.controller('SearchQueryCtrl', [
         ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
 
         if (filter.orgOwned){
+            // If the checkbox is ticked, add the chip to the serach bar
             const structuredQuery = structureQuery(ctrl.filter.query);
             if (!structuredQuery.find(item => item.value === ctrl.orgOwnedValue)){
                 structuredQuery.push({
@@ -185,6 +186,7 @@ query.controller('SearchQueryCtrl', [
 
             ctrl.filter.query = renderQuery(structuredQuery);
         } else {
+            // If the checkbox is unticked, remove the chip from the serach bar
             const structuredQuery = structureQuery(ctrl.filter.query);
             const indexToDelete = structuredQuery.findIndex(item => item.value === ctrl.orgOwnedValue);
             if (indexToDelete >= 0){

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -169,6 +169,7 @@ query.controller('SearchQueryCtrl', [
             filter.uploadedBy = filter.uploadedByMe ? ctrl.user.email : undefined;
         }
         storage.setJs("isUploadedByMe", ctrl.filter.uploadedByMe, true);
+        storage.setJs("orgOwned", ctrl.filter.orgOwned, true);
 
         ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
 
@@ -200,7 +201,7 @@ query.controller('SearchQueryCtrl', [
                 storage.setJs("isNonFree", newNonFree ? newNonFree : false, true);
                 storage.setJs("isUploadedByMe", false, true);
                 storage.setJs("defaultNonFreeFilter", {isDefault: false, isNonFree: false}, true);
-                storage.setJS("orgOwned", filter.orgOwned);
+                storage.setJS("orgOwned", filter.orgOwned, true);
           }
           Object.assign(filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
         }
@@ -252,9 +253,8 @@ query.controller('SearchQueryCtrl', [
         } else {
           ctrl.filter.nonFree = undefined;
         }
-
         if (orgOwned === null) {
-            storage.setJs("orgOwned",ctrl.filter.orgOwned);
+            storage.setJs("orgOwned", ctrl.filter.orgOwned, true);
         }
         else {
             ctrl.filter.orgOwned = orgOwned;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -169,7 +169,6 @@ query.controller('SearchQueryCtrl', [
             filter.uploadedBy = filter.uploadedByMe ? ctrl.user.email : undefined;
         }
         storage.setJs("isUploadedByMe", ctrl.filter.uploadedByMe, true);
-        storage.setJs("orgOwned", ctrl.filter.orgOwned, true);
 
         ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
 
@@ -201,7 +200,6 @@ query.controller('SearchQueryCtrl', [
                 storage.setJs("isNonFree", newNonFree ? newNonFree : false, true);
                 storage.setJs("isUploadedByMe", false, true);
                 storage.setJs("defaultNonFreeFilter", {isDefault: false, isNonFree: false}, true);
-                storage.setJS("orgOwned", filter.orgOwned, true);
           }
           Object.assign(filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
         }
@@ -233,8 +231,8 @@ query.controller('SearchQueryCtrl', [
     mediaApi.getSession().then(session => {
         const isNonFree = storage.getJs("isNonFree", true);
         const isUploadedByMe = storage.getJs("isUploadedByMe", true);
-        const orgOwned = storage.getJs("orgOwned", true);
-
+        const structuredQuery = structureQuery(ctrl.filter.query);
+        const orgOwned = (structuredQuery.some(item => item.value === ctrl.orgOwnedValue))
         ctrl.user = session.user;
         if (isUploadedByMe === null) {
               ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;
@@ -253,12 +251,7 @@ query.controller('SearchQueryCtrl', [
         } else {
           ctrl.filter.nonFree = undefined;
         }
-        if (orgOwned === null) {
-            storage.setJs("orgOwned", ctrl.filter.orgOwned, true);
-        }
-        else {
-            ctrl.filter.orgOwned = orgOwned;
-        }
+        ctrl.filter.orgOwned = orgOwned;
     });
 
     function resetQuery() {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -257,12 +257,13 @@ query.controller('SearchQueryCtrl', [
             storage.setJs("orgOwned",ctrl.filter.orgOwned);
         }
         else {
-            ctrl.filter.orgOwned =  orgOwned;
+            ctrl.filter.orgOwned = orgOwned;
         }
     });
 
     function resetQuery() {
         ctrl.filter.query = undefined;
+        ctrl.filter.orgOwned = false;
     }
 
     const { nonFree, uploadedByMe } = ctrl.filter;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -232,7 +232,7 @@ query.controller('SearchQueryCtrl', [
         const isNonFree = storage.getJs("isNonFree", true);
         const isUploadedByMe = storage.getJs("isUploadedByMe", true);
         const structuredQuery = structureQuery(ctrl.filter.query);
-        const orgOwned = (structuredQuery.some(item => item.value === ctrl.orgOwnedValue))
+        const orgOwned = (structuredQuery.some(item => item.value === ctrl.orgOwnedValue));
         ctrl.user = session.user;
         if (isUploadedByMe === null) {
               ctrl.filter.uploadedByMe = ctrl.uploadedBy === ctrl.user.email;

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -18,12 +18,18 @@ export const grStructuredQuery = angular.module('gr.structuredQuery', [
 
 
 grStructuredQuery.controller('grStructuredQueryCtrl',
-                             ['querySuggestions',
-                              function(querySuggestions) {
+                             ['querySuggestions', '$scope',
+                              function(querySuggestions, $scope) {
     const ctrl = this;
+    ctrl.orgOwnedValue = window._clientConfig.orgOwnedValue;
 
     const structuredQueryUpdates$ = Rx.Observable.create(observer => {
         ctrl.structuredQueryChanged = function(structuredQuery) {
+            if (ctrl.orgOwnedValue && structuredQuery.find(item => item.value === ctrl.orgOwnedValue)){
+                $scope.searchQuery.filter.orgOwned = true;
+            } else {
+                $scope.searchQuery.filter.orgOwned = false;
+            }
             observer.onNext(structuredQuery);
         };
     });

--- a/kahuna/public/js/search/structured-query/syntax.js
+++ b/kahuna/public/js/search/structured-query/syntax.js
@@ -15,15 +15,18 @@ const falsyValuesToEmptyString = (value) => {
 // TODO: expose the server-side query parser via an API instead of
 // replicating it poorly here
 export function structureQuery(query) {
+
     const struct = [];
     let m;
+    if (query === undefined) {
+        return struct;
+    }
     while ((m = parserRe.exec(query)) !== null) {
         const sign  = m[1];
         const field = m[2];
         const symbol  = m[3] || m[4];
         const value = m[5] || m[6] || m[7];
         const text  = m[8] || m[9] || m[10];
-
         const key = {
             '#': 'label',
             '~': 'collection'
@@ -41,7 +44,6 @@ export function structureQuery(query) {
         } else {
             // Maintain negatable "any" search as text
             const prepend = (sign === '-' ? '-' : '');
-
             struct.push({
                 type: 'text',
                 value: prepend + falsyValuesToEmptyString(text)

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -778,6 +778,10 @@ textarea.ng-invalid {
         min-width: inherit;
     }
 
+    gr-top-bar-actions {
+      min-width: 128px;
+    }
+
     .results-toolbar-item .gr-confirm-delete gr-icon-label {
         padding: 0
     }


### PR DESCRIPTION
Co-authored with @andrew-nowak 

## What does this change?

This PR adds a checkbox for organisation-owned images. Clicking the checkbox adds or removes an `is:` filter with a value set in config. The checkbox should not show if the value is not set.

The checkbox is also labelled by a value set in config. E.g. in `kahuna.conf`:
```
orgOwned.label="GNM-owned"
orgOwned.value="GNM-owned"
```
![image](https://user-images.githubusercontent.com/34686302/208706031-6a0c1d72-b6a9-4643-b0dd-61017f763806.png)
## How should a reviewer test this change?

Run the Grid locally and try the checkbox with/without the required config values. Does it behave as expected?

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
