### PR TITLE
Fix Jackson vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ Global / concurrentRestrictions := Seq(
 )
 
 val awsSdkVersion = "1.12.470"
-val elastic4sVersion = "8.0.0"
+val elastic4sVersion = "8.3.0"
 val okHttpVersion = "3.12.1"
 
 val bbcBuildProcess: Boolean = System.getenv().asScala.get("BUILD_ORG").contains("bbc")

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ Global / concurrentRestrictions := Seq(
   Tags.limitAll(12)
 )
 
-val awsSdkVersion = "1.11.302"
+val awsSdkVersion = "1.12.470"
 val elastic4sVersion = "7.16.1"
 val okHttpVersion = "3.12.1"
 
@@ -90,7 +90,7 @@ lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
     "com.gu" %% "editorial-permissions-client" % "2.14",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.0",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.2",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ Global / concurrentRestrictions := Seq(
 )
 
 val awsSdkVersion = "1.12.470"
-val elastic4sVersion = "7.16.1"
+val elastic4sVersion = "8.7.0"
 val okHttpVersion = "3.12.1"
 
 val bbcBuildProcess: Boolean = System.getenv().asScala.get("BUILD_ORG").contains("bbc")

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ Global / concurrentRestrictions := Seq(
 )
 
 val awsSdkVersion = "1.12.470"
-val elastic4sVersion = "8.7.0"
+val elastic4sVersion = "8.0.0"
 val okHttpVersion = "3.12.1"
 
 val bbcBuildProcess: Boolean = System.getenv().asScala.get("BUILD_ORG").contains("bbc")
@@ -121,7 +121,6 @@ lazy val commonLib = project("common-lib").settings(
     "org.codehaus.janino" % "janino" % "3.0.6",
     "com.typesafe.play" %% "play-json-joda" % "2.9.2",
     "com.gu" %% "scanamo" % "1.0.0-M8",
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.7",
     // Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
     "com.typesafe.play" %% "play-ahc-ws" % "2.8.9"
   ),

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -38,7 +38,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
   def replicas: Int
 
   lazy val client = {
-    logger.info("Connecting to Elastic 7: " + url)
+    logger.info("Connecting to Elastic 8: " + url)
     val client = JavaClient(ElasticProperties(url))
     ElasticClient(client)
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
+
+// needed by Snyk to accurately report vulnerabilities
+// https://docs.snyk.io/scan-application-code/snyk-open-source/snyk-open-source-supported-languages-and-package-managers/snyk-for-scala
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

Updates the following libraries: 
 - aws
 - pan-domain
 - elastic4s

These are the latest versions I could get working without updating the java version for the project. 
 
## How should a reviewer test this change?

I have run the Snyk action from this branch and Jackson vulnerabilities are gone 
https://app.snyk.io/org/guardian/project/62bc02ca-607c-4a30-90ee-9c9b1522673f

If you'd like to test this on code, perhaps just check there are no new errors in the logs