### PR TITLE
bring back syndication icon colours

### DIFF
--- a/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
+++ b/kahuna/public/js/components/gr-syndication-icon/gr-syndication-icon.html
@@ -1,5 +1,5 @@
 <div title="{{ ctrl.states.syndicationReason }}">
-    <gr-icon class="gr-icon--large" class="syndication-status--{{ ctrl.states.syndicationStatus }}">
+    <gr-icon class="gr-icon--large syndication-status--{{ ctrl.states.syndicationStatus }}">
         monetization_on
     </gr-icon>
 </div>


### PR DESCRIPTION
## What does this change?

We used to have colours on the syndication icons, they were useful, @paperboyo noticed they're gone, tracked it down to this (repeated class attributes doesn't work, they need to be space delimited)