### PR TITLE
DO NOT delete from Dynamo (user edits etc.) on hard-delete

### DIFF
--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -162,7 +162,7 @@ class MessageProcessor(
             store.deleteOriginal(message.id)
             store.deleteThumbnail(message.id)
             store.deletePng(message.id)
-            metadataEditorNotifications.publishImageDeletion(message.id)
+//            metadataEditorNotifications.publishImageDeletion(message.id) // let's not delete from Dynamo as user edits might be useful if we restore from replica
             EsResponse(s"Image deleted: ${message.id}")
         } recoverWith {
           case ImageNotDeletable =>


### PR DESCRIPTION
Storing user edits in Dynamo indefinetely shouldn't make much of an impact on performance or cost very much and could be useful if we ever need to restore a hard-deleted image (see https://github.com/guardian/grid/pull/4128).