### PR TITLE
use testcontainers directly instead of docker-testkit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,8 @@ lazy val commonLib = project("common-lib").settings(
     "com.gu" %% "scanamo" % "1.0.0-M8",
     // Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
     "com.typesafe.play" %% "play-ahc-ws" % "2.8.9",
-    "org.yaml" % "snakeyaml" % "1.31"
+    "org.yaml" % "snakeyaml" % "1.31",
+    "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0"
 )
@@ -136,28 +137,31 @@ lazy val kahuna = playProject("kahuna", 9005).settings(
 
 lazy val leases = playProject("leases", 9012)
 
-lazy val mediaApi = playProject("media-api", 9001).settings(
-  libraryDependencies ++= Seq(
-    "org.apache.commons" % "commons-email" % "1.5",
-    "org.parboiled" %% "parboiled" % "2.1.5",
-    "org.http4s" %% "http4s-core" % "0.23.17",
-    "com.softwaremill.quicklens" %% "quicklens" % "1.4.11",
-    "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
+lazy val mediaApi = playProject("media-api", 9001)
+  .dependsOn(commonLib % "compile;test->test")
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.apache.commons" % "commons-email" % "1.5",
+      "org.parboiled" %% "parboiled" % "2.1.5",
+      "org.http4s" %% "http4s-core" % "0.23.17",
+      "com.softwaremill.quicklens" %% "quicklens" % "1.4.11",
+    )
   )
-)
 
 lazy val metadataEditor = playProject("metadata-editor", 9007)
 
-lazy val thrall = playProject("thrall", 9002).settings(
-  pipelineStages := Seq(digest, gzip),
-  libraryDependencies ++= Seq(
-    "org.codehaus.groovy" % "groovy-json" % "3.0.7",
-    "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
-    "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
-    "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
-    "com.google.protobuf" % "protobuf-java" % "3.19.6"
+lazy val thrall = playProject("thrall", 9002)
+  .dependsOn(commonLib % "compile;test->test")
+  .settings(
+    pipelineStages := Seq(digest, gzip),
+    libraryDependencies ++= Seq(
+      "org.codehaus.groovy" % "groovy-json" % "3.0.7",
+      "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
+      "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
+      "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
+      "com.google.protobuf" % "protobuf-java" % "3.19.6"
+    )
   )
-)
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -142,8 +142,7 @@ lazy val mediaApi = playProject("media-api", 9001).settings(
     "org.parboiled" %% "parboiled" % "2.1.5",
     "org.http4s" %% "http4s-core" % "0.23.17",
     "com.softwaremill.quicklens" %% "quicklens" % "1.4.11",
-    "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
-    "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test
+    "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   )
 )
 
@@ -155,8 +154,7 @@ lazy val thrall = playProject("thrall", 9002).settings(
     "org.codehaus.groovy" % "groovy-json" % "3.0.7",
     "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
-    "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
-    "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test,
+    "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
     "com.google.protobuf" % "protobuf-java" % "3.19.6"
   )
 )

--- a/common-lib/src/test/scala/com/gu/mediaservice/testlib/ElasticSearchDockerBase.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/testlib/ElasticSearchDockerBase.scala
@@ -1,0 +1,46 @@
+package com.gu.mediaservice.testlib
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.elasticsearch.ElasticsearchContainer
+
+import scala.util.Properties
+import scala.concurrent.duration._
+import scala.compat.java8.DurationConverters._
+import scala.jdk.CollectionConverters._
+
+
+trait ElasticSearchDockerBase extends BeforeAndAfterAll {
+  self: Suite =>
+  val useEsDocker = Properties.envOrElse("USE_DOCKER_FOR_TESTS", "true").toBoolean
+
+  val esContainer: Option[ElasticsearchContainer] = if (useEsDocker) {
+    {
+      val container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.16.2")
+        .withExposedPorts(9200)
+        .withAccessToHost(true)
+        .withEnv(Map(
+          "cluster.name" -> "media-service",
+          "xpack.security.enabled" -> "false",
+          "discovery.type" -> "single-node",
+          "network.host" -> "0.0.0.0"
+        ).asJava)
+        .waitingFor(Wait.forHttp("/")
+          .forPort(9200)
+          .forStatusCode(200)
+          .withStartupTimeout(180.seconds.toJava)
+        )
+      container.start()
+      Some(container)
+    }
+  } else None
+
+  val esPort = esContainer.map(_.getMappedPort(9200)).getOrElse(9200)
+  val esTestUrl = Properties.envOrElse("ES6_TEST_URL", s"http://localhost:$esPort")
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+
+    esContainer foreach { _.stop() }
+  }
+}

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -11,20 +11,24 @@ import com.gu.mediaservice.model.leases.DenySyndicationLease
 import com.gu.mediaservice.model.usage.PublishedUsageStatus
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.whisk.docker.{DockerContainer, DockerReadyChecker}
 import lib.querysyntax._
 import lib.{MediaApiConfig, MediaApiMetrics}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.Eventually
 import org.scalatestplus.mockito.MockitoSugar
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.elasticsearch.ElasticsearchContainer
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc.AnyContent
 import play.api.mvc.Security.AuthenticatedRequest
 
+import scala.compat.java8.DurationConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
 
 class ElasticSearchTest extends ElasticSearchTestBase with Eventually with ElasticSearchExecutions with MockitoSugar {
 
@@ -53,14 +57,6 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
   )
 
 
-
-  def esContainer = if (useEsDocker) Some(DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.16.2")
-    .withPorts(9200 -> Some(9200))
-    .withEnv("cluster.name=media-service", "xpack.security.enabled=false", "discovery.type=single-node", "network.host=0.0.0.0")
-    .withReadyChecker(
-      DockerReadyChecker.HttpResponseCode(9200, "/", Some("0.0.0.0")).within(10.minutes).looped(40, 1250.millis)
-    )
-  ) else None
   private lazy val ES = new ElasticSearch(mediaApiConfig, mediaApiMetrics, elasticConfig, () => List.empty, mock[Scheduler])
   lazy val client = ES.client
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -16,19 +16,15 @@ import lib.{MediaApiConfig, MediaApiMetrics}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.Eventually
 import org.scalatestplus.mockito.MockitoSugar
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.elasticsearch.ElasticsearchContainer
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc.AnyContent
 import play.api.mvc.Security.AuthenticatedRequest
 
-import scala.compat.java8.DurationConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.jdk.CollectionConverters._
 
 class ElasticSearchTest extends ElasticSearchTestBase with Eventually with ElasticSearchExecutions with MockitoSugar {
 
@@ -51,7 +47,7 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       current = "Images_Current",
       migration = "Images_Migration"
     ),
-    url = es6TestUrl,
+    url = esTestUrl,
     shards = 1,
     replicas = 0
   )

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,61 +1,22 @@
 package lib.elasticsearch
 
-import java.util.UUID
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.testlib.ElasticSearchDockerBase
 import org.joda.time.DateTime
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.time.{Milliseconds, Seconds, Span}
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.elasticsearch.ElasticsearchContainer
+import org.scalatest.time.{Milliseconds, Seconds, Span}
 import play.api.libs.json.JsString
 
-import java.util.concurrent.atomic.AtomicReference
-import scala.util.Properties
-import scala.concurrent.duration._
-import scala.compat.java8.DurationConverters._
-import scala.jdk.CollectionConverters._
+import java.util.UUID
 
 
-trait ElasticSearchTestBase extends AnyFunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with ConditionFixtures {
+trait ElasticSearchTestBase extends AnyFunSpec with ElasticSearchDockerBase with Matchers with ScalaFutures with Fixtures with ConditionFixtures {
 
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))
-
-  val useEsDocker = Properties.envOrElse("USE_DOCKER_FOR_TESTS", "true").toBoolean
-
-  val esContainer: Option[ElasticsearchContainer] = if (useEsDocker) {
-    {
-      val container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.16.2")
-        .withExposedPorts(9200)
-        .withAccessToHost(true)
-        .withEnv(Map(
-          "cluster.name" -> "media-service",
-          "xpack.security.enabled" -> "false",
-          "discovery.type" -> "single-node",
-          "network.host" -> "0.0.0.0"
-        ).asJava)
-        .waitingFor(Wait.forHttp("/")
-          .forPort(9200)
-          .forStatusCode(200)
-          .withStartupTimeout(180.seconds.toJava)
-        )
-      container.start()
-      Some(container)
-    }
-  } else None
-
-  val esPort = esContainer.map(_.getMappedPort(9200)).getOrElse(9200)
-  val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", s"http://localhost:$esPort")
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-
-    esContainer foreach { _.stop() }
-  }
 
   lazy val images = Seq(
     createImage("getty-image-1", Agency("Getty Images")),

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,11 +1,7 @@
 package lib.elasticsearch
 
 import java.util.UUID
-import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
-import com.whisk.docker.impl.spotify.DockerKitSpotify
-import com.whisk.docker.scalatest.DockerTestKit
-import com.whisk.docker.{DockerContainer, DockerKit}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.ScalaFutures
@@ -13,26 +9,53 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.elasticsearch.ElasticsearchContainer
 import play.api.libs.json.JsString
 
-import scala.concurrent.duration._
+import java.util.concurrent.atomic.AtomicReference
 import scala.util.Properties
+import scala.concurrent.duration._
+import scala.compat.java8.DurationConverters._
+import scala.jdk.CollectionConverters._
 
-trait ElasticSearchTestBase extends AnyFunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with DockerKit with DockerTestKit with DockerKitSpotify with ConditionFixtures {
 
+trait ElasticSearchTestBase extends AnyFunSpec with BeforeAndAfterAll with Matchers with ScalaFutures with Fixtures with ConditionFixtures {
 
   val interval = Interval(Span(100, Milliseconds))
   val timeout = Timeout(Span(10, Seconds))
 
   val useEsDocker = Properties.envOrElse("USE_DOCKER_FOR_TESTS", "true").toBoolean
-  val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", "http://localhost:9200")
 
-  def esContainer: Option[DockerContainer]
+  val esContainer: Option[ElasticsearchContainer] = if (useEsDocker) {
+    {
+      val container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.16.2")
+        .withExposedPorts(9200)
+        .withAccessToHost(true)
+        .withEnv(Map(
+          "cluster.name" -> "media-service",
+          "xpack.security.enabled" -> "false",
+          "discovery.type" -> "single-node",
+          "network.host" -> "0.0.0.0"
+        ).asJava)
+        .waitingFor(Wait.forHttp("/")
+          .forPort(9200)
+          .forStatusCode(200)
+          .withStartupTimeout(180.seconds.toJava)
+        )
+      container.start()
+      Some(container)
+    }
+  } else None
 
-  final override def dockerContainers: List[DockerContainer] =
-    esContainer.toList ++ super.dockerContainers
+  val esPort = esContainer.map(_.getMappedPort(9200)).getOrElse(9200)
+  val es6TestUrl = Properties.envOrElse("ES6_TEST_URL", s"http://localhost:$esPort")
 
-  final override val StartContainersTimeout = 1.minute
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+
+    esContainer foreach { _.stop() }
+  }
 
   lazy val images = Seq(
     createImage("getty-image-1", Agency("Getty Images")),

--- a/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -1,18 +1,16 @@
 package lib.elasticsearch
 
-import java.util.UUID
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.{PublishedUsageStatus, SyndicatedUsageStatus}
-import com.gu.mediaservice.model.usage.Usage
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.http._
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.json.{JsDefined, JsLookupResult, JsObject, JsString, Json}
+import play.api.libs.json.{JsString, Json}
 
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 
 class ElasticSearchTest extends ElasticSearchTestBase {

--- a/thrall/test/lib/elasticsearch/GoodToGoCheckTest.scala
+++ b/thrall/test/lib/elasticsearch/GoodToGoCheckTest.scala
@@ -2,11 +2,10 @@ package lib.elasticsearch
 
 import com.gu.mediaservice.lib.elasticsearch.MappingTest
 import com.gu.mediaservice.lib.logging.LogMarker
-import com.sksamuel.elastic4s.requests.count.CountResponse
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.Response
 import org.joda.time.{DateTime, DateTimeZone, Period}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class GoodToGoCheckTest extends ElasticSearchTestBase {

--- a/thrall/test/lib/elasticsearch/ImageModelTest.scala
+++ b/thrall/test/lib/elasticsearch/ImageModelTest.scala
@@ -4,7 +4,8 @@ import com.gu.mediaservice.lib.elasticsearch.MappingTest
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 
 import scala.collection.TraversableLike
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class ImageModelTest extends ElasticSearchTestBase {
   implicit val logMarker: LogMarker = MarkerMap()


### PR DESCRIPTION
## What does this change?

@Conalb97 raised that docker-testkit has some sort of incompatibility with M1 macs on certain JDKs. docker-testkit isn't receiving maintenance updates, and neither is the underlying docker client, so this is a good opportunity to replace it with a direct usage of [testcontainers](https://testcontainers.com/) (mainly taking inspiration from Ophan https://github.com/guardian/ophan/blob/2ecb80da40915ce097e4a1de0e29b352b396323e/shared-lib/src/test/scala/app/BaseElasticTest.scala#L153 though we share the container between the tests, instead of a container per test, for a mild performance boost)