### PR TITLE
recover from file not existing in the S3 IngestQueueBucket

### DIFF
--- a/image-loader/app/lib/ImageLoaderStore.scala
+++ b/image-loader/app/lib/ImageLoaderStore.scala
@@ -3,14 +3,32 @@ package lib.storage
 import lib.ImageLoaderConfig
 import com.gu.mediaservice.lib
 import com.amazonaws.HttpMethod
-import com.amazonaws.services.s3.model.{AmazonS3Exception, GeneratePresignedUrlRequest}
+import com.amazonaws.services.s3.model.{AmazonS3Exception, GeneratePresignedUrlRequest, S3Object}
+import com.gu.mediaservice.lib.logging.LogMarker
 
 import java.time.ZonedDateTime
 import java.util.Date
 
+class S3FileDoesNotExistException extends Exception()
+
 class ImageLoaderStore(config: ImageLoaderConfig) extends lib.ImageIngestOperations(config.imageBucket, config.thumbnailBucket, config) {
 
-  def getS3Object(key: String) = client.getObject(config.maybeIngestBucket.get, key)
+  private def handleNotFound[T](key: String)(doWork: => T)(loggingIfNotFound: => Unit): T = {
+    try {
+      doWork
+    } catch {
+      case e: AmazonS3Exception if e.getStatusCode == 404 =>
+        loggingIfNotFound
+        throw new S3FileDoesNotExistException
+      case other: Throwable => throw other
+    }
+  }
+
+  def getS3Object(key: String)(implicit logMarker: LogMarker): S3Object = handleNotFound(key) {
+    client.getObject(config.maybeIngestBucket.get, key)
+  } {
+    logger.error(logMarker, s"Attempted to read $key from ingest bucket, but it does not exist.")
+  }
 
   def generatePreSignedUploadUrl(filename: String, expiration: ZonedDateTime, uploadedBy: String, mediaId: String): String = {
     val request = new GeneratePresignedUrlRequest(
@@ -26,23 +44,17 @@ class ImageLoaderStore(config: ImageLoaderConfig) extends lib.ImageIngestOperati
     client.generatePresignedUrl(request).toString
   }
 
-  def moveObjectToFailedBucket(key: String) = {
-    try {
-      client.copyObject(config.maybeIngestBucket.get, key, config.maybeFailBucket.get, key)
-      deleteObjectFromIngestBucket(key)
-    } catch {
-      case e: AmazonS3Exception if e.getErrorCode == "AccessDenied" && !client.doesObjectExist(config.maybeIngestBucket.get, key) =>
-        logger.warn(s"Attempted to copy $key from ingest bucket to fail bucket, but it does not exist.")
-      case other: Throwable => throw other
-    }
+  def moveObjectToFailedBucket(key: String)(implicit logMarker: LogMarker) = handleNotFound(key){
+    client.copyObject(config.maybeIngestBucket.get, key, config.maybeFailBucket.get, key)
+    deleteObjectFromIngestBucket(key)
+  } {
+    logger.warn(logMarker, s"Attempted to copy $key from ingest bucket to fail bucket, but it does not exist.")
   }
 
-  def deleteObjectFromIngestBucket(key: String) = try {
+  def deleteObjectFromIngestBucket(key: String)(implicit logMarker: LogMarker) = handleNotFound(key) {
     client.deleteObject(config.maybeIngestBucket.get,key)
-  } catch {
-    case e: AmazonS3Exception if e.getErrorCode == "AccessDenied" && !client.doesObjectExist(config.maybeIngestBucket.get, key) =>
-      logger.warn(s"Attempted to delete $key from ingest bucket, but it does not exist.")
-    case other: Throwable => throw other
+  } {
+    logger.warn(logMarker, s"Attempted to delete $key from ingest bucket, but it does not exist.")
   }
 }
 

--- a/image-loader/app/model/S3IngestObject.scala
+++ b/image-loader/app/model/S3IngestObject.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.mediaservice.lib.logging.LogMarker
 import lib.storage.ImageLoaderStore
 
 import scala.jdk.CollectionConverters.mapAsScalaMapConverter
@@ -16,7 +17,7 @@ case class S3IngestObject (
 
 object S3IngestObject {
 
-  def apply (key: String, store: ImageLoaderStore): S3IngestObject  = {
+  def apply (key: String, store: ImageLoaderStore)(implicit logMarker: LogMarker): S3IngestObject  = {
 
     val keyParts = key.split("/")
 


### PR DESCRIPTION
Co-authored-by: @dblatcher 

Despite the improved permissions in https://github.com/guardian/editorial-tools-platform/pull/744 our logic for handling when the S3 object referenced in the SQS message doesn't exist (albeit rare) is still problematic, the message is retried every 30mins indefinitely because we don't recover from the specific scenario BEFORE deleting the SQS message... this PR along with https://github.com/guardian/editorial-tools-platform/pull/746 puts that right!