### PR TITLE
[graphic-content blurring] fix ORing logic broken in #4208

### DIFF
--- a/kahuna/public/js/services/graphic-image-blur.js
+++ b/kahuna/public/js/services/graphic-image-blur.js
@@ -47,10 +47,11 @@ export const graphicImageBlurService = angular.module("kahuna.services.graphicIm
           image.data?.metadata?.title?.toLowerCase()?.includes(searchPhrase) ||
           image.data?.metadata?.specialInstructions?.toLowerCase()?.includes(searchPhrase) ||
           image.data?.metadata?.keywords?.find(keyword => keyword?.toLowerCase()?.includes(searchPhrase))
-        ))
+        )
         // SMOUT is short for sensitive material out, often used in specialInstructions
         || image.data?.metadata?.specialInstructions?.includes("SMOUT")
         || !!image.data?.metadata?.keywords?.find(keyword => keyword?.toUpperCase() === "SMOUT")
+      )
     };
   }]
 );


### PR DESCRIPTION
https://github.com/guardian/grid/pull/4208 changed the blurring logic w.r.t. `SMOUT` but outside the () so was applying blurring regardless of the overall user preference. Ooops.