### PR TITLE
IMAGEDAM-1096: update people field mapping to be case insensitive

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -110,7 +110,7 @@ object Mappings {
     standardAnalysed("city").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     standardAnalysed("state").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     standardAnalysed("country").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
-    nonAnalysedList("peopleInImage").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
+    standardAnalysed("peopleInImage").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     sStemmerAnalysed("englishAnalysedCatchAll"),
     dynamicObj("domainMetadata")
   ))
@@ -133,7 +133,7 @@ object Mappings {
     standardAnalysed("city"),
     standardAnalysed("state"),
     standardAnalysed("country"),
-    nonAnalysedList("peopleInImage"),
+    standardAnalysed("peopleInImage"),
     dynamicObj("domainMetadata")
   ))
 


### PR DESCRIPTION
## What does this change?

update elastic search Mapping (people field mapping) to be case insensitive

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
clean and set-up the grid locally to create the new mapping
upload an image and add people to the image: **_`John Doe`_**
and search for **_`john doe`_** using +person search filter should return that image

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
