### PR TITLE
override UserPrincipal.toString to avoid logging info that we shouldn't be logging

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -104,6 +104,8 @@ object Authentication {
   /** A human user with a name */
   case class UserPrincipal(firstName: String, lastName: String, email: String, attributes: TypedMap = TypedMap.empty) extends Principal {
     def accessor: ApiAccessor = ApiAccessor(identity = email, tier = Internal)
+
+    override def toString: String = s"UserPrincipal(${(firstName, lastName, email)})"
   }
   /** A machine user doing work automatically for its human programmers */
   case class MachinePrincipal(accessor: ApiAccessor, attributes: TypedMap = TypedMap.empty) extends Principal


### PR DESCRIPTION
## What does this change?

there's a field that we shouldn't have been logging but we have for a while oops.

override this toString to not contain that field so we stop logging it