### PR TITLE
Prevent scheduler failures

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
@@ -1,14 +1,13 @@
 package com.gu.mediaservice.lib
 
-import java.io.InputStream
 import akka.actor.{Cancellable, Scheduler}
 import com.gu.Box
 import com.gu.mediaservice.lib.aws.S3
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.GridLogging
 import org.joda.time.DateTime
-import org.slf4j.LoggerFactory
 
+import java.io.InputStream
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -43,8 +42,15 @@ abstract class BaseStore[TStoreKey, TStoreVal](bucket: String, config: CommonCon
 
   private var cancellable: Option[Cancellable] = None
 
-  def scheduleUpdates(scheduler: Scheduler) {
-    cancellable = Some(scheduler.scheduleAtFixedRate(0.seconds, 10.minutes)(() => update()))
+  def scheduleUpdates(scheduler: Scheduler): Unit = {
+    cancellable = Some(scheduler.scheduleAtFixedRate(0.seconds, 10.minutes)(() => {
+      try { update() }
+      catch {
+        case e: Exception => logger.error("Store update failed", e)
+        case e: RuntimeException => logger.error("Store update failed", e)
+      }
+      finally { lastUpdated.send(DateTime.now()) }
+    }))
   }
 
   def stopUpdates(): Unit = {
@@ -53,4 +59,3 @@ abstract class BaseStore[TStoreKey, TStoreVal](bucket: String, config: CommonCon
 
   def update(): Unit
 }
-

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
@@ -44,12 +44,13 @@ abstract class BaseStore[TStoreKey, TStoreVal](bucket: String, config: CommonCon
 
   def scheduleUpdates(scheduler: Scheduler): Unit = {
     cancellable = Some(scheduler.scheduleAtFixedRate(0.seconds, 10.minutes)(() => {
-      try { update() }
-      catch {
+      try {
+        update()
+        lastUpdated.send(DateTime.now())
+      } catch {
         case e: Exception => logger.error("Store update failed", e)
         case e: RuntimeException => logger.error("Store update failed", e)
       }
-      finally { lastUpdated.send(DateTime.now()) }
     }))
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/KeyStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/auth/KeyStore.scala
@@ -2,7 +2,6 @@ package com.gu.mediaservice.lib.auth
 
 import com.gu.mediaservice.lib.BaseStore
 import com.gu.mediaservice.lib.config.CommonConfig
-import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -14,9 +13,8 @@ class KeyStore(bucket: String, config: CommonConfig)(implicit ec: ExecutionConte
 
   def findKey(prefix: String): Option[String] = s3.syncFindKey(bucket, prefix)
 
-  def update() {
-    lastUpdated.send(_ => DateTime.now())
-    store.send(_ => fetchAll)
+  def update(): Unit = {
+    store.send(fetchAll)
   }
 
   private def fetchAll: Map[String, ApiAccessor] = {

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -141,8 +141,7 @@ class UsageStore(
     case (_, status) if status.exceeded => status.usage.agency
   }.toList
 
-  def update() {
-    lastUpdated.send(_ => DateTime.now())
+  def update(): Unit = {
     fetchUsage.foreach { usage => store.send(usage) }
   }
 
@@ -200,8 +199,8 @@ class QuotaStore(
 
   def getQuota: Future[Map[String, SupplierUsageQuota]] = Future.successful(store.get())
 
-  def update() {
-    store.send(_ => fetchQuota)
+  def update(): Unit = {
+    store.send(fetchQuota)
   }
 
   private def fetchQuota: Map[String, SupplierUsageQuota] = {


### PR DESCRIPTION
## What does this change?

If the Runnable in a scheduler throws, the scheduler will stop and no longer run, even if future executions would succeed.

eg. If a quota report fails to parse, sending through a fixed report will still leave no quotas available until media-api is redeployed/restarted.

I checked the codebase for other schedulers and spotted that Reaper would be susceptible to the same problem, so put a try/catch in there too.

## How should a reviewer test this change?

A bit hard to trigger an error like this. Possibly we can drop a malformed report into the mail bucket locally or on TEST? give me a shout if you'd like to pair on trying it.

## How can success be measured?

Intermittent failures do not cause consistent failure 👍 
