### PR TITLE
configurable default on/off for 'graphic image' blurring (with tooltip/explainer which must be acknowledged)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -38,6 +38,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   val requestMetricsEnabled: Boolean = boolean("metrics.request.enabled")
 
+  val defaultShouldBlurGraphicImages: Boolean = boolean("defaultShouldBlurGraphicImages")
+
   val staffPhotographerOrganisation: String = stringOpt("branding.staffPhotographerOrganisation").filterNot(_.isEmpty).getOrElse("GNM")
 
   val shouldDisplayOrgOwnedCountAndFilterCheckbox: Boolean = boolean("filters.shouldDisplayOrgOwnedCountAndFilterCheckbox")

--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -19,6 +19,7 @@ function getCommonConfig(config) {
         |es.index.aliases.current="Images_Current"
         |es.index.aliases.migration="Images_Migration"
         |image.record.download=false
+        |defaultShouldBlurGraphicImages=true
         |filters.shouldDisplayOrgOwnedCountAndFilterCheckbox=true
         |dynamo.table.softDelete.metadata="SoftDeletedMetadataTable"
         ${isNoAuth ? '|authentication.providers.user="com.gu.mediaservice.lib.auth.provider.LocalAuthenticationProvider"' : ''}

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -74,7 +74,8 @@
           imagePreviewFlagLeaseAttachedCopy: "@Html(kahunaConfig.imagePreviewFlagLeaseAttachedCopy)",
           useReaper: @kahunaConfig.useReaper.getOrElse(false),
           featureSwitches: @Html(featureSwitches),
-          telemetryUri: '@kahunaConfig.telemetryUri.getOrElse("")'
+          telemetryUri: '@kahunaConfig.telemetryUri.getOrElse("")',
+          defaultShouldBlurGraphicImages: @kahunaConfig.defaultShouldBlurGraphicImages,
         }
     </script>
 

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -44,7 +44,12 @@
                                 original comms email on 1 Nov 2023
                             </a>.
                         </p>
-                        <button class="button" ng-click="ctrl.acceptDefaultOfBlurringGraphicImages()">Acknowledge</button>
+                        <button id="acknowledge-blur-graphic-images-default"
+                                class="button"
+                                ng-click="ctrl.acceptDefaultOfBlurringGraphicImages()"
+                        >
+                            Acknowledge
+                        </button>
                     </div>
                 </div>
             </li>

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -5,7 +5,7 @@
             aria-label="Secondary navigation menu">
         <gr-icon>more_vert</gr-icon>
     </button>
-    <div class="drop-menu__items drop-menu__items--right" ng-if="ctrl.showUserActions">
+    <div class="drop-menu__items drop-menu__items--right" ng-if="ctrl.showUserActions" ng-class="graphic-image-blur-explainer__spotlight">
         <ul class="drop-menu__items__separator">
             <li><a class="drop-menu__items__quotas" href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
             <li ng-repeat="additionalLink in ctrl.additionalLinks">
@@ -17,13 +17,35 @@
             </li>
             <li><a class="drop-menu__items__feedback" ng-href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
             <li>
-                <div>
+                <div ng-if="ctrl.isYetToAcknowledgeBlurGraphicImages"
+                     class="graphic-image-blur-explainer__background">
+                </div>
+                <div ng-class="{
+                    'graphic-image-blur-explainer__spotlight': ctrl.isYetToAcknowledgeBlurGraphicImages
+                }">
                     <label style="cursor: pointer">
                         Blur potentially graphic images&nbsp;
                         <input type="checkbox"
                                ng-model="ctrl.shouldBlurGraphicImages"
                                ng-change="ctrl.toggleShouldBlurGraphicImages()">
                     </label>
+                    <div ng-if="ctrl.isYetToAcknowledgeBlurGraphicImages"
+                         class="graphic-image-blur-explainer__tooltip">
+                        <strong>Potentially upsetting/graphic images are now blurred in the Grid with a new setting that is switched on by default.</strong>
+                        <p>
+                            Should you need to see a blurred image, simply hover over it.<br/>
+                            You can also hover over the title beneath the blur to see the description
+                            before deciding whether to reveal the image.<br/>
+                            This feature is now on by default, but can be turned off/on at any time via the top-right menu.<br/>
+                            Flagging relies on agency metadata, checked against a
+                            <a href="https://docs.google.com/document/d/1Ltu8fQRXfPLtbgOKRc0z9s-ErgPl1F4DWG9duiWp7wA/edit?usp=sharing">list of criteria</a>,
+                            and may not catch images that are not appropriately described. For more information, please see the
+                            <a href="https://docs.google.com/document/d/1Xxh6dfkPfFZo9_EeqRa2gmKhEy-BBQ_UVRXQwMw-WFI/edit?usp=sharing">
+                                original comms email on 1 Nov 2023
+                            </a>.
+                        </p>
+                        <button class="button" ng-click="ctrl.acceptDefaultOfBlurringGraphicImages()">Acknowledge</button>
+                    </div>
                 </div>
             </li>
         </ul>

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -1,11 +1,11 @@
 <nav class="user-actions drop-menu" aria-label="Secondary">
     <button class="drop-menu__button"
             type="button"
-            ng-click="showUserActions = !showUserActions"
+            ng-click="ctrl.showUserActions = !ctrl.showUserActions"
             aria-label="Secondary navigation menu">
         <gr-icon>more_vert</gr-icon>
     </button>
-    <div class="drop-menu__items drop-menu__items--right" ng-if="showUserActions">
+    <div class="drop-menu__items drop-menu__items--right" ng-if="ctrl.showUserActions">
         <ul class="drop-menu__items__separator">
             <li><a class="drop-menu__items__quotas" href="/quotas" rel="noopener" target="_blank">Quotas</a></li>
             <li ng-repeat="additionalLink in ctrl.additionalLinks">
@@ -18,7 +18,12 @@
             <li><a class="drop-menu__items__feedback" ng-href="{{ctrl.feedbackFormLink}}" rel="noopener" target="_blank">Feedback</a></li>
             <li>
                 <div>
-                    <label>Blur potentially graphic images <input type="checkbox" ng-model="ctrl.shouldBlurGraphicImages" ng-change="ctrl.syncShouldBlurGraphicImages()"></label>
+                    <label style="cursor: pointer">
+                        Blur potentially graphic images&nbsp;
+                        <input type="checkbox"
+                               ng-model="ctrl.shouldBlurGraphicImages"
+                               ng-change="ctrl.toggleShouldBlurGraphicImages()">
+                    </label>
                 </div>
             </li>
         </ul>

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -34,7 +34,7 @@
                         <strong>Potentially upsetting/graphic images are now blurred in the Grid with a new setting that is switched on by default.</strong>
                         <p>
                             Should you need to see a blurred image, simply hover over it.<br/>
-                            You can also hover over the title beneath the blur to see the description
+                            You can also hover over the title beneath the blur to see the caption
                             before deciding whether to reveal the image.<br/>
                             This feature is now on by default, but can be turned off/on at any time via the top-right menu.<br/>
                             Flagging relies on agency metadata, checked against a

--- a/kahuna/public/js/common/user-actions.js
+++ b/kahuna/public/js/common/user-actions.js
@@ -1,31 +1,22 @@
 import angular from 'angular';
-import 'angular-cookies';
 import template from './user-actions.html';
 import '../components/gr-feature-switch-panel/gr-feature-switch-panel';
+import {graphicImageBlurService} from "../services/graphic-image-blur";
 
-export const COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES = 'SHOULD_BLUR_GRAPHIC_IMAGES';
-const cookieOptions = {domain: `.${window.location.host}`, path: '/'};
-
-export var userActions = angular.module('kahuna.common.userActions', ['gr.featureSwitchPanel', 'ngCookies']);
+export var userActions = angular.module('kahuna.common.userActions', ['gr.featureSwitchPanel', graphicImageBlurService.name]);
 
 userActions.controller('userActionCtrl',
     [
-        '$cookies', function($cookies) {
+        '$scope', 'graphicImageBlurService', function($scope, graphicImageBlurService) {
             var ctrl = this;
 
             ctrl.$onInit = () => {
               ctrl.feedbackFormLink = window._clientConfig.feedbackFormLink;
               ctrl.logoutUri = document.querySelector('link[rel="auth-uri"]').href + "logout";
               ctrl.additionalLinks = window._clientConfig.additionalNavigationLinks;
-              ctrl.shouldBlurGraphicImages = $cookies.get(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES) === "true";
-              ctrl.syncShouldBlurGraphicImages = () => {
-                if (ctrl.shouldBlurGraphicImages){
-                  $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, "true", cookieOptions);
-                } else {
-                  $cookies.remove(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, cookieOptions);
-                }
-                window.location.reload();
-              };
+              ctrl.shouldBlurGraphicImages = graphicImageBlurService.shouldBlurGraphicImages;
+              ctrl.toggleShouldBlurGraphicImages = graphicImageBlurService.toggleShouldBlurGraphicImages;
+              ctrl.showUserActions = graphicImageBlurService.isYetToAcknowledgeBlurGraphicImages; // expand user actions until blurring is acknowledged
             };
         }]);
 

--- a/kahuna/public/js/common/user-actions.js
+++ b/kahuna/public/js/common/user-actions.js
@@ -23,6 +23,12 @@ userActions.controller('userActionCtrl',
                 ctrl.showUserActions = false;
               };
               ctrl.showUserActions = graphicImageBlurService.isYetToAcknowledgeBlurGraphicImages; // expand user actions until blurring is acknowledged
+              if (ctrl.isYetToAcknowledgeBlurGraphicImages) {
+                setTimeout(
+                  () => document.getElementById("acknowledge-blur-graphic-images-default")?.focus(),
+                  250
+                );
+              }
             };
         }]);
 

--- a/kahuna/public/js/common/user-actions.js
+++ b/kahuna/public/js/common/user-actions.js
@@ -16,6 +16,12 @@ userActions.controller('userActionCtrl',
               ctrl.additionalLinks = window._clientConfig.additionalNavigationLinks;
               ctrl.shouldBlurGraphicImages = graphicImageBlurService.shouldBlurGraphicImages;
               ctrl.toggleShouldBlurGraphicImages = graphicImageBlurService.toggleShouldBlurGraphicImages;
+              ctrl.isYetToAcknowledgeBlurGraphicImages = graphicImageBlurService.isYetToAcknowledgeBlurGraphicImages;
+              ctrl.acceptDefaultOfBlurringGraphicImages = () => {
+                graphicImageBlurService.acceptDefaultOfBlurringGraphicImages();
+                ctrl.isYetToAcknowledgeBlurGraphicImages = false;
+                ctrl.showUserActions = false;
+              };
               ctrl.showUserActions = graphicImageBlurService.isYetToAcknowledgeBlurGraphicImages; // expand user actions until blurring is acknowledged
             };
         }]);

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -47,7 +47,10 @@
             ng-src="{{::ctrl.image.data.thumbnail | assetFile}}"/>
     </a>
 
-    <span ng-if="ctrl.selectionMode" class="preview__no-link">
+    <span ng-if="ctrl.selectionMode"
+          class="preview__no-link"
+          ng-class="{'is-potentially-graphic': ctrl.image.isPotentiallyGraphic}"
+    >
         <div class="preview__fade"></div>
         <img class="preview__image"
              ng-class="{'preview__image--staff': ctrl.states.isStaffPhotographer}"

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -16,6 +16,7 @@ import '../services/image-accessor';
 import '../components/gr-add-label/gr-add-label';
 import '../components/gr-archiver-status/gr-archiver-status';
 import '../components/gr-syndication-icon/gr-syndication-icon';
+import {graphicImageBlurService} from "../services/graphic-image-blur";
 
 export var image = angular.module('kahuna.preview.image', [
     'gr.image.service',
@@ -27,7 +28,8 @@ export var image = angular.module('kahuna.preview.image', [
     'gr.syndicationIcon',
     'util.rx',
     'kahuna.imgops',
-    'util.storage'
+    'util.storage',
+    graphicImageBlurService.name
 ]);
 
 image.controller('uiPreviewImageCtrl', [
@@ -40,6 +42,7 @@ image.controller('uiPreviewImageCtrl', [
   'labelService',
   'imageAccessor',
   'storage',
+  'graphicImageBlurService',
   function (
       $scope,
       inject$,
@@ -49,7 +52,8 @@ image.controller('uiPreviewImageCtrl', [
       imageUsagesService,
       labelService,
       imageAccessor,
-      storage) {
+      storage,
+      graphicImageBlurService) {
     var ctrl = this;
 
     ctrl.$onInit = () => {
@@ -82,23 +86,7 @@ image.controller('uiPreviewImageCtrl', [
           `${window._clientConfig.staffPhotographerOrganisation}-owned: ${ctrl.image.data.metadata.description}` :
           ctrl.image.data.metadata.description;
 
-      ctrl.image.isPotentiallyGraphic = $rootScope.shouldBlurGraphicImages && (ctrl.image.data.isPotentiallyGraphic || !![
-        'graphic content',
-        'depicts death',
-        'dead child',
-        'child casualty',
-        'sensitive material',
-        'dead body',
-        'dead bodies',
-        'body of',
-        'bodies of',
-        'smout' // this is short for sensitive material out, often used in specialInstructions
-      ].find( searchPhrase =>
-        ctrl.image.data?.metadata?.description?.toLowerCase()?.includes(searchPhrase) ||
-        ctrl.image.data?.metadata?.title?.toLowerCase()?.includes(searchPhrase) ||
-        ctrl.image.data?.metadata?.specialInstructions?.toLowerCase()?.includes(searchPhrase) ||
-        ctrl.image.data?.metadata?.keywords?.find(keyword => keyword?.toLowerCase()?.includes(searchPhrase))
-      ));
+      ctrl.image.isPotentiallyGraphic = graphicImageBlurService.isPotentiallyGraphic(ctrl.image);
 
       ctrl.flagState = ctrl.states.costState;
 

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import 'angular-cookies';
 import Rx from 'rx';
 import moment from 'moment';
 
@@ -19,7 +18,6 @@ import '../components/gr-downloader/gr-downloader';
 import '../components/gr-batch-export-original-images/gr-batch-export-original-images';
 import '../components/gr-panel-button/gr-panel-button';
 import '../components/gr-toggle-button/gr-toggle-button';
-import {COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES} from "../common/user-actions";
 
 export var results = angular.module('kahuna.search.results', [
     'kahuna.services.scroll-position',
@@ -37,8 +35,7 @@ export var results = angular.module('kahuna.search.results', [
     'gr.deleteImage',
     'gr.undeleteImage',
     'gr.panelButton',
-    'gr.toggleButton',
-    'ngCookies'
+    'gr.toggleButton'
 ]);
 
 
@@ -64,7 +61,6 @@ results.controller('SearchResultsCtrl', [
     '$timeout',
     '$log',
     '$q',
-    '$cookies',
     'inject$',
     'delay',
     'onNextEvent',
@@ -85,7 +81,6 @@ results.controller('SearchResultsCtrl', [
              $timeout,
              $log,
              $q,
-             $cookies,
              inject$,
              delay,
              onNextEvent,
@@ -99,8 +94,6 @@ results.controller('SearchResultsCtrl', [
              globalErrors) {
 
         const ctrl = this;
-
-        $rootScope.shouldBlurGraphicImages = $cookies.get(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES) === "true";
 
         // Panel control
         ctrl.metadataPanel    = panels.metadataPanel;

--- a/kahuna/public/js/services/graphic-image-blur.js
+++ b/kahuna/public/js/services/graphic-image-blur.js
@@ -1,0 +1,42 @@
+import angular from "angular";
+import 'angular-cookies';
+
+const COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES = 'SHOULD_BLUR_GRAPHIC_IMAGES';
+const cookieOptions = {domain: `.${window.location.host}`, path: '/'};
+
+export const graphicImageBlurService = angular.module("kahuna.services.graphicImageBlur", ['ngCookies']).factory(
+  "graphicImageBlurService",
+  ['$cookies', function($cookies) {
+    const shouldBlurGraphicImagesCookieValue = $cookies.get(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES);
+    const isYetToAcknowledgeBlurGraphicImages = !shouldBlurGraphicImagesCookieValue; // i.e. cookie not set, one way or the other
+    const shouldBlurGraphicImages = (shouldBlurGraphicImagesCookieValue || "true") === "true"; // defaults to true
+    return {
+      shouldBlurGraphicImages,
+      isYetToAcknowledgeBlurGraphicImages,
+      toggleShouldBlurGraphicImages: () => {
+        const newCookieValue = (!shouldBlurGraphicImages).toString();
+        $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, newCookieValue, cookieOptions);
+        window.location.reload();
+      },
+      isPotentiallyGraphic: (image) => shouldBlurGraphicImages && (
+        image.data.isPotentiallyGraphic || // server can flag images as potentially graphic by inspecting deep in the metadata at query time (not available to the client)
+        !![
+          'graphic content',
+          'depicts death',
+          'dead child',
+          'child casualty',
+          'sensitive material',
+          'dead body',
+          'dead bodies',
+          'body of',
+          'bodies of',
+          'smout' // this is short for sensitive material out, often used in specialInstructions
+        ].find( searchPhrase =>
+          image.data?.metadata?.description?.toLowerCase()?.includes(searchPhrase) ||
+          image.data?.metadata?.title?.toLowerCase()?.includes(searchPhrase) ||
+          image.data?.metadata?.specialInstructions?.toLowerCase()?.includes(searchPhrase) ||
+          image.data?.metadata?.keywords?.find(keyword => keyword?.toLowerCase()?.includes(searchPhrase))
+        ))
+    };
+  }]
+);

--- a/kahuna/public/js/services/graphic-image-blur.js
+++ b/kahuna/public/js/services/graphic-image-blur.js
@@ -7,9 +7,10 @@ const cookieOptions = {domain: `.${window.location.host}`, path: '/'};
 export const graphicImageBlurService = angular.module("kahuna.services.graphicImageBlur", ['ngCookies']).factory(
   "graphicImageBlurService",
   ['$cookies', function($cookies) {
+    const defaultShouldBlurGraphicImages = window._clientConfig.defaultShouldBlurGraphicImages;
     const shouldBlurGraphicImagesCookieValue = $cookies.get(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES);
-    const isYetToAcknowledgeBlurGraphicImages = !shouldBlurGraphicImagesCookieValue; // i.e. cookie not set, one way or the other
-    const shouldBlurGraphicImages = (shouldBlurGraphicImagesCookieValue || "true") === "true"; // defaults to true
+    const isYetToAcknowledgeBlurGraphicImages = defaultShouldBlurGraphicImages && !shouldBlurGraphicImagesCookieValue; // i.e. cookie not set, one way or the other
+    const shouldBlurGraphicImages = (shouldBlurGraphicImagesCookieValue || defaultShouldBlurGraphicImages.toString()) === "true";
     return {
       shouldBlurGraphicImages,
       isYetToAcknowledgeBlurGraphicImages,

--- a/kahuna/public/js/services/graphic-image-blur.js
+++ b/kahuna/public/js/services/graphic-image-blur.js
@@ -18,6 +18,8 @@ export const graphicImageBlurService = angular.module("kahuna.services.graphicIm
         $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, newCookieValue, cookieOptions);
         window.location.reload();
       },
+      acceptDefaultOfBlurringGraphicImages: () =>
+        $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, "true", cookieOptions),
       isPotentiallyGraphic: (image) => shouldBlurGraphicImages && (
         image.data.isPotentiallyGraphic || // server can flag images as potentially graphic by inspecting deep in the metadata at query time (not available to the client)
         !![

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1545,6 +1545,44 @@ textarea.ng-invalid {
   opacity: 0;
 }
 
+.graphic-image-blur-explainer__background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding-top: 10vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.graphic-image-blur-explainer__spotlight {
+  z-index: 101;
+  position: relative;
+  outline: white solid 1px;
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+.graphic-image-blur-explainer__tooltip {
+  z-index: 101;
+  position: absolute;
+  width: 410px;
+  top: -4px;
+  left: -430px;
+  background: white;
+  color: black;
+  padding: 5px;
+  border-radius: 3px;
+  text-wrap: initial;
+}
+.graphic-image-blur-explainer__tooltip a {
+  color: black;
+  text-decoration: underline;
+}
+
 .preview__image.preview__image--staff {
     border: 10px solid #005689;
     box-sizing: border-box;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1582,6 +1582,10 @@ textarea.ng-invalid {
   color: black;
   text-decoration: underline;
 }
+.graphic-image-blur-explainer__tooltip a:focus {
+  outline: #00adee solid 2px;
+  outline-offset: 3px;
+}
 
 .preview__image.preview__image--staff {
     border: 10px solid #005689;

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -413,7 +413,8 @@ class MediaApi(
   def imageSearch() = auth.async { request =>
     implicit val r = request
 
-    val shouldFlagGraphicImages = request.cookies.get("SHOULD_BLUR_GRAPHIC_IMAGES").exists(_.value == "true")
+    // defaults to true if not specified
+    val shouldFlagGraphicImages = request.cookies.get("SHOULD_BLUR_GRAPHIC_IMAGES").map(_.value).getOrElse("true") == "true"
 
     implicit val logMarker = MarkerMap(
       "shouldFlagGraphicImages" -> shouldFlagGraphicImages,

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -413,8 +413,8 @@ class MediaApi(
   def imageSearch() = auth.async { request =>
     implicit val r = request
 
-    // defaults to true if not specified
-    val shouldFlagGraphicImages = request.cookies.get("SHOULD_BLUR_GRAPHIC_IMAGES").map(_.value).getOrElse("true") == "true"
+    val shouldFlagGraphicImages = request.cookies.get("SHOULD_BLUR_GRAPHIC_IMAGES")
+      .map(_.value).getOrElse(config.defaultShouldBlurGraphicImages.toString) == "true"
 
     implicit val logMarker = MarkerMap(
       "shouldFlagGraphicImages" -> shouldFlagGraphicImages,


### PR DESCRIPTION
Although we've proved out the value of #4174 (opt-in), usage remains fairly low (around 5%) - so this PR makes the default configurable.

If configured (`defaultShouldBlurGraphicImages = true` in `common.conf`), for users who've not yet used the feature (i.e. no `SHOULD_BLUR_GRAPHIC_IMAGES` cookie) then we now present a modal/overlay explaining the feature and the fact its on by default - which must be acknowledged (sets the cookie value to `"true"`) OR can be turned off via the tickbox (sets the cookie value to `"false"`)...

<img width="899" alt="image" src="https://github.com/guardian/grid/assets/19289579/f92c864a-3bf7-4bd1-9939-83e63ea35236">


Also includes refactor of all 'graphic image' blurring logic into its own Angular 'service'.

