### PR TITLE
Set syndication filters based on `now` to be `def`

### DIFF
--- a/media-api/app/lib/elasticsearch/SyndicationFilter.scala
+++ b/media-api/app/lib/elasticsearch/SyndicationFilter.scala
@@ -61,17 +61,17 @@ class SyndicationFilter(config: MediaApiConfig) extends ImageFields {
     SyndicationUsage.toString
   )
 
-  private val leaseHasStarted: Query = filters.or(
+  private def leaseHasStarted: Query = filters.or(
     filters.existsOrMissing("leases.leases.startDate", exists = false),
     filters.date("leases.leases.startDate", None, Some(DateTime.now)).get
   )
 
-  private val leaseHasNotExpired: Query = filters.or(
+  private def leaseHasNotExpired: Query = filters.or(
     filters.existsOrMissing("leases.leases.endDate", exists = false),
     filters.date("leases.leases.endDate", Some(DateTime.now), None).get
   )
 
-  private val syndicationRightsPublished: Query = filters.or(
+  private def syndicationRightsPublished: Query = filters.or(
     filters.existsOrMissing("syndicationRights.published", exists = false),
     filters.date("syndicationRights.published", None, Some(DateTime.now)).get
   )


### PR DESCRIPTION
## What does this change?

If they're `val` then `DateTime.now` will only be evaluated once - at instance startup.

If instances survive for a moderate period of time, we will start seeing images that are all set to join the queue appear to go missing, because the check will go out of date
