### PR TITLE
exclude original metadata from free text search

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -50,7 +50,7 @@ object Mappings {
       properties = List(
         keywordField("id"),
         metadataMapping("metadata"),
-        metadataMapping("originalMetadata"),
+        originalMetadataMapping("originalMetadata"),
         usageRightsMapping("usageRights"),
         syndicationRightsMapping("syndicationRights"),
         usageRightsMapping("originalUsageRights"),
@@ -112,6 +112,28 @@ object Mappings {
     standardAnalysed("country").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     nonAnalysedList("peopleInImage").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     sStemmerAnalysed("englishAnalysedCatchAll"),
+    dynamicObj("domainMetadata")
+  ))
+
+  def originalMetadataMapping(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
+    dateField("dateTaken"),
+    sStemmerAnalysed("description"),
+    standardAnalysed("byline"),
+    standardAnalysed("bylineTitle"),
+    sStemmerAnalysed("title"),
+    keywordField("credit"),
+    keywordField("creditUri"),
+    standardAnalysed("copyright"),
+    standardAnalysed("suppliersReference"),
+    keywordField("source"),
+    nonAnalysedList("keywords"),
+    nonAnalysedList("subjects"),
+    standardAnalysed("specialInstructions"),
+    standardAnalysed("subLocation"),
+    standardAnalysed("city"),
+    standardAnalysed("state"),
+    standardAnalysed("country"),
+    nonAnalysedList("peopleInImage"),
     dynamicObj("domainMetadata")
   ))
 


### PR DESCRIPTION
## What does this change?

update elastic search Mapping excludes original metadata from free text search (englishAnalysedCatchAll)

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
clean and set-up the grid locally to create the new mapping
upload an image and edit any field of _originalMetadata_
free text search of the old text should not get any result

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
