### PR TITLE
cropperjs: ignore orientation data

### DIFF
--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -57,6 +57,7 @@ cropBox.directive('uiCropBox', [
                     background: false,
                     responsive: false,
                     autoCropArea: 1,
+                    checkOrientation: false, // TODO later: reset to default true when backend can handle rotation/orientation
                     crop: update,
                     ready: getRatio
                 };

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -57,9 +57,8 @@ cropBox.directive('uiCropBox', [
                     background: false,
                     responsive: false,
                     autoCropArea: 1,
-                    checkOrientation: false, // TODO later: reset to default true when backend can handle rotation/orientation
                     crop: update,
-                    ready: getRatio
+                    ready: onReady
                 };
 
                 cropper = new Cropper(image, options);
@@ -75,10 +74,19 @@ cropBox.directive('uiCropBox', [
                 }
             }
 
-            function getRatio() {
+            function onReady() {
                 previewImg = cropper.getCanvasData();
                 widthRatio = scope.originalWidth / previewImg.naturalWidth;
                 heightRatio = scope.originalHeight / previewImg.naturalHeight;
+
+                const data = cropper.getData();
+                // data.rotate is only non-0 on load if image has orientation metadata.
+                // unfortunately grid backend can't resolve orientation metadata, so we need to make sure to
+                // ignore it on the frontend too. so ask cropperjs if image is rotated, and if so, rotate it an equal amount
+                // in the other direction (to get to 0!)
+                if (data.rotate) {
+                    cropper.rotate(-data.rotate);
+                }
             }
 
             function update(c) {

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -83,7 +83,7 @@ cropBox.directive('uiCropBox', [
                 if (data.rotate) {
                     cropper.rotate(-data.rotate);
                 }
-              
+
                 previewImg = cropper.getCanvasData();
                 widthRatio = scope.originalWidth / previewImg.naturalWidth;
                 heightRatio = scope.originalHeight / previewImg.naturalHeight;

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -75,10 +75,6 @@ cropBox.directive('uiCropBox', [
             }
 
             function onReady() {
-                previewImg = cropper.getCanvasData();
-                widthRatio = scope.originalWidth / previewImg.naturalWidth;
-                heightRatio = scope.originalHeight / previewImg.naturalHeight;
-
                 const data = cropper.getData();
                 // data.rotate is only non-0 on load if image has orientation metadata.
                 // unfortunately grid backend can't resolve orientation metadata, so we need to make sure to
@@ -87,6 +83,10 @@ cropBox.directive('uiCropBox', [
                 if (data.rotate) {
                     cropper.rotate(-data.rotate);
                 }
+              
+                previewImg = cropper.getCanvasData();
+                widthRatio = scope.originalWidth / previewImg.naturalWidth;
+                heightRatio = scope.originalHeight / previewImg.naturalHeight;
             }
 
             function update(c) {


### PR DESCRIPTION

## What does this change?

in #4132 I attempted to set kahuna to ignore orientation data - unfortunately I missed that cropperjs also [tries to follow orientation data itself](https://github.com/fengyuanchen/cropperjs#checkorientation). Disable that functionality.


## How should a reviewer test this change?

same as #4132, but remembering to check crop page!

## How can success be measured?

same as #4132 - ignore orientation data until we support it in the backend

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
