### PR TITLE
tweak reaper dashboard

### DIFF
--- a/thrall/app/views/reaper.scala.html
+++ b/thrall/app/views/reaper.scala.html
@@ -37,9 +37,11 @@
                 </form>
             }
             <h3>Records from last 48 hours (UTC timestamps)</h3>
+            <div style="font-family: monospace">
             @recentRecordKeys.map { key =>
                 <a href="@routes.ReaperController.reaperRecord(key)">@key</a><br/>
             }
+            </div>
         </main>
     </body>
 </html>


### PR DESCRIPTION
use monospace for list of reaper files, so letters & numbers line up vertically (given soft/hard prefix)

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/grid/assets/19289579/f9114a1c-7bc6-4a75-bc73-6f659587887a) | ![image](https://github.com/guardian/grid/assets/19289579/a3c0c7e5-2382-492f-bcd1-f58b5c2b409e) |