### PR TITLE
[reaper] add `batchSoftDelete` and `batchHardDelete` endpoints (batches of up to 1000)

### DIFF
--- a/media-api/app/lib/S3Client.scala
+++ b/media-api/app/lib/S3Client.scala
@@ -7,11 +7,12 @@ import java.util.Date
 import com.amazonaws.services.cloudfront.CloudFrontUrlSigner
 import com.amazonaws.services.cloudfront.util.SignerUtils
 import com.amazonaws.services.cloudfront.util.SignerUtils.Protocol
-import com.amazonaws.services.s3.model.GetObjectRequest
+import com.amazonaws.services.s3.model.{DeleteObjectsRequest, GetObjectRequest, MultiObjectDeleteException}
 import com.gu.mediaservice.lib.aws.S3
 import org.joda.time.DateTime
 
 import java.security.PrivateKey
+import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
 import scala.util.Try
 
 trait CloudFrontDistributable {
@@ -46,6 +47,24 @@ class S3Client(config: MediaApiConfig) extends S3(config) with CloudFrontDistrib
       }
     }).orElse(Try(SignerUtils.loadPrivateKey("/etc/grid/ssl/private/cloudfront.pem")).toOption)
       .getOrElse(throw new RuntimeException("No private key found"))
+  }
+
+  def bulkDelete(bucket: String, keys: Seq[String]): Map[String, Boolean] = {
+    try {
+      client.deleteObjects(
+        new DeleteObjectsRequest(bucket).withKeys(keys: _*)
+      )
+      keys.map { key =>
+        key -> true
+      }.toMap
+    } catch {
+      case partialFailure: MultiObjectDeleteException =>
+        // TODO log partial failure
+        keys.map { key =>
+          key -> partialFailure.getErrors.asScala.map(_.getKey).toList.contains(key)
+        }.toMap
+    }
+
   }
 }
 

--- a/media-api/app/lib/SoftDeletedMetadataTable.scala
+++ b/media-api/app/lib/SoftDeletedMetadataTable.scala
@@ -20,6 +20,10 @@ class SoftDeletedMetadataTable(config: MediaApiConfig) extends DynamoDB(config, 
     ScanamoAsync.exec(client)(softDeletedMetadataTable.put(imageStatus))
   }
 
+  def setStatuses(imageStatuses: Set[ImageStatusRecord]) = {
+    ScanamoAsync.exec(client)(softDeletedMetadataTable.putAll(imageStatuses))
+  }
+
   def updateStatus(imageId: String, isDeleted: Boolean) = {
     val updateExpression = set('isDeleted -> isDeleted)
     ScanamoAsync.exec(client)(

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -12,6 +12,10 @@ GET     /images/edits/:field                                        controllers.
 GET     /images/:id/softDeletedMetadata                             controllers.MediaApi.getSoftDeletedMetadata(id: String)
 GET     /images/aggregations/date/:field                            controllers.AggregationController.dateHistogram(field: String, q: Option[String])
 
+# Reaping related
+GET     /images/nextIdsToBeSoftReaped                               controllers.MediaApi.nextIdsToBeSoftReaped(size: Int)
+GET     /images/nextIdsToBeHardReaped                               controllers.MediaApi.nextIdsToBeHardReaped(size: Int)
+
 # Images
 GET     /images/:id                                                 controllers.MediaApi.getImage(id: String)
 GET     /images/:id/_elasticsearch                                  controllers.MediaApi.getImageFromElasticSearch(id: String)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -15,6 +15,8 @@ GET     /images/aggregations/date/:field                            controllers.
 # Reaping related
 GET     /images/nextIdsToBeSoftReaped                               controllers.MediaApi.nextIdsToBeSoftReaped(size: Int)
 GET     /images/nextIdsToBeHardReaped                               controllers.MediaApi.nextIdsToBeHardReaped(size: Int)
+DELETE  /images/batchSoftDelete                                     controllers.MediaApi.batchSoftDelete
+DELETE  /images/batchHardDelete                                     controllers.MediaApi.batchHardDelete
 
 # Images
 GET     /images/:id                                                 controllers.MediaApi.getImage(id: String)
@@ -27,7 +29,7 @@ GET     /images/:imageId/export/:exportId/asset/:width/download     controllers.
 GET     /images/:imageId/export                                     controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                                   controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
-DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
+DELETE  /images/:id                                                 controllers.MediaApi.softDeleteImage(id: String)
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch


### PR DESCRIPTION
The 'reaper' has been turned off for many years and its implementation was never the most efficient. Thanks to the work in previous PRs (notably https://github.com/guardian/grid/pull/3926) we can easily filter for images which meet the criteria for 'reaping'. 

The new approach will **first 'soft delete' reapable images for two weeks,** so they're not visible in the grid UI (unless the `is:deleted` filter is applied, note all queries have `-is:deleted` by default) and so there's a place to view the candidates for hard deletion for a period of time before they're actually hard deleted.

This PR introduces, four new `media-api` endpoints...

- `/images/nextIdsToBeSoftReaped` and `/images/nextIdsToBeHardReaped` to retrieve next X ids of reapable images (to facilitate the two phases of reaping) where X is the 'size' query param (max. 1000)`
- `/images/batchSoftDelete` and `/images/batchHardDelete` which take a JSON array of IDs in the body, then...
   1. deletes from S3 (main image, thumbs and optimised PNG [if applicable]) in bulk using the [S3 bulk delete API](https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-multiple-objects.html) (max. 1000)
   2. processes just the ES mutations in `thrall` (via mixin of a new `BatchExternalThrallMessage` message type) making use of the 'update-by-query' and 'delete-by-query' ES operations respectively

... these will be primarily utilised by a re-write of the scheduled 'reaper' lambda (see https://github.com/guardian/grid/pull/4135).

_Note, thanks to #4128 we have a way to restore images even once they've been hard deleted 🪄_ 