### PR TITLE
Add `title` chip

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -36,6 +36,7 @@ export const filterFields = [
     'subject',
     'supplier',
     'suppliersReference',
+    'title',
     'uploader',
     'usages@<added',
     'usages@>added',

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -119,6 +119,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     "suppliersReference" |
     "supplier" |
     "specialInstructions" |
+    "title" |
     "collection" |
     "keyword" |
     "label" |


### PR DESCRIPTION
## What does this change?

Adds a chip for easier searches of `title`.

## How should a reviewer test this change?

Press `+` and notice `title` in the dropdown. Type `title` followed by a colon and notice it turning into a chip. I haven’t added it to Advanced search flyout, coz self-explanatory and the flyout is too long already.

Just a note that adding it to `QuerySyntax.scala` seems superfluous as @andrew-nowak notes “https://github.com/guardian/grid/pull/3132 made AllowedFieldName pretty pointless”. But added for cleanliness.

## How can success be measured?
@honorcb is happy.

## Who should look at this?
@guardian/digital-cms 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
