### PR TITLE
[ingestion] handle S3 file not existing manifesting as a 403 not just a 404

### DIFF
--- a/image-loader/app/lib/ImageLoaderStore.scala
+++ b/image-loader/app/lib/ImageLoaderStore.scala
@@ -17,7 +17,7 @@ class ImageLoaderStore(config: ImageLoaderConfig) extends lib.ImageIngestOperati
     try {
       doWork
     } catch {
-      case e: AmazonS3Exception if e.getStatusCode == 404 =>
+      case e: AmazonS3Exception if e.getStatusCode == 404 || e.getStatusCode == 403 =>
         loggingIfNotFound
         throw new S3FileDoesNotExistException
       case other: Throwable => throw other


### PR DESCRIPTION
Observing this in PROD 
![image](https://github.com/guardian/grid/assets/19289579/cba2be60-fa1b-4774-a2de-c2eefe77a2fc)

so broadening the definition of not existing to cover 403 too