### PR TITLE
Fix "undefined" appearing in search telemetry

### DIFF
--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -50,7 +50,7 @@ const sendFilterTelemetryEvent = (key: string, value: string, searchUuid: string
 };
 
 export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string, uploadedByMe?: boolean ) => {
-    const structuredQuery = structureQuery(query);
+    const structuredQuery = structureQuery(query || "");
     const searchUuid = v4();
     // nonFree is unfortunately either a boolean, stringified boolean, or undefined
     const freeToUseOnly = (!(nonFree === 'true' || nonFree === true));


### PR DESCRIPTION
## What does this change?

This stops 'undefined' being sent as a search to our telemetry service when the search is empty.

## How should a reviewer test this change?

1. Run `./dev/scripts/start.sh --use-TEST`
2. Open [media.local.dev-gutools.co.uk](https://media.local.dev-gutools.co.uk/)
3. Check the network tab for requests going to 'event'
4. Does the options request contain a row with the tags `type:"text"` `value: ""`, rather than `value:'undefined'`?

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
