### PR TITLE
FIX pattern matching in the extraction of S3 key from SQS message

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsHelpers.scala
@@ -14,11 +14,12 @@ trait SqsHelpers {
 
     // we only need the key, the full message shape can be seen at
     // https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
+    // or see the SqsHelpersTest which uses example in test/resources/s3SqsMessage.json
 
     // note that we don't bother reading the bucket name currently, but attempt the read elsewhere based on the
     // configured bucket value, this could be checked here if we're concerned (s3Records.head \ "bucket" \ "name")
 
-    Json.parse(message.getBody) \ "Records" \\ "s3" match {
+    (Json.parse(message.getBody) \ "Records" \\ "s3").toList match {
       case head :: Nil => uriDecode((head \ "object" \ "key").as[String])
       case s3Records => throw new Exception(s"Expected 1 record containing 's3' in message body, got ${s3Records.size}")
     }

--- a/common-lib/src/test/resources/s3SqsMessage.json
+++ b/common-lib/src/test/resources/s3SqsMessage.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "awsRegion": "eu-west-1",
+      "eventTime": "2023-12-19T12:57:19.116Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "AWS:AROAJFJ3R35ABBH5ZOP2Q:i-041d72c20eba9e2d4"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "1.1.1.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "9DG52BCBG9HMR73K",
+        "x-amz-id-2": "FLrMbtNZWhTSbSCrLYMaRnc7ryVEHzxIaia5TtTMhy69eJSpHmZQaPBos9crqKQL2QOeOwvjRdHytbEdAVqBH7cqsOBmsnyS"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "YjRlM2M0MDUtNDk1Yi00NzQwLWFjZGEtNGRkNzYxZmMxZjkx",
+        "bucket": {
+          "name": "media-service-prod-ingestqueuebucket-h7olblmxmf9e",
+          "ownerIdentity": {
+            "principalId": "A2WXMAO3QWDXTH"
+          },
+          "arn": "arn:aws:s3:::media-service-prod-ingestqueuebucket-h7olblmxmf9e"
+        },
+        "object": {
+          "key": "bill.bloggs%40example.co.uk/0cd747d665e2c59e86d256e6f45c369664e558bd",
+          "size": 7028718,
+          "eTag": "7fc05ba774bfc19cc9445eae78da0b81",
+          "sequencer": "006581932EF313EE13"
+        }
+      }
+    }
+  ]
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/SqsHelpersTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/SqsHelpersTest.scala
@@ -1,0 +1,21 @@
+package com.gu.mediaservice.lib.aws
+
+import org.scalatest.funsuite.AnyFunSuiteLike
+import com.amazonaws.services.sqs.model.{Message => SQSMessage}
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+import scala.io.Source
+import scala.util.Success
+
+
+class SqsHelpersTest extends AnyFunSuiteLike with SqsHelpers {
+
+  test("extractS3KeyFromSqsMessage") {
+
+    val message = new SQSMessage()
+    message.setBody(Source.fromResource("s3SqsMessage.json").mkString)
+
+    extractS3KeyFromSqsMessage(message) shouldBe Success("bill.bloggs@example.co.uk/0cd747d665e2c59e86d256e6f45c369664e558bd")
+  }
+
+}


### PR DESCRIPTION
FIX to some of the pattern matching added towards the end of #4201 since parsing was failing - added a test to be sure (which also nicely provides an example of an S3 SQS message)

Co-authored-by: @dblatcher 