### PR TITLE
[reaper] fix display of 'recent records' and display last 48 hours of records instead

### DIFF
--- a/thrall/app/views/reaper.scala.html
+++ b/thrall/app/views/reaper.scala.html
@@ -35,7 +35,7 @@
                     <input type="submit" value="Pause">
                 </form>
             }
-            <h3>Recent Records</h3>
+            <h3>Records from last 48 hours</h3>
             @recentRecordKeys.map { key =>
                 <a href="@routes.ReaperController.reaperRecord(key)">@key</a><br/>
             }


### PR DESCRIPTION
https://trello.com/c/AxiYosIs/1791-fix-grid-reaper-recent-records-display

Noticed when unpausing the reaper (after https://trello.com/c/oNxloIHp/1763-commence-soft-clear-down-of-reaper-backlog-65m-images finished) that the recent records list was not displaying the most recent records, but instead an arbitrary set (because we now have over 1000 reaper record files).

### Tested in `TEST` ✅ 
<img width="454" alt="image" src="https://github.com/guardian/grid/assets/19289579/e1872973-c98f-4c41-bb61-85b03d3cb531">

