### PR TITLE
add youtube as a valid `frame-src` in CSP

### DIFF
--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -39,7 +39,7 @@ object KahunaSecurityConfig {
 
     val gaHost = "www.google-analytics.com"
 
-    val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com ${config.scriptsToLoad.map(_.host).mkString(" ")}"
+    val frameSources = s"frame-src ${config.services.authBaseUri} ${config.services.kahunaBaseUri} https://accounts.google.com https://www.youtube.com ${config.scriptsToLoad.map(_.host).mkString(" ")}"
     val frameAncestors = s"frame-ancestors ${config.frameAncestors.mkString(" ")}"
     val connectSources = s"connect-src 'self' ${(services :+ config.imageOrigin).mkString(" ")} $gaHost ${config.connectSources.mkString(" ")}"
 


### PR DESCRIPTION
... so pinboard can render video atoms in the grid

Avoids this...
![image](https://github.com/guardian/grid/assets/19289579/85bef108-ed00-4b78-b367-6ccb6a754efc)

