### PR TITLE
add script to batch delete files from S3

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,3 +70,17 @@ It's most efficient to do this as a 'scan and scroll' (see [stackoverflow.com/a/
     $ sbt
     > scripts/run DownloadAllEsIds http://localhost:9200 /tmp/testing
     ```
+
+### BulkDeleteS3Files
+
+    ```
+    $ sbt
+    > scripts/run BulkDeleteS3Files <bucketName> <inputFile> <auditFile>
+    ```
+
+Input file needs to be a CSV, with a heading row and a single column containing the S3 paths to delete from the specified bucket.
+
+This script groups the input IDs into 1000s so it can use the [bulk delete API](https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-multiple-objects.html) and reports the success or failure for each S3 path to both the console but also the `auditFile` path provided (CSV output).
+
+Note: bulk delete API reports 'deleted' if the path is not found, so this can be run multiple times without issue (although delete markers will be created in S3 for every execution).
+

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/BulkDeleteS3Files.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/BulkDeleteS3Files.scala
@@ -1,0 +1,69 @@
+package com.gu.mediaservice.scripts
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{Delete, DeleteObjectsRequest, ObjectIdentifier}
+
+import java.io.{File, PrintWriter}
+import scala.io.Source
+import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
+
+object BulkDeleteS3Files {
+
+  private val profile = "media-service"
+  private val region = Region.EU_WEST_1
+  private val credentials = DefaultCredentialsProvider.builder.profileName(profile).build
+  private val s3: S3Client = S3Client.builder
+    .region(region)
+    .credentialsProvider(credentials)
+    .build
+  def apply(args: List[String]): Unit = {
+    args match {
+      case bucketName :: inputFileName :: auditFileName :: _ =>
+        apply(bucketName, inputFileName, auditFileName)
+      case _ => throw new IllegalArgumentException("Usage: BulkDeleteS3Files <bucketName> <inputFile> <auditFile>")
+    }
+  }
+
+  def apply(bucketName: String, inputFileName: String, auditFileName: String) = {
+
+    val inputFileSource = Source.fromFile(inputFileName)
+    val auditFileWriter = new PrintWriter(new File(auditFileName))
+    auditFileWriter.println("path, result")
+    try {
+      for {
+        bucketKeys <- inputFileSource.getLines().drop(1 /* column heading */).grouped(1000).toList
+        objectIdentifiers = bucketKeys.map(key => ObjectIdentifier.builder().key(key.trim().drop(1).dropRight(1)).build())
+        batchResult = s3.deleteObjects(
+          DeleteObjectsRequest.builder()
+            .bucket(bucketName)
+            .delete(
+              Delete.builder()
+                .objects(objectIdentifiers:_*)
+                .quiet(false) // so we get success back too
+                .build()
+            )
+            .build()
+        )
+        successfulDeletesLogLines = batchResult.deleted().asScala.map{ deletedObject =>
+          s"${deletedObject.key()}, DELETED"
+        }
+        failedDeletesLogLines = batchResult.errors().asScala.map{ error =>
+          s"${error.key()}, FAILED, ${error.code()}, ${error.message()}"
+        }
+        logLines = successfulDeletesLogLines ++ failedDeletesLogLines
+        unit = logLines.foreach {logLine =>
+          println(logLine)
+          auditFileWriter.println(logLine)
+        }
+      } yield unit
+    }
+    finally {
+      inputFileSource.close()
+      auditFileWriter.close()
+    }
+
+  }
+
+}

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/BulkDeleteS3Files.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/BulkDeleteS3Files.scala
@@ -52,12 +52,11 @@ object BulkDeleteS3Files {
         failedDeletesLogLines = batchResult.errors().asScala.map{ error =>
           s"${error.key()}, FAILED, ${error.code()}, ${error.message()}"
         }
-        logLines = successfulDeletesLogLines ++ failedDeletesLogLines
-        unit = logLines.foreach {logLine =>
-          println(logLine)
-          auditFileWriter.println(logLine)
-        }
-      } yield unit
+        logLine <- successfulDeletesLogLines ++ failedDeletesLogLines
+      } {
+        println(logLine)
+        auditFileWriter.println(logLine)
+      }
     }
     finally {
       inputFileSource.close()

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
@@ -24,7 +24,7 @@ object EnactS3Changes {
 
   private val profile = "media-service"
   private val region = Region.EU_WEST_1
-  private val credentials = DefaultCredentialsProvider.builder.profileName("media-service").build
+  private val credentials = DefaultCredentialsProvider.builder.profileName(profile).build
   private val s3: S3Client = S3Client.builder
     .region(region)
     .credentialsProvider(credentials)

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/Main.scala
@@ -15,6 +15,7 @@ object Main extends App {
     case "BucketMetadata"   :: as => BucketMetadata(as)
     case "DecodeComparator" :: as => DecodeComparator(as)
     case "EnactS3Changes"   :: as => EnactS3Changes(as)
+    case "BulkDeleteS3Files":: as => BulkDeleteS3Files(as)
     case "EsMetadata"       :: as => EsImageMetadata(as)
     case "ProposeS3Changes" :: as => ProposeS3Changes(as)
     case "BackfillEditLastModified" :: as => BackfillEditLastModified(as)


### PR DESCRIPTION
Following on from https://github.com/guardian/grid/pull/4114 and lots of follow-up data mashing in Athena we now have a list of S3 paths we can safely delete (not in ES anymore, but that we have a copy in the replica bucket [and delete marker replication is OFF]) - this stands at over 50million in PROD, so we need a way to bulk delete...

**```Usage: BulkDeleteS3Files <bucketName> <inputFile> <auditFile>```**

Input file needs to be a CSV, with a heading row and a single column containing the S3 paths to delete from the specified bucket.

This script groups the input IDs into 1000s so it can use the [bulk delete API](https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-multiple-objects.html) and reports the success or failure for each S3 path to both the console but also the `auditFile` path provided (CSV output).

Note: [bulk delete API](https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-multiple-objects.html) reports 'deleted' if the path is not found, so this can be run multiple times without issue.

### TESTED in `TEST` ✅ 
Processed 385k deletions in a few mins.