### PR TITLE
Bump exiftool dependency

### DIFF
--- a/scripts/inadvisable-metadata-backup/package.json
+++ b/scripts/inadvisable-metadata-backup/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@types/node": "^14.14.37",
     "aws-sdk": "^2.876.0",
-    "exiftool-vendored": "^14.3.0",
+    "exiftool-vendored": "^22.2.0",
     "shell-escape": "^0.2.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"

--- a/scripts/inadvisable-metadata-backup/yarn.lock
+++ b/scripts/inadvisable-metadata-backup/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@photostructure/tz-lookup@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@photostructure/tz-lookup/-/tz-lookup-8.0.0.tgz#9742eedc61e6cf75539f5adbb3d0d90dab7294ee"
+  integrity sha512-D5ggPEWSNGEKzKTx6+Gn0NZXHQ4ywgRd2p2h7i/tjEmkv/uJ9SzQd0o7v7FzEAt4bP3dxDoWm43aPfUs9qMOGg==
+
+"@types/luxon@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.2.tgz#f6e3524c2486b949a4db445e85d93c8e9886dfe2"
+  integrity sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ==
+
 "@types/node@^14.14.37":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
@@ -32,10 +42,10 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-batch-cluster@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/batch-cluster/-/batch-cluster-6.0.2.tgz#78f862a850fcf81bb0bc946239b1482f82c2339a"
-  integrity sha512-/I2OYHPGjBpncmuCMruwkSefD5CEUaF620lJgEwX2YSl3/3hKk5yiHO9rUPX1i4ra7MKlTFbQvv12aw5CGWXvg==
+batch-cluster@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/batch-cluster/-/batch-cluster-12.1.0.tgz#697f3e11d7bc49d6befea139025431efe0e1e16f"
+  integrity sha512-whGyJU4tr7kyg2USByu0/51mML5HsLAeNz5s03kMDYZNsQsGgDJgI47RdY3r7MciCjPkTaTD5O4eOVqOfEO7pg==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -66,28 +76,29 @@ events@1.1.1:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
-exiftool-vendored.exe@^12.25.0:
-  version "12.25.0"
-  resolved "https://registry.yarnpkg.com/exiftool-vendored.exe/-/exiftool-vendored.exe-12.25.0.tgz#16a0ba3e689d253ed4dcee66059431a08ea2dc1d"
-  integrity sha512-8JfXFUex8D0HtHOKA89f45IEBS2ZBMc39DvvcbK4DcT6egNLZdwduO/asHPUS9epY6iIaN2AokAdyqn8bKpzWw==
+exiftool-vendored.exe@12.65.0:
+  version "12.65.0"
+  resolved "https://registry.yarnpkg.com/exiftool-vendored.exe/-/exiftool-vendored.exe-12.65.0.tgz#28898bad74228be90f622068dda0d089af581aee"
+  integrity sha512-VDTSW3/u5bdLlg516g1oTypq2Sxd3I2pWTzdd5EmDtSjmvvBCLyDlMpv4Gnz8dnlQTRsEqwIgv/TAtdWykwEBg==
 
-exiftool-vendored.pl@^12.25.0:
-  version "12.25.0"
-  resolved "https://registry.yarnpkg.com/exiftool-vendored.pl/-/exiftool-vendored.pl-12.25.0.tgz#1649508cb1b084af0cc1776158b748b89a9ce3ec"
-  integrity sha512-AqNy26adsMiNiMYxq+E4RhLNoOXo9Bc3Add/tBl8I2zkjOO/6/zGP5EiMvXFooZfb406mJ3b6sokBPxfRBA+jQ==
+exiftool-vendored.pl@12.65.0:
+  version "12.65.0"
+  resolved "https://registry.yarnpkg.com/exiftool-vendored.pl/-/exiftool-vendored.pl-12.65.0.tgz#ad4f19da9be56055e5fb9dd40b395ccd998ff754"
+  integrity sha512-BpR+rwKLWqUAPbsW17fw+8FAmyijkMhjaLu3fWU2QX6rpBJnOfn+lQp4Txkq44avL1LDV+eQ8pbWXyimjkPw0Q==
 
-exiftool-vendored@^14.3.0:
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/exiftool-vendored/-/exiftool-vendored-14.3.0.tgz#5f209d01de7c63ec8954f8ef49c6332791dffc2d"
-  integrity sha512-qEwyt6U4NFcFxdIOyv4mAx/JJkf7zrGr9enSanTn8NPvq1hwExfs3DP9LdVR0iNWTu4AopndGQCdsL0SqynJEg==
+exiftool-vendored@^22.2.0:
+  version "22.2.0"
+  resolved "https://registry.yarnpkg.com/exiftool-vendored/-/exiftool-vendored-22.2.0.tgz#af2065d141de8d7edffce5a3b1efce0d06a27d85"
+  integrity sha512-NOGwIuQ386VQSjrV4YVZ0QI1dmoDVESfKmXsQwWBtcP0IBCrC9LJPhw5p3jR3jY9ehYi8sEdYWL1kI6fb/Ojaw==
   dependencies:
-    batch-cluster "^6.0.2"
+    "@photostructure/tz-lookup" "^8.0.0"
+    "@types/luxon" "^3.3.2"
+    batch-cluster "^12.1.0"
     he "^1.2.0"
-    luxon "^1.26.0"
-    tz-lookup "^6.1.25"
+    luxon "^3.4.2"
   optionalDependencies:
-    exiftool-vendored.exe "^12.25.0"
-    exiftool-vendored.pl "^12.25.0"
+    exiftool-vendored.exe "12.65.0"
+    exiftool-vendored.pl "12.65.0"
 
 he@^1.2.0:
   version "1.2.0"
@@ -114,10 +125,10 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-luxon@^1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
-  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
+luxon@^3.4.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.3.tgz#8ddf0358a9492267ffec6a13675fbaab5551315d"
+  integrity sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -178,11 +189,6 @@ typescript@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
-
-tz-lookup@^6.1.25:
-  version "6.1.25"
-  resolved "https://registry.yarnpkg.com/tz-lookup/-/tz-lookup-6.1.25.tgz#34d68a7e1ccfcb51f29a9893d2d48e4118d873cd"
-  integrity sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==
 
 url@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
## What does this change?

Small one to remove a high vulnerability. 

## How to test and measure success? ##

So interestingly, this is part of a particular script which, as far as I can tell, exists as a safety net if an image is missing its metadata, and would only get run manually by following the instructions in the [readme](https://github.com/guardian/grid/tree/main/scripts/inadvisable-metadata-backup). 

I tried running the tool with this command in my terminal: `AWS_PROFILE=$aws_profile ./run.sh $image_bucket $id`, filling in the variables with a random image from a test bucket. Running the command itself didn't completely succeed due to an issue with the aws-sdk version we're using (which it seems should be [bumped to v3](https://aws.amazon.com/blogs/developer/why-and-how-you-should-use-aws-sdk-for-javascript-v3-on-node-js-18/), but that feels just out of scope for this work of resolving a snyk vulnerability. Importantly, one of the commands that does seem to succeed in the script relates to the exiftool, which feels like sufficient proof that the dependency bump has worked. 





## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
