### PR TITLE
Add usage-rights suppliers field to metadata template configuration

### DIFF
--- a/kahuna/app/lib/MetadataTemplateConfig.scala
+++ b/kahuna/app/lib/MetadataTemplateConfig.scala
@@ -33,7 +33,8 @@ case class MetadataTemplateUsageRights(category: String,
                                        photographer: Option[String] = None,
                                        publication: Option[String] = None,
                                        restrictions: Option[String] = None,
-                                       source: Option[String] = None)
+                                       source: Option[String] = None,
+                                       suppliers: Option[String] = None)
 
 object MetadataTemplateUsageRights {
   implicit val writes: Writes[MetadataTemplateUsageRights] = Json.writes[MetadataTemplateUsageRights]
@@ -97,7 +98,9 @@ object MetadataTemplate {
             restrictions = if (usageRightConfig.hasPath("restrictions"))
               Some(usageRightConfig.getString("restrictions")) else None,
             source = if (usageRightConfig.hasPath("source"))
-              Some(usageRightConfig.getString("source")) else None
+              Some(usageRightConfig.getString("source")) else None,
+            suppliers = if (usageRightConfig.hasPath("suppliers"))
+              Some(usageRightConfig.getString("suppliers")) else None
           ))
         } else None
 

--- a/kahuna/test/lib/MetadataTemplateConfigTest.scala
+++ b/kahuna/test/lib/MetadataTemplateConfigTest.scala
@@ -36,9 +36,14 @@ class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
         Map(
           "templateName" -> "C",
           "usageRights" -> Map(
-            "category" -> "original-source"
+            "category" -> "composite",
+            "creator" -> "Creator A",
+            "photographer" -> "Photographer A",
+            "publication" -> "Publication A",
+            "suppliers" -> "Supplier A",
+            "restrictions" -> "Sample composite restriction",
           ),
-        ),
+        )
       )
     ))
 
@@ -90,8 +95,12 @@ class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
       template.usageRights shouldBe defined
 
       val usageRights = template.usageRights.get
-      usageRights.category shouldBe "original-source"
-      usageRights.restrictions shouldBe None
+      usageRights.category shouldBe "composite"
+      usageRights.creator shouldBe Some("Creator A")
+      usageRights.photographer shouldBe Some("Photographer A")
+      usageRights.publication shouldBe Some("Publication A")
+      usageRights.restrictions shouldBe Some("Sample composite restriction")
+      usageRights.suppliers shouldBe Some("Supplier A")
     }
   }
 


### PR DESCRIPTION
## What does this change?

This PR:
- Adds the "suppliers" field to the usage-rights configuration in a metadata template.
- Fills the "Suppliers" field in the Image Rights form with the configured value when the metadata template is selected e.g. Composite usage rights.
- Saves the configured "suppliers" value to the images's usage rights when the template is applied.

This is a follow-up PR to the:

- #3664
- #3772 
- #3867 

### Upload page

![Screenshot 2022-12-29 at 18 05 54](https://user-images.githubusercontent.com/12212239/209972199-93f30601-883a-4668-a48c-e32360928e57.png)

### Image search page with Info Panel open
![Screenshot 2022-12-29 at 18 06 30](https://user-images.githubusercontent.com/12212239/209972213-f43b100e-8cf8-46c1-9ab8-ed603eb6193b.png)

### Image view page
![Screenshot 2022-12-29 at 18 06 56](https://user-images.githubusercontent.com/12212239/209972226-e6ac2e5c-84eb-433c-96de-bb7b68839687.png)

## How should a reviewer test this change?

Add the test metadata template configuration (below) to Kahuna's configuration.

```hocon
metadata.templates = [
  {
    templateName: "Template A"
    usageRights: {
      category: "composite"
      suppliers: "Supplier A"
      restrictions: "Sample restriction for Supplier A."
    }
  }
]
```

## How can success be measured?

Adding the above configuration to kahuna should:

- Render "Template select" component on the "My uploads" page, info panel on search images view page and Image view page as shown in the attached screenshots.
- Allow a user to select the metadata template "Template A" that highlights staged image rights changes that have been defined in the template.
- On clicking "Apply", the staged image rights should be applied to the image.

## Who should look at this?

@guardian/digital-cms

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
