### PR TITLE
bump Scala dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,8 @@ lazy val commonLib = project("common-lib").settings(
     "com.gu" %% "scanamo" % "1.0.0-M8",
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.7",
     // Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
-    "com.typesafe.play" %% "play-ahc-ws" % "2.8.9"
+    "com.typesafe.play" %% "play-ahc-ws" % "2.8.9",
+    "org.yaml" % "snakeyaml" % "1.31"
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0"
 )


### PR DESCRIPTION
## What does this change?
Bumped a number of Scala dependencies which which have reduced the number of high Snyk vulnerabilities from 13 to 3.

The last remaining 3 require major changes which are probably best addressed as separate PRs.
<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
Grid runs as normal locally and on TEST.
<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?
Grid works as usual and the number of high vulns are down at the same time.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->
@guardian/digital-cms 
## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
