### PR TITLE
prevent autorotation on image display and crop page

### DIFF
--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -105,6 +105,7 @@
     <div class="easel__canvas">
         <div class="easel__image-container" oncontextmenu="return false;">
             <img class="easel__image easel__image--cropper"
+                 crossorigin="anonymous"
                  oncontextmenu="return false;"
                  alt="original image to crop"
                  ng-src="{{ctrl.optimisedImageUri}}"

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -174,6 +174,7 @@
              draggable="true"
              ui-drag-data="ctrl.image | asImageDragData">
           <img ng-class="{'easel__image':true,'easel__image--checkered__background': ctrl.image.data.optimisedPng }"
+               crossorigin="anonymous"
                alt="preview of original image"
                ng-src="{{:: ctrl.optimisedImageUri}}"
                grid:track-image="ctrl.image"

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1918,6 +1918,7 @@ FIXME: what to do with touch devices
   max-width: calc(100% - 20px); /* 20px here for padding */
   max-height: calc(100vh - 68px);
   pointer-events: none;
+  image-orientation: none;
 }
 
 .easel__image:fullscreen,


### PR DESCRIPTION
## What does this change?

Some images with rotation metadata get autorotated if the requested image means imgops doesn't have to transform.
Browsers see the metadata and do the rotation.
There is a CSS property to control this, but to take effect it needs the `crossorigin` property set on the `<img>` - even if setting to the default `anonymous`

There is another bug in Firefox <= 113 which will prevent this having an effect.

## How should a reviewer test this change?

Check with an image with rotation metadata (@paperboyo knows one in guardian grid)

## How can success be measured?

Grid chooses to explicitly ignore rotation metadata (until we also support it in the backend! then we'll make good use of it!)
