### PR TITLE
Update RiffRaff deploy to use ARM AMIs

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -95,7 +95,7 @@ deployments:
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-imaging
+          Recipe: grid-imaging-ARM
         ImgOpsAmiId:
           BuiltBy: amigo
           AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -91,7 +91,7 @@ deployments:
         AmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: editorial-tools-focal-java8
+          Recipe: editorial-tools-focal-java8-ARM
         ImagingAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
@@ -99,7 +99,7 @@ deployments:
         ImgOpsAmiId:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-imgops-focal
+          Recipe: grid-imgops-focal-ARM
 
   elasticsearch-ami-update:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
_co-authored-by: @twrichards_

## What's changed?
Update RiffRaff deploy to use ARM-based AMI. This is in support of migrating our apps to EC2 instance types with ARM-based Graviton processors, which are cheaper to run.