### PR TITLE
no longer user media id as filename for UI uploads in queue-based ingestion

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -179,19 +179,19 @@ class ImageLoaderController(auth: Authentication,
   def getPreSignedUploadUrlsAndTrack: Action[AnyContent] = AuthenticatedAndAuthorised.async { request =>
     val expiration = DateTimeUtils.now().plusHours(1)
 
-    val mediaIdToOriginalFilenameMap = request.body.asJson.get.as[Map[String, String]]
+    val mediaIdToFilenameMap = request.body.asJson.get.as[Map[String, String]]
 
     val uploadedBy = Authentication.getIdentity(request.user)
 
     Future.sequence(
 
-      mediaIdToOriginalFilenameMap.map{case (mediaId, originalFilename) =>
+      mediaIdToFilenameMap.map{case (mediaId, filename) =>
 
-        val preSignedUrl = store.generatePreSignedUploadUrl(filename = mediaId, expiration, uploadedBy, originalFilename)
+        val preSignedUrl = store.generatePreSignedUploadUrl(filename, expiration, uploadedBy, mediaId)
 
         uploadStatusTable.setStatus(UploadStatusRecord(
           id = mediaId,
-          fileName = Some(originalFilename),
+          fileName = Some(filename),
           uploadedBy,
           uploadTime = DateTimeUtils.toString(DateTimeUtils.now()),
           identifiers = None,

--- a/image-loader/app/lib/ImageLoaderStore.scala
+++ b/image-loader/app/lib/ImageLoaderStore.scala
@@ -4,7 +4,6 @@ import lib.ImageLoaderConfig
 import com.gu.mediaservice.lib
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.model.{AmazonS3Exception, GeneratePresignedUrlRequest}
-import com.gu.mediaservice.lib.ImageStorageProps
 
 import java.time.ZonedDateTime
 import java.util.Date
@@ -13,7 +12,7 @@ class ImageLoaderStore(config: ImageLoaderConfig) extends lib.ImageIngestOperati
 
   def getS3Object(key: String) = client.getObject(config.maybeIngestBucket.get, key)
 
-  def generatePreSignedUploadUrl(filename: String, expiration: ZonedDateTime, uploadedBy: String, originalFilename: String): String = {
+  def generatePreSignedUploadUrl(filename: String, expiration: ZonedDateTime, uploadedBy: String, mediaId: String): String = {
     val request = new GeneratePresignedUrlRequest(
       config.maybeIngestBucket.get, // bucket
       s"$uploadedBy/$filename", // key
@@ -22,7 +21,7 @@ class ImageLoaderStore(config: ImageLoaderConfig) extends lib.ImageIngestOperati
       .withExpiration(Date.from(expiration.toInstant));
 
     // sent by the client in manager.js
-    request.putCustomRequestHeader(s"x-amz-meta-${ImageStorageProps.filenameMetadataKey}", originalFilename)
+    request.putCustomRequestHeader("x-amz-meta-media-id", mediaId)
 
     client.generatePresignedUrl(request).toString
   }

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -121,7 +121,7 @@ upload.factory('fileUploader',
         method: "PUT",
         body: file,
         headers: {
-          "x-amz-meta-file-name": file.name
+          "x-amz-meta-media-id": mediaId
         }
       });
 


### PR DESCRIPTION
This was a bit counter intuitive on reflection and this approach avoids the need for more explicit URL encoding/decoding (see https://github.com/guardian/grid/pull/4221).