### PR TITLE
upsert images by projection

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/GridClient.scala
@@ -133,6 +133,15 @@ class GridClient(services: Services)(implicit wsClient: WSClient) extends LazyLo
     }
   }
 
+  def getProjectionDiff(mediaId: String, authFn: WSRequest => WSRequest)(implicit ec: ExecutionContext): Future[Option[JsValue]] = {
+    val url = new URL(s"${services.apiBaseUri}/images/$mediaId/projection/diff")
+    makeGetRequestAsync(url, authFn, requestTimeout = Some(120.seconds)).map {
+      case Found(json, _) => Some(json)
+      case NotFound(_, _) => None
+      case e@Error(_, _, _) => e.logErrorAndThrowException()
+    }
+  }
+
   def getImageLoaderProjection(mediaId: String, authFn: WSRequest => WSRequest)
                               (implicit ec: ExecutionContext): Future[Option[Image]] = {
     getImageLoaderProjection(mediaId, services.projectionBaseUri, authFn)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -36,6 +36,7 @@ object MigrateImageMessage {
   }
 }
 
+
 /**
   * EXTERNAL THRALL MESSAGES (these go over Kinesis)
   */
@@ -81,6 +82,7 @@ object ExternalThrallMessage{
 
   implicit val createMigrationIndexMessage = Json.format[CreateMigrationIndexMessage]
   implicit val completeMigrationMessage = Json.format[CompleteMigrationMessage]
+  implicit val upsertFromProjectionMessage = Json.format[UpsertFromProjectionMessage]
 
   implicit val writes = Json.writes[ExternalThrallMessage]
   implicit val reads = Json.reads[ExternalThrallMessage]
@@ -144,6 +146,8 @@ case class CreateMigrationIndexMessage(
   val newIndexName =
     s"images_${migrationStart.toString(DateTimeFormat.forPattern("yyyy-MM-dd_HH-mm-ss").withZoneUTC())}_${gitHash.take(7)}"
 }
+
+case class UpsertFromProjectionMessage(id: String, image: Image, lastModified: DateTime) extends ExternalThrallMessage
 
 case class CompleteMigrationMessage(lastModified: DateTime) extends ExternalThrallMessage {
   val id: String = "N/A"

--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -236,14 +236,8 @@ class ThrallController(
       maybeImage <- gridClient.getImageLoaderProjection(imageId, auth.innerServiceCall)
     } yield { maybeImage match {
       case Some(projectedImage) =>
-        try {
-          messageSender.publish(UpsertFromProjectionMessage(imageId, projectedImage, DateTime.now))
-          Ok(s"upsert request for $imageId submitted")
-        } catch {
-          case t: Throwable =>
-            logger.error("Submitting upsertFromProjectionMessage failed", t)
-            throw t // rethrow to get default play error message
-        }
+        messageSender.publish(UpsertFromProjectionMessage(imageId, projectedImage, DateTime.now))
+        Ok(s"upsert request for $imageId submitted")
       case None => NotFound("")
     }}
   }

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -44,7 +44,7 @@
 </head>
 <body>
     <nav>
-        <span><a href="/upsertProject">Upsert from projection</a></span>
+        <span><a href="@routes.ThrallController.upsertProjectPage(None)">Upsert from projection</a></span>
     </nav>
     <main>
         <h1>Current elasticsearch indices</h1>

--- a/thrall/app/views/index.scala.html
+++ b/thrall/app/views/index.scala.html
@@ -43,82 +43,87 @@
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
-    <h1>Current elasticsearch indices</h1>
-    <table>
-        <tr>
-            <th>Alias</th>
-            <th>Index</th>
-            <th>Image count</th>
-        </tr>
-        <tr>
-            <td>@currentAlias</td>
-            <td>@currentIndex</td>
-            <td>@currentIndexCount</td>
-        </tr>
-        <tr>
-            <td>@migrationAlias</td>
-            <td>@migrationIndexCell</td>
-            <td>
-                @migrationIndexCount
-                @migrationStatus match {
-                    case CompletionPreview(_) => {}
-                    case Paused(_) => {
-                        @form(routes.ThrallController.resumeMigration) {
-                            PAUSED
-                            <input type="submit" value="Resume">
+    <nav>
+        <span><a href="/upsertProject">Upsert from projection</a></span>
+    </nav>
+    <main>
+        <h1>Current elasticsearch indices</h1>
+        <table>
+            <tr>
+                <th>Alias</th>
+                <th>Index</th>
+                <th>Image count</th>
+            </tr>
+            <tr>
+                <td>@currentAlias</td>
+                <td>@currentIndex</td>
+                <td>@currentIndexCount</td>
+            </tr>
+            <tr>
+                <td>@migrationAlias</td>
+                <td>@migrationIndexCell</td>
+                <td>
+                    @migrationIndexCount
+                    @migrationStatus match {
+                        case CompletionPreview(_) => {}
+                        case Paused(_) => {
+                            @form(routes.ThrallController.resumeMigration) {
+                                PAUSED
+                                <input type="submit" value="Resume">
+                            }
                         }
-                    }
-                    case InProgress(_) => {
-                        @form(routes.ThrallController.pauseMigration) {
-                            <input type="submit" value="Pause">
+                        case InProgress(_) => {
+                            @form(routes.ThrallController.pauseMigration) {
+                                <input type="submit" value="Pause">
+                            }
                         }
+                        case _ => {}
                     }
-                    case _ => {}
-                }
-            </td>
-        </tr>
-    </table>
+                </td>
+            </tr>
+        </table>
 
-    <h2>MigrationStatus (from the MigrationStatusProvider, a.k.a. 'migration status refresher')</h2>
-    <pre>@migrationStatus</pre>
-    <em>Note that the above represents the value at the point this page was loaded.</em>
+        <h2>MigrationStatus (from the MigrationStatusProvider, a.k.a. 'migration status refresher')</h2>
+        <pre>@migrationStatus</pre>
+        <em>Note that the above represents the value at the point this page was loaded.</em>
 
-    @if(migrationStatus.isInstanceOf[Running] || hasHistoricalIndex) {
-        <p><a href="@routes.ThrallController.migrationFailuresOverview">
-            View images that have failed to migrate @if(migrationStatus.isInstanceOf[Running]) {
-            <span>and retry.</span>
-        } else {
-            <span>in the PREVIOUS MIGRATION.</span>
-        }
-        </a></p>
-    }
-
-    @if(migrationStatus.isInstanceOf[Running]) {
-        <h3>Complete Migration?</h3>
-        <p>
-            If you're happy that the migration is complete (typically when it hasn't migrated any images in a good while
-            and we're happy that all images in failure can become inaccessible).
-            @if(migrationStatus.isInstanceOf[CompletionPreview]) {
-                @form(routes.ThrallController.unPreviewMigrationCompletion) {
-                    <input type="submit" value="UnPreview Completion"> (this will make grid search both indexes again)
-                }
-                @form(routes.ThrallController.completeMigration) {
-                    or fully complete the migration:
-                    <input type="text" id="complete-confirmation" name="complete-confirmation" placeholder="Type 'complete' to confirm" required>
-                    <input type="submit" value="ONLY CLICK THIS BUTTON IF YOU'RE SURE">
-                }
+        @if(migrationStatus.isInstanceOf[Running] || hasHistoricalIndex) {
+            <p><a href="@routes.ThrallController.migrationFailuresOverview">
+                View images that have failed to migrate @if(migrationStatus.isInstanceOf[Running]) {
+                <span>and retry.</span>
             } else {
-                @form(routes.ThrallController.previewMigrationCompletion) {
-                    <input type="submit" value="Preview Completion">
-                    <div>
-                        This will make grid only search the migration index (both indexes will continue to be populated
-                        and reads/writes of images will continue to use both indexes).
-                    </div>
-                }
+                <span>in the PREVIOUS MIGRATION.</span>
             }
+            </a></p>
+        }
 
-        </p>
-    }
+        @if(migrationStatus.isInstanceOf[Running]) {
+            <h3>Complete Migration?</h3>
+            <p>
+                If you're happy that the migration is complete (typically when it hasn't migrated any images in a good while
+                and we're happy that all images in failure can become inaccessible).
+                @if(migrationStatus.isInstanceOf[CompletionPreview]) {
+                    @form(routes.ThrallController.unPreviewMigrationCompletion) {
+                        <input type="submit" value="UnPreview Completion"> (this will make grid search both indexes again)
+                    }
+                    @form(routes.ThrallController.completeMigration) {
+                        or fully complete the migration:
+                        <input type="text" id="complete-confirmation" name="complete-confirmation" placeholder="Type 'complete' to confirm" required>
+                        <input type="submit" value="ONLY CLICK THIS BUTTON IF YOU'RE SURE">
+                    }
+                } else {
+                    @form(routes.ThrallController.previewMigrationCompletion) {
+                        <input type="submit" value="Preview Completion">
+                        <div>
+                            This will make grid only search the migration index (both indexes will continue to be populated
+                            and reads/writes of images will continue to use both indexes).
+                        </div>
+                    }
+                }
+
+            </p>
+        }
+    </main>
 
 </body>
 </html>

--- a/thrall/app/views/migrationFailuresOverview.scala.html
+++ b/thrall/app/views/migrationFailuresOverview.scala.html
@@ -13,39 +13,46 @@
     <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
 </head>
 <body>
+    <nav>
+        <span>
+            <a href="@routes.ThrallController.index">&lt; back to Thrall Dashboard</a>
+        </span>
+    </nav>
+    <main>
     <div class="sticky headingSection">
         <h1>
             Migration Failures Overview
         </h1>
         <p>@failuresOverview.totalFailed images failed in total!</p>
     </div>
-    <table>
-        <tr>
-            <th>Failure cause</th>
-            <th>Count</th>
-            <th>Examples</th>
-        </tr>
-        @for(failureGrouping <- failuresOverview.grouped) {
+        <table>
             <tr>
-                <td>
-                    <a href="@routes.ThrallController.migrationFailures(failureGrouping.message, None)">
-                        @failureGrouping.message
-                    </a>
-                </td>
-                <td>@failureGrouping.count</td>
-                <td>
-                    <ul>
-                    @for(failureExampleID <- failureGrouping.exampleIDs) {
-                        <li>
-                            <pre class="imageId">@failureExampleID</pre>
-                            <a href="@uiBaseUrl/images/@failureExampleID" target="_blank">[Grid]</a>
-                            <a href="@apiBaseUrl/images/@failureExampleID" target="_blank">[API]</a>
-                        </li>
-                    }
-                    </ul>
-                </td>
+                <th>Failure cause</th>
+                <th>Count</th>
+                <th>Examples</th>
             </tr>
-        }
-    </table>
+            @for(failureGrouping <- failuresOverview.grouped) {
+                <tr>
+                    <td>
+                        <a href="@routes.ThrallController.migrationFailures(failureGrouping.message, None)">
+                            @failureGrouping.message
+                        </a>
+                    </td>
+                    <td>@failureGrouping.count</td>
+                    <td>
+                        <ul>
+                        @for(failureExampleID <- failureGrouping.exampleIDs) {
+                            <li>
+                                <pre class="imageId">@failureExampleID</pre>
+                                <a href="@uiBaseUrl/images/@failureExampleID" target="_blank">[Grid]</a>
+                                <a href="@apiBaseUrl/images/@failureExampleID" target="_blank">[API]</a>
+                            </li>
+                        }
+                        </ul>
+                    </td>
+                </tr>
+            }
+        </table>
+    </main>
 </body>
 </html>

--- a/thrall/app/views/previewUpsertProject.scala.html
+++ b/thrall/app/views/previewUpsertProject.scala.html
@@ -1,0 +1,24 @@
+@import helper._
+
+@(imageId: String, diff: String)(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Previewing projection of @imageId</title>
+    </head>
+    <body>
+        <h1>Upsert image via projection</h1>
+        <p>This is a JSON diff describing what will happen if you run this upsert via projection:</p>
+        <pre>@diff</pre>
+        <h2>Happy to proceed?</h2>
+        @form(routes.ThrallController.upsertFromProjectionSingleImage) {
+            @CSRF.formField
+            <input type="hidden" id="id" name="id" value="@imageId">
+            <input type="submit" value="Proceed">
+            @* button type="button" prevents the button acting as a input type="submit" 🙄 *@
+            <a href="https://www.theguardian.com/" referrerpolicy="no-referrer"><button type="button">No! Get me out of here!</button></a>
+        }
+    </body>
+</html>

--- a/thrall/app/views/previewUpsertProject.scala.html
+++ b/thrall/app/views/previewUpsertProject.scala.html
@@ -7,17 +7,25 @@
     <head>
         <meta charset="UTF-8">
         <title>Previewing projection of @imageId</title>
+        <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
     </head>
     <body>
-        <h1>Upsert image via projection</h1>
-        <p>This is a JSON diff describing what will happen if you run this upsert via projection:</p>
-        <pre>@diff</pre>
-        <h2>Happy to proceed?</h2>
-        @form(routes.ThrallController.upsertFromProjectionSingleImage) {
-            @CSRF.formField
-            <input type="hidden" id="id" name="id" value="@imageId">
-            <input type="submit" value="Proceed">
-        }
-        <a href="https://www.theguardian.com/" referrerpolicy="no-referrer"><button type="button">No! Get me out of here!</button></a>
+        <nav>
+            <span>
+                <a href="@routes.ThrallController.index">&lt; back to Thrall Dashboard</a>
+            </span>
+        </nav>
+        <main>
+            <h1>Upsert image via projection</h1>
+            <p>This is a JSON diff describing what will happen if you run this upsert via projection:</p>
+            <pre>@diff</pre>
+            <h2>Happy to proceed?</h2>
+            @form(routes.ThrallController.upsertFromProjectionSingleImage) {
+                @CSRF.formField
+                <input type="hidden" id="id" name="id" value="@imageId">
+                <input type="submit" value="Proceed">
+            }
+            <a href="https://www.theguardian.com/" referrerpolicy="no-referrer"><button type="button">No! Get me out of here!</button></a>
+        </main>
     </body>
 </html>

--- a/thrall/app/views/previewUpsertProject.scala.html
+++ b/thrall/app/views/previewUpsertProject.scala.html
@@ -17,8 +17,7 @@
             @CSRF.formField
             <input type="hidden" id="id" name="id" value="@imageId">
             <input type="submit" value="Proceed">
-            @* button type="button" prevents the button acting as a input type="submit" 🙄 *@
-            <a href="https://www.theguardian.com/" referrerpolicy="no-referrer"><button type="button">No! Get me out of here!</button></a>
         }
+        <a href="https://www.theguardian.com/" referrerpolicy="no-referrer"><button type="button">No! Get me out of here!</button></a>
     </body>
 </html>

--- a/thrall/app/views/upsertProject.scala.html
+++ b/thrall/app/views/upsertProject.scala.html
@@ -2,9 +2,9 @@
 @()(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-
 <html lang="en">
     <head>
+        <meta charset="UTF-8">
         <title>Upsert image via projection</title>
     </head>
     <body>
@@ -16,10 +16,9 @@
         <p>This is a potentially <strong>destructive</strong> operation, so be sure to check the result of projection before running!</p>
         <p>If you're happy, then enter the media ID below and hit 'submit'...</p>
 
-        @form(routes.ThrallController.upsertFromProjectionSingleImage) {
-            @CSRF.formField
-            <label for="id">Image ID:</label>
-            <input type="text" id="id" name="id">
+        @form(routes.ThrallController.upsertProjectPage(None)) {
+            <label for="imageId">Image ID:</label>
+            <input type="text" id="imageId" name="imageId">
             <input type="submit" value="Submit">
         }
 

--- a/thrall/app/views/upsertProject.scala.html
+++ b/thrall/app/views/upsertProject.scala.html
@@ -1,0 +1,27 @@
+@import helper._
+@()(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+
+<html lang="en">
+    <head>
+        <title>Upsert image via projection</title>
+    </head>
+    <body>
+        <h1>Upsert image via projection</h1>
+        <p>
+            This option will run a projection against the given media ID, and <strong>OVERWRITE</strong> any currently stored image data in Elasticsearch.
+            (ie. metadata, usage rights, leases etc. The image file itself will not be touched)
+        </p>
+        <p>This is a potentially <strong>destructive</strong> operation, so be sure to check the result of projection before running!</p>
+        <p>If you're happy, then enter the media ID below and hit 'submit'...</p>
+
+        @form(routes.ThrallController.upsertFromProjectionSingleImage) {
+            @CSRF.formField
+            <label for="id">Image ID:</label>
+            <input type="text" id="id" name="id">
+            <input type="submit" value="Submit">
+        }
+
+    </body>
+</html>

--- a/thrall/app/views/upsertProject.scala.html
+++ b/thrall/app/views/upsertProject.scala.html
@@ -6,21 +6,28 @@
     <head>
         <meta charset="UTF-8">
         <title>Upsert image via projection</title>
+        <link rel="stylesheet" href="@routes.Assets.versioned("stylesheets/main.css")" />
     </head>
     <body>
-        <h1>Upsert image via projection</h1>
-        <p>
-            This option will run a projection against the given media ID, and <strong>OVERWRITE</strong> any currently stored image data in Elasticsearch.
-            (ie. metadata, usage rights, leases etc. The image file itself will not be touched)
-        </p>
-        <p>This is a potentially <strong>destructive</strong> operation, so be sure to check the result of projection before running!</p>
-        <p>If you're happy, then enter the media ID below and hit 'submit'...</p>
+        <nav>
+            <span>
+                <a href="@routes.ThrallController.index">&lt; back to Thrall Dashboard</a>
+            </span>
+        </nav>
+        <main>
+            <h1>Upsert image via projection</h1>
+            <p>
+                This option will run a projection against the given media ID, and <strong>OVERWRITE</strong> any currently stored image data in Elasticsearch.
+                (ie. metadata, usage rights, leases etc. The image file itself will not be touched)
+            </p>
+            <p>This is a potentially <strong>destructive</strong> operation, so be sure to check the result of projection before running!</p>
+            <p>If you're happy, then enter the media ID below and hit 'submit'...</p>
 
-        @form(routes.ThrallController.upsertProjectPage(None)) {
-            <label for="imageId">Image ID:</label>
-            <input type="text" id="imageId" name="imageId">
-            <input type="submit" value="Submit">
-        }
-
+            @form(routes.ThrallController.upsertProjectPage(None)) {
+                <label for="imageId">Image ID:</label>
+                <input type="text" id="imageId" name="imageId">
+                <input type="submit" value="Submit">
+            }
+        </main>
     </body>
 </html>

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -3,6 +3,7 @@
 # ~~~~
 
 GET     /                                             controllers.ThrallController.index
+GET     /upsertProject                                controllers.ThrallController.upsertProjectPage()
 GET     /migrationFailuresOverview                    controllers.ThrallController.migrationFailuresOverview()
 GET     /migrationFailures                            controllers.ThrallController.migrationFailures(filter: String, page: Option[Int])
 +nocsrf
@@ -16,6 +17,7 @@ POST    /pauseMigration                               controllers.ThrallControll
 POST    /resumeMigration                              controllers.ThrallController.resumeMigration
 +nocsrf
 POST    /migrate                                      controllers.ThrallController.migrateSingleImage
+POST    /upsertProject                                controllers.ThrallController.upsertFromProjectionSingleImage
 +nocsrf
 POST    /completeMigration                            controllers.ThrallController.completeMigration
 +nocsrf

--- a/thrall/conf/routes
+++ b/thrall/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 GET     /                                             controllers.ThrallController.index
-GET     /upsertProject                                controllers.ThrallController.upsertProjectPage()
+GET     /upsertProject                                controllers.ThrallController.upsertProjectPage(imageId: Option[String])
 GET     /migrationFailuresOverview                    controllers.ThrallController.migrationFailuresOverview()
 GET     /migrationFailures                            controllers.ThrallController.migrationFailures(filter: String, page: Option[Int])
 +nocsrf

--- a/thrall/public/stylesheets/main.css
+++ b/thrall/public/stylesheets/main.css
@@ -32,3 +32,9 @@ body {
 .headingRow {
   top: 190px;
 }
+
+nav {
+  padding: 12px;
+  border-bottom: 1px solid black;
+  width: 100%;
+}


### PR DESCRIPTION
## What does this change?

Add new endpoint and matching Thrall HTML forms which allow to submit an image to be "upserted by projection".

For context, "projection" is the process of reforming the image data by ingesting the original image file, and then "replaying" the metadata changes via the Grid UI, and attaching all of the other Grid-specific data (leases, photoshoots, usages, etc.). ie. rebuilding the data stored in Elasticsearch _without referring to Elasticsearch_. Projection was originally implemented to make [migration](https://github.com/guardian/grid/blob/main/docs/05-migration/01-about.md) useful, but it would occasionally be helpful to update (or insert!) a single image into the Elasticsearch index "fresh". 

In our specific case, we have removed some images from the index but not yet removed their image files out of S3, but now want to restore seamlessly. Running a full migration for a handful of images is quite heavy, and the list of images to migrate _is_ generated by querying the current index, so wouldn't even really help here! So we implement the feature at long last to unblock ourselves.

There is a UI flow, which will fetch the projection and diff it against what's in the index (if there is something there! if there's not the diff will be 100% additions :) ), but also services with API keys can make requests directly against the endpoint which does the work if that's useful

### Potential other things to do:

I haven't added a link to this pages from the Thrall dashboard - should I? (probably yes)
While implementing this I figured out what was preventing CSRF protections on the other Thrall dashboard endpoints. I think I'll raise another PR after this one which removes the `+nocsrf`s 

## How should a reviewer test this change?

Deploy to TEST if not already. Delete an image from Elasticsearch without deleting from S3 and dynamo (not possible in Grid UI! must delete directly against elasticsearch. feel free to ask for help if you've not done this before). Check the image is now "not-found" in Grid UI. Open /upsertProject on the Thrall endpoint, and paste the image ID into the form and submit. Check if the diff looks like you expect (should be all additions), and then submit again. Is the image back on Grid? With all the data it previously had?

This PR I think fixes all problems with the CSRF protection which made them unusable on the other Thrall endpoints - do you see any problems?

## How can success be measured?

We can restore images we wanted to restore


## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
