### PR TITLE
[graphic content] log `user` and `shouldFlagGraphicImages` as markers for every image search

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -117,8 +117,7 @@ class ElasticSearch(
     )
   }
 
-  def search(params: SearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[SearchResults] = {
-    implicit val logMarker = MarkerMap()
+  def search(params: SearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal], logMarker:MarkerMap = MarkerMap()): Future[SearchResults] = {
 
     val isPotentiallyGraphicFieldName = "isPotentiallyGraphic"
 


### PR DESCRIPTION
… so we can pull stats on uptake of blurring functionality

You can see these being surfaced in logs like so...
<img width="508" alt="image" src="https://github.com/guardian/grid/assets/19289579/718eba83-63a6-441d-923c-478f72ec1316">
<img width="648" alt="image" src="https://github.com/guardian/grid/assets/19289579/fe0e938b-d640-4942-b64d-fa266c0920c9">
