### PR TITLE
make `stripDoubleQuotes` function handle undefined rather than throwing

### DIFF
--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -4,8 +4,8 @@ import {getCollection} from '../search-query/query-syntax';
 
 export var queryFilters = angular.module('kahuna.search.filters.query', []);
 
-var containsSpace = s => / /.test(s);
-var stripDoubleQuotes = s => s.replace(/"/g, '');
+const containsSpace = s => / /.test(s);
+const stripDoubleQuotes = s => s && s.replace(/"/g, '');
 
 export function maybeQuoted(value) {
     if (containsSpace(value)) {


### PR DESCRIPTION
Addressing a big offender in Sentry
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/19289579/210332616-5f6d22d7-21ff-42e7-81d4-79373cc88502.png">