### PR TITLE
skip reapable images when migrating (to effectively reap them from ES only)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -42,6 +42,11 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   val systemName: String = stringOpt("branding.systemName").filterNot(_.isEmpty).getOrElse("the Grid")
 
+  val persistedRootCollections: List[String] = stringOpt("persistence.collections") match {
+    case Some(collections) => collections.split(',').toList
+    case None => List(s"$staffPhotographerOrganisation Archive")
+  }
+
   // Note: had to make these lazy to avoid init order problems ;_;
   val domainRoot: String = string("domain.root")
   val domainRootOverride: Option[String] = stringOpt("domain.root-override")

--- a/common-lib/src/main/scala/lib/elasticsearch/PersistedQueries.scala
+++ b/common-lib/src/main/scala/lib/elasticsearch/PersistedQueries.scala
@@ -1,0 +1,42 @@
+package lib.elasticsearch
+
+import com.gu.mediaservice.lib.ImageFields
+import com.gu.mediaservice.model._
+import scalaz.NonEmptyList
+import scalaz.syntax.std.list._
+
+object PersistedQueries extends ImageFields {
+  val photographerCategories = NonEmptyList(
+    StaffPhotographer.category,
+    ContractPhotographer.category,
+    CommissionedPhotographer.category
+  )
+
+  val illustratorCategories = NonEmptyList(
+    ContractIllustrator.category,
+    StaffIllustrator.category,
+    CommissionedIllustrator.category
+  )
+
+  val agencyCommissionedCategories = NonEmptyList(
+    CommissionedAgency.category
+  )
+
+  val hasCrops = filters.bool.must(filters.existsOrMissing("exports", exists = true))
+  val usedInContent = filters.nested("usages", filters.exists(NonEmptyList("usages")))
+
+  def existedPreGrid(persistenceIdentifier: String) = filters.exists(NonEmptyList(identifierField(persistenceIdentifier)))
+
+  val addedToLibrary = filters.bool.must(filters.boolTerm(editsField("archived"), value = true))
+  val hasUserEditsToImageMetadata = filters.exists(NonEmptyList(editsField("metadata")))
+  val hasPhotographerUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), photographerCategories))
+  val hasIllustratorUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), illustratorCategories))
+  val hasAgencyCommissionedUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), agencyCommissionedCategories))
+
+  def addedGNMArchiveOrPersistedCollections(persistedRootCollections: List[String]) = filters.bool.must(filters.terms(collectionsField("path"), persistedRootCollections.toNel.get))
+
+  val addedToPhotoshoot = filters.exists(NonEmptyList(editsField("photoshoot")))
+  val hasLabels = filters.exists(NonEmptyList(editsField("labels")))
+  val hasLeases = filters.exists(NonEmptyList(leasesField("leases")))
+
+}

--- a/common-lib/src/main/scala/lib/elasticsearch/ReapableEligibility.scala
+++ b/common-lib/src/main/scala/lib/elasticsearch/ReapableEligibility.scala
@@ -1,0 +1,35 @@
+package lib.elasticsearch
+
+import com.sksamuel.elastic4s.ElasticApi.matchNoneQuery
+import com.sksamuel.elastic4s.ElasticDsl.matchAllQuery
+import com.sksamuel.elastic4s.requests.searches.queries.Query
+import org.joda.time.DateTime
+
+trait ReapableEligibility {
+
+  val persistedRootCollections: List[String] // typically from config
+  val maybePersistenceIdentifier: Option[String] // typically from config
+
+  private def moreThanTwentyDaysOld =
+    filters.date("uploadTime", None, Some(DateTime.now().minusDays(20))).getOrElse(matchAllQuery())
+
+  private lazy val persistedQueries = filters.or(
+    PersistedQueries.hasCrops,
+    PersistedQueries.usedInContent,
+    PersistedQueries.addedToLibrary,
+    PersistedQueries.hasUserEditsToImageMetadata,
+    PersistedQueries.hasPhotographerUsageRights,
+    PersistedQueries.hasIllustratorUsageRights,
+    PersistedQueries.hasAgencyCommissionedUsageRights,
+    PersistedQueries.addedToPhotoshoot,
+    PersistedQueries.hasLabels,
+    PersistedQueries.hasLeases,
+    maybePersistenceIdentifier.map(PersistedQueries.existedPreGrid).getOrElse(matchNoneQuery()),
+    PersistedQueries.addedGNMArchiveOrPersistedCollections(persistedRootCollections)
+  )
+
+  def query: Query = filters.and(
+    moreThanTwentyDaysOld,
+    filters.not(persistedQueries)
+  )
+}

--- a/common-lib/src/main/scala/lib/elasticsearch/filters.scala
+++ b/common-lib/src/main/scala/lib/elasticsearch/filters.scala
@@ -3,8 +3,8 @@ package lib.elasticsearch
 import com.gu.mediaservice.lib.formatting.printDateTime
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.searches.queries.{NestedQuery, Query}
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
+import com.sksamuel.elastic4s.requests.searches.queries.{NestedQuery, Query}
 import com.sksamuel.elastic4s.requests.searches.term.TermQuery
 import org.joda.time.DateTime
 import scalaz.NonEmptyList

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -18,6 +18,7 @@ function getCommonConfig(config) {
         |thrall.kinesis.lowPriorityStream.name="${config.coreStackProps.ThrallLowPriorityMessageStream}"
         |es.index.aliases.current="Images_Current"
         |es.index.aliases.migration="Images_Migration"
+        |persistence.identifier="picdarUrn"
         |image.record.download=false
         ${isNoAuth ? '|authentication.providers.user="com.gu.mediaservice.lib.auth.provider.LocalAuthenticationProvider"' : ''}
         ${isNoAuth ? '|authorisation.provider="com.gu.mediaservice.lib.auth.provider.LocalAuthorisationProvider"' : ''}
@@ -122,7 +123,6 @@ function getMediaApiConfig(config) {
         |s3.thumb.bucket="${config.coreStackProps.ThumbBucket}"
         |s3.config.bucket="${config.coreStackProps.ConfigBucket}"
         |s3.usagemail.bucket="${config.coreStackProps.UsageMailBucket}"
-        |persistence.identifier="picdarUrn"
         |es6.url="${config.es6.url}"
         |es6.cluster="${config.es6.cluster}"
         |es6.shards=${config.es6.shards}
@@ -163,7 +163,6 @@ function getThrallConfig(config) {
         |aws.region="${config.AWS_DEFAULT_REGION}"
         |s3.image.bucket="${config.coreStackProps.ImageBucket}"
         |s3.thumb.bucket="${config.coreStackProps.ThumbBucket}"
-        |persistence.identifier="picdarUrn"
         |indexed.image.sns.topic.arn="${config.coreStackProps.IndexedImageTopic}"
         |es6.url="${config.es6.url}"
         |es6.cluster="${config.es6.cluster}"

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -50,11 +50,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val persistenceIdentifier = string("persistence.identifier")
   val queriableIdentifiers = Seq(persistenceIdentifier)
 
-  val persistedRootCollections: List[String] = stringOpt("persistence.collections") match {
-    case Some(collections) => collections.split(',').toList
-    case None => List(s"${staffPhotographerOrganisation} Archive")
-  }
-
   def convertToInt(s: String): Option[Int] = Try { s.toInt }.toOption
 
   val syndicationStartDate: Option[DateTime] = Try {

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -2,44 +2,11 @@ package lib.elasticsearch
 
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.auth.{Syndication, Tier}
-import com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig
 import com.gu.mediaservice.model._
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import lib.{ImagePersistenceReasons, MediaApiConfig, PersistenceReason}
-import scalaz.NonEmptyList
 import scalaz.syntax.std.list._
 
-object PersistedQueries extends ImageFields {
-  val photographerCategories = NonEmptyList(
-    StaffPhotographer.category,
-    ContractPhotographer.category,
-    CommissionedPhotographer.category
-  )
-
-  val illustratorCategories = NonEmptyList(
-    ContractIllustrator.category,
-    StaffIllustrator.category,
-    CommissionedIllustrator.category
-  )
-
-  val agencyCommissionedCategories = NonEmptyList(
-    CommissionedAgency.category
-  )
-
-  val hasCrops = filters.bool.must(filters.existsOrMissing("exports", exists = true))
-  val usedInContent = filters.nested("usages", filters.exists(NonEmptyList("usages")))
-  def existedPreGrid(persistenceIdentifier: String) = filters.exists(NonEmptyList(identifierField(persistenceIdentifier)))
-  val addedToLibrary = filters.bool.must(filters.boolTerm(editsField("archived"), value = true))
-  val hasUserEditsToImageMetadata = filters.exists(NonEmptyList(editsField("metadata")))
-  val hasPhotographerUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), photographerCategories))
-  val hasIllustratorUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), illustratorCategories))
-  val hasAgencyCommissionedUsageRights = filters.bool.must(filters.terms(usageRightsField("category"), agencyCommissionedCategories))
-  def addedGNMArchiveOrPersistedCollections(persistedRootCollections: List[String]) = filters.bool.must(filters.terms(collectionsField("path"), persistedRootCollections.toNel.get))
-  val addedToPhotoshoot = filters.exists(NonEmptyList(editsField("photoshoot")))
-  val hasLabels = filters.exists(NonEmptyList(editsField("labels")))
-  val hasLeases = filters.exists(NonEmptyList(leasesField("leases")))
-
-}
 
 class SearchFilters(config: MediaApiConfig) extends ImageFields {
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -53,7 +53,17 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)
-  val migrationSourceWithSender: MigrationSourceWithSender = MigrationSourceWithSender(materializer, auth.innerServiceCall, es, gridClient, config.projectionParallelism)
+  val migrationSourceWithSender: MigrationSourceWithSender = MigrationSourceWithSender(
+    materializer,
+    auth.innerServiceCall,
+    es,
+    gridClient,
+    config.projectionParallelism,
+    isReapableQuery = new ReapableEligibility {
+      val persistedRootCollections: List[String] = config.persistedRootCollections
+      val maybePersistenceIdentifier: Option[String] = config.maybePersistenceIdentifier
+    }.query
+  )
 
   val thrallEventConsumer = new ThrallEventConsumer(
     es,

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -43,6 +43,8 @@ class ThrallConfig(resources: GridConfigResources) extends CommonConfigWithElast
 
   val projectionParallelism: Int = intDefault("thrall.projection.parallelism", 1)
 
+  val maybePersistenceIdentifier = stringOpt("persistence.identifier")
+
   def kinesisConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisStream, rewindFrom, this)
   def kinesisLowPriorityConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)
 }

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -10,8 +10,9 @@ import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.json.JsonByteArrayUtil
 import com.gu.mediaservice.model.{MigrateImageMessage, StaffPhotographer, ThrallMessage}
+import com.sksamuel.elastic4s.ElasticApi.matchNoneQuery
 import helpers.Fixtures
-import lib.elasticsearch.{ElasticSearch, ScrolledSearchResults}
+import lib.elasticsearch.{ElasticSearch, ReapableEligibility, ScrolledSearchResults}
 import lib.kinesis.ThrallEventConsumer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -109,7 +110,7 @@ class ThrallStreamProcessorTest extends AnyFunSpec with BeforeAndAfterAll with M
     lazy val mockEs = mock[ElasticSearch]
     when(mockEs.continueScrollingImageIdsToMigrate(any())(any(), any()))
       .thenReturn(Future.successful(ScrolledSearchResults(List.empty, None)))
-    when(mockEs.startScrollingImageIdsToMigrate(any())(any(), any()))
+    when(mockEs.startScrollingImageIdsToMigrate(any(), any())(any(), any()))
     .thenReturn(Future.successful(ScrolledSearchResults(List.empty, None)))
 
     val uiPrioritySource: Source[KinesisRecord, Future[Done.type]] =
@@ -121,7 +122,8 @@ class ThrallStreamProcessorTest extends AnyFunSpec with BeforeAndAfterAll with M
       (req: WSRequest) => req,
       mockEs,
       mockGrid,
-      projectionParallelism = 1
+      projectionParallelism = 1,
+      isReapableQuery = matchNoneQuery()
     )
 
     lazy val mockConsumer: ThrallEventConsumer = mock[ThrallEventConsumer]


### PR DESCRIPTION
In order to realise some of the benefits of reaping our huge backlog of images we want to at least drop reapable images from ElasticSearch to get search performance improvements and to prevent images being available that ought not to be (purging images/data from S3 and dynamo will need to come later and will bring the cost savings).

**_We'd expect to revert this change after this one-off mega-reaping._**

## What does this change?

- refactpr `IsReapable` behaviour into `common-lib` (as `ReapableEligibility` trait)
- add that to the list of 'not' criteria used to determine what to migrate (in `thrall`)

## tested in `TEST` ✅  
