### PR TITLE
URI encode the filename in transit through the queue-based mechanism to ensure it handles diacritics etc.

### DIFF
--- a/image-loader/app/model/S3IngestObject.scala
+++ b/image-loader/app/model/S3IngestObject.scala
@@ -5,6 +5,8 @@ import lib.storage.ImageLoaderStore
 
 import scala.jdk.CollectionConverters.mapAsScalaMapConverter
 
+import com.gu.mediaservice.lib.net.URI.{decode => uriDecode}
+
 case class S3IngestObject (
   key: String,
   uploadedBy: String,
@@ -28,7 +30,8 @@ object S3IngestObject {
     val filenameInS3: String = keyParts.last
     val s3Object = store.getS3Object(key)
     val metadata = s3Object.getObjectMetadata
-    val maybeFilenameFromMetadata = metadata.getUserMetadata.asScala.get(ImageStorageProps.filenameMetadataKey) // set on the upload metadata by the client when uploading to ingest bucket
+    // set on the upload metadata by the client when uploading to ingest bucket
+    val maybeFilenameFromMetadata = metadata.getUserMetadata.asScala.get(ImageStorageProps.filenameMetadataKey).map(uriDecode)
 
 
     S3IngestObject(

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -42,7 +42,7 @@ upload.factory('uploadManager',
         );
 
         const preSignedPutUrls = await fileUploader.prepare(
-          Object.fromEntries(Object.entries(mediaIdToFileMap).map(([mediaId, file])=> [mediaId, file.name]))
+          Object.fromEntries(Object.entries(mediaIdToFileMap).map(([mediaId, file])=> [mediaId, encodeURI(file.name)]))
         );
 
         return Object.entries(mediaIdToFileMap).map(([mediaId, file]) => createJobItem(file, mediaId, preSignedPutUrls[mediaId]));
@@ -121,7 +121,7 @@ upload.factory('fileUploader',
         method: "PUT",
         body: file,
         headers: {
-          "x-amz-meta-file-name": file.name
+          "x-amz-meta-file-name": encodeURIComponent(file.name)
         }
       });
 


### PR DESCRIPTION
Small tweak following #4201 to ensure we can handle diacritics in filenames uploaded from UI (FTP is unaffected AFAICT) as they pass through S3 metadata.

One could argue instead we use the filename in S3 for filename, and a new metadata header for media id to avoid this 🤔 EDIT: we did go this way in the end in https://github.com/guardian/grid/pull/4222