### PR TITLE
hide 'org-owned' badge if zero

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -30,7 +30,7 @@
                         gr-tooltip-updates>
                     {{ctrl.newImagesCount | toLocaleString}} new
                 </button>
-                <button ng-if="ctrl.orgOwnedCount !== undefined && ctrl.orgOwnedCount !== ctrl.totalResults"
+                <button ng-if="ctrl.orgOwnedCount !== undefined && ctrl.orgOwnedCount !== ctrl.totalResults && (ctrl.orgOwnedCount + (ctrl.newOrgOwnedCount || 0))"
                         ng-click="ctrl.applyOrgOwnedFilter()"
                         class="image-results-count__org-owned"
                         gr-tooltip="last updated {{ctrl.newImagesLastCheckedMoment.from(moment())}}"


### PR DESCRIPTION
Slight tweak following https://github.com/guardian/grid/pull/4059, @paperboyo thinks it would be nice to hide the `org-owned` badge if the count is `zero`