### PR TITLE
TEMPORARY FOR XMAS BREAK - don't use queue for UI uploads

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -75,5 +75,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     .getOrElse("Not configured")
   val imagePreviewFlagLeaseAttachedCopy: String = configuration.getOptional[String]("warningText.imagePreviewFlag.leaseAttachedCopy")
     .getOrElse("Not configured")
+
+  val shouldUploadStraightToBucket: Boolean = false // maybeIngestBucket.isDefined TODO reinstate after xmas break 2023
 }
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -76,7 +76,7 @@
           featureSwitches: @Html(featureSwitches),
           telemetryUri: '@kahunaConfig.telemetryUri.getOrElse("")',
           defaultShouldBlurGraphicImages: @kahunaConfig.defaultShouldBlurGraphicImages,
-          shouldUploadStraightToBucket: @kahunaConfig.maybeIngestBucket.isDefined
+          shouldUploadStraightToBucket: @kahunaConfig.shouldUploadStraightToBucket,
         }
     </script>
 


### PR DESCRIPTION
Co-authored-by: @dblatcher 

As per https://trello.com/c/5NchFBNj/1947-phased-switchover-of-grid-ftp-to-queue-based-ingestion we've been ramping up to 100% of images (UI, FTP, SFTP & grid-feeds) using the [new queue-based ingestion](https://github.com/guardian/grid/pull/4201) with good results 🎉  - as planned though we want to revert back to everything via S3 watcher over the xmas break (for peace of mind, 24/7 etc.) with the confidence to flick back to all queue-based first thing in 2024. **This PR forces the UI to use the old direct (i.e. push) mechanism.**