### PR TITLE
[reaper] count all soft and hard reapable images and publish metrics…

### DIFF
--- a/thrall/app/lib/ThrallMetrics.scala
+++ b/thrall/app/lib/ThrallMetrics.scala
@@ -10,6 +10,8 @@ class ThrallMetrics(config: ThrallConfig) extends CloudWatchMetrics(s"${config.s
 
   val softReaped = new CountMetric("SoftReaped")
   val hardReaped = new CountMetric("HardReaped")
+  val softReapable = new CountMetric("SoftReapable")
+  val hardReapable = new CountMetric("HardReapable")
 
   val failedDeletedImages = new CountMetric("FailedDeletedImages")
 

--- a/thrall/app/views/reaper.scala.html
+++ b/thrall/app/views/reaper.scala.html
@@ -30,12 +30,12 @@
                     <input type="submit" value="Resume">
                 </form>
             } else {
-                <p>Reaper is currently <strong>running<strong> (up to 1000 images every @interval)</p>
+                <p>Reaper is currently <strong>running</strong> (up to 1000 images every @interval)</p>
                 <form action="@routes.ReaperController.pauseReaper" method="POST">
                     <input type="submit" value="Pause">
                 </form>
             }
-            <h3>Records from last 48 hours</h3>
+            <h3>Records from last 48 hours (UTC timestamps)</h3>
             @recentRecordKeys.map { key =>
                 <a href="@routes.ReaperController.reaperRecord(key)">@key</a><br/>
             }


### PR DESCRIPTION
…so we can visualise how the rate we're reaping compares.

https://github.com/guardian/grid/pull/4145 introduced the `HardReaped` and `SoftReaped` metrics which show the amount of images hard and soft reaped respectively - which have been very useful. The reaping rate is proportional to the 7day rolling average of ingestion, so these two new metrics...
- `SoftReapable`
- `HardReapable` 

... will be useful to know whether the reaping rate is sufficient... or if it needs a rethink.