### PR TITLE
make `stripDoubleQuotes` function handle undefined and non-strings rather than throwing

### DIFF
--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -5,7 +5,7 @@ import {getCollection} from '../search-query/query-syntax';
 export var queryFilters = angular.module('kahuna.search.filters.query', []);
 
 const containsSpace = s => / /.test(s);
-const stripDoubleQuotes = s => s && s.replace(/"/g, '');
+const stripDoubleQuotes = s => s?.replace?.(/"/g, '');
 
 export function maybeQuoted(value) {
     if (containsSpace(value)) {


### PR DESCRIPTION
follow up to #4006 - because sometimes this function is called with things other than strings 🙈 

✅  TESTED in TEST