### PR TITLE
fix reporting of `searchResponseCount` as it was always 10k

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchClient.scala
@@ -82,7 +82,7 @@ trait ElasticSearchClient extends ElasticSearchExecutions with GridLogging {
   def countImages(indexName: String = imagesCurrentAlias): Future[ElasticSearchImageCounts] = {
     implicit val logMarker = MarkerMap()
     val queryCatCount = catCount(indexName) // document count only of index including live documents, not deleted documents which have not yet been removed by the merge process
-    val queryImageSearch = search(indexName) limit 0 // hits that match the query defined in the request
+    val queryImageSearch = search(indexName) trackTotalHits true limit 0 // hits that match the query defined in the request
     val queryStats = indexStats(indexName) // total accumulated values of an index for both primary and replica shards
     val indexForAlias = getIndexForAlias(indexName)
 


### PR DESCRIPTION
noticed the `management/imageCounts` endpoint of `media-api` was always reporting 10k as the `searchResponseCount` because it was lacking the `trackTotalHits`=`true` (like searches via the UI get by default) and hence was capping out.

Looks to have fixed things in `TEST`...
<img width="653" alt="image" src="https://github.com/guardian/grid/assets/19289579/9df3f0b3-2614-48ba-887b-6b33b94b335f">
