### PR TITLE
No error logging for unsupported file type

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -159,7 +159,6 @@ class ImageLoaderController(auth: Authentication,
             store.deleteObjectFromIngestBucket(s3IngestObject.key)
           } recover {
             case unsupportedMimeTypeException: UnsupportedMimeTypeException =>
-              println(s"THE FILE WAS A ${unsupportedMimeTypeException.mimeType}")
               metrics.failedIngestsFromQueue.incrementBothWithAndWithoutDimensions(metricDimensions).run
               metrics.invalidMimeTypeUploaded.increment(List(
                 new Dimension().withName("MimeType").withValue(unsupportedMimeTypeException.mimeType),

--- a/image-loader/app/lib/ImageLoaderMetrics.scala
+++ b/image-loader/app/lib/ImageLoaderMetrics.scala
@@ -9,4 +9,6 @@ class ImageLoaderMetrics(config: ImageLoaderConfig) extends CloudWatchMetrics (n
   val failedIngestsFromQueue = new CountMetric("FailedIngestsFromQueue")
 
   val abandonedMessagesFromQueue = new CountMetric("AbandonedMessagesFromQueue")
+
+  val invalidMimeTypeUploaded = new CountMetric("invalidMimeTypeUploaded")
 }


### PR DESCRIPTION
## What does this change?

Refactors the `updateUploadStatusTable` to throw the exception to the upload operation (where the upload failed)

The `recover` on `attemptToProcessIngestedFile` has a separate case block for `UnsupportedMimeType` exceptions so that:
 - the failure to process the file for this reason will be logged as info rather than an error
 - increments a metric with the uploader and and mimetype


<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
Upload a non-image file and check the logs for a "File has unsupported mime type" entry.


## How can success be measured?
Less errors in the logs. Able to see which unsupported file types are often uploaded and by whom

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
