### PR TITLE
fix dev config for usage service

### DIFF
--- a/dev/script/generate-config/config.json5
+++ b/dev/script/generate-config/config.json5
@@ -42,6 +42,9 @@
       live: {
         url: '',
         key: ''
+      },
+      preview: {
+        url: '',
       }
     },
     crier: {

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -177,6 +177,7 @@ function getUsageConfig(config) {
     return stripMargin`${getCommonConfig(config)}
         |aws.region="${config.AWS_DEFAULT_REGION}"
         |capi.live.url="${config.guardian.capi.live.url}"
+        |capi.preview.url="${config.guardian.capi.preview.url}"
         |capi.apiKey="${config.guardian.capi.live.key}"
         |dynamo.tablename.usageRecordTable="UsageRecordTable"
         |composer.baseUrl="composer.${config.DOMAIN}"


### PR DESCRIPTION

## What does this change?

right now running usage locally fails, because its missing this required config (even though it wont and cant connect, the value needs to be there to work...)
so add the value as an empty string 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
