### PR TITLE
Add API filters for print usage info

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/formatting/package.scala
@@ -1,9 +1,10 @@
 package com.gu.mediaservice.lib
 
-import scala.concurrent.duration.Duration
-import scala.util.Try
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ISODateTimeFormat}
+
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 package object formatting {
 
@@ -11,7 +12,8 @@ package object formatting {
     val parsers = Array(
       // Allow ISO date time with millis even though ES has no millis so they are ignored
       ISODateTimeFormat.dateTime,
-      ISODateTimeFormat.dateTimeNoMillis
+      ISODateTimeFormat.dateTimeNoMillis,
+      ISODateTimeFormat.date
     ).map(_.getParser)
     new DateTimeFormatterBuilder().
       append(null, parsers).

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/PrintUsageFilters.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/PrintUsageFilters.scala
@@ -1,0 +1,10 @@
+package com.gu.mediaservice.model
+
+import org.joda.time.DateTime
+
+case class PrintUsageFilters(
+  issueDate: DateTime,
+  sectionCode: Option[String],
+  pageNumber: Option[Int],
+  edition: Option[Int]
+)

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/PrintUsageFilters.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/PrintUsageFilters.scala
@@ -6,5 +6,6 @@ case class PrintUsageFilters(
   issueDate: DateTime,
   sectionCode: Option[String],
   pageNumber: Option[Int],
-  edition: Option[Int]
+  edition: Option[Int],
+  orderedBy: Option[String]
 )

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -144,6 +144,8 @@ class ElasticSearch(
       case _ => None
     }
 
+    val printUsageFilter = params.printUsageFilters.map(searchFilters.printUsageFilters)
+
     val hasRightsCategory = params.hasRightsCategory.filter(_ == true).map(_ => searchFilters.hasRightsCategoryFilter)
 
     val validityFilter = params.valid.flatMap(valid => if (valid) searchFilters.validFilter else searchFilters.invalidFilter)
@@ -195,6 +197,7 @@ class ElasticSearch(
         ++ searchFilters.tierFilter(params.tier)
         ++ syndicationStatusFilter
         ++ dateAddedToCollectionFilter
+        ++ printUsageFilter
       ).toNel.map(filter => filter.list.reduceLeft(filters.and(_, _)))
 
     val withFilter = filterOpt.map { f =>

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -131,7 +131,8 @@ object SearchParams {
         issueDate = issueDate,
         sectionCode = request.getQueryString("printUsageSectionCode"),
         pageNumber = request.getQueryString("printUsagePageNumber") flatMap parseIntFromQuery,
-        edition = request.getQueryString("printUsageEdition") flatMap parseIntFromQuery
+        edition = request.getQueryString("printUsageEdition") flatMap parseIntFromQuery,
+        orderedBy = request.getQueryString("printUsageOrderedBy")
       )
     }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -3,7 +3,7 @@ package lib.elasticsearch
 import com.gu.mediaservice.lib.auth.{Authentication, Tier}
 import com.gu.mediaservice.lib.formatting.{parseDateFromQuery, printDateTime}
 import com.gu.mediaservice.model.usage.UsageStatus
-import com.gu.mediaservice.model.{Image, SyndicationStatus}
+import com.gu.mediaservice.model.{Image, PrintUsageFilters, SyndicationStatus}
 import lib.querysyntax.{Condition, Parser}
 import org.joda.time.DateTime
 import play.api.libs.json.Json
@@ -56,36 +56,37 @@ object AggregateSearchParams {
 }
 
 case class SearchParams(
-                         query: Option[String] = None,
-                         structuredQuery: List[Condition] = List.empty,
-                         ids: Option[List[String]] = None,
-                         offset: Int = 0,
-                         length: Int = 10,
-                         orderBy: Option[String] = None,
-                         since: Option[DateTime] = None,
-                         until: Option[DateTime] = None,
-                         modifiedSince: Option[DateTime] = None,
-                         modifiedUntil: Option[DateTime] = None,
-                         takenSince: Option[DateTime] = None,
-                         takenUntil: Option[DateTime] = None,
-                         archived: Option[Boolean] = None,
-                         hasExports: Option[Boolean] = None,
-                         hasIdentifier: Option[String] = None,
-                         missingIdentifier: Option[String] = None,
-                         valid: Option[Boolean] = None,
-                         free: Option[Boolean] = None,
-                         payType: Option[PayType.Value] = None,
-                         hasRightsCategory: Option[Boolean] = None,
-                         uploadedBy: Option[String] = None,
-                         labels: List[String] = List.empty,
-                         hasMetadata: List[String] = List.empty,
-                         persisted: Option[Boolean] = None,
-                         usageStatus: List[UsageStatus] = List.empty,
-                         usagePlatform: List[String] = List.empty,
-                         tier: Tier,
-                         syndicationStatus: Option[SyndicationStatus] = None,
-  countAll: Option[Boolean] = None
-                       )
+  query: Option[String] = None,
+  structuredQuery: List[Condition] = List.empty,
+  ids: Option[List[String]] = None,
+  offset: Int = 0,
+  length: Int = 10,
+  orderBy: Option[String] = None,
+  since: Option[DateTime] = None,
+  until: Option[DateTime] = None,
+  modifiedSince: Option[DateTime] = None,
+  modifiedUntil: Option[DateTime] = None,
+  takenSince: Option[DateTime] = None,
+  takenUntil: Option[DateTime] = None,
+  archived: Option[Boolean] = None,
+  hasExports: Option[Boolean] = None,
+  hasIdentifier: Option[String] = None,
+  missingIdentifier: Option[String] = None,
+  valid: Option[Boolean] = None,
+  free: Option[Boolean] = None,
+  payType: Option[PayType.Value] = None,
+  hasRightsCategory: Option[Boolean] = None,
+  uploadedBy: Option[String] = None,
+  labels: List[String] = List.empty,
+  hasMetadata: List[String] = List.empty,
+  persisted: Option[Boolean] = None,
+  usageStatus: List[UsageStatus] = List.empty,
+  usagePlatform: List[String] = List.empty,
+  tier: Tier,
+  syndicationStatus: Option[SyndicationStatus] = None,
+  countAll: Option[Boolean] = None,
+  printUsageFilters: Option[PrintUsageFilters] = None,
+)
 
 case class InvalidUriParams(message: String) extends Throwable
 object InvalidUriParams {
@@ -125,6 +126,15 @@ object SearchParams {
     val query = request.getQueryString("q")
     val structuredQuery = query.map(Parser.run) getOrElse List()
 
+    val printUsageFilters = request.getQueryString("printUsageIssueDate").flatMap(parseDateFromQuery).map { issueDate =>
+      PrintUsageFilters(
+        issueDate = issueDate,
+        sectionCode = request.getQueryString("printUsageSectionCode"),
+        pageNumber = request.getQueryString("printUsagePageNumber") flatMap parseIntFromQuery,
+        edition = request.getQueryString("printUsageEdition") flatMap parseIntFromQuery
+      )
+    }
+
     SearchParams(
       query,
       structuredQuery,
@@ -155,6 +165,7 @@ object SearchParams {
       request.user.accessor.tier,
       request.getQueryString("syndicationStatus") flatMap parseSyndicationStatus,
       request.getQueryString("countAll") flatMap parseBooleanFromQuery,
+      printUsageFilters,
     )
   }
 

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -96,11 +96,11 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
   }
 
   def printUsageFilters(printFilters: PrintUsageFilters): Query = filters.nested("usages", filters.and(Seq(
-    Some(filters.date("printUsageMetadata.issueDate", from = printFilters.issueDate.minusSeconds(1), to = printFilters.issueDate.plusDays(1))),
-    printFilters.sectionCode.map(filters.term("printUsageMetadata.sectionCode", _)),
-    printFilters.pageNumber.map(filters.term("printUsageMetadata.pageNumber", _)),
-    printFilters.edition.map(filters.term("printUsageMetadata.edition", _)),
-    printFilters.orderedBy.map(filters.term("printUsageMetadata.orderedBy", _)),
+    Some(filters.date("usages.printUsageMetadata.issueDate", from = printFilters.issueDate, to = printFilters.issueDate.plusDays(1))),
+    printFilters.sectionCode.map(filters.term("usages.printUsageMetadata.sectionCode", _)),
+    printFilters.pageNumber.map(filters.term("usages.printUsageMetadata.pageNumber", _)),
+    printFilters.edition.map(filters.term("usages.printUsageMetadata.edition", _)),
+    printFilters.orderedBy.map(filters.term("usages.printUsageMetadata.orderedBy", _)),
   ).flatten:_*))
 
   def filterOrFilter(filter: Option[Query], orFilter: Option[Query]): Option[Query] = (filter, orFilter) match {

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -98,7 +98,11 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
   def printUsageFilters(printFilters: PrintUsageFilters): Query = filters.nested("usages", filters.and(Seq(
     Some(filters.term("usages.status", "published")),
     Some(filters.term("usages.platform", "print")),
-    Some(filters.date("usages.printUsageMetadata.issueDate", from = printFilters.issueDate, to = printFilters.issueDate.plusDays(1))),
+    Some(filters.date(
+      "usages.printUsageMetadata.issueDate",
+      from = printFilters.issueDate.minusSeconds(1), // minus 1 second to account for exclusive range
+      to = printFilters.issueDate.plusDays(1)
+    )),
     printFilters.sectionCode.map(filters.term("usages.printUsageMetadata.sectionCode", _)),
     printFilters.pageNumber.map(filters.term("usages.printUsageMetadata.pageNumber", _)),
     printFilters.edition.map(filters.term("usages.printUsageMetadata.edition", _)),

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -96,6 +96,8 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
   }
 
   def printUsageFilters(printFilters: PrintUsageFilters): Query = filters.nested("usages", filters.and(Seq(
+    Some(filters.term("usages.status", "published")),
+    Some(filters.term("usages.platform", "print")),
     Some(filters.date("usages.printUsageMetadata.issueDate", from = printFilters.issueDate, to = printFilters.issueDate.plusDays(1))),
     printFilters.sectionCode.map(filters.term("usages.printUsageMetadata.sectionCode", _)),
     printFilters.pageNumber.map(filters.term("usages.printUsageMetadata.pageNumber", _)),

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -100,6 +100,7 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
     printFilters.sectionCode.map(filters.term("printUsageMetadata.sectionCode", _)),
     printFilters.pageNumber.map(filters.term("printUsageMetadata.pageNumber", _)),
     printFilters.edition.map(filters.term("printUsageMetadata.edition", _)),
+    printFilters.orderedBy.map(filters.term("printUsageMetadata.orderedBy", _)),
   ).flatten:_*))
 
   def filterOrFilter(filter: Option[Query], orFilter: Option[Query]): Option[Query] = (filter, orFilter) match {

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -95,6 +95,13 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
     case _ => None
   }
 
+  def printUsageFilters(printFilters: PrintUsageFilters): Query = filters.nested("usages", filters.and(Seq(
+    Some(filters.date("printUsageMetadata.issueDate", from = printFilters.issueDate.minusSeconds(1), to = printFilters.issueDate.plusDays(1))),
+    printFilters.sectionCode.map(filters.term("printUsageMetadata.sectionCode", _)),
+    printFilters.pageNumber.map(filters.term("printUsageMetadata.pageNumber", _)),
+    printFilters.edition.map(filters.term("printUsageMetadata.edition", _)),
+  ).flatten:_*))
+
   def filterOrFilter(filter: Option[Query], orFilter: Option[Query]): Option[Query] = (filter, orFilter) match {
     case (Some(someFilter), Some(orSomeFilter)) => Some(filters.or(someFilter, orSomeFilter))
     case (filterOpt,    orFilterOpt)    => filterOpt orElse orFilterOpt

--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -22,6 +22,25 @@ object filters {
 
   def boolTerm(field: String, value: Boolean): TermQuery = termQuery(field, value)
 
+  /**
+   * Range query based on dates
+   * Note that `from` is _inclusive_ in this function
+   * @param field Field name to query
+   * @param from Lower bound for date (inclusive)
+   * @param to Upper bound for date (exclusive)
+   * @return Suitable query
+   */
+  def date(field: String, from: DateTime, to: DateTime): Query =
+    rangeQuery(field).gte(printDateTime(from)).lt(printDateTime(to))
+
+  /**
+   * Range query based on dates - handles optional to and from
+   * Note that `from` is _exclusive_ in this function
+   * @param field Field name to query
+   * @param from Lower bound for date (exclusive)
+   * @param to Upper bound for date (exclusive)
+   * @return Suitable query if at least one of `from` and `to` is defined; otherwise nothing
+   */
   def date(field: String, from: Option[DateTime], to: Option[DateTime]): Option[Query] =
     if (from.isDefined || to.isDefined) {
       val builder = rangeQuery(field)
@@ -44,6 +63,7 @@ object filters {
   def mustNot(queries: Query*): Query = ElasticDsl.not(queries)
 
   def term(field: String, term: String): Query = termQuery(field, term)
+  def term(field: String, term: Int): Query = termQuery(field, term)
 
   def terms(field: String, terms: NonEmptyList[String]): Query = {
     termsQuery(field, terms.list)

--- a/media-api/app/lib/elasticsearch/filters.scala
+++ b/media-api/app/lib/elasticsearch/filters.scala
@@ -24,18 +24,16 @@ object filters {
 
   /**
    * Range query based on dates
-   * Note that `from` is _inclusive_ in this function
    * @param field Field name to query
-   * @param from Lower bound for date (inclusive)
+   * @param from Lower bound for date (exclusive)
    * @param to Upper bound for date (exclusive)
    * @return Suitable query
    */
   def date(field: String, from: DateTime, to: DateTime): Query =
-    rangeQuery(field).gte(printDateTime(from)).lt(printDateTime(to))
+    rangeQuery(field).gt(printDateTime(from)).lt(printDateTime(to))
 
   /**
    * Range query based on dates - handles optional to and from
-   * Note that `from` is _exclusive_ in this function
    * @param field Field name to query
    * @param from Lower bound for date (exclusive)
    * @param to Upper bound for date (exclusive)


### PR DESCRIPTION
## What does this change?

Adds some media API search filters to allow drilling down into images which have print usages which meet several criteria:

- printUsageIssueDate
- printUsageSectionCode
- printUsagePageNumber
- printUsageEdition
- printUsageOrderedBy

printUsageIssueDate is required to query on print usages like this (there's no technical reason, but it doesn't really make sense to query without it)

These use filters rather than query syntax / chips because that I originally thought that gave us an extra level of control over the querying of nested fields (I thought that `+usage@issueDate:2023-01-01 +usage@sectionCode:1jo` would give us images where at least one usage was on the date, and at least one usage was in the section, but not necessarily the same usage. I'm less convinced of that now.). But I still think it's nicer for our purposes to use filters than chips (where grid UI helps phrase the chip correctly, but in API you're on your own). Lmk if you disagree and I'll double check viability of using chips instead.

## How should a reviewer test this change?

Make some print usages, try to slice them with queries.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
