### PR TITLE
FIX `acceptDefaultOfBlurringGraphicImages`

### DIFF
--- a/kahuna/public/js/services/graphic-image-blur.js
+++ b/kahuna/public/js/services/graphic-image-blur.js
@@ -19,8 +19,10 @@ export const graphicImageBlurService = angular.module("kahuna.services.graphicIm
         $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, newCookieValue, cookieOptions);
         window.location.reload();
       },
-      acceptDefaultOfBlurringGraphicImages: () =>
-        $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, "true", cookieOptions),
+      acceptDefaultOfBlurringGraphicImages: () => {
+        $cookies.put(COOKIE_SHOULD_BLUR_GRAPHIC_IMAGES, "true", cookieOptions);
+        window.location.reload();
+      },
       isPotentiallyGraphic: (image) => shouldBlurGraphicImages && (
         image.data.isPotentiallyGraphic || // server can flag images as potentially graphic by inspecting deep in the metadata at query time (not available to the client)
         !![


### PR DESCRIPTION
tiny fix to #4187 so that when navigating round the SPA (e.g. clicking on an image) user is not re-prompted with pop-up