### PR TITLE
run CI on `push` to ALL branches too (but only actually run if this is a pull_request [incl. from forks] OR push to a branch without a PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,10 @@ on:
   workflow_dispatch: # Manual invocation.
   pull_request:
   push:
-    branches:
-      - main
-      - 'pr**'
 jobs:
   CI:
+    # only actually run if this is a pull_request (incl. from forks) OR push to a branch without a PR
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.pr-check.outputs.number == null
     runs-on: ubuntu-latest
     permissions:
       # required by aws-actions/configure-aws-credentials


### PR DESCRIPTION
Prior to https://github.com/guardian/grid/pull/4238 we were running CI on custom runners which cost money, so we were only building once there was a PR, but now we're back using standard runners (i.e. free, since public repo) its useful to have a build for all pushes - however PRs from forks still need to be built and we don't want to build twice for pull_request and push for our internal branches, so added an `if` condition to the overall CI job to hopefully achieve the best of both worlds.

Looks to manifest correctly on this branch... 
<img width="964" alt="image" src="https://github.com/guardian/grid/assets/19289579/66724023-4d70-4db2-84dd-3638b2eed080">
