### PR TITLE
fix regression bug when adding labels/people to collection of images

### DIFF
--- a/kahuna/public/js/edits/list-editor.js
+++ b/kahuna/public/js/edits/list-editor.js
@@ -67,7 +67,7 @@ listEditor.controller('ListEditorCtrl', [
 
           //-clear removed list-
           let ctrlElementName = ctrl.elementNamePlural ? ctrl.elementNamePlural : ctrl.elementName;
-          if (removedElements.length > 0 && ctrlElementName === elementName) {
+          if (removedElements && removedElements.length > 0 && ctrlElementName === elementName) {
             ctrl.images.forEach(img => {
               if (img.uri === originatingImage) {
                 ctrl.imageRemovedElements = [];


### PR DESCRIPTION
fix regression bug when adding labels/people to collection of images via info panel

## What does this change?

Adds null check for variable added as part of work on upload page but not reuired or used here

## How should a reviewer test this change?

Ensure that adding labels to multiple images works from info panel when label exists on 1 image but not the others

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
