### PR TITLE
[CI] only run the credentials and riff-raff steps for our own branches (not forks, since it will fail)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,6 @@ jobs:
         env:
           USE_DOCKER_FOR_TESTS: false # i.e. don't initialise the DockerContainer within tests, instead rely on the ones defined in the 'services' section of this file
         run: sbt clean compile Test/compile test Debian/packageBin
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
       - name: Image Counter Lambda
         working-directory: ./image-counter-lambda
         run: |
@@ -81,7 +77,13 @@ jobs:
           npm install-clean
           npm test
           npm run build
+      - uses: aws-actions/configure-aws-credentials@v4
+        if: "! github.event.pull_request.head.repo.fork"
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
       - uses: guardian/actions-riff-raff@v2
+        if: "! github.event.pull_request.head.repo.fork"
         with:
           projectName: media-service::grid::all
           buildNumberOffset: 7565


### PR DESCRIPTION
Although the CI is now running for external PRs (from forks) 👍 they're failing when they get to the credentials & riff-raff steps (as they're supposed to). This PR makes those last steps conditional, so external contributors still get their CI checks/tests. 

Related: https://github.com/guardian/grid/pull/4146 and https://github.com/guardian/grid/pull/4148