### PR TITLE
improve phrasing of ticker tooltips

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -25,7 +25,7 @@
                 <button ng-if="ctrl.newImagesCount > 0"
                         ng-click="ctrl.revealNewImages()"
                         class="image-results-count__new"
-                        gr-tooltip="{{ctrl.newImagesCount}} new images as of {{ctrl.lastestTimeMoment}}"
+                        gr-tooltip="{{ctrl.newImagesCount | toLocaleString}} new images since {{ctrl.lastestTimeMoment}}"
                         gr-tooltip-position="bottom"
                         gr-tooltip-updates>
                     {{ctrl.newImagesCount | toLocaleString}} new
@@ -33,7 +33,7 @@
                 <button ng-if="ctrl.orgOwnedCount !== undefined && ctrl.orgOwnedCount !== ctrl.totalResults"
                         ng-click="ctrl.applyOrgOwnedFilter()"
                         class="image-results-count__org-owned"
-                        gr-tooltip="{{ctrl.orgOwnedCount + (ctrl.newOrgOwnedCount || 0)}} {{ctrl.maybeOrgOwnedValue}} images as of {{ctrl.lastestTimeMoment || 'just now'}}"
+                        gr-tooltip="last updated {{(ctrl.lastCheckedMoment || moment()).from(moment())}}"
                         gr-tooltip-position="bottom"
                         gr-tooltip-updates>
                     {{(ctrl.orgOwnedCount + (ctrl.newOrgOwnedCount || 0)) | toLocaleString}} {{ctrl.maybeOrgOwnedValue}}

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -248,6 +248,7 @@ results.controller('SearchResultsCtrl', [
                     }
 
                     ctrl.lastestTimeMoment = moment(latestTime).from(moment());
+                    ctrl.lastCheckedMoment = moment();
 
                     if (! scopeGone) {
                         checkForNewImages();


### PR DESCRIPTION
- the `as of` on the 'new images' ticker tooltip should read `since` because the timestamp is in fact `lastSearchFirstResultTime`
  <img width="277" alt="image" src="https://user-images.githubusercontent.com/19289579/234404853-d4906a88-bf33-44ca-8ad0-a2f06a41a3ec.png">

- the 'org-owned' ticker tooltip should really show when it was last updated (since its the total when the main search happens PLUS any new org-owned images
  <img width="177" alt="image" src="https://user-images.githubusercontent.com/19289579/234402592-8809fa6e-fb4d-49a6-811d-35e70ae72729.png">
