### PR TITLE
[reaper] reap at configured rate (rather than dynamic based on ingestion rate)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -223,8 +223,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   final def stringOpt(key: String): Option[String] = configuration.getOptional[String](key)
 
-  final def int(key: String): Int =
-    configuration.getOptional[Int](key) getOrElse missing(key, "integer")
+  final def intOpt(key: String): Option[Int] =  configuration.getOptional[Int](key)
 
   final def intDefault(key: String, default: Int): Int =
     configuration.getOptional[Int](key) getOrElse default

--- a/thrall/app/controllers/ReaperController.scala
+++ b/thrall/app/controllers/ReaperController.scala
@@ -36,8 +36,6 @@ class ReaperController(
   private val CONTROL_FILE_NAME = "PAUSED"
 
   private val INTERVAL = 15 minutes // based on max of 1000 per reap, this interval will max out at 96,000 images per day
-  private val ONE_WEEK = 7 days
-  private val REAPS_PER_WEEK = ONE_WEEK / INTERVAL
 
   implicit val logMarker: MarkerMap = MarkerMap()
 
@@ -46,35 +44,25 @@ class ReaperController(
     override val persistenceIdentifier: String = config.persistenceIdentifier
   }
 
-  config.maybeReaperBucket.foreach { reaperBucket =>
-    scheduler.scheduleAtFixedRate(
-      initialDelay = 0 seconds,
-      interval = INTERVAL,
-    ){ () =>
-      if(store.client.doesObjectExist(reaperBucket, CONTROL_FILE_NAME)) {
-        logger.info("Reaper is paused")
-        es.countTotalSoftReapable(isReapable).map(metrics.softReapable.increment(Nil, _).run)
-        es.countTotalHardReapable(isReapable).map(metrics.hardReapable.increment(Nil, _).run)
-      } else {
-        es.countImagesIngestedInLast(ONE_WEEK)(DateTime.now(DateTimeZone.UTC)).flatMap { imagesIngestedInLast7Days =>
-
-          val imagesIngestedPer15Mins = imagesIngestedInLast7Days / REAPS_PER_WEEK
-
-          val countOfImagesToReap = Math.min(imagesIngestedPer15Mins, 1000).toInt
-
-          if (countOfImagesToReap == 1000) {
-            logger.warn(s"Reaper is reaping at maximum rate of 1000 images per $INTERVAL. If this persists, the INTERVAL will need to become more frequent.")
-          }
-
+  (config.maybeReaperBucket, config.maybeReaperCountPerRun) match {
+    case (Some(reaperBucket), Some(countOfImagesToReap)) =>
+      scheduler.scheduleAtFixedRate(
+        initialDelay = 0 seconds,
+        interval = INTERVAL,
+      ){ () =>
+        if(store.client.doesObjectExist(reaperBucket, CONTROL_FILE_NAME)) {
+          logger.info("Reaper is paused")
+          es.countTotalSoftReapable(isReapable).map(metrics.softReapable.increment(Nil, _).run)
+          es.countTotalHardReapable(isReapable).map(metrics.hardReapable.increment(Nil, _).run)
+        } else {
           val deletedBy = "reaper"
-
           Future.sequence(Seq(
             doBatchSoftReap(countOfImagesToReap, deletedBy),
             doBatchHardReap(countOfImagesToReap, deletedBy)
           ))
         }
       }
-    }
+    case _ => logger.info("scheduled reaper will not run since 's3.reaper.bucket' and 'reaper.countPerRun' need to be configured in thrall.conf")
   }
 
   private def batchDeleteWrapper(count: Int)(func: (Int, String) => Future[JsValue]) = auth.async { request =>

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -34,6 +34,7 @@ class ThrallConfig(resources: GridConfigResources) extends CommonConfigWithElast
   val thumbnailBucket: String = string("s3.thumb.bucket")
 
   val maybeReaperBucket: Option[String] = stringOpt("s3.reaper.bucket")
+  val maybeReaperCountPerRun: Option[Int] = intOpt("reaper.countPerRun")
 
   val metadataTopicArn: String = string("indexed.image.sns.topic.arn")
 

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -12,18 +12,18 @@ import com.gu.mediaservice.model.usage.Usage
 import com.gu.mediaservice.syntax._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.script.Script
-import com.sksamuel.elastic4s.requests.searches.{SearchRequest, SearchResponse}
+import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.sort.SortOrder
 import com.sksamuel.elastic4s.requests.update.UpdateRequest
 import com.sksamuel.elastic4s.{ElasticDsl, Executor, Functor, Handler, Response}
 import lib.{BatchDeletionIds, ThrallMetrics}
-import org.joda.time.{DateTime, ReadableDuration}
+import org.joda.time.DateTime
 import play.api.libs.json._
 
 import scala.annotation.nowarn
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 object ImageNotDeletable extends Throwable("Image cannot be deleted")
@@ -291,13 +291,6 @@ class ElasticSearch(
       logMessageFromIndexName = indexName => s"ES7 un soft delete image $id in $indexName"
     ).map(_ => ElasticSearchUpdateResponse()))
   }
-
-  def countImagesIngestedInLast(duration: FiniteDuration)(now: DateTime)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = executeAndLog(
-    ElasticDsl.count(imagesCurrentAlias).query(
-      filters.date("uploadTime", from = now minusMillis duration.toMillis.toInt, to = now)
-    ),
-    s"count images in the last $duration (relative to $now)"
-  ).map(_.result.count)
 
   private def getNextBatchOfImageIdsForDeletion(query: Query, count: Int, deletionType: String)
                                                (implicit ex: ExecutionContext, logMarker: LogMarker) =

--- a/thrall/app/views/reaper.scala.html
+++ b/thrall/app/views/reaper.scala.html
@@ -1,6 +1,7 @@
 @(
     isPaused: Boolean,
     interval: String,
+    count: Int,
     recentRecordKeys: List[String],
 )
 
@@ -30,7 +31,7 @@
                     <input type="submit" value="Resume">
                 </form>
             } else {
-                <p>Reaper is currently <strong>running</strong> (up to 1000 images every @interval)</p>
+                <p>Reaper is currently <strong>running</strong> (up to @count images every @interval)</p>
                 <form action="@routes.ReaperController.pauseReaper" method="POST">
                     <input type="submit" value="Pause">
                 </form>


### PR DESCRIPTION
Thanks to #4168, we can see that although we do catch-up slightly each night, the amount of reapable images is slowing getting away from us...
![image](https://github.com/guardian/grid/assets/19289579/762375d9-bd96-43fe-9f97-1219baf4c7ae)

I had become a little fixated on avoiding config and tried to be too clever (trying to base the reaping rate on the 7day rolling average of ingestion in #4145) which isn't keeping up and is harder to reason about. 

Should've heeded the suggestion from prophet @andrew-nowak that reaping rate should be fixed/configured.

... this PR does exactly that; **[scheduled] reaping is now based on `reaper.countPerRun` config property**.

