### PR TITLE
fix the zipping of `image-counter-lambda` as was failing to execute

### DIFF
--- a/image-counter-lambda/package.json
+++ b/image-counter-lambda/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "compile": "ncc build src/handler.ts -o dist -m -e aws-sdk -s && (cd dist; zip image-counter-lambda.zip index.js)"
+    "compile": "ncc build src/handler.ts -o dist -m -e aws-sdk -s && (cd dist; zip image-counter-lambda.zip *)"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
…since 5th October 🤦‍️ (with `Cannot find module './sourcemap-register.js'`)

Made quite a boo boo in https://github.com/guardian/grid/pull/4146 where I was only ZIPing just `index.js` (rather than the whole dist dir as before by https://github.com/guardian/node-riffraff-artifact) - this PR puts that right.

Annoyingly this was missed as major reaping was going on at the same time, and I confused the alarms going off about image count (as they will have been firing from 'no data' rather than in breach of their threshold).