### PR TITLE
correct initial tooltip state on org-owned ticker

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -33,7 +33,7 @@
                 <button ng-if="ctrl.orgOwnedCount !== undefined && ctrl.orgOwnedCount !== ctrl.totalResults"
                         ng-click="ctrl.applyOrgOwnedFilter()"
                         class="image-results-count__org-owned"
-                        gr-tooltip="last updated {{(ctrl.lastCheckedMoment || moment()).from(moment())}}"
+                        gr-tooltip="last updated {{ctrl.lastCheckedMoment?.from(moment()) || 'just now'}}"
                         gr-tooltip-position="bottom"
                         gr-tooltip-updates>
                     {{(ctrl.orgOwnedCount + (ctrl.newOrgOwnedCount || 0)) | toLocaleString}} {{ctrl.maybeOrgOwnedValue}}


### PR DESCRIPTION
tweak/fix following #4078 to ensure it reads `last updated just now` if the new check has not run yet (not sure how I missed this)