### PR TITLE
Conal/imagedam 1593 send to capture syndication

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -176,7 +176,7 @@ object MappingTest {
       )),
       syndicationUsageMetadata = Some(SyndicationUsageMetadata(
         partnerName = "friends of ours",
-        syndicatedBy = None
+        syndicatedBy = Some("Bob")
       )),
       frontUsageMetadata = Some(FrontUsageMetadata(
         addedBy = "me",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -175,7 +175,8 @@ object MappingTest {
         composerUrl = Some(new URI("https://composer/api/2345678987654321345678"))
       )),
       syndicationUsageMetadata = Some(SyndicationUsageMetadata(
-        partnerName = "friends of ours"
+        partnerName = "friends of ours",
+        syndicatedBy = None
       )),
       frontUsageMetadata = Some(FrontUsageMetadata(
         addedBy = "me",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -281,7 +281,8 @@ object Mappings {
   ))
 
   def syndicationUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
-    keywordField("partnerName")
+    keywordField("partnerName"),
+    keywordField("syndicatedBy")
   ))
 
   def frontUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -280,7 +280,7 @@ object Mappings {
     keywordField("composerUrl")
   ))
 
-  def syndicationUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
+  def syndicationUsageMetadata(name: String): ObjectField = dynamicObj(name).copy(properties = Seq(
     keywordField("partnerName"),
     keywordField("syndicatedBy")
   ))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -294,7 +294,7 @@ object Mappings {
     keywordField("downloadedBy")
   ))
 
-  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy(properties = Seq(
+  def usagesMapping(name: String): NestedField = nestedField(name).copy(properties = Seq(
     keywordField("id"),
     sStemmerAnalysed("title"),
     usageReference("references"),
@@ -336,7 +336,6 @@ object Mappings {
   private def nonDynamicObjectField(name: String) = ObjectField(name = name, dynamic = Some("strict"))
 
   private def nestedField(name: String) = NestedField(name).dynamic("strict") // ES1 include_in_parent needs to be emulated with field bby field copy_tos
-  private def nestedFieldDynamic(name: String) = nestedField(name).copy(dynamic = Some("true"))
 
   private def dynamicObj(name: String) = objectField(name).copy(dynamic = Some("true"))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -280,7 +280,7 @@ object Mappings {
     keywordField("composerUrl")
   ))
 
-  def syndicationUsageMetadata(name: String): ObjectField = dynamicObj(name).copy(properties = Seq(
+  def syndicationUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
     keywordField("partnerName"),
     keywordField("syndicatedBy")
   ))
@@ -294,7 +294,7 @@ object Mappings {
     keywordField("downloadedBy")
   ))
 
-  def usagesMapping(name: String): NestedField = nestedField(name).copy( properties = Seq(
+  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy( properties = Seq(
     keywordField("id"),
     sStemmerAnalysed("title"),
     usageReference("references"),
@@ -336,6 +336,7 @@ object Mappings {
   private def nonDynamicObjectField(name: String) = ObjectField(name = name, dynamic = Some("strict"))
 
   private def nestedField(name: String) = NestedField(name).dynamic("strict") // ES1 include_in_parent needs to be emulated with field bby field copy_tos
+  private def nestedFieldDynamic(name: String) = NestedField(name).dynamic("true")
 
   private def dynamicObj(name: String) = objectField(name).copy(dynamic = Some("true"))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -294,7 +294,7 @@ object Mappings {
     keywordField("downloadedBy")
   ))
 
-  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy( properties = Seq(
+  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy(properties = Seq(
     keywordField("id"),
     sStemmerAnalysed("title"),
     usageReference("references"),
@@ -336,7 +336,7 @@ object Mappings {
   private def nonDynamicObjectField(name: String) = ObjectField(name = name, dynamic = Some("strict"))
 
   private def nestedField(name: String) = NestedField(name).dynamic("strict") // ES1 include_in_parent needs to be emulated with field bby field copy_tos
-  private def nestedFieldDynamic(name: String) = NestedField(name).dynamic("true")
+  private def nestedFieldDynamic(name: String) = nestedField(name).copy(dynamic = Some("true"))
 
   private def dynamicObj(name: String) = objectField(name).copy(dynamic = Some("true"))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
@@ -52,7 +52,7 @@ object ItemToMediaUsage {
     Try {
       SyndicationUsageMetadata(
         metadataMap("partnerName").asInstanceOf[String],
-        None
+        metadataMap.get("syndicatedBy").map(x => x.asInstanceOf[String])
       )
     }.toOption
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
@@ -1,7 +1,6 @@
 package com.gu.mediaservice.lib.usage
 
 import java.net.URI
-
 import com.amazonaws.services.dynamodbv2.document.Item
 import com.gu.mediaservice.model.usage._
 import org.joda.time.DateTime
@@ -52,7 +51,8 @@ object ItemToMediaUsage {
   private def buildSyndication(metadataMap: Map[String, Any]): Option[SyndicationUsageMetadata] = {
     Try {
       SyndicationUsageMetadata(
-        metadataMap("partnerName").asInstanceOf[String]
+        metadataMap("partnerName").asInstanceOf[String],
+        None
       )
     }.toOption
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -64,7 +64,7 @@ object UsageBuilder {
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(
       UsageReference(
-        SyndicationUsageReference, None, Some(metadata.partnerName)
+        SyndicationUsageReference, None, Some(List(metadata.partnerName, metadata.syndicatedBy).mkString(", "))
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -64,7 +64,7 @@ object UsageBuilder {
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(
       UsageReference(
-        SyndicationUsageReference, None, metadata.syndicatedBy.map(_ => s"${metadata.partnerName}, ${metadata.syndicatedBy}").orElse(Some(metadata.partnerName))
+        SyndicationUsageReference, None, metadata.syndicatedBy.map(_ => s"${metadata.partnerName}, ${metadata.syndicatedBy.get}").orElse(Some(metadata.partnerName))
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -64,7 +64,7 @@ object UsageBuilder {
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(
       UsageReference(
-        SyndicationUsageReference, None, Some(List(metadata.partnerName, metadata.syndicatedBy).mkString(", "))
+        SyndicationUsageReference, None, metadata.syndicatedBy.map(_ => s"${metadata.partnerName}, ${metadata.syndicatedBy}").orElse(Some(metadata.partnerName))
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -124,6 +124,8 @@ case class DeleteSingleUsageMessage(id: String, lastModified: DateTime, usageId:
 
 case class DeleteUsagesMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 
+case class UpdateSingleUsageMessage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime) extends ExternalThrallMessage
+
 object DeleteUsagesMessage {
   implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
   implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -76,6 +76,7 @@ object ExternalThrallMessage{
   implicit val updateImagePhotoshootMetadataMessage = Json.format[UpdateImagePhotoshootMetadataMessage]
   implicit val deleteUsagesMessage = Json.format[DeleteUsagesMessage]
   implicit val deleteSingleUsageMessage = Json.format[DeleteSingleUsageMessage]
+  implicit val updateSingleUsageMessage = Json.format[UpdateSingleUsageMessage]
   implicit val updateImageUsagesMessage = Json.format[UpdateImageUsagesMessage]
   implicit val addImageLeaseMessage = Json.format[AddImageLeaseMessage]
   implicit val removeImageLeaseMessage = Json.format[RemoveImageLeaseMessage]

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -76,7 +76,7 @@ object ExternalThrallMessage{
   implicit val updateImagePhotoshootMetadataMessage = Json.format[UpdateImagePhotoshootMetadataMessage]
   implicit val deleteUsagesMessage = Json.format[DeleteUsagesMessage]
   implicit val deleteSingleUsageMessage = Json.format[DeleteSingleUsageMessage]
-  implicit val updateSingleUsageMessage = Json.format[UpdateSingleUsageMessage]
+  implicit val updateUsageStatusMessage = Json.format[UpdateUsageStatusMessage]
   implicit val updateImageUsagesMessage = Json.format[UpdateImageUsagesMessage]
   implicit val addImageLeaseMessage = Json.format[AddImageLeaseMessage]
   implicit val removeImageLeaseMessage = Json.format[RemoveImageLeaseMessage]
@@ -125,7 +125,7 @@ case class DeleteSingleUsageMessage(id: String, lastModified: DateTime, usageId:
 
 case class DeleteUsagesMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 
-case class UpdateSingleUsageMessage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime) extends ExternalThrallMessage
+case class UpdateUsageStatusMessage(id: String, usageNotice: UsageNotice, lastModified: DateTime) extends ExternalThrallMessage
 
 object DeleteUsagesMessage {
   implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
@@ -4,14 +4,11 @@ import play.api.libs.json._
 
 case class SyndicationUsageMetadata(
   partnerName: String,
-  syndicatedBy: Option[String]
+  syndicatedBy: Option[String] = None
 ) extends UsageMetadata {
-  override def toMap: Map[String, Any] = {
-    syndicatedBy match {
-      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user) // why isn't this working?
-      case None       => Map("partnerName" -> partnerName)
-    }
-  }
+  override def toMap: Map[String, Any] = Map(
+    "partnerName" -> partnerName
+  ) ++ syndicatedBy.map("syndicatedBy" -> _)
 }
 
 object SyndicationUsageMetadata {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
@@ -8,7 +8,7 @@ case class SyndicationUsageMetadata(
 ) extends UsageMetadata {
   override def toMap: Map[String, Any] = {
     syndicatedBy match {
-      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user)
+      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user) // why isn't this working?
       case None       => Map("partnerName" -> partnerName)
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
@@ -3,11 +3,15 @@ package com.gu.mediaservice.model.usage
 import play.api.libs.json._
 
 case class SyndicationUsageMetadata(
-  partnerName: String
+  partnerName: String,
+  syndicatedBy: Option[String]
 ) extends UsageMetadata {
-  override def toMap: Map[String, Any] = Map(
-    "partnerName" -> partnerName
-  )
+  override def toMap: Map[String, Any] = {
+    syndicatedBy match {
+      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user)
+      case None       => Map("partnerName" -> partnerName)
+    }
+  }
 }
 
 object SyndicationUsageMetadata {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
@@ -5,8 +5,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, JsArray, JsObject, Json}
 
 case class UsageNotice(mediaId: String, usageJson: JsArray) {
-  def toJson =
-    Json.obj(
+  def toJson = Json.obj(
     "id" -> mediaId,
     "data" -> usageJson,
     "lastModified" -> printDateTime(DateTime.now())

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
@@ -5,7 +5,8 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, JsArray, JsObject, Json}
 
 case class UsageNotice(mediaId: String, usageJson: JsArray) {
-  def toJson = Json.obj(
+  def toJson =
+    Json.obj(
     "id" -> mediaId,
     "data" -> usageJson,
     "lastModified" -> printDateTime(DateTime.now())

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
@@ -9,6 +9,7 @@ sealed trait UsageStatus {
     case RemovedUsageStatus => "removed"
     case SyndicatedUsageStatus => "syndicated"
     case DownloadedUsageStatus => "downloaded"
+    case FailedUsageStatus => "failed"
     case UnknownUsageStatus => "unknown"
   }
 }
@@ -20,7 +21,9 @@ object UsageStatus {
     case "removed" => RemovedUsageStatus
     case "syndicated" => SyndicatedUsageStatus
     case "downloaded" => DownloadedUsageStatus
+    case "failed" => FailedUsageStatus
     case "unknown" => UnknownUsageStatus
+    case _ => throw new IllegalArgumentException("Invalid usage status")
   }
 
   implicit val reads: Reads[UsageStatus] = JsPath.read[String].map(UsageStatus(_))
@@ -35,6 +38,7 @@ object PublishedUsageStatus extends UsageStatus
 object RemovedUsageStatus extends UsageStatus
 object SyndicatedUsageStatus extends UsageStatus
 object DownloadedUsageStatus extends UsageStatus
+object FailedUsageStatus extends UsageStatus
 
 // For Fronts usages as we don't know if a front is in draft or is live
 // TODO remove this once we do!

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -16,6 +16,7 @@ trait MessageSubjects {
   val AddImageLease = "add-image-lease"
   val RemoveImageLease = "remove-image-lease"
   val SetImageCollections = "set-image-collections"
+  val UpdateUsageStatus = "update-usage-status"
   val DeleteUsages = "delete-usages"
   val DeleteSingleUsage = "delete-single-usage"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -16,7 +16,7 @@ trait MessageSubjects {
   val AddImageLease = "add-image-lease"
   val RemoveImageLease = "remove-image-lease"
   val SetImageCollections = "set-image-collections"
-  val UpdateUsageStatus = "update-usage-status"
+  val UpdateSingleUsage = "update-single-usage"
   val DeleteUsages = "delete-usages"
   val DeleteSingleUsage = "delete-single-usage"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -16,7 +16,7 @@ trait MessageSubjects {
   val AddImageLease = "add-image-lease"
   val RemoveImageLease = "remove-image-lease"
   val SetImageCollections = "set-image-collections"
-  val UpdateSingleUsage = "update-single-usage"
+  val UpdateUsageStatus = "update-usage-status"
   val DeleteUsages = "delete-usages"
   val DeleteSingleUsage = "delete-single-usage"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -509,8 +509,8 @@ class ElasticSearch(
 
     val updateSingleUsageScript = s"""
          |ctx._source.usages.stream().filter(usage ->
-         |usage.id == params.usageParameter.usageId).forEach(usage ->
-         |{ usage.status = params.usageParameter.status;})
+         |usage.id == params.usagesParameter.usageId).forEach(usage ->
+         |{ usage.status = params.usagesParameter.status;})
          |""".stripMargin // need to update the script for all values not just status
 
     val usagesParameter = usageNotice.usageJson.value.flatMap(jsValue => asNestedMap(jsValue)).toMap //should be an option/have .orNull like metadata/syndication update?

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -8,7 +8,7 @@ import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
-import com.gu.mediaservice.model.usage.Usage
+import com.gu.mediaservice.model.usage.{Usage, UsageNotice}
 import com.gu.mediaservice.syntax._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.script.Script
@@ -501,6 +501,11 @@ class ElasticSearch(
       }
       ElasticSearchUpdateResponse()
     }))
+  }
+
+  def updateSingleUsage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime)
+                       (implicit ex: ExecutionContext, logMarker: LogMarker): List[Future[ElasticSearchUpdateResponse]] = {
+
   }
 
   def deleteSyndicationRights(id: String, lastModified: DateTime)

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -509,12 +509,12 @@ class ElasticSearch(
 
   val updateUsageStatusScript =
     s"""
-       |
+       | def lastUpdatedDate = ctx._source.usagesLastModified != null ? Date.from(Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(ctx._source.usagesLastModified))) : null;
        | for(int i = 0; i < ctx._source.usages.size(); i++) {
-       |    int dummy = ctx._source.usages.size();
-       |    if(ctx._source.usages[i].id == params.usage.id) {
+       |    if(lastUpdatedDate == null || modificationDate.after(lastUpdatedDate) && ctx._source.usages[i].id == params.usage.id) {
        |        ctx._source.usages[i].status = params.usage.status;
        |        ctx._source.usages[i].lastModified = params.lastModified;
+       |        ctx._source.usagesLastModified = params.lastModified;
        |    }
        | }
        |""".stripMargin

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -509,9 +509,8 @@ class ElasticSearch(
 
   val updateUsageStatusScript =
     s"""
-       | def lastUpdatedDate = ctx._source.usagesLastModified != null ? Date.from(Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(ctx._source.usagesLastModified))) : null;
        | for(int i = 0; i < ctx._source.usages.size(); i++) {
-       |    if(lastUpdatedDate == null || modificationDate.after(lastUpdatedDate) && ctx._source.usages[i].id == params.usage.id) {
+       |    if(ctx._source.usages[i].id == params.usage.id) {
        |        ctx._source.usages[i].status = params.usage.status;
        |        ctx._source.usages[i].lastModified = params.lastModified;
        |        ctx._source.usagesLastModified = params.lastModified;

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -504,21 +504,38 @@ class ElasticSearch(
     }))
   }
 
-  def updateSingleUsage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime)
+  def updateSingleUsage(id: String, usageId: String, usages: Seq[Usage], lastModified: DateTime)
                        (implicit ex: ExecutionContext, logMarker: LogMarker): List[Future[ElasticSearchUpdateResponse]] = {
+//    implicit val unw: Writes[UsageNotice] = Json.writes[UsageNotice]
+//    implicit val unr: Reads[UsageNotice] = Json.reads[UsageNotice]
     // like in the case of leases it might be that I need to use 'usages' instead of 'usage'
     // further, instead of using the approach of streaming the source, I may simplify and assume a single usage
     val updateSingleUsageScript = s"""
          |
          | for(int i = 0; i < ctx._source.usages.size(); i++) {
          |    int dummy = ctx._source.usages.size();
-         |    if(ctx._source.usages[i].id == "syndication/1defb893fd70ac054f212ddbe2aab485_1e54245a8a937e66d03d7abafa8048f3") {
-         |        ctx._source.usages[i].status = params.status;
+         |    if(ctx._source.usages[i].id == params.id) {
+         |        ctx._source.usages[i].status = "foo";
          |    }
          | }
          |""".stripMargin // need to update the script for all values not just status
 
-    val usagesParameter = usageNotice.usageJson.value.flatMap(jsValue => asNestedMap(jsValue)).toMap //should be an option/have .orNull like metadata/syndication update?
+    //val usagesParameter = usageNotice.usageJson.value.flatMap(jsValue => asNestedMap(jsValue)).toMap
+    val usagesParameter = JsDefined(Json.toJson(usages)).toOption.map(_.as[Usage]).map(i => asNestedMap(Json.toJson(i))).orNull
+
+//      .map{
+//      case (key, value: Option[_]) => key -> value.getOrElse("default")
+//      case (key, value) => key -> value
+//    }
+
+//      .filterKeys(key => key == "id" || key == "status")
+//      .mapValues {
+//        case Some(value: String) => value
+//        case None => "default"
+//        case other => other.toString
+//      }
+
+    //should be an option/have .orNull like metadata/syndication update?
 //    val processedParameters: Map[String, Any] = usagesParameter.collect {
 //      case (key, Some(value)) => value
 //      case (key, value) if value != None => key -> value
@@ -527,7 +544,25 @@ class ElasticSearch(
     // how will 'prepareUpdateRequest' take two params: usageId & usagesParameters? Can just get from usage params (esp if use sequence of usageNotice) so two not required
     println(s"Usage parameters are: $usagesParameter")
     println(s"usage id from params is: ${usagesParameter.get("id")}")
-    println(s"status from params is: ${usagesParameter.get("status")}")
+    println(s"status frm params is: ${usagesParameter.get("status")}")
+
+//    val unwrappedMap: Map[String, Any] = usagesParameter.flatMap {
+//      case (key, Some(value)) => Some(key -> value)
+//      case (key, value) if value != None => Some(key -> value)
+//      case _ => None
+//    }
+//    println(s"unwrapped parameters are: $unwrappedMap")
+//    println(s"unwrapped id is: ${unwrappedMap.getOrElse("id","default")}")
+//    println(s"unwrapped references is: ${unwrappedMap.getOrElse("references","default")}")
+
+//    val testId = usagesParameter.get("id")
+//    val stringId = testId.getOrElse("default")
+//
+//    println(s"*****String id is: $stringId")
+//
+//    usagesParameter.foreach { case (key, value) =>
+//      println(s"Key: $key, Value Type: ${value.getClass.getName}")
+//    }
     val scriptSource = loadUpdatingModificationPainless(updateSingleUsageScript)
 
     List(migrationAwareUpdater(

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -514,6 +514,7 @@ class ElasticSearch(
        |    int dummy = ctx._source.usages.size();
        |    if(ctx._source.usages[i].id == params.usage.id) {
        |        ctx._source.usages[i].status = params.usage.status;
+       |        ctx._source.usages[i].lastModified = params.lastModified;
        |    }
        | }
        |""".stripMargin

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -49,6 +49,7 @@ class MessageProcessor(
       case message: CreateMigrationIndexMessage => createMigrationIndex(message, logMarker)
       case message: MigrateImageMessage => migrateImage(message, logMarker)
       case message: UpsertFromProjectionMessage => upsertImageFromProjection(message, logMarker)
+      case message: UpdateSingleUsageMessage => updateSingleUsage(message, logMarker)
       case _: CompleteMigrationMessage => completeMigration(logMarker)
     }
   }
@@ -181,6 +182,9 @@ class MessageProcessor(
   private def deleteSingleUsage(message: DeleteSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) = {
     Future.sequence(es.deleteSingleImageUsage(message.id, message.usageId, message.lastModified)(ec, logMarker))
   }
+
+  private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
+    Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
 
   def upsertSyndicationRightsOnly(message: UpdateImageSyndicationMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     implicit val marker: LogMarker = logMarker ++ imageIdMarker(ImageId(message.id))

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -184,12 +184,13 @@ class MessageProcessor(
   }
 
   private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[List[ElasticSearchUpdateResponse]] = {
-    Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
-//    implicit val lm: LogMarker = combineMarkers(message, logMarker)
-//    val usages = message.usageNotice.usageJson.as[Seq[Usage]]
-//    Future.traverse(es.updateImageUsages(message.id, usages, message.lastModified))(_.recoverWith {
-//      case ElasticNotFoundException => Future.successful(ElasticSearchUpdateResponse())
-//    })
+//    Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
+      implicit val unw: OWrites[UsageNotice] = Json.writes[UsageNotice]
+      implicit val lm: LogMarker = combineMarkers(message, logMarker)
+      val usages = message.usageNotice.usageJson.as[Seq[Usage]]
+      Future.traverse(es.updateSingleUsage(message.id, message.usageId, usages, message.lastModified ))(_.recoverWith {
+        case ElasticNotFoundException => Future.successful(ElasticSearchUpdateResponse())
+    })
   }
 
   def upsertSyndicationRightsOnly(message: UpdateImageSyndicationMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -183,8 +183,14 @@ class MessageProcessor(
     Future.sequence(es.deleteSingleImageUsage(message.id, message.usageId, message.lastModified)(ec, logMarker))
   }
 
-  private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
+  private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[List[ElasticSearchUpdateResponse]] = {
     Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
+//    implicit val lm: LogMarker = combineMarkers(message, logMarker)
+//    val usages = message.usageNotice.usageJson.as[Seq[Usage]]
+//    Future.traverse(es.updateImageUsages(message.id, usages, message.lastModified))(_.recoverWith {
+//      case ElasticNotFoundException => Future.successful(ElasticSearchUpdateResponse())
+//    })
+  }
 
   def upsertSyndicationRightsOnly(message: UpdateImageSyndicationMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     implicit val marker: LogMarker = logMarker ++ imageIdMarker(ImageId(message.id))

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -73,6 +73,10 @@ object MessageTranslator extends GridLogging {
         case (Some(id), Some(edits)) => Right(UpdateImagePhotoshootMetadataMessage(id, updateMessage.lastModified, edits))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
+      case UpdateSingleUsage => (updateMessage.id, updateMessage.usageId, updateMessage.usageNotice ) match {
+        case (Some(id), Some(usageId), Some(usageNotice)) => Right(UpdateSingleUsageMessage(id, usageId, usageNotice, updateMessage.lastModified))
+        case _ => Left(MissingFieldsException(updateMessage.subject))
+      }
       case _ => Left(ProcessorNotFoundException(updateMessage.subject))
     }
   }

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -73,8 +73,8 @@ object MessageTranslator extends GridLogging {
         case (Some(id), Some(edits)) => Right(UpdateImagePhotoshootMetadataMessage(id, updateMessage.lastModified, edits))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
-      case UpdateSingleUsage => (updateMessage.id, updateMessage.usageId, updateMessage.usageNotice ) match {
-        case (Some(id), Some(usageId), Some(usageNotice)) => Right(UpdateSingleUsageMessage(id, usageId, usageNotice, updateMessage.lastModified))
+      case UpdateUsageStatus => (updateMessage.id, updateMessage.usageNotice ) match {
+        case (Some(id), Some(usageNotice)) => Right(UpdateUsageStatusMessage(id, usageNotice, updateMessage.lastModified))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
       case _ => Left(ProcessorNotFoundException(updateMessage.subject))

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -9,7 +9,7 @@ import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import com.gu.mediaservice.lib.usage.UsageBuilder
-import com.gu.mediaservice.model.usage.{MediaUsage, Usage}
+import com.gu.mediaservice.model.usage.{MediaUsage, Usage, UsageStatus}
 import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
 import model._
@@ -252,6 +252,39 @@ class UsageApi(
         val group = usageGroupOps.build(usageRequest)
         usageApiSubject.onNext(WithLogMarker.includeUsageGroup(group))
         Accepted
+      }
+    )
+  }}
+
+  def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
+    print(mediaId, usageId)
+    val request = (req.body \ "data").validate[UsageStatus]
+    request.fold(
+      e => respondError(
+        BadRequest,
+        errorKey = "update-image-usage-status-failed",
+        errorMessage = JsError.toJson(e).toString()
+      ),
+      usageStatusRequest => {
+        implicit val logMarker: LogMarker = MarkerMap(
+          "requestType" -> "update-usage-status",
+          "requestId" -> RequestLoggingFilter.getRequestId(req),
+          "usageStatus" -> usageStatusRequest.toString,
+          "image-id" -> mediaId,
+          "usage-id" -> usageId,
+        ) ++ apiKeyMarkers(req.user.accessor)
+        logger.info(logMarker, "recording usage status update")
+        usageTable.queryByUsageId(usageId).map {
+          case Some(mediaUsage) =>
+            mediaUsage.copy(status = UsageStatus("some string")) // this will need to change
+            usageTable.update(mediaUsage)
+            val updateMessage = UpdateMessage(subject = UpdateUsageStatus, id = Some(mediaId), usageId = Some(usageId))
+            notifications.publish(updateMessage)
+            Ok
+          case None =>
+            NotFound
+        }
+        Ok // this will need to change
       }
     )
   }}

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -255,7 +255,7 @@ class UsageApi(
       }
     )
   }}
-
+  // Might need to rename to updateSingleUsage -> will involve further changes
   def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
     val request = (req.body \ "data").validate[UsageStatus]
     request.fold(

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -257,7 +257,6 @@ class UsageApi(
   }}
 
   def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
-    println(s"mediaid is: $mediaId, usageid is: $usageId")
     val request = (req.body \ "data").validate[UsageStatus]
     request.fold(
       e => respondError(

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -255,7 +255,7 @@ class UsageApi(
       }
     )
   }}
-  // Might need to rename to updateSingleUsage -> will involve further changes
+
   def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
     val request = (req.body \ "data").validate[UsageStatus]
     request.fold(
@@ -280,15 +280,15 @@ class UsageApi(
             val usageNotice = UsageNotice(mediaId,
               JsArray(Seq(Json.toJson(UsageBuilder.build(updatedStatusMediaUsage)))))
             val updateMessage = UpdateMessage(
-              subject = UpdateSingleUsage, id = Some(mediaId),
-              usageId = Some(usageId), usageNotice = Some(usageNotice)
+              subject = UpdateUsageStatus, id = Some(mediaId),
+              usageNotice = Some(usageNotice)
             )
             notifications.publish(updateMessage)
             Ok
           case None =>
             NotFound
         }
-        Ok // this will need to change
+        Ok
       }
     )
   }}

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -14,7 +14,7 @@ case class SyndicationUsageRequest (
     case "Capture" => PendingUsageStatus
     case _ => SyndicatedUsageStatus
   }
-  val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName)
+  val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName, syndicatedBy)
 }
 object SyndicationUsageRequest {
   import JodaWrites._

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -1,15 +1,19 @@
 package model
 
-import com.gu.mediaservice.model.usage.{SyndicatedUsageStatus, SyndicationUsageMetadata, UsageStatus}
+import com.gu.mediaservice.model.usage.{PendingUsageStatus, SyndicatedUsageStatus, SyndicationUsageMetadata, UsageStatus}
 import org.joda.time.DateTime
 import play.api.libs.json._
 
 case class SyndicationUsageRequest (
   partnerName: String,
+  syndicatedBy: Option[String],
   mediaId: String,
   dateAdded: DateTime
 ) {
-  val status: UsageStatus = SyndicatedUsageStatus
+  val status: UsageStatus = partnerName match {
+    case "Capture" => PendingUsageStatus
+    case _ => SyndicatedUsageStatus
+  }
   val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName)
 }
 object SyndicationUsageRequest {

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -7,11 +7,12 @@ import play.api.libs.json._
 case class SyndicationUsageRequest (
   partnerName: String,
   syndicatedBy: Option[String],
+  startPending: Option[Boolean],
   mediaId: String,
   dateAdded: DateTime
 ) {
-  val status: UsageStatus = partnerName match {
-    case "Capture" => PendingUsageStatus
+  val status: UsageStatus = startPending match {
+    case Some(true) => PendingUsageStatus
     case _ => SyndicatedUsageStatus
   }
   val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName, syndicatedBy)

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -29,6 +29,7 @@ class UsageGroupOps(config: UsageConfig, mediaWrapperOps: MediaWrapperOps)
   def buildId(syndicationUsageRequest: SyndicationUsageRequest): String = s"syndication/${
     MD5.hash(List(
       syndicationUsageRequest.metadata.partnerName,
+      syndicationUsageRequest.metadata.syndicatedBy,
       syndicationUsageRequest.mediaId
     ).mkString("_"))
   }"

--- a/usage/app/model/UsageIdBuilder.scala
+++ b/usage/app/model/UsageIdBuilder.scala
@@ -23,6 +23,7 @@ object UsageIdBuilder {
   def build(syndicationUsageRequest: SyndicationUsageRequest) = buildId(List(
     Some(syndicationUsageRequest.mediaId),
     Some(syndicationUsageRequest.metadata.partnerName),
+    Some(syndicationUsageRequest.metadata.syndicatedBy),
     Some(syndicationUsageRequest.status)
   ))
 

--- a/usage/app/model/UsageIdBuilder.scala
+++ b/usage/app/model/UsageIdBuilder.scala
@@ -23,7 +23,7 @@ object UsageIdBuilder {
   def build(syndicationUsageRequest: SyndicationUsageRequest) = buildId(List(
     Some(syndicationUsageRequest.mediaId),
     Some(syndicationUsageRequest.metadata.partnerName),
-    Some(syndicationUsageRequest.metadata.syndicatedBy),
+    syndicationUsageRequest.metadata.syndicatedBy,
     Some(syndicationUsageRequest.status)
   ))
 

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -8,7 +8,7 @@ POST    /usages/print                                   controllers.UsageApi.set
 POST    /usages/syndication                             controllers.UsageApi.setSyndicationUsages
 POST    /usages/front                                   controllers.UsageApi.setFrontUsages
 POST    /usages/download                                controllers.UsageApi.setDownloadUsages
-
+PUT     /usages/status/update/:mediaId/*usageId         controllers.UsageApi.updateUsageStatus(mediaId: String, usageId: String)
 GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
 
 # Management


### PR DESCRIPTION
## What does this change?
This PR introduces changes that are required as part of the BBC's integration with Capture, specifically the ability to send images to Capture. These changes have been developed on top of the existing syndication usage functionality, but have been designed to ensure backwards compatibility so that other users of the Grid are unaffected. 

The syndication usage has been updated to be able to track the user that has requested an image be syndicated, via an optional 'syndicatedBy' field. Additionally, logic has been added such that if the syndication partner is "Capture", the usage status will be set as 'Pending' - otherwise the behavious remains the same. 

The usage status is set to 'Pending' as the BBC are pre-empting potential failures in the delivery of images to Capture. If an image fails to be delivered to Capture then the usage status will be updated to 'Failed', if an image is successfully delivered the usage status will be updated to 'Syndicated'. Therefore, in this context, the 'Pending' usage status is being used by the BBC as an intermediate status.

In order to achieve the above workflow, a new usage status, 'Failed', has been added to 'UsageStatus' and the 'updateUsageStatus' endpoint has been added to the usages API, to provide the functionality to update the usage status for an individual usage. 

These changes required an update of mappings.scala, so to deploy them an update to the Elasticsearch mapping is neccessary.  

## How should a reviewer test this change?

### To test the changes to the syndication usage:
Make GET requests to : `/usages/syndication`

With the following request bodies:

```
{
    "data":{
        "partnerName":"Capture",
        "syndicatedBy":"<username>",
        "mediaId":"<mediaId>",
        "dateAdded":"<date>"
    }
}

{
    "data":{
        "partnerName":"BBC",
        "syndicatedBy":"<username>",
        "mediaId":"<mediaId>",
        "dateAdded":"<date>"
    }
}

{
    "data":{
        "partnerName":"BBC",
         "mediaId":"<mediaId>",
        "dateAdded":"<date>"
    }
}
```
### To test the updateUsageStatus endpoint
Make GET requests to : `/usages/status/update/<meidaId>/<usageId>`

With the following request bodies:

```
{
    "data":
          "failed"
}

{
    "data":
          "syndicated"
}

{
    "data":
          "foo"
}
```

## How can success be measured?

### Success for the syndication usage:
1. The request is successful and a new 'Pending' usage is added to the image specified by the mediaId - this tests that in the case of a syndication usage with a 'Capture' partner the usage status is set to 'Pending'.
2. The request is successful and a new 'Syndicated' usage is added to the image specified by the mediaId - this tests that in the case of a syndication usage with a partner other than 'Capture' the usage status is set to 'Syndicated' (i.e. the current functionality is maintained).
3. The request is successful and a new 'Syndicated' usage is added to the image specified by the mediaId - this tests that a successfull request can be made without including data for the new 'syndicatedBy' field in the body of the request (i.e. the current functionality is maintained).

### Success for the updateUsageStatus endpoint:
1. The request is successful and the usage status of the usage with id <usageId> on the image with media id <mediaId> is changed to 'failed' - this tests that the endpoint can successfully update the usage status to the newly added 'failed' endpoint
2. The request is successful and the usage status of the usage with id <usageId> on the image with media id <mediaId> is changed to 'syndicated' - this test that the endpoint can successfully update the usage status to an existing usage status
3. The request fails and the usage status does not change - this tests the the endpoint only accepts valid usage statuses

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
