### PR TITLE
use queue bucket for UI uploads

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -76,6 +76,6 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val imagePreviewFlagLeaseAttachedCopy: String = configuration.getOptional[String]("warningText.imagePreviewFlag.leaseAttachedCopy")
     .getOrElse("Not configured")
 
-  val shouldUploadStraightToBucket: Boolean = false // maybeIngestBucket.isDefined TODO reinstate after xmas break 2023
+  val shouldUploadStraightToBucket: Boolean = maybeIngestBucket.isDefined
 }
 


### PR DESCRIPTION
In https://github.com/guardian/grid/pull/4223 we forced the UI back to using the old-style uploading (i.e. straight to image-loader) for peace of mind of xmas break. 

This PR re-instates the direct uploads to the ingest queue bucket (following successful PROD testing before xmas break).

Co-authored-by: @dblatcher 