### PR TITLE
make the 'graphic content blurring' explainer per-organisation

### DIFF
--- a/kahuna/public/js/common/blurring/GNM-explainer.html
+++ b/kahuna/public/js/common/blurring/GNM-explainer.html
@@ -1,0 +1,20 @@
+<div class="graphic-image-blur-explainer__tooltip">
+    <strong>Potentially upsetting/graphic images are now blurred in the Grid with a new setting that is switched on by default.</strong>
+    <p>
+        Should you need to see a blurred image, simply hover over it.<br/>
+        You can also hover over the title beneath the blur to see the caption
+        before deciding whether to reveal the image.<br/>
+        This feature is now on by default, but can be turned off/on at any time via the top-right menu.<br/>
+        Flagging relies on agency metadata, checked against a
+        <a href="https://docs.google.com/document/d/1Ltu8fQRXfPLtbgOKRc0z9s-ErgPl1F4DWG9duiWp7wA/edit?usp=sharing">list of criteria</a>,
+        and may not catch images that are not appropriately described. For more information, please see the
+        <a href="https://docs.google.com/document/d/1Xxh6dfkPfFZo9_EeqRa2gmKhEy-BBQ_UVRXQwMw-WFI/edit?usp=sharing">
+            original comms email on 1 Nov 2023</a>.
+    </p>
+    <button id="acknowledge-blur-graphic-images-default"
+            class="button"
+            ng-click="ctrl.acceptDefaultOfBlurringGraphicImages()"
+    >
+        Acknowledge
+    </button>
+</div>

--- a/kahuna/public/js/common/user-actions.html
+++ b/kahuna/public/js/common/user-actions.html
@@ -29,28 +29,10 @@
                                ng-model="ctrl.shouldBlurGraphicImages"
                                ng-change="ctrl.toggleShouldBlurGraphicImages()">
                     </label>
-                    <div ng-if="ctrl.isYetToAcknowledgeBlurGraphicImages"
-                         class="graphic-image-blur-explainer__tooltip">
-                        <strong>Potentially upsetting/graphic images are now blurred in the Grid with a new setting that is switched on by default.</strong>
-                        <p>
-                            Should you need to see a blurred image, simply hover over it.<br/>
-                            You can also hover over the title beneath the blur to see the caption
-                            before deciding whether to reveal the image.<br/>
-                            This feature is now on by default, but can be turned off/on at any time via the top-right menu.<br/>
-                            Flagging relies on agency metadata, checked against a
-                            <a href="https://docs.google.com/document/d/1Ltu8fQRXfPLtbgOKRc0z9s-ErgPl1F4DWG9duiWp7wA/edit?usp=sharing">list of criteria</a>,
-                            and may not catch images that are not appropriately described. For more information, please see the
-                            <a href="https://docs.google.com/document/d/1Xxh6dfkPfFZo9_EeqRa2gmKhEy-BBQ_UVRXQwMw-WFI/edit?usp=sharing">
-                                original comms email on 1 Nov 2023
-                            </a>.
-                        </p>
-                        <button id="acknowledge-blur-graphic-images-default"
-                                class="button"
-                                ng-click="ctrl.acceptDefaultOfBlurringGraphicImages()"
-                        >
-                            Acknowledge
-                        </button>
-                    </div>
+                    <ng-include ng-if="ctrl.isYetToAcknowledgeBlurGraphicImages"
+                                src="ctrl.explainerContentFile">
+                    </ng-include>
+
                 </div>
             </li>
         </ul>

--- a/kahuna/public/js/common/user-actions.js
+++ b/kahuna/public/js/common/user-actions.js
@@ -16,6 +16,7 @@ userActions.controller('userActionCtrl',
               ctrl.additionalLinks = window._clientConfig.additionalNavigationLinks;
               ctrl.shouldBlurGraphicImages = graphicImageBlurService.shouldBlurGraphicImages;
               ctrl.toggleShouldBlurGraphicImages = graphicImageBlurService.toggleShouldBlurGraphicImages;
+              ctrl.explainerContentFile = `/assets/js/common/blurring/${window._clientConfig.staffPhotographerOrganisation}-explainer.html`;
               ctrl.isYetToAcknowledgeBlurGraphicImages = graphicImageBlurService.isYetToAcknowledgeBlurGraphicImages;
               ctrl.acceptDefaultOfBlurringGraphicImages = () => {
                 graphicImageBlurService.acceptDefaultOfBlurringGraphicImages();


### PR DESCRIPTION
We need different organisation specific explainers for the 'graphic content' blurring, since it's 'opt-out' (see https://github.com/guardian/grid/pull/4187).

So based on the existing config property `branding.staffPhotographerOrganisation`, it loads the relevant HTML file from the new `public/js/common/blurring` directory (e.g. staffPhotographerOrganisation is `GNM` so loads `GNM-explainer.html` from that directory. This is rendered on top of the translucent overlay and the GNM implementation references the `graphic-image-blur-explainer__tooltip` class as before but allows for completely different styling/layout if needs be).

From a GNM perspective this is a no-op (which can be verified in `TEST` by deleting the `SHOULD_BLUR_GRAPHIC_IMAGES` cookie and reloading to reveal the explainer).