### PR TITLE
Revert to standard GHA runners, since they're now more powerful (or rather powerful enough)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'pr**'
 jobs:
   CI:
-    runs-on: 4core-ubuntu-latest
+    runs-on: ubuntu-latest
     permissions:
       # required by aws-actions/configure-aws-credentials
       id-token: write


### PR DESCRIPTION
Reverts guardian/grid#4158 following the announcement (https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/) that standard-runners are now double in size and should be sufficient for grid (since guardian/grid#4158 stated we were likely just on the borderline before).