### PR TITLE
Logging Appender shouldn't reference itself

### DIFF
--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -32,7 +32,6 @@
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
       <appender-ref ref="STDOUT" />
-      <appender-ref ref="ASYNCSTDOUT"/>
     </appender>
 
     <logger name="play" level="INFO" />


### PR DESCRIPTION
## What does this change?

Fixes an error in the logback configuration. Fortunately the error just results in a log message "Ignoring additional appender named" rather than a logging loop.

## How should a reviewer test this change?

Check that logging still works post deploy, and that central elk no longer contains messages like `Ignoring additional appender named [ASYNCSTDOUT]`
