### PR TITLE
Add multiple leases using metadata-templates

### DIFF
--- a/kahuna/app/lib/MetadataTemplateConfig.scala
+++ b/kahuna/app/lib/MetadataTemplateConfig.scala
@@ -44,7 +44,7 @@ case class MetadataTemplate(
    templateName: String,
    metadataFields: Seq[MetadataTemplateField] = Nil,
    collectionFullPath: CollectionFullPath = Nil,
-   lease: Option[MetadataTemplateLease] = None,
+   leases: Seq[MetadataTemplateLease] = Nil,
    usageRights: Option[MetadataTemplateUsageRights] = None)
 
 object MetadataTemplate {
@@ -72,17 +72,17 @@ object MetadataTemplate {
           config.getStringList("collectionFullPath").asScala.seq
         } else Nil
 
-        val lease = if (config.hasPath("lease")) {
-          val leaseConfig = config.getConfig("lease")
-
-          Some(MetadataTemplateLease(
-            leaseType = leaseConfig.getString("leaseType"),
-            durationInMillis = if (leaseConfig.hasPath("duration"))
-              Some(leaseConfig.getDuration("duration").toMillis) else None,
-            notes = if (leaseConfig.hasPath("notes"))
-              Some(leaseConfig.getString("notes")) else None
-          ))
-        } else None
+        val leases = if (config.hasPath("leases")) {
+          config.getConfigList("leases").asScala.map(leaseConfig => {
+            MetadataTemplateLease(
+              leaseType = leaseConfig.getString("leaseType"),
+              durationInMillis = if (leaseConfig.hasPath("duration"))
+                Some(leaseConfig.getDuration("duration").toMillis) else None,
+              notes = if (leaseConfig.hasPath("notes"))
+                Some(leaseConfig.getString("notes")) else None
+            )
+          })
+        } else Nil
 
         val usageRights = if (config.hasPath("usageRights")) {
           val usageRightConfig = config.getConfig("usageRights")
@@ -104,6 +104,6 @@ object MetadataTemplate {
           ))
         } else None
 
-        MetadataTemplate(config.getString("templateName"), metadataFields, collectionFullPath, lease, usageRights)
+        MetadataTemplate(config.getString("templateName"), metadataFields, collectionFullPath, leases, usageRights)
       }))
 }

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -7,7 +7,7 @@
             image="ctrl.singleImage"
             metadata="ctrl.singleImage.data.metadata"
             usage-rights="ctrl.singleImage.data.usageRights"
-            gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, leases)"
+            gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, leasesWithConfig)"
             gr-on-metadata-template-applying="ctrl.onMetadataTemplateApplying(leases)"
             gr-on-metadata-template-applied="ctrl.onMetadataTemplateApplied()"
             gr-on-metadata-template-cancelled="ctrl.onMetadataTemplateCancelled(metadata, usageRights)"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -7,8 +7,8 @@
             image="ctrl.singleImage"
             metadata="ctrl.singleImage.data.metadata"
             usage-rights="ctrl.singleImage.data.usageRights"
-            gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, lease)"
-            gr-on-metadata-template-applying="ctrl.onMetadataTemplateApplying(lease)"
+            gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, leases)"
+            gr-on-metadata-template-applying="ctrl.onMetadataTemplateApplying(leases)"
             gr-on-metadata-template-applied="ctrl.onMetadataTemplateApplied()"
             gr-on-metadata-template-cancelled="ctrl.onMetadataTemplateCancelled(metadata, usageRights)"
             class="metadata-templates-flex">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -426,7 +426,7 @@ module.controller('grImageMetadataCtrl', [
         freeUpdateListener();
     });
 
-    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, lease) => {
+    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leases) => {
       ctrl.collectionUpdatedByTemplate = false;
       ctrl.leasesUpdatedByTemplate = false;
       ctrl.showUsageRights = false;
@@ -438,9 +438,13 @@ module.controller('grImageMetadataCtrl', [
         ctrl.metadata = metadata;
       }
 
-      if (angular.isDefined(lease)) {
+      if (angular.isDefined(leases)) {
+        const leasesFromTemplate = leases.map(lease => {
+          return {...lease, fromTemplate: true};
+        });
+
         ctrl.updatedLeases = [
-          {...lease, fromTemplate: true},
+          ...leasesFromTemplate,
           ...ctrl.singleImage.data.leases.data.leases
         ];
         ctrl.leasesUpdatedByTemplate = true;

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -426,7 +426,7 @@ module.controller('grImageMetadataCtrl', [
         freeUpdateListener();
     });
 
-    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leases) => {
+    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leasesWithConfig) => {
       ctrl.collectionUpdatedByTemplate = false;
       ctrl.leasesUpdatedByTemplate = false;
       ctrl.showUsageRights = false;
@@ -438,15 +438,11 @@ module.controller('grImageMetadataCtrl', [
         ctrl.metadata = metadata;
       }
 
-      if (angular.isDefined(leases)) {
-        const leasesFromTemplate = leases.map(lease => {
+      if (angular.isDefined(leasesWithConfig)) {
+        const leasesFromTemplate = leasesWithConfig.leases.map(lease => {
           return {...lease, fromTemplate: true};
         });
-
-        ctrl.updatedLeases = [
-          ...leasesFromTemplate,
-          ...ctrl.singleImage.data.leases.data.leases
-        ];
+        ctrl.updatedLeases = [...leasesFromTemplate, ...(leasesWithConfig.replace ? [] : ctrl.singleImage.data.leases.data.leases)];
         ctrl.leasesUpdatedByTemplate = true;
       }
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -470,8 +470,8 @@ module.controller('grImageMetadataCtrl', [
       }
     };
 
-    ctrl.onMetadataTemplateApplying = (lease) => {
-      if (angular.isDefined(lease)) {
+    ctrl.onMetadataTemplateApplying = (leases) => {
+      if (angular.isDefined(leases)) {
         ctrl.leasesUpdatingByTemplate = true;
       }
     };

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -112,7 +112,7 @@
                    image="ctrl.image"
                    metadata="ctrl.image.data.metadata"
                    usage-rights="ctrl.image.data.usageRights"
-                   gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, leases)"
+                   gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, leasesWithConfig)"
                    gr-on-metadata-template-applying="ctrl.onMetadataTemplateApplying(leases)"
                    gr-on-metadata-template-applied="ctrl.onMetadataTemplateApplied()"
                    gr-on-metadata-template-cancelled="ctrl.onMetadataTemplateCancelled(metadata, usageRights)"

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -212,13 +212,13 @@
                    gr-collection-updated-by-template="ctrl.collectionUpdatedByTemplate"
                ></gr-collection-overlay>
                <span class="preview__collections__collection__apply-all" ng-if="ctrl.withBatch">
-                    <button ng-if="! ctrl.confirmDelete"
+                    <button ng-if="! ctrl.confirmDelete && !ctrl.collectionUpdatedByTemplate"
                             title="Apply these collections to all your current uploads"
                             ng-click="ctrl.batchApplyCollections()"
                     >⇔</button>
                     <button title="Remove ALL collections"
                             class="button button--confirm-delete"
-                            ng-if="ctrl.confirmDelete"
+                            ng-if="ctrl.confirmDelete && !ctrl.collectionUpdatedByTemplate"
                             ng-click="ctrl.batchRemoveCollections()">
                         <gr-icon>warning</gr-icon>Remove ALL collections in job?
                     </button>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -112,8 +112,8 @@
                    image="ctrl.image"
                    metadata="ctrl.image.data.metadata"
                    usage-rights="ctrl.image.data.usageRights"
-                   gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, lease)"
-                   gr-on-metadata-template-applying="ctrl.onMetadataTemplateApplying(lease)"
+                   gr-on-metadata-template-selected="ctrl.onMetadataTemplateSelected(metadata, usageRights, collection, leases)"
+                   gr-on-metadata-template-applying="ctrl.onMetadataTemplateApplying(leases)"
                    gr-on-metadata-template-applied="ctrl.onMetadataTemplateApplied()"
                    gr-on-metadata-template-cancelled="ctrl.onMetadataTemplateCancelled(metadata, usageRights)"
                    class="metadata-templates-flex">

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -159,7 +159,7 @@ imageEditor.controller('ImageEditorCtrl', [
       ctrl.usageRightsUpdatedByTemplate = false;
     };
 
-    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leases) => {
+    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leasesWithConfig) => {
       $scope.$broadcast('events:metadata-template:template-selected', { metadata });
 
       ctrl.collectionUpdatedByTemplate = false;
@@ -168,15 +168,11 @@ imageEditor.controller('ImageEditorCtrl', [
       ctrl.usageRightsUpdatedByTemplate = false;
       ctrl.usageRights.data = usageRights;
 
-      if (angular.isDefined(leases)) {
-        const leasesFromTemplate = leases.map(lease => {
+      if (angular.isDefined(leasesWithConfig)) {
+        const leasesFromTemplate = leasesWithConfig.leases.map(lease => {
           return {...lease, fromTemplate: true};
         });
-
-        ctrl.updatedLeases = [
-          ...leasesFromTemplate,
-          ...ctrl.image.data.leases.data.leases
-        ];
+        ctrl.updatedLeases = [...leasesFromTemplate, ...(leasesWithConfig.replace ? [] : ctrl.image.data.leases.data.leases)];
         ctrl.leasesUpdatedByTemplate = true;
       }
 

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -159,7 +159,7 @@ imageEditor.controller('ImageEditorCtrl', [
       ctrl.usageRightsUpdatedByTemplate = false;
     };
 
-    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, lease) => {
+    ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leases) => {
       $scope.$broadcast('events:metadata-template:template-selected', { metadata });
 
       ctrl.collectionUpdatedByTemplate = false;
@@ -168,9 +168,13 @@ imageEditor.controller('ImageEditorCtrl', [
       ctrl.usageRightsUpdatedByTemplate = false;
       ctrl.usageRights.data = usageRights;
 
-      if (angular.isDefined(lease)) {
+      if (angular.isDefined(leases)) {
+        const leasesFromTemplate = leases.map(lease => {
+          return {...lease, fromTemplate: true};
+        });
+
         ctrl.updatedLeases = [
-          {...lease, fromTemplate: true},
+          ...leasesFromTemplate,
           ...ctrl.image.data.leases.data.leases
         ];
         ctrl.leasesUpdatedByTemplate = true;

--- a/kahuna/public/js/edits/image-editor.js
+++ b/kahuna/public/js/edits/image-editor.js
@@ -133,8 +133,8 @@ imageEditor.controller('ImageEditorCtrl', [
         offUsageRightsUpdateError();
     });
 
-    ctrl.onMetadataTemplateApplying = (lease) => {
-      if (angular.isDefined(lease)) {
+    ctrl.onMetadataTemplateApplying = (leases) => {
+      if (angular.isDefined(leases)) {
         ctrl.leasesUpdatingByTemplate = true;
       }
     };

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -13,7 +13,7 @@
        <span ng-show="ctrl.adding">Updating...</span>
     </span>
 </button>
-<span ng-if="ctrl.withBatch" class="leases__apply-all">
+<span ng-if="ctrl.withBatch && !ctrl.leasesUpdatedByTemplate" class="leases__apply-all">
     <button
         title="Apply these leases to all your current uploads"
         ng-if="!ctrl.confirmDelete"

--- a/kahuna/public/js/metadata-templates/metadata-templates.css
+++ b/kahuna/public/js/metadata-templates/metadata-templates.css
@@ -2,3 +2,7 @@
   color: #ccc;
   padding: 10px 0;
 }
+.metadata-templates__bar {
+  padding: 10px 0;
+  text-align: right;
+}

--- a/kahuna/public/js/metadata-templates/metadata-templates.html
+++ b/kahuna/public/js/metadata-templates/metadata-templates.html
@@ -12,7 +12,7 @@
         </select>
     </label>
 
-    <div class="ure__bar" ng-if="ctrl.metadataTemplate">
+    <div class="metadata-templates__bar" ng-if="ctrl.metadataTemplate">
         <button class="ure__action button-ico button-cancel" type="button"
                 ng-click="ctrl.cancel()"
                 title="Close">

--- a/kahuna/public/js/metadata-templates/metadata-templates.js
+++ b/kahuna/public/js/metadata-templates/metadata-templates.js
@@ -149,7 +149,7 @@ metadataTemplates.controller('MetadataTemplatesCtrl', [
 
   ctrl.applyTemplate = () => {
     ctrl.saving = true;
-    ctrl.onMetadataTemplateApplying({lease: ctrl.metadataTemplate.lease});
+    ctrl.onMetadataTemplateApplying({leases: ctrl.metadataTemplate.templateLeases.leases});
 
     let promise = Promise.resolve();
 
@@ -177,8 +177,7 @@ metadataTemplates.controller('MetadataTemplatesCtrl', [
 
         if (ctrl.metadataTemplate.templateLeases.replace){
           return leaseService.replace(ctrl.image, leases);
-        }
-        else {
+        } else {
           return leaseService.addLeases(ctrl.image, leases);
         }
       }

--- a/kahuna/public/js/services/api/leases.js
+++ b/kahuna/public/js/services/api/leases.js
@@ -82,6 +82,18 @@ leaseService.factory('leaseService', [
             return image.perform('add-lease', { body: newLease });
         }
 
+        function addLeases(image, leases) {
+          const updatedLeases = leases.map((lease) => {
+            let newLease = angular.copy(lease);
+            newLease.mediaId = image.data.id;
+            return newLease;
+          });
+
+          return image
+            .perform('add-leases', { body: updatedLeases })
+            .then(() => pollLeasesAndUpdateUI([image]));
+        }
+
         function batchAdd(lease, images) {
 
           // search page has fancy image list
@@ -196,6 +208,7 @@ leaseService.factory('leaseService', [
     }
 
     return {
+        addLeases,
         batchAdd,
         getLeases,
         canUserEdit,

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -23,7 +23,7 @@
                 class="job-editor__apply-to-all"
                 title="Apply this description to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit && (ctrl.originalMetadata['description'] === ctrl.metadata['description'])"
                 ng-click="ctrl.batchApplyMetadata('description')"
             >⇔</button>
         </label>
@@ -50,7 +50,7 @@
                 class="job-editor__apply-to-all"
                 title="Apply this byline to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('byline')"
                 ng-click="ctrl.batchApplyMetadata('byline')"
             >⇔</button>
 
@@ -81,7 +81,7 @@
                 class="job-editor__apply-to-all"
                 title="Apply this credit to all"
                 type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('credit')"
                 ng-click="ctrl.batchApplyMetadata('credit')"
             >⇔</button>
         </div>
@@ -103,7 +103,7 @@
                 class="job-editor__apply-to-all"
                 title="Apply this copyright to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('copyright')"
                 ng-click="ctrl.batchApplyMetadata('copyright')"
             >⇔</button>
         </label>
@@ -126,7 +126,7 @@
                 class="job-editor__apply-to-all"
                 title="Apply these instructions to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('specialInstructions')"
                 ng-click="ctrl.batchApplyMetadata('specialInstructions')"
             >⇔</button>
         </label>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -33,6 +33,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
     // We do this check to ensure the copyright field doesn't disappear
     // if we set it to "".
     ctrl.copyrightWasInitiallyThere = !!ctrl.originalMetadata.copyright;
+    ctrl.metadataUpdatedByTemplate = [];
 
     ctrl.save = function() {
         ctrl.saving = true;

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -64,6 +64,8 @@ jobs.controller('RequiredMetadataEditorCtrl',
       if (ctrl.userCanEdit && angular.isDefined(metadata)) {
         ctrl.metadataUpdatedByTemplate = Object.keys(metadata).filter(key => ctrl.originalMetadata[key] !== metadata[key]);
         ctrl.metadata = metadata;
+      } else {
+        ctrl.metadata = ctrl.originalMetadata;
       }
     });
 

--- a/kahuna/test/lib/MetadataTemplateConfigTest.scala
+++ b/kahuna/test/lib/MetadataTemplateConfigTest.scala
@@ -21,6 +21,16 @@ class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
               "value" -> "Sample byline from template",
               "resolveStrategy" -> "replace"
             )
+          ),
+          "leases" -> List(
+            Map(
+              "leaseType" -> "allow-use",
+              "notes" -> "Sample allow cropping lease note"
+            ),
+            Map(
+              "leaseType" -> "deny-syndication",
+              "notes" -> "Sample deny syndication lease note"
+            )
           )
         ),
         Map(
@@ -55,11 +65,14 @@ class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
       metadataTemplates.length shouldBe 3
     }
 
-    "should return a template with usage rights and metadata fields" in {
+    "should return a template with leases, usage rights and metadata fields" in {
       metadataTemplates.headOption.nonEmpty shouldBe true
       val template = metadataTemplates.head
       template.templateName shouldBe "A"
       template.usageRights shouldBe defined
+
+      val leases = template.leases
+      leases.nonEmpty shouldBe true
 
       val usageRights = template.usageRights.get
       usageRights.category shouldBe "social-media"

--- a/kahuna/test/lib/MetadataTemplateConfigTest.scala
+++ b/kahuna/test/lib/MetadataTemplateConfigTest.scala
@@ -22,16 +22,19 @@ class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
               "resolveStrategy" -> "replace"
             )
           ),
-          "leases" -> List(
-            Map(
-              "leaseType" -> "allow-use",
-              "notes" -> "Sample allow cropping lease note"
-            ),
-            Map(
-              "leaseType" -> "deny-syndication",
-              "notes" -> "Sample deny syndication lease note"
+          "templateLeases" -> Map(
+            "replace" -> false,
+            "leases" -> List(
+              Map(
+                "leaseType" -> "allow-use",
+                "notes" -> "Sample allow cropping lease note"
+              ),
+              Map(
+                "leaseType" -> "deny-syndication",
+                "notes" -> "Sample deny syndication lease note"
+              )
             )
-          )
+          ),
         ),
         Map(
           "templateName" -> "B",
@@ -71,7 +74,10 @@ class MetadataTemplateConfigTest extends AnyFreeSpec with Matchers {
       template.templateName shouldBe "A"
       template.usageRights shouldBe defined
 
-      val leases = template.leases
+      val templateLeases = template.templateLeases
+      templateLeases shouldBe defined
+      templateLeases.get.replace shouldBe false
+      val leases = templateLeases.get.leases
       leases.nonEmpty shouldBe true
 
       val usageRights = template.usageRights.get

--- a/leases/conf/routes
+++ b/leases/conf/routes
@@ -3,7 +3,8 @@ GET     /                                             controllers.MediaLeaseCont
 # Leases by Media
 GET     /leases/media/:id                             controllers.MediaLeaseController.getLeasesForMedia(id: String)
 DELETE  /leases/media/:id                             controllers.MediaLeaseController.deleteLeasesForMedia(id: String)
-POST    /leases/media/:id                             controllers.MediaLeaseController.replaceLeasesForMedia(id: String)
+PUT     /leases/media/:id                             controllers.MediaLeaseController.replaceLeasesForMedia(id: String)
+POST    /leases/media/:id                             controllers.MediaLeaseController.addLeasesForMedia(id: String)
 
 # Leases
 GET     /leases/reindex                               controllers.MediaLeaseController.reindex

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -158,7 +158,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val imageUri = URI.create(s"${config.rootUri}/images/$id")
     val reindexUri = URI.create(s"${config.rootUri}/images/$id/reindex")
     val addCollectionUri = URI.create(s"${config.collectionsUri}/images/$id")
-    val addLeasesUri = URI.create(s"${config.leasesUri}/leases")
+    val addLeaseUri = URI.create(s"${config.leasesUri}/leases")
+    val addLeasesUri = URI.create(s"${config.leasesUri}/leases/media/$id")
     val replaceLeasesUri = URI.create(s"${config.leasesUri}/leases/media/$id")
     val deleteLeasesUri = URI.create(s"${config.leasesUri}/leases/media/$id")
     val deleteUsagesUri = URI.create(s"${config.usageUri}/usages/media/$id")
@@ -168,14 +169,16 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
 
     val addCollectionAction = Action("add-collection", addCollectionUri, "POST")
 
-    val addLeasesAction = Action("add-lease", addLeasesUri, "POST")
-    val replaceLeasesAction = Action("replace-leases", replaceLeasesUri, "POST")
+    val addLeaseAction = Action("add-lease", addLeaseUri, "POST")
+    val addLeasesAction = Action("add-leases", addLeasesUri, "POST")
+    val replaceLeasesAction = Action("replace-leases", replaceLeasesUri, "PUT")
     val deleteLeasesAction = Action("delete-leases", deleteLeasesUri, "DELETE")
     val deleteUsagesAction = Action("delete-usages", deleteUsagesUri, "DELETE")
 
     List(
       deleteAction -> isDeletable,
       reindexAction -> withWritePermission,
+      addLeaseAction -> withWritePermission,
       addLeasesAction -> withWritePermission,
       replaceLeasesAction -> withWritePermission,
       deleteLeasesAction -> withWritePermission,


### PR DESCRIPTION
## What does this change?

This PR replaces the ability to define a single lease (#3867) with the ability to define multiple leases in a metadata template and applying the configured "leases" to an image when the template is applied.

This is a follow-up PR to:

- #3664
- #3772 
- #3867 
- #4003

### Adding multiple leases

![Metadata template with multiple add leases](https://github.com/guardian/grid/assets/12212239/0197f037-b85b-46c4-a005-4a035b601bf8)


### Replacing lease(s) with multiple leases

![Metadata template with multiple replace leases](https://github.com/guardian/grid/assets/12212239/872f175b-b4e3-40d8-83ed-411cf4029299)


## How should a reviewer test this change?

Add the test metadata template configuration (below) to Kahuna's configuration.

```hocon
metadata.templates = [
  {
    templateName: "Template A w/ add"
    templateLeases: {
      replace: false
      leases: [
        {
          leaseType: "allow-use"
          notes: "Sample allow use note"
          duration: 1d
        }
        {
          leaseType: "deny-syndication"
          notes: "Sample deny syndication note"
        }
      ]
    }
  },
  {
    templateName: "Template B w/ replace"
    templateLeases: {
      replace: true
      leases: [
        {
          leaseType: "allow-use"
          notes: "Sample allow use note"
          duration: 1d
        }
        {
          leaseType: "deny-syndication"
          notes: "Sample deny syndication note"
        }
      ]
    }
  }
]
```

## How can success be measured?

Adding the above configuration to kahuna should:

- Render "Template select" component on the "My uploads" page, info panel on search images view page and Image view page as shown in the attached screenshots.
- Allow a user to select the metadata template "Template A w/add" or "Template B w/replace" that highlights multiple staged leases that have been defined in the template to add to or replace existing lease(s).
- On clicking "Apply", the staged leases should be applied to the image.

## Who should look at this?

@guardian/digital-cms

## Tested? Documented?
- [X] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
