### PR TITLE
tiny layout fix following #4140

### DIFF
--- a/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
+++ b/kahuna/public/js/components/gr-panel-button/gr-panel-button-small.html
@@ -23,7 +23,7 @@
             gr-track-click="{{:: ctrl.trackingName}}"
             gr-track-click-data="ctrl.trackingData('Show panel')"
             aria-label="Show {{ctrl.name}} panel">
-        <gr-icon>{{ctrl.icon}}</gr-icon>
+        <gr-icon style="margin-bottom: 2.5px;">{{ctrl.icon}}</gr-icon>
         <span class="icon-label">{{ctrl.label}}</span>
     </button>
 


### PR DESCRIPTION
https://github.com/guardian/grid/pull/4140 added a label to the Collections icon in the top right. I [suggested](https://github.com/guardian/grid/pull/4140#discussion_r1329907847) a tweak of the icon position, but didn't realise there was a state for collapsed vs expanded collections panel... this PR applies the same tweak to collapsed state.