### PR TITLE
'preview migration completion' in `thrall` dashboard (i.e. `media-api` only searches new index)

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -3,7 +3,7 @@ package lib.elasticsearch
 import akka.actor.Scheduler
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.auth.Authentication.Principal
-import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, ElasticSearchConfig, MigrationStatusProvider, Running}
+import com.gu.mediaservice.lib.elasticsearch.{CompletionPreview, ElasticSearchClient, ElasticSearchConfig, MigrationStatusProvider, Running}
 import com.gu.mediaservice.lib.logging.{GridLogging, MarkerMap}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
 import com.gu.mediaservice.model.{Agencies, Agency, AwaitingReviewForSyndication, Image}
@@ -324,6 +324,7 @@ class ElasticSearch(
 
   private def prepareSearch(query: Query): SearchRequest = {
     val indexes = migrationStatus match {
+      case completionPreview: CompletionPreview => List(completionPreview.migrationIndexName)
       case running: Running => List(imagesCurrentAlias, running.migrationIndexName)
       case _ => List(imagesCurrentAlias)
     }

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -5,6 +5,7 @@
 @import com.gu.mediaservice.lib.elasticsearch.InProgress
 @import com.gu.mediaservice.lib.elasticsearch.Paused
 @import com.gu.mediaservice.lib.elasticsearch.NotRunning
+@import com.gu.mediaservice.lib.elasticsearch.CompletionPreview
 @(currentAlias: String,
   currentIndex: String,
   currentIndexCount: String,
@@ -60,6 +61,7 @@
             <td>
                 @migrationIndexCount
                 @migrationStatus match {
+                    case CompletionPreview(_) => {}
                     case Paused(_) => {
                         @form(routes.ThrallController.resumeMigration) {
                             PAUSED
@@ -96,10 +98,25 @@
         <p>
             If you're happy that the migration is complete (typically when it hasn't migrated any images in a good while
             and we're happy that all images in failure can become inaccessible).
-            @form(routes.ThrallController.completeMigration) {
-                <input type="text" id="complete-confirmation" name="complete-confirmation" placeholder="Type 'complete' to confirm" required>
-                <input type="submit" value="ONLY CLICK THIS BUTTON IF YOU'RE SURE">
+            @if(migrationStatus.isInstanceOf[CompletionPreview]) {
+                @form(routes.ThrallController.unPreviewMigrationCompletion) {
+                    <input type="submit" value="UnPreview Completion"> (this will make grid search both indexes again)
+                }
+                @form(routes.ThrallController.completeMigration) {
+                    or fully complete the migration:
+                    <input type="text" id="complete-confirmation" name="complete-confirmation" placeholder="Type 'complete' to confirm" required>
+                    <input type="submit" value="ONLY CLICK THIS BUTTON IF YOU'RE SURE">
+                }
+            } else {
+                @form(routes.ThrallController.previewMigrationCompletion) {
+                    <input type="submit" value="Preview Completion">
+                    <div>
+                        This will make grid only search the migration index (both indexes will continue to be populated
+                        and reads/writes of images will continue to use both indexes).
+                    </div>
+                }
             }
+
         </p>
     }
 

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -18,6 +18,10 @@ POST    /resumeMigration                              controllers.ThrallControll
 POST    /migrate                                      controllers.ThrallController.migrateSingleImage
 +nocsrf
 POST    /completeMigration                            controllers.ThrallController.completeMigration
++nocsrf
+POST    /previewMigrationCompletion                   controllers.ThrallController.previewMigrationCompletion
++nocsrf
+POST    /unPreviewMigrationCompletion                 controllers.ThrallController.unPreviewMigrationCompletion
 
 # Management
 GET     /management/healthcheck                       controllers.HealthCheck.healthCheck


### PR DESCRIPTION
This introduces a new migration status `CompletionPreview` (with  some endpoints and basic UI in `thrall` dashboard to transition in/out of this state). When in this state `media-api` only searches the new index, to give users the illusion migration is complete, whilst still keeping both indexes up to date (this will be particularly useful when making use of https://github.com/guardian/grid/pull/4066), and allowing us to 'unpreview' migration completion if we discover some images are missing etc. (much harder when migration is actually completed as the old index will stop being updated, so would require manual reconciliation).

### when `InProgress` or `Paused`...
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/19289579/232538273-bf376719-f045-4404-a237-93d6ecb6d0b8.png">

### when in new `CompletionPreview`...
![image](https://user-images.githubusercontent.com/19289579/232466830-ad5750b9-4ebd-4dfc-93e6-c7f76dc25c9b.png)
