### PR TITLE
Rename elasticsearch stack to match rest of app

### DIFF
--- a/dev/script/es-ssh-ssm-tunnel.sh
+++ b/dev/script/es-ssh-ssm-tunnel.sh
@@ -42,7 +42,7 @@ fi
 
 echo "🛰 fetching connection details from ssm"
 
-SSM_COMMAND=$(ssm ssh --profile media-service -t elasticsearch-data,grid-elasticsearch,$STAGE --newest --ssm-tunnel --raw)
+SSM_COMMAND=$(ssm ssh --profile media-service -t elasticsearch-data,media-service,$STAGE --newest --ssm-tunnel --raw)
 
 echo "📠 ESTABLISHING CONNECTION"
 

--- a/dev/script/start.sh
+++ b/dev/script/start.sh
@@ -97,7 +97,7 @@ startDockerContainers() {
       echo "RE-USING EXISTING TUNNEL TO TEST ELASTICSEARCH (on port 9200)"
     else
       TUNNEL_OPTS="-o ExitOnForwardFailure=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=2"
-      SSH_COMMAND=$(ssm ssh --profile media-service -t elasticsearch-data,grid-elasticsearch,TEST --newest --raw)
+      SSH_COMMAND=$(ssm ssh --profile media-service -t elasticsearch-data,media-service,TEST --newest --raw)
       eval $SSH_COMMAND -f -N $TUNNEL_OPTS -L 9200:localhost:9200
       echo "TUNNEL ESTABLISHED TO TEST ELASTICSEARCH (on port 9200)"
     fi


### PR DESCRIPTION
## What does this change?

Renames ES stack from grid-elasticsearch to media-service. This will also require a manual cloudformation parameter update.  This change is helpful as we move to deploy cloudformation via riff-raff, and also resolve https://github.com/guardian/grid-cerebro/issues/1