### PR TITLE
IMAGEDAM-1484 - Add label 'Collections' to icon in Navigation

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -8,8 +8,6 @@
     final -->
     <!-- We use $parent.editing here as ng-if creates it's own child scope -->
     <div class="flex-container collections-panel-heading text-small" ng-if="! ctrl.error">
-        <div class="flex-spacer">Collections</div>
-
         <button data-cy="edit-collections-button"
                 ng-class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
                 ng-click="$parent.editing = !$parent.editing"

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.html
@@ -8,6 +8,7 @@
     final -->
     <!-- We use $parent.editing here as ng-if creates it's own child scope -->
     <div class="flex-container collections-panel-heading text-small" ng-if="! ctrl.error">
+        <div class="flex-spacer"></div>
         <button data-cy="edit-collections-button"
                 ng-class="{'button-edit': ! $parent.editing, 'button-save': $parent.editing}"
                 ng-click="$parent.editing = !$parent.editing"

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -10,7 +10,7 @@
             gr-track-click="{{:: ctrl.trackingName}}"
             gr-track-click-data="ctrl.trackingData('Hide panel')"
             aria-label="Hide {{ctrl.name}} panel">
-        <gr-icon>{{ctrl.icon}}</gr-icon>
+        <gr-icon style="margin-bottom: 2.5px;">{{ctrl.icon}}</gr-icon>
         <span class="icon-label">{{ctrl.label}}</span>
     </button>
 

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -1,6 +1,6 @@
 <div class="fill-height flex-container"
      ng-class="{ 'flex-container--rtl': ctrl.position == 'right' }">
-    <button class="button-ico-square clickable"
+    <button class="button-ico-square clickable side-padded"
             type="button"
             ng-if="!ctrl.state.hidden"
             ng-click="ctrl.hidePanel()"
@@ -11,9 +11,10 @@
             gr-track-click-data="ctrl.trackingData('Hide panel')"
             aria-label="Hide {{ctrl.name}} panel">
         <gr-icon>{{ctrl.icon}}</gr-icon>
+        <span class="icon-label">{{ctrl.label}}</span>
     </button>
 
-    <button class="button-ico-square clickable"
+    <button class="button-ico-square clickable side-padded"
             type="button"
             ng-if="ctrl.state.hidden"
             ng-click="ctrl.showPanel()"
@@ -23,10 +24,11 @@
             gr-track-click-data="ctrl.trackingData('Show panel')"
             aria-label="Show {{ctrl.name}} panel">
         <gr-icon>{{ctrl.icon}}</gr-icon>
+        <span class="icon-label">{{ctrl.label}}</span>
     </button>
 
     <div ng-if="!ctrl.state.hidden">
-        <button class="button-ico-square clickable"
+        <button class="button-ico-square clickable side-padded"
                 type="button"
                 ng-if="!ctrl.state.locked"
                 ng-click="ctrl.lockPanel()"
@@ -35,7 +37,7 @@
                 aria-label="Lock {{ctrl.name}} panel">
             <gr-icon>lock_open</gr-icon>
         </button>
-        <button class="button-ico-square clickable"
+        <button class="button-ico-square clickable side-padded"
                 type="button"
                 ng-if="ctrl.state.locked"
                 ng-click="ctrl.unlockPanel()"

--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button.js
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button.js
@@ -66,6 +66,7 @@ panelButton.directive('grPanelButtonSmall', [function() {
             panel: '=grPanel',
             position: '@grPosition',
             name: '@grName',
+            label: '@grLabel',
             icon: '@grIcon'
         }
     };

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -16,6 +16,7 @@
                 gr-panel="ctrl.collectionsPanel"
                 gr-position="left"
                 gr-name="collections"
+                gr-label="Collections"
                 gr-icon="collections">
             </gr-panel-button-small>
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -468,7 +468,6 @@ button[disabled],
     padding: 4px;
 }
 .button-ico-square {
-    width: 36px;
     height: 36px;
 }
 


### PR DESCRIPTION
## What does this change?

To raise visibility and awareness of Collections, the word 'Collections' has been added next to the Collections icon in the navigation. The behaviour of this label must match the existing labels and as such is resizeable, so the text is removed when the user shrinks the page.

![image](https://github.com/guardian/grid/assets/129299738/0bb4bdf2-1077-461e-8b36-7eba691fd9bc)
![image](https://github.com/guardian/grid/assets/129299738/18866789-f4cf-4e9b-9897-83ce1052ec7c)

## How should a reviewer test this change?

These changes can be tested by confirming that when landing on BBC Images tester can clearly see the link to Collections in the navigation, in the same style as 'Show preview' and 'Show info panel' buttons. Clicking on the icon or the word 'Collections' opens up the Collections panel.

On smaller breakpoints where there isn't room for the full button just the icon should display - consistent with 'Show preview' and 'Show info panel' buttons which just display as icons.

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
