### PR TITLE
handle update fn returning false in batch edit

### DIFF
--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -328,13 +328,11 @@ service.factory('editsService',
 
 
     function batchUpdateMetadataField(images, field, value, editOption = overwrite.key) {
-        return trackAll($q, $rootScope, field, images, async (image) => {
+        return trackAll($q, $rootScope, field, images, (image) => {
             const newFieldValue = getNewFieldValue(image, field, value, editOption);
-            const updated = await updateMetadataField(image, field, newFieldValue, true);
-            if (!updated) { // updateMetadataField returns false if no change
-                return image;
-            }
-            return updated;
+            return updateMetadataField(image, field, newFieldValue, true).then(
+            	updated => updated || image; // updateMetadataField returns false if no change
+            );
         }, 'images-updated');
     }
 

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -330,7 +330,11 @@ service.factory('editsService',
     function batchUpdateMetadataField(images, field, value, editOption = overwrite.key) {
         return trackAll($q, $rootScope, field, images, image => {
             const newFieldValue = getNewFieldValue(image, field, value, editOption);
-            return updateMetadataField(image, field, newFieldValue, true);
+            const updated = updateMetadataField(image, field, newFieldValue, true);
+            if (!updated) { // updateMetadataField returns false if no change
+                return image;
+            }
+            return updated;
         },'images-updated');
     }
 

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -331,7 +331,7 @@ service.factory('editsService',
         return trackAll($q, $rootScope, field, images, (image) => {
             const newFieldValue = getNewFieldValue(image, field, value, editOption);
             return updateMetadataField(image, field, newFieldValue, true).then(
-            	updated => updated || image; // updateMetadataField returns false if no change
+            	updated => updated || image // updateMetadataField returns false if no change
             );
         }, 'images-updated');
     }

--- a/kahuna/public/js/edits/service.js
+++ b/kahuna/public/js/edits/service.js
@@ -282,9 +282,9 @@ service.factory('editsService',
 
         var changed = getMetadataDiff(image, proposedMetadata);
 
-         if (field === 'location') {
+        if (field === 'location') {
             Object.assign(changed, value);
-          }
+        }
 
         return update(image.data.userMetadata.data.metadata, changed, image, inBatch)
           .then(() => image.get());
@@ -328,14 +328,14 @@ service.factory('editsService',
 
 
     function batchUpdateMetadataField(images, field, value, editOption = overwrite.key) {
-        return trackAll($q, $rootScope, field, images, image => {
+        return trackAll($q, $rootScope, field, images, async (image) => {
             const newFieldValue = getNewFieldValue(image, field, value, editOption);
-            const updated = updateMetadataField(image, field, newFieldValue, true);
+            const updated = await updateMetadataField(image, field, newFieldValue, true);
             if (!updated) { // updateMetadataField returns false if no change
                 return image;
             }
             return updated;
-        },'images-updated');
+        }, 'images-updated');
     }
 
     return {

--- a/kahuna/public/js/util/batch-tracking.js
+++ b/kahuna/public/js/util/batch-tracking.js
@@ -32,7 +32,7 @@ export const trackAll = async ($q, $rootScope, key, input, tasks, emit) => {
     completed,
     total: input.size ? input.size : input.length
   });
-    const process = async (item, result, [fn, ...remaining]) => {
+  const process = async (item, result, [fn, ...remaining]) => {
     if (fn == undefined) {
       completed++;
       $rootScope.$broadcast("events:batch-operations:progress", {


### PR DESCRIPTION
## What does this change?

the `batchUpdateMetadataField` function is responsible for managing metadata changes (by delegating to `updateMetadataField`) and propagating those changes back into the model. If you've selected several images and change a field in such a way that one image has no change to be applied, then `updateMetadataField` will return `false` for that image ( this communicates "no change" to angular-xeditable - see this comment https://github.com/guardian/grid/blob/51734b8443d1cafd246818eddde4ea3c36e4a86a/kahuna/public/js/edits/service.js#L257-L269 ). This meant that we now tried to replace the image model with `false`, which is missing all of the expected fields of an image object causing some UI breakage and some very noisy console logs.

we now catch this case, and return the original image unchanged instead of the `false`

cc @paperboyo 

