### PR TITLE
move `SoftDeletedMetadataTable` to `common-lib`

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -44,6 +44,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   val systemName: String = stringOpt("branding.systemName").filterNot(_.isEmpty).getOrElse("the Grid")
 
+  lazy val softDeletedMetadataTable: String = string("dynamo.table.softDelete.metadata")
+
   // Note: had to make these lazy to avoid init order problems ;_;
   val domainRoot: String = string("domain.root")
   val domainRootOverride: Option[String] = stringOpt("domain.root-override")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/SoftDeletedMetadataTable.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/SoftDeletedMetadataTable.scala
@@ -1,13 +1,14 @@
-package lib
+package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.lib.aws.DynamoDB
+import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.model.ImageStatusRecord
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 
 import scala.concurrent.ExecutionContext
 
-class SoftDeletedMetadataTable(config: MediaApiConfig) extends DynamoDB[ImageStatusRecord](config, config.softDeletedMetadataTable) {
+class SoftDeletedMetadataTable(config: CommonConfig) extends DynamoDB[ImageStatusRecord](config, config.softDeletedMetadataTable) {
   private val softDeletedMetadataTable = Table[ImageStatusRecord](table.getTableName)
 
   def getStatus(imageId: String)(implicit ex: ExecutionContext) = {

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -20,6 +20,7 @@ function getCommonConfig(config) {
         |es.index.aliases.migration="Images_Migration"
         |image.record.download=false
         |filters.shouldDisplayOrgOwnedCountAndFilterCheckbox=true
+        |dynamo.table.softDelete.metadata="SoftDeletedMetadataTable"
         ${isNoAuth ? '|authentication.providers.user="com.gu.mediaservice.lib.auth.provider.LocalAuthenticationProvider"' : ''}
         ${isNoAuth ? '|authorisation.provider="com.gu.mediaservice.lib.auth.provider.LocalAuthorisationProvider"' : ''}
         |`;
@@ -131,7 +132,6 @@ function getMediaApiConfig(config) {
         |quota.store.key="rcs-quota.json"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |metrics.request.enabled=false
-        |dynamo.table.softDelete.metadata="SoftDeletedMetadataTable"
         |syndication.review.useRuntimeFieldsFix=true
         |`;
 }

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,6 +1,7 @@
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
 import com.gu.mediaservice.lib.imaging.ImageOperations
-import com.gu.mediaservice.lib.management.{InnerServiceStatusCheckController, ElasticSearchHealthCheck, Management}
+import com.gu.mediaservice.lib.management.{ElasticSearchHealthCheck, InnerServiceStatusCheckController, Management}
+import com.gu.mediaservice.lib.metadata.SoftDeletedMetadataTable
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers._
 import lib._
@@ -30,9 +31,9 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)
 
-  val imageStatusTable = new SoftDeletedMetadataTable(config)
+  val softDeletedMetadataTable = new SoftDeletedMetadataTable(config)
 
-  val mediaApi = new MediaApi(auth, messageSender, imageStatusTable, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, wsClient, authorisation)
+  val mediaApi = new MediaApi(auth, messageSender, softDeletedMetadataTable, elasticSearch, imageResponse, config, controllerComponents, s3Client, mediaApiMetrics, wsClient, authorisation)
   val suggestionController = new SuggestionController(auth, elasticSearch, controllerComponents)
   val aggController = new AggregationController(auth, elasticSearch, controllerComponents)
   val usageController = new UsageController(auth, config, elasticSearch, usageQuota, controllerComponents)

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -30,8 +30,6 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val cloudFrontPrivateKeyBucketKey: Option[String] = stringOpt("cloudfront.private-key.key")
   val cloudFrontKeyPairId: Option[String]           = stringOpt("cloudfront.keypair.id")
 
- lazy val softDeletedMetadataTable: String = string("dynamo.table.softDelete.metadata")
-
   val rootUri: String = services.apiBaseUri
   val kahunaUri: String = services.kahunaBaseUri
   val cropperUri: String = services.cropperBaseUri

--- a/media-api/app/lib/SoftDeletedMetadataTable.scala
+++ b/media-api/app/lib/SoftDeletedMetadataTable.scala
@@ -2,25 +2,23 @@ package lib
 
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.model.ImageStatusRecord
-import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
-class SoftDeletedMetadataTable(config: MediaApiConfig) extends DynamoDB(config, config.softDeletedMetadataTable) {
-  private val softDeletedMetadataTable = Table[ImageStatusRecord](config.softDeletedMetadataTable)
+class SoftDeletedMetadataTable(config: MediaApiConfig) extends DynamoDB[ImageStatusRecord](config, config.softDeletedMetadataTable) {
+  private val softDeletedMetadataTable = Table[ImageStatusRecord](table.getTableName)
 
-  def getStatus(imageId: String) = {
+  def getStatus(imageId: String)(implicit ex: ExecutionContext) = {
     ScanamoAsync.exec(client)(softDeletedMetadataTable.get('id -> imageId))
   }
 
-  def setStatus(imageStatus: ImageStatusRecord) = {
+  def setStatus(imageStatus: ImageStatusRecord)(implicit ex: ExecutionContext) = {
     ScanamoAsync.exec(client)(softDeletedMetadataTable.put(imageStatus))
   }
 
-  def updateStatus(imageId: String, isDeleted: Boolean) = {
+  def updateStatus(imageId: String, isDeleted: Boolean)(implicit ex: ExecutionContext) = {
     val updateExpression = set('isDeleted -> isDeleted)
     ScanamoAsync.exec(client)(
       softDeletedMetadataTable


### PR DESCRIPTION
https://trello.com/c/DrGAH8Y0/893-turn-on-the-reaper

Following on from https://github.com/guardian/grid/pull/4143 (which moved 'reapable' eligibility logic into common) this PR moves the `SoftDeletedMetadataTable` to common (so that we can use it from both `media-api` and `thrall` in [upcoming PR](https://github.com/guardian/grid/pull/4145)). It's in its own PR to make it easier to review.

Also removes usage of the global execution context, in favour of an implicit param for execution context.

## IMPORTANT
This involves moving the `dynamo.table.softDelete.metadata` property from `media-api.conf` up to `common.conf`. Since this is a lazy val and only referenced in media-api, AFAICT nothing should break... but since it's going to be relied upon in https://github.com/guardian/grid/pull/4145 very soon and does no harm in `common.conf` it ought to be moved before this PR is merged.

#### Guardian checklist

- [x] `TEST`
- [x] `PROD`