### PR TITLE
fix endless retry for ingestion queue

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SimpleSqsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SimpleSqsMessageConsumer.scala
@@ -6,17 +6,17 @@ import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.sqs.model.{DeleteMessageRequest, ReceiveMessageRequest, Message => SQSMessage}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 class SimpleSqsMessageConsumer (queueUrl: String, config: CommonConfig) {
 
   lazy val client: AmazonSQS = config.withAWSCredentials(AmazonSQSClientBuilder.standard()).build()
 
-  def getNextMessage(): Option[SQSMessage] =
+  def getNextMessage(messageAttributeNames: String*): Option[SQSMessage] =
     client.receiveMessage(
       new ReceiveMessageRequest(queueUrl)
         .withWaitTimeSeconds(20) // Wait for maximum duration (20s) as per doc recommendation: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html
         .withMaxNumberOfMessages(1) // Pull 1 message at a time to avoid starvation
+        .withMessageAttributeNames(messageAttributeNames: _*)
     ).getMessages.asScala.headOption
 
   def deleteMessage(message: SQSMessage): Unit =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsHelpers.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsHelpers.scala
@@ -7,8 +7,10 @@ import play.api.libs.json.Json
 import scala.util.Try
 
 trait SqsHelpers {
+
+  val attrApproximateReceiveCount = "ApproximateReceiveCount"
   def getApproximateReceiveCount(message: SQSMessage): Int =
-   Try(message.getAttributes.get("ApproximateReceiveCount").toInt).toOption.getOrElse(-1)
+   Try(message.getAttributes.get(attrApproximateReceiveCount).toInt).toOption.getOrElse(-1)
 
   def extractS3KeyFromSqsMessage(message: SQSMessage): Try[String] = Try {
 

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -62,7 +62,7 @@ class ImageLoaderController(auth: Authentication,
   val maybeIngestQueueAndProcessor: Option[(SimpleSqsMessageConsumer, Future[Done])] = maybeIngestQueue.map { ingestQueue =>
     val processor = Source.repeat(())
       .mapAsyncUnordered(parallelism=1)(_ => {
-        ingestQueue.getNextMessage() match {
+        ingestQueue.getNextMessage(attrApproximateReceiveCount) match {
           case None =>
             Future.successful(logger.debug(s"No message at ${DateTimeUtils.now()}"))
           case Some(sqsMessage) =>


### PR DESCRIPTION
We observed some files retrying indefinitely (rather than max of two attempts) even though we have logic to check for `ApproximateReceiveCount`... turns out you need to request attributes explicitly when 'receiving' the message... so this PR, requests the `ApproximateReceiveCount` SQS message attribute when receiving message from ingestion queue (otherwise things will retry until the eventually expire - after 4 days currently).