### PR TITLE
IMAGEDAM-1400 - Fixing 'Social Media' and 'R&M Photographer - staff' templates

### DIFF
--- a/kahuna/public/js/metadata-templates/metadata-templates.js
+++ b/kahuna/public/js/metadata-templates/metadata-templates.js
@@ -150,7 +150,9 @@ metadataTemplates.controller('MetadataTemplatesCtrl', [
 
     ctrl.applyTemplate = () => {
       ctrl.saving = true;
-      ctrl.onMetadataTemplateApplying({leases: ctrl.metadataTemplate.templateLeases.leases});
+      if (ctrl.metadataTemplate.templateLeases) {
+        ctrl.onMetadataTemplateApplying({leases: ctrl.metadataTemplate.templateLeases.leases});
+      }
 
       let promise = Promise.resolve();
 


### PR DESCRIPTION
## What does this change?
Both the Social Media and R&M Photographer - staff templates were not working as they could not be applied.

This was due to the leases for these templates being undefined as they did not have leases associated with them.

The solution was to add an if-statement on line 153 where the undefined error was occurring, that way a lease is not attempted to be accessed if the template does not contain any.

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

Add the following to application.conf, to be able to select the 'Social Media' template:

metadata.templates = [
{
    templateName: "Social Media" 
    usageRights: {
      category: "social-media"
      restrictions: "SOCIAL MEDIA - Usage requires approval by a Senior Editor"
    }
    metadataFields: [
      {
        name: "specialInstructions"
        value: "Approval needed from a senior editor"
        resolveStrategy: "replace"
      }
    ]
  }
]

To reproduce the issue this PR is fixing:

Upload a new image to the grid and select the 'Social Media' template from the templates dropdown. Click the apply button for the template to be applied. The apply button will change to have a 'clock' icon within the button. Attempting to click it now will not work and the changes from the template won't be saved.

![image](https://github.com/guardian/grid/assets/129299738/1a668d64-bda4-46ad-af73-2a40b668a521)

To confirm the fix is working:

Upload a new image to the grid and select the 'Social Media' template from the templates dropdown. Click the apply button for the template to be applied. The apply button will briefly change to have a 'clock' icon within the button and the changes from the template will be saved.

![image](https://github.com/guardian/grid/assets/129299738/398ed514-0099-4021-98a7-d00d699f8f55)

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

The Social Media and R&M Photographer - staff templates can be successfully applied. 

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
