### PR TITLE
fix wrapping on 'graphic content' explainer

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1576,7 +1576,8 @@ textarea.ng-invalid {
   color: black;
   padding: 5px;
   border-radius: 3px;
-  text-wrap: initial;
+  word-break: normal;
+  white-space: normal;
 }
 .graphic-image-blur-explainer__tooltip a {
   color: black;


### PR DESCRIPTION
…as it was spilling out in FF & Safari (turns out [`text-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) is an experimental property accepted only by chrome 🤦‍)

## Before
<img width="650" alt="image" src="https://github.com/guardian/grid/assets/19289579/8b8f04dd-ca22-4c05-9ac6-6265d3762658">

## After
<img width="653" alt="image" src="https://github.com/guardian/grid/assets/19289579/08825e09-db26-462f-8253-cd6fb7fd821a">
