### PR TITLE
Imagedam 1564 reapable eligibility conf

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ReapableEligibiltyResources.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ReapableEligibiltyResources.scala
@@ -1,0 +1,9 @@
+package com.gu.mediaservice.lib.cleanup
+
+import akka.actor.ActorSystem
+import com.gu.mediaservice.lib.config.{CommonConfig, CommonConfigWithElastic}
+
+/**
+  * Resources that can be injected into a dynamically loaded ReaperEligibility implementation
+  */
+case class ReapableEligibiltyResources(esConf: CommonConfigWithElastic, actorSystem: ActorSystem)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ReapableEligibilityLoader.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/ReapableEligibilityLoader.scala
@@ -1,0 +1,6 @@
+package com.gu.mediaservice.lib.config
+
+import com.gu.mediaservice.lib.cleanup.ReapableEligibiltyResources
+import com.gu.mediaservice.lib.elasticsearch.ReapableEligibility
+
+object ReapableEligibilityLoader extends ProviderLoader[ReapableEligibility, ReapableEligibiltyResources]("Reapable Eligibility")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ReapableEligibility.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ReapableEligibility.scala
@@ -3,8 +3,14 @@ package com.gu.mediaservice.lib.elasticsearch
 import com.sksamuel.elastic4s.ElasticDsl.matchAllQuery
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import org.joda.time.DateTime
+import com.gu.mediaservice.lib.config. Provider
+import scala.concurrent.Future
 
-trait ReapableEligibility {
+trait ReapableEligibility extends Provider{
+
+  def initialise(): Unit = {}
+  def shutdown(): Future[Unit] = Future.successful(())
+
 
   val persistedRootCollections: List[String] // typically from config
   val persistenceIdentifier: String // typically from config

--- a/dev/cloudformation/grid-dev-core.yml
+++ b/dev/cloudformation/grid-dev-core.yml
@@ -30,6 +30,9 @@ Resources:
   ThumbBucket:
     Type: AWS::S3::Bucket
 
+  ReaperBucket:
+    Type: AWS::S3::Bucket
+
   QuarantineBucket:
     Type: AWS::S3::Bucket
 

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -164,6 +164,7 @@ function getThrallConfig(config) {
         |aws.region="${config.AWS_DEFAULT_REGION}"
         |s3.image.bucket="${config.coreStackProps.ImageBucket}"
         |s3.thumb.bucket="${config.coreStackProps.ThumbBucket}"
+        |s3.reaper.bucket="${config.coreStackProps.ReaperBucket}"
         |persistence.identifier="picdarUrn"
         |indexed.image.sns.topic.arn="${config.coreStackProps.IndexedImageTopic}"
         |es6.url="${config.es6.url}"

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -84,10 +84,10 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val syncCheckerStream: Future[Done] = syncChecker.run()
 
   val softDeletedMetadataTable = new SoftDeletedMetadataTable(config)
-  val maybeReapable = config.maybeReapableEligibilityClass(applicationLifecycle)
+  val maybeCustomReapableEligibility = config.maybeReapableEligibilityClass(applicationLifecycle)
 
   val thrallController = new ThrallController(es, store, migrationSourceWithSender.send, messageSender, actorSystem, auth, config.services, controllerComponents, gridClient)
-  val reaperController = new ReaperController(es, store, authorisation, config, actorSystem.scheduler, maybeReapable, softDeletedMetadataTable, thrallMetrics, auth, config.services, controllerComponents)
+  val reaperController = new ReaperController(es, store, authorisation, config, actorSystem.scheduler, maybeCustomReapableEligibility, softDeletedMetadataTable, thrallMetrics, auth, config.services, controllerComponents)
   val healthCheckController = new HealthCheck(es, streamRunning.isCompleted, config, controllerComponents)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -84,9 +84,10 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
   val syncCheckerStream: Future[Done] = syncChecker.run()
 
   val softDeletedMetadataTable = new SoftDeletedMetadataTable(config)
+  val maybeReapable = config.maybeReapableEligibilityClass(applicationLifecycle)
 
   val thrallController = new ThrallController(es, store, migrationSourceWithSender.send, messageSender, actorSystem, auth, config.services, controllerComponents, gridClient)
-  val reaperController = new ReaperController(es, store, authorisation, config, actorSystem.scheduler, softDeletedMetadataTable, thrallMetrics, auth, config.services, controllerComponents)
+  val reaperController = new ReaperController(es, store, authorisation, config, actorSystem.scheduler, maybeReapable, softDeletedMetadataTable, thrallMetrics, auth, config.services, controllerComponents)
   val healthCheckController = new HealthCheck(es, streamRunning.isCompleted, config, controllerComponents)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 

--- a/thrall/app/controllers/ReaperController.scala
+++ b/thrall/app/controllers/ReaperController.scala
@@ -26,7 +26,7 @@ class ReaperController(
   authorisation: Authorisation,
   config: ThrallConfig,
   scheduler: Scheduler,
-  maybeReapable: Option[ReapableEligibility],
+  maybeCustomReapableEligibility: Option[ReapableEligibility],
   softDeletedMetadataTable: SoftDeletedMetadataTable,
   metrics: ThrallMetrics,
   override val auth: Authentication,
@@ -36,18 +36,15 @@ class ReaperController(
 
   private val CONTROL_FILE_NAME = "PAUSED"
 
-  private val INTERVAL = config.reaperInterval minutes //default 15 minutes, based on max of 1000 per reap, this interval will max out at 96,000 images per day
+  private val INTERVAL = config.reaperInterval //default 15 minutes, based on max of 1000 per reap, this interval will max out at 96,000 images per day
 
   implicit val logMarker: MarkerMap = MarkerMap()
 
-  private val isReapable = maybeReapable match {
-    case Some(reapable) => reapable
-    case None =>
-      logger.info("Reaper is not configured loading default ReapableEligibility")
-      new ReapableEligibility {
-        override val persistedRootCollections: List[String] = config.persistedRootCollections
-        override val persistenceIdentifier: String = config.persistenceIdentifier
-      }
+  private val isReapable = maybeCustomReapableEligibility getOrElse {
+    new ReapableEligibility {
+      override val persistedRootCollections: List[String] = config.persistedRootCollections
+      override val persistenceIdentifier: String = config.persistenceIdentifier
+    }
   }
 
   (config.maybeReaperBucket, config.maybeReaperCountPerRun) match {
@@ -59,7 +56,7 @@ class ReaperController(
         if(store.client.doesObjectExist(reaperBucket, CONTROL_FILE_NAME)) {
           logger.info("Reaper is paused")
           es.countTotalSoftReapable(isReapable).map(metrics.softReapable.increment(Nil, _).run)
-          es.countTotalHardReapable(isReapable, config.hardDeleteImagesAge).map(metrics.hardReapable.increment(Nil, _).run)
+          es.countTotalHardReapable(isReapable, config.hardReapImagesAge).map(metrics.hardReapable.increment(Nil, _).run)
         } else {
           val deletedBy = "reaper"
           Future.sequence(Seq(
@@ -138,12 +135,12 @@ class ReaperController(
 
   def doBatchHardReap(count: Int, deletedBy: String): Future[JsValue] = persistedBatchDeleteOperation("hard"){
 
-    es.countTotalHardReapable(isReapable, config.hardDeleteImagesAge).map(metrics.hardReapable.increment(Nil, _).run)
+    es.countTotalHardReapable(isReapable, config.hardReapImagesAge).map(metrics.hardReapable.increment(Nil, _).run)
 
     logger.info(s"Hard deleting next $count images...")
 
     (for {
-      BatchDeletionIds(esIds, esIdsActuallyDeleted) <- es.hardDeleteNextBatchOfImages(isReapable, count, config.hardDeleteImagesAge)
+      BatchDeletionIds(esIds, esIdsActuallyDeleted) <- es.hardDeleteNextBatchOfImages(isReapable, count, config.hardReapImagesAge)
       mainImagesS3Deletions <- store.deleteOriginals(esIdsActuallyDeleted)
       thumbsS3Deletions <- store.deleteThumbnails(esIdsActuallyDeleted)
       pngsS3Deletions <- store.deletePNGs(esIdsActuallyDeleted)

--- a/thrall/app/controllers/ReaperController.scala
+++ b/thrall/app/controllers/ReaperController.scala
@@ -26,6 +26,7 @@ class ReaperController(
   authorisation: Authorisation,
   config: ThrallConfig,
   scheduler: Scheduler,
+  maybeReapable: Option[ReapableEligibility],
   softDeletedMetadataTable: SoftDeletedMetadataTable,
   metrics: ThrallMetrics,
   override val auth: Authentication,
@@ -35,13 +36,18 @@ class ReaperController(
 
   private val CONTROL_FILE_NAME = "PAUSED"
 
-  private val INTERVAL = 15 minutes // based on max of 1000 per reap, this interval will max out at 96,000 images per day
+  private val INTERVAL = config.reaperInterval minutes //default 15 minutes, based on max of 1000 per reap, this interval will max out at 96,000 images per day
 
   implicit val logMarker: MarkerMap = MarkerMap()
 
-  private val isReapable = new ReapableEligibility {
-    override val persistedRootCollections: List[String] = config.persistedRootCollections
-    override val persistenceIdentifier: String = config.persistenceIdentifier
+  private val isReapable = maybeReapable match {
+    case Some(reapable) => reapable
+    case None =>
+      logger.info("Reaper is not configured loading default ReapableEligibility")
+      new ReapableEligibility {
+        override val persistedRootCollections: List[String] = config.persistedRootCollections
+        override val persistenceIdentifier: String = config.persistenceIdentifier
+      }
   }
 
   (config.maybeReaperBucket, config.maybeReaperCountPerRun) match {
@@ -53,7 +59,7 @@ class ReaperController(
         if(store.client.doesObjectExist(reaperBucket, CONTROL_FILE_NAME)) {
           logger.info("Reaper is paused")
           es.countTotalSoftReapable(isReapable).map(metrics.softReapable.increment(Nil, _).run)
-          es.countTotalHardReapable(isReapable).map(metrics.hardReapable.increment(Nil, _).run)
+          es.countTotalHardReapable(isReapable, config.hardDeleteImagesAge).map(metrics.hardReapable.increment(Nil, _).run)
         } else {
           val deletedBy = "reaper"
           Future.sequence(Seq(
@@ -132,12 +138,12 @@ class ReaperController(
 
   def doBatchHardReap(count: Int, deletedBy: String): Future[JsValue] = persistedBatchDeleteOperation("hard"){
 
-    es.countTotalHardReapable(isReapable).map(metrics.hardReapable.increment(Nil, _).run)
+    es.countTotalHardReapable(isReapable, config.hardDeleteImagesAge).map(metrics.hardReapable.increment(Nil, _).run)
 
     logger.info(s"Hard deleting next $count images...")
 
     (for {
-      BatchDeletionIds(esIds, esIdsActuallyDeleted) <- es.hardDeleteNextBatchOfImages(isReapable, count)
+      BatchDeletionIds(esIds, esIdsActuallyDeleted) <- es.hardDeleteNextBatchOfImages(isReapable, count, config.hardDeleteImagesAge)
       mainImagesS3Deletions <- store.deleteOriginals(esIdsActuallyDeleted)
       thumbsS3Deletions <- store.deleteThumbnails(esIdsActuallyDeleted)
       pngsS3Deletions <- store.deletePNGs(esIdsActuallyDeleted)

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -9,6 +9,8 @@ import com.gu.mediaservice.lib.elasticsearch.ReapableEligibility
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import play.api.inject.ApplicationLifecycle
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.language.postfixOps
 
 case class KinesisReceiverConfig(
   override val awsRegion: String,
@@ -48,8 +50,8 @@ class ThrallConfig(resources: GridConfigResources) extends CommonConfigWithElast
 
   val projectionParallelism: Int = intDefault("thrall.projection.parallelism", 1)
 
-  val reaperInterval: Int = intDefault("reaper.interval", 15)
-  val hardDeleteImagesAge: Int = intDefault("hard.delete.images.age", 14) // soft deleted images age to be hard deleted by Reaper Controller
+  val reaperInterval: FiniteDuration = intDefault("reaper.interval", 15) minutes
+  val hardReapImagesAge: Int = intDefault("reaper.hard.daysInSoftDelete", 14) // soft deleted images age to be hard deleted by Reaper Controller
 
   def kinesisConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisStream, rewindFrom, this)
   def kinesisLowPriorityConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)

--- a/thrall/app/lib/ThrallConfig.scala
+++ b/thrall/app/lib/ThrallConfig.scala
@@ -3,9 +3,12 @@ package lib
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import com.gu.mediaservice.lib.aws.AwsClientBuilderUtils
-import com.gu.mediaservice.lib.config.{CommonConfigWithElastic, GridConfigResources}
+import com.gu.mediaservice.lib.config.{CommonConfigWithElastic, GridConfigResources, ReapableEligibilityLoader}
+import com.gu.mediaservice.lib.cleanup.ReapableEligibiltyResources
+import com.gu.mediaservice.lib.elasticsearch.ReapableEligibility
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
+import play.api.inject.ApplicationLifecycle
 
 case class KinesisReceiverConfig(
   override val awsRegion: String,
@@ -45,6 +48,14 @@ class ThrallConfig(resources: GridConfigResources) extends CommonConfigWithElast
 
   val projectionParallelism: Int = intDefault("thrall.projection.parallelism", 1)
 
+  val reaperInterval: Int = intDefault("reaper.interval", 15)
+  val hardDeleteImagesAge: Int = intDefault("hard.delete.images.age", 14) // soft deleted images age to be hard deleted by Reaper Controller
+
   def kinesisConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisStream, rewindFrom, this)
   def kinesisLowPriorityConfig: KinesisReceiverConfig = KinesisReceiverConfig(thrallKinesisLowPriorityStream, lowPriorityRewindFrom, this)
+
+  def maybeReapableEligibilityClass(applicationLifecycle: ApplicationLifecycle): Option[ReapableEligibility] = {
+    val configLoader = ReapableEligibilityLoader.singletonConfigLoader(ReapableEligibiltyResources(this, resources.actorSystem), applicationLifecycle)
+    configuration.getOptional[ReapableEligibility]("reaper.provider")(configLoader)
+  }
 }

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -344,19 +344,19 @@ class ElasticSearch(
     }
   }
 
-  private def hardReapableQuery(isReapable: ReapableEligibility, days: Int) = must(
+  private def hardReapableQuery(isReapable: ReapableEligibility, daysInSoftDeletedState: Int) = must(
     isReapable.query,
     filters.existsOrMissing("softDeletedMetadata", exists = true), // already soft deleted
-    rangeQuery("softDeletedMetadata.deleteTime").lt(DateTime.now.minusDays(days).toString) // soft deleted more than 2 weeks ago (default)
+    rangeQuery("softDeletedMetadata.deleteTime").lt(DateTime.now.minusDays(daysInSoftDeletedState).toString) // soft deleted more than 2 weeks ago (default)
   )
 
-  def countTotalHardReapable(isReapable: ReapableEligibility, days: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] =
-    countTotalReapable(hardReapableQuery(isReapable, days), "hard")
+  def countTotalHardReapable(isReapable: ReapableEligibility, daysInSoftDeletedState: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] =
+    countTotalReapable(hardReapableQuery(isReapable, daysInSoftDeletedState), "hard")
 
-  def hardDeleteNextBatchOfImages(isReapable: ReapableEligibility, count: Int, days: Int)
+  def hardDeleteNextBatchOfImages(isReapable: ReapableEligibility, count: Int, daysInSoftDeletedState: Int)
                                  (implicit ex: ExecutionContext, logMarker: LogMarker): Future[BatchDeletionIds] = {
 
-    val query = hardReapableQuery(isReapable, days)
+    val query = hardReapableQuery(isReapable, daysInSoftDeletedState)
 
     for {
       // unfortunately 'deleteByQuery' doesn't return the affected IDs so can't do this whole thing in one operation - https://github.com/elastic/elasticsearch/issues/45460

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -344,19 +344,19 @@ class ElasticSearch(
     }
   }
 
-  private def hardReapableQuery(isReapable: ReapableEligibility) = must(
+  private def hardReapableQuery(isReapable: ReapableEligibility, days: Int) = must(
     isReapable.query,
     filters.existsOrMissing("softDeletedMetadata", exists = true), // already soft deleted
-    rangeQuery("softDeletedMetadata.deleteTime").lt(DateTime.now.minusWeeks(2).toString) // soft deleted more than 2 weeks ago
+    rangeQuery("softDeletedMetadata.deleteTime").lt(DateTime.now.minusDays(days).toString) // soft deleted more than 2 weeks ago (default)
   )
 
-  def countTotalHardReapable(isReapable: ReapableEligibility)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] =
-    countTotalReapable(hardReapableQuery(isReapable), "hard")
+  def countTotalHardReapable(isReapable: ReapableEligibility, days: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] =
+    countTotalReapable(hardReapableQuery(isReapable, days), "hard")
 
-  def hardDeleteNextBatchOfImages(isReapable: ReapableEligibility, count: Int)
+  def hardDeleteNextBatchOfImages(isReapable: ReapableEligibility, count: Int, days: Int)
                                  (implicit ex: ExecutionContext, logMarker: LogMarker): Future[BatchDeletionIds] = {
 
-    val query = hardReapableQuery(isReapable)
+    val query = hardReapableQuery(isReapable, days)
 
     for {
       // unfortunately 'deleteByQuery' doesn't return the affected IDs so can't do this whole thing in one operation - https://github.com/elastic/elasticsearch/issues/45460


### PR DESCRIPTION
## What does this change?
reads ReapableEligibility trait implementation from configuration if it exists `reaper.provider`
<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

without defining the`reaper.provider` configuration it should behave the same as the current implementation
with defining the`reaper.provider` configuration 
i.e. reaper.provider = "com.gu.mediaservice.lib.CustomReaper"
it should use this implementation of the ReapableEligibility trait

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
