### PR TITLE
Use bigger runner for CI to avoid timeouts/failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'pr**'
 jobs:
   CI:
-    runs-on: ubuntu-latest
+    runs-on: 4core-ubuntu-latest
     permissions:
       # required by aws-actions/configure-aws-credentials
       id-token: write


### PR DESCRIPTION
Since #4146 the CI job has been timing out etc. intermittently as I think its just on the edge of CPU/memory capacity of a standard-runner. 

In this PR I'm bumping that up to `4core-ubuntu-latest`. This should also speed up the build but will cost money (cheaper than engineering time of restarting failed workflows and generally waiting on CI to test in `TEST` etc.)

### UPDATE
It took a while for a large runner to become available, but once it did the build was faster.