### PR TITLE
Update to panda v1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     // also exists in plugins.sbt, TODO deduplicate this
     "com.gu" %% "editorial-permissions-client" % "2.14",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.2.2",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.3.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

See https://github.com/guardian/pan-domain-authentication/releases/tag/v1.3.0

## How should a reviewer test this change?

Panda continues to work as expected?

## How can success be measured?

Troubleshooting of reauth failures can be performed