### PR TITLE
further improve & fix ticker/badge tooltips

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -25,7 +25,7 @@
                 <button ng-if="ctrl.newImagesCount > 0"
                         ng-click="ctrl.revealNewImages()"
                         class="image-results-count__new"
-                        gr-tooltip="{{ctrl.newImagesCount | toLocaleString}} new images since {{ctrl.lastestTimeMoment}}"
+                        gr-tooltip="{{ctrl.newImagesCount | toLocaleString}} new images since {{ctrl.lastestTimeMoment.from(moment())}}"
                         gr-tooltip-position="bottom"
                         gr-tooltip-updates>
                     {{ctrl.newImagesCount | toLocaleString}} new
@@ -33,7 +33,7 @@
                 <button ng-if="ctrl.orgOwnedCount !== undefined && ctrl.orgOwnedCount !== ctrl.totalResults"
                         ng-click="ctrl.applyOrgOwnedFilter()"
                         class="image-results-count__org-owned"
-                        gr-tooltip="last updated {{ctrl.lastCheckedMoment?.from(moment()) || 'just now'}}"
+                        gr-tooltip="last updated {{ctrl.newImagesLastCheckedMoment.from(moment())}}"
                         gr-tooltip-position="bottom"
                         gr-tooltip-updates>
                     {{(ctrl.orgOwnedCount + (ctrl.newOrgOwnedCount || 0)) | toLocaleString}} {{ctrl.maybeOrgOwnedValue}}

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -102,6 +102,7 @@ results.controller('SearchResultsCtrl', [
         ctrl.images = [];
         if (ctrl.image && ctrl.image.data.softDeletedMetadata !== undefined) { ctrl.isDeleted = true; }
         ctrl.newImagesCount = 0;
+        ctrl.newImagesLastCheckedMoment = moment();
 
         // Preview control
         ctrl.previewView = false;
@@ -247,8 +248,8 @@ results.controller('SearchResultsCtrl', [
                         $rootScope.$emit('events:new-images', { count: ctrl.newImagesCount});
                     }
 
-                    ctrl.lastestTimeMoment = moment(latestTime).from(moment());
-                    ctrl.lastCheckedMoment = moment();
+                    ctrl.lastestTimeMoment = moment(latestTime);
+                    ctrl.newImagesLastCheckedMoment = moment();
 
                     if (! scopeGone) {
                         checkForNewImages();


### PR DESCRIPTION
Fixes horrendous bug in https://github.com/guardian/grid/pull/4079 (since angular templating isn't full javascript the optional chaining operator was breaking whole of grid UI), now we initialise the variable at the beginning so it reads `a few seconds ago` from the very beginning...
<img width="199" alt="image" src="https://user-images.githubusercontent.com/19289579/235191566-f8af852b-80a0-4614-945b-bea6cd0aacd4.png">


Also further tweaks what was done in https://github.com/guardian/grid/pull/4078 to ensure the badge/ticker for new images is relative to now rather than the last poll.