### PR TITLE
Fix snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      DEBUG: true
+      DEBUG: false
       ORG: guardian
       SKIP_NODE: false
       SKIP_PYTHON: false

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,6 +15,6 @@ jobs:
       SKIP_NODE: false
       SKIP_PYTHON: false
       PIP_REQUIREMENTS_FILES: quarantine-status/lambda/requirements.txt
-      PYTHON_VERSION: 3.6
+      PYTHON_VERSION: 3.6.7
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,5 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian
       SKIP_NODE: false
+      SKIP_PYTHON: false
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      DEBUG: false
+      DEBUG: true
       ORG: guardian
       SKIP_NODE: false
       SKIP_PYTHON: false

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@nt/fix-python
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: false
       ORG: guardian

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,6 +15,6 @@ jobs:
       SKIP_NODE: false
       SKIP_PYTHON: false
       PIP_REQUIREMENTS_FILES: quarantine-status/lambda/requirements.txt
-      PYTHON_VERSION: 3.6.7
+      PYTHON_VERSION: 3.7.13
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,5 +15,6 @@ jobs:
       SKIP_NODE: false
       SKIP_PYTHON: false
       PIP_REQUIREMENTS_FILES: quarantine-status/lambda/requirements.txt
+      PYTHON_VERSION: 3.6
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@nt/fix-python
     with:
       DEBUG: false
       ORG: guardian

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,5 +14,6 @@ jobs:
       ORG: guardian
       SKIP_NODE: false
       SKIP_PYTHON: false
+      PIP_REQUIREMENTS_FILES: quarantine-status/lambda/requirements.txt
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/quarantine-status/lambda/requirements.txt
+++ b/quarantine-status/lambda/requirements.txt
@@ -1,1 +1,2 @@
+urllib3
 requests

--- a/quarantine-status/lambda/requirements.txt
+++ b/quarantine-status/lambda/requirements.txt
@@ -1,2 +1,1 @@
-urllib3
 requests


### PR DESCRIPTION
Co-authored-by Julia Branke <julia.branke@guardian.co.uk>
Co-authored-by Michael McNamara <michael.mcnamara@guardian.co.uk>
Co-authored-by Jorge Azevedo <jorge.azevedo@guardian.co.uk>

## What does this change?

There was an error in our snyk workflow that meant python 3 projects were not being submitted properly. This has now been fixed [here](https://github.com/guardian/.github/pull/45)

We've enabled python in this project, as well as submitting the lowest python version compatible with the github runner, so that the project can be scanned successfully


## How should a reviewer test this change?

The change has been tested by running the snyk action against the branch [here](https://github.com/guardian/grid/actions/workflows/snyk.yml?query=branch%3Ant%2Finclude-python-snyk)

## How can success be measured?

The GHA no longer fails

## Who should look at this?
@guardian/digital-cms
@guardian/developer-experience 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
