### PR TITLE
add ImageLoaderMetrics - track successful, fail and abandoned ingests

### DIFF
--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -41,8 +41,10 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
   val services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   private val gridClient = GridClient(services)(wsClient)
 
+  val metrics = new ImageLoaderMetrics(config)
+
   val controller = new ImageLoaderController(
-    auth, downloader, store, maybeIngestQueue, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient, authorisation)
+    auth, downloader, store, maybeIngestQueue, uploadStatusTable, notifications, config, uploader, quarantineUploader, projector, controllerComponents, gridClient, authorisation, metrics)
   val uploadStatusController = new UploadStatusController(auth, uploadStatusTable, config, controllerComponents, authorisation)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
   val imageLoaderManagement = new ImageLoaderManagement(controllerComponents, buildInfo, controller.maybeIngestQueueAndProcessor)

--- a/image-loader/app/lib/ImageLoaderMetrics.scala
+++ b/image-loader/app/lib/ImageLoaderMetrics.scala
@@ -1,0 +1,12 @@
+package lib
+
+import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
+
+class ImageLoaderMetrics(config: ImageLoaderConfig) extends CloudWatchMetrics (namespace = s"${config.stage}/ImageLoader", config){
+
+  val successfulIngestsFromQueue = new CountMetric("SuccessfulIngestsFromQueue")
+
+  val failedIngestsFromQueue = new CountMetric("FailedIngestsFromQueue")
+
+  val abandonedMessagesFromQueue = new CountMetric("AbandonedMessagesFromQueue")
+}


### PR DESCRIPTION
## What does this change?

add ImageLoaderMetrics - track successful, fail and abandoned ingest from queue.

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

Deploy to TEST, ingest some files - check that the metrics for the TEST cloud metrics for ImageLoader show the activity.

## How can success be measured?
The new metrics will be viewable on the AWS cloudwatch console and useable for setting alarms.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
