### PR TITLE
[graphic-content blurring] refine the blurring based on SMOUT (Sensitive Material Out)

### DIFF
--- a/kahuna/public/js/services/graphic-image-blur.js
+++ b/kahuna/public/js/services/graphic-image-blur.js
@@ -31,8 +31,8 @@ export const graphicImageBlurService = angular.module("kahuna.services.graphicIm
         window.location.reload();
       },
       isPotentiallyGraphic: (image) => shouldBlurGraphicImages && (
-        image.data.isPotentiallyGraphic || // server can flag images as potentially graphic by inspecting deep in the metadata at query time (not available to the client)
-        !![
+        image.data.isPotentiallyGraphic // server can flag images as potentially graphic by inspecting deep in the metadata at query time (not available to the client)
+        || !![
           'graphic content',
           'depicts death',
           'dead child',
@@ -41,14 +41,16 @@ export const graphicImageBlurService = angular.module("kahuna.services.graphicIm
           'dead body',
           'dead bodies',
           'body of',
-          'bodies of',
-          'smout' // this is short for sensitive material out, often used in specialInstructions
+          'bodies of'
         ].find( searchPhrase =>
           image.data?.metadata?.description?.toLowerCase()?.includes(searchPhrase) ||
           image.data?.metadata?.title?.toLowerCase()?.includes(searchPhrase) ||
           image.data?.metadata?.specialInstructions?.toLowerCase()?.includes(searchPhrase) ||
           image.data?.metadata?.keywords?.find(keyword => keyword?.toLowerCase()?.includes(searchPhrase))
         ))
+        // SMOUT is short for sensitive material out, often used in specialInstructions
+        || image.data?.metadata?.specialInstructions?.includes("SMOUT")
+        || !!image.data?.metadata?.keywords?.find(keyword => keyword?.toUpperCase() === "SMOUT")
     };
   }]
 );


### PR DESCRIPTION
Now only blur images where _smout_ in when it appears capitalised in special instructions or as an entire keyword (case in-sensitive). Crucially, no longer matching on title & description too (like the other search phrases) since this was causing many false positives e.g. when description includes the word `Portsmouth`.

Based on all the [horrific] images I've seen when searching for 'smout' which aren't Portsmouth football games, they consistently have `SMOUT` in special instructions.