### PR TITLE
Change upload description control to have non-funny prompt

### DIFF
--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -153,36 +153,10 @@ jobs.controller('DescriptionPlaceholderCtrl',
                 ['$scope',
                  function($scope) {
 
-    var people = [
-        'George Osborne',
-        'A teary Nick Clegg',
-        'Pop singer Rihanna',
-        'US actress and director Angelina Jolie',
-        'George W. Bush'
-    ];
-
-    var actions = [
-        'eating',
-        'caught with',
-        'wrestling',
-        'chants while marching for a third night of protests about',
-        'making a toast to'
-    ];
-
-    var things = [
-        'a large pheasant burger',
-        'two human-sized rubber ducks',
-        'a proposal for a new Union Jack',
-        'the recently passed Owning The Internet bill',
-        'the first crewed spaceship to reach Mars',
-        'the largest ever koala recorded in history'
-    ];
-
-    function random(array) {
-        var index = Math.floor(Math.random() * array.length);
-        return array[index];
+    function descriptionPrompt() {
+      return 'Give some context about the image including who, what, where, when and why';
     }
 
-    $scope.funnyDescription = [people, actions, things].map(random).join(' ');
+    $scope.funnyDescription = descriptionPrompt();
 
 }]);

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -153,10 +153,6 @@ jobs.controller('DescriptionPlaceholderCtrl',
                 ['$scope',
                  function($scope) {
 
-    function descriptionPrompt() {
-      return 'Give some context about the image including who, what, where, when and why';
-    }
-
-    $scope.funnyDescription = descriptionPrompt();
+    $scope.funnyDescription = 'Give some context about the image including who, what, where, when and why';
 
 }]);


### PR DESCRIPTION
## What does this change do?
Changes the prompt in the description field on the Upload page.

When testing the addition of keywords to the upload page BBC BA spotted the 'funny descriptions' that appear if the upload file name is deleted in the description field. Consenus in the team was that these personalised messages were a bit inappropriate and should be replaced by something less likely to offend.

## How should a reviewer test this change?

Go to recent uploads and upload a file - delete the content of the description field and review the eg. propmt that is presented it should read 'eg Give some context about the image including who, what, where, when and why'

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
