### PR TITLE
[feature] Hold Alt to exclude, Shift to include when clicking search links

### DIFF
--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -324,7 +324,6 @@
                                 <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by'), nonFree: ctrl.srefNonfree()})"
                                    ng-click="ctrl.searchWithModifiers($event, 'by', ctrl.metadata.byline)"
                                    aria-label="Search images by {{ctrl.metadata.byline}} byline"
-                                   title="Hold alt to exclude or hold shift to include {{ctrl.metadata.byline}}">{{ctrl.metadata.byline}}</a>
                             </span>
 
                             <span class="editable-empty" ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add)</span>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -104,6 +104,7 @@
                             <dd class="image-info__title"
                                 ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
                                 <a ui-sref="search.results({query: (ctrl.metadata.title | queryFilter:'title'), nonFree: ctrl.srefNonfree()})"
+                                   ng-click="ctrl.searchWithModifiers($event, 'title', ctrl.metadata.title)"
                                    aria-label="Search images by {{ctrl.metadata.title}} title">{{ctrl.metadata.title}}</a>
                             </dd>
                         </div>
@@ -112,6 +113,7 @@
                             <dd class="image-info__title"
                                 ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.title)">
                                 <a ui-sref="search.results({query: (ctrl.metadata.title | queryFilter:'title'), nonFree: ctrl.srefNonfree()})"
+                                   ng-click="ctrl.searchWithModifiers($event, 'title', ctrl.metadata.title)"
                                    aria-label="Search images by {{ctrl.metadata.title}} title">{{ctrl.metadata.title}}</a>
                             </dd>
                         </div>
@@ -323,7 +325,7 @@
                             <span ng-if="ctrl.metadata.byline">
                                 <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by'), nonFree: ctrl.srefNonfree()})"
                                    ng-click="ctrl.searchWithModifiers($event, 'by', ctrl.metadata.byline)"
-                                   aria-label="Search images by {{ctrl.metadata.byline}} byline"
+                                   aria-label="Search images by {{ctrl.metadata.byline}} byline">{{ctrl.metadata.byline}}</a>
                             </span>
 
                             <span class="editable-empty" ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add)</span>
@@ -371,6 +373,7 @@
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.credit)">
                             <span ng-if="ctrl.metadata.credit">
                                 <a ui-sref="search.results({query: (ctrl.metadata.credit | queryFilter:'credit'), nonFree: ctrl.srefNonfree()})"
+                                   ng-click="ctrl.searchWithModifiers($event, 'credit', ctrl.metadata.credit)"
                                    aria-label="Search images by {{ctrl.metadata.credit}} credit">{{ctrl.metadata.credit}}</a>
                             </span>
 
@@ -401,6 +404,7 @@
                         <a
                             ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
                             ui-sref="search.results({query: (ctrl.metadata[prop] | queryFilter:ctrl.locationFieldMap[prop]), nonFree: ctrl.srefNonfree()})"
+                            ng-click="ctrl.searchWithModifiers($event, ctrl.locationFieldMap[prop], ctrl.metadata[prop])"
                             aria-label="Search images by {{ctrl.metadata[prop]}} {{prop}}"
                         >{{ctrl.metadata[prop]}}</a><span
                             ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata[prop])"
@@ -539,6 +543,7 @@
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.copyright)">
                             <span ng-if="ctrl.metadata.copyright">
                                 <a ui-sref="search.results({query: (ctrl.metadata.copyright | queryFilter:'copyright'), nonFree: ctrl.srefNonfree()})"
+                                   ng-click="ctrl.searchWithModifiers($event, 'copyright', ctrl.metadata.copyright)"
                                    aria-label="Search images by {{ctrl.metadata.copyright}} copyright">{{ctrl.metadata.copyright}}</a>
                             </span>
 
@@ -560,6 +565,7 @@
             <dd ng-if="!ctrl.hasMultipleValues(ctrl.extraInfo.uploadedBy)" class="image-info__wrap metadata-line metadata-line__info image-info__group--dl__value--panel">
                 <span class="metadata-line__info">
                     <a ui-sref="search.results({query: (ctrl.extraInfo.uploadedBy | queryFilter:'uploader'), nonFree: ctrl.srefNonfree()})"
+                       ng-click="ctrl.searchWithModifiers($event, 'uploader', ctrl.extraInfo.uploadedBy)"
                        aria-label="Search images uploaded by {{ctrl.extraInfo.uploadedBy}}">{{ctrl.extraInfo.uploadedBy | stripEmailDomain}}</a>
                 </span>
             </dd>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -322,7 +322,9 @@
                         <span class="metadata-line__info" ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.byline)">
                             <span ng-if="ctrl.metadata.byline">
                                 <a ui-sref="search.results({query: (ctrl.metadata.byline | queryFilter:'by'), nonFree: ctrl.srefNonfree()})"
-                                   aria-label="Search images by {{ctrl.metadata.byline}} byline">{{ctrl.metadata.byline}}</a>
+                                   ng-click="ctrl.searchWithModifiers($event, 'by', ctrl.metadata.byline)"
+                                   aria-label="Search images by {{ctrl.metadata.byline}} byline"
+                                   title="Hold alt to exclude or hold shift to include {{ctrl.metadata.byline}}">{{ctrl.metadata.byline}}</a>
                             </span>
 
                             <span class="editable-empty" ng-if="!ctrl.metadata.byline && ctrl.userCanEdit">Unknown (click ✎ to add)</span>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -841,6 +841,7 @@
                   ng-repeat="collection in ctrl.singleImage.data.collections"
                   ng-switch-default>
                 <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter), nonFree: ctrl.srefNonfree()})"
+                   ng-click="ctrl.searchWithModifiers($event, 'collection', collection.data.pathId)"
                    aria-label="Search images by {{collection.data.description}} collection">
                     {{collection.data.path.join(' ▸ ')}}
                 </a>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -646,6 +646,7 @@
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key | spaceWords}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">
                 <a ui-sref="search.results({query: (value | queryFilter:'{{key}}'), nonFree: ctrl.srefNonfree()})"
+                ng-click="ctrl.searchWithModifiers($event, key, value)"
                 aria-label="Search images with {{key}} '{{value}}'">{{value}}</a>
                 </dd>
             </dl>
@@ -654,6 +655,7 @@
                 <dt class="metadata-line__key image-info__group--dl__key--full-metadata">{{key}}</dt>
                 <dd class="metadata-line__info image-info__group--dl__value--full-metadata">
                 <a ui-sref="search.results({query: (metadata.value | queryFilter:'{{metadata.alias}}'), nonFree: ctrl.srefNonfree()})"
+                ng-click="ctrl.searchWithModifiers($event, metadata.alias, metadata.value)"
                 aria-label="Search images with {{key}} '{{metadata.value}}'">{{metadata.value}}</a>
                 </dd>
             </dl>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -515,17 +515,17 @@ module.controller('grImageMetadataCtrl', [
         return totalAdditionalMetadataCount == 0;
       };
 
-      function updateQueryWithModifiers(field, byline, alt, shift, prevQuery) {
+      function updateQueryWithModifiers(field, fieldValue, alt, shift, prevQuery) {
         if (alt && prevQuery) {
-          return `${prevQuery} -${fieldFilter(field, byline)}`;
+          return `${prevQuery} -${fieldFilter(field, fieldValue)}`;
         }
         if (alt) {
-          return `-${fieldFilter(field, byline)}`;
+          return `-${fieldFilter(field, fieldValue)}`;
         }
         if (shift && prevQuery) {
-          return `${prevQuery} ${fieldFilter(field, byline)}`;
+          return `${prevQuery} ${fieldFilter(field, fieldValue)}`;
         }
-        return fieldFilter(field, byline);
+        return fieldFilter(field, fieldValue);
       }
 
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -12,9 +12,9 @@ import { editOptions, overwrite } from '../../util/constants/editOptions';
 import '../../services/image-accessor';
 import '../../services/image-list';
 import '../../services/label';
-import { List } from 'immutable';
+import '../../search/query-filter';
 
-import { fieldFilter} from '../../search/query-filter';
+import { List } from 'immutable';
 
 export const module = angular.module('gr.imageMetadata', [
     'gr.image.service',
@@ -26,8 +26,6 @@ export const module = angular.module('gr.imageMetadata', [
 module.controller('grImageMetadataCtrl', [
   '$rootScope',
   '$scope',
-  '$state',
-  '$stateParams',
   '$window',
   'editsService',
   'mediaApi',
@@ -38,12 +36,9 @@ module.controller('grImageMetadataCtrl', [
   'inject$',
   'labelService',
   'storage',
-
-
+  'searchWithModifiers',
   function ($rootScope,
     $scope,
-    $state,
-    $stateParams,
     $window,
     editsService,
     mediaApi,
@@ -53,7 +48,8 @@ module.controller('grImageMetadataCtrl', [
     imageAccessor,
     inject$,
     labelService,
-    storage) {
+    storage,
+    searchWithModifiers) {
 
     let ctrl = this;
 
@@ -64,14 +60,14 @@ module.controller('grImageMetadataCtrl', [
     ctrl.metadataUpdatedByTemplate = [];
 
     ctrl.$onInit = () => {
-      $scope.$watchCollection('ctrl.selectedImages', function() {
+      $scope.$watchCollection('ctrl.selectedImages', function () {
         ctrl.singleImage = singleImage();
         ctrl.selectedLabels = selectedLabels();
         ctrl.usageRights = selectedUsageRights();
         inject$($scope, Rx.Observable.fromPromise(selectedUsageCategory(ctrl.usageRights)), ctrl, 'usageCategory');
         ctrl.rawMetadata = rawMetadata();
         ctrl.metadata = displayMetadata();
-        ctrl.metadata.dateTaken =  ctrl.displayDateTakenMetadata();
+        ctrl.metadata.dateTaken = ctrl.displayDateTakenMetadata();
         ctrl.newPeopleInImage = "";
         ctrl.newKeywords = "";
         ctrl.extraInfo = extraInfo();
@@ -82,7 +78,7 @@ module.controller('grImageMetadataCtrl', [
       });
 
       const freeUpdateListener = $rootScope.$on('images-updated',
-      (e, updatedImages) => updateHandler(updatedImages));
+        (e, updatedImages) => updateHandler(updatedImages));
 
       const updateHandler = (updatedImages) => {
         ctrl.selectedImages = new List(updatedImages);
@@ -90,18 +86,20 @@ module.controller('grImageMetadataCtrl', [
 
       ctrl.hasMultipleValues = (val) => Array.isArray(val) && val.length > 1;
 
-      ctrl.displayDateTakenMetadata = function() {
+      ctrl.displayDateTakenMetadata = function () {
         let dateTaken = ctrl.metadata.dateTaken ? new Date(ctrl.metadata.dateTaken) : undefined;
-        if (dateTaken) { dateTaken.setSeconds(0, 0); }
+        if (dateTaken) {
+          dateTaken.setSeconds(0, 0);
+        }
         return dateTaken;
       };
 
-      ctrl.credits = function(searchText) {
+      ctrl.credits = function (searchText) {
         return ctrl.metadataSearch('credit', searchText);
       };
 
       ctrl.metadataSearch = (field, q) => {
-        return mediaApi.metadataSearch(field,  { q }).then(resource => {
+        return mediaApi.metadataSearch(field, {q}).then(resource => {
           return resource.data.map(d => d.key);
         });
       };
@@ -110,11 +108,11 @@ module.controller('grImageMetadataCtrl', [
 
       ctrl.descriptionOptions = editOptions;
 
-      ctrl.updateDescriptionField = function() {
+      ctrl.updateDescriptionField = function () {
         ctrl.updateMetadataField('description', ctrl.metadata.description);
       };
 
-      ctrl.updateLocationField = function(data, value) {
+      ctrl.updateLocationField = function (data, value) {
         Object.keys(value).forEach(key => {
           if (value[key] === undefined) {
             delete value[key];
@@ -126,7 +124,7 @@ module.controller('grImageMetadataCtrl', [
       ctrl.updateMetadataField = function (field, value) {
         var imageArray = Array.from(ctrl.selectedImages);
         if (field === 'dateTaken') {
-            value = value.toISOString();
+          value = value.toISOString();
         }
         if (field === 'peopleInImage') {
           ctrl.addPersonToImages(imageArray, value);
@@ -144,7 +142,7 @@ module.controller('grImageMetadataCtrl', [
         );
       };
 
-      ctrl.updateDomainMetadataField = function(name, field, value) {
+      ctrl.updateDomainMetadataField = function (name, field, value) {
         return editsService.updateDomainMetadataField(ctrl.singleImage, name, field, value)
           .then((updatedImage) => {
             if (updatedImage) {
@@ -246,7 +244,7 @@ module.controller('grImageMetadataCtrl', [
             .map(([key, value]) => {
               let fieldAlias = ctrl.fieldAliases.find(_ => _.alias === key);
               if (fieldAlias && fieldAlias.displayInAdditionalMetadata === true) {
-                return [fieldAlias.label, { value, alias: fieldAlias.alias}];
+                return [fieldAlias.label, {value, alias: fieldAlias.alias}];
               }
             })
             .filter(_ => _ !== undefined));
@@ -256,7 +254,7 @@ module.controller('grImageMetadataCtrl', [
         ctrl.domainMetadata = ctrl.domainMetadataSpecs
           .filter(domainMetadataSpec => domainMetadataSpec.fields.length > 0)
           .reduce((acc, domainMetadataSpec) => {
-            let domainMetadata = { ...domainMetadataSpec };
+            let domainMetadata = {...domainMetadataSpec};
 
             if (ctrl.singleImage.data.metadata) {
               const imageDomainMetadata = ctrl.singleImage.data.metadata.domainMetadata ? ctrl.singleImage.data.metadata.domainMetadata : {};
@@ -290,7 +288,7 @@ module.controller('grImageMetadataCtrl', [
           field.selectOptions = field.options
             .filter(option => option)
             .map(option => {
-              return { value: option, text: option };
+              return {value: option, text: option};
             });
         }
 
@@ -338,7 +336,7 @@ module.controller('grImageMetadataCtrl', [
       ctrl.hasLocationInformation = hasLocationInformation;
 
       function singleImage() {
-        if (ctrl.selectedImages.size === 1){
+        if (ctrl.selectedImages.size === 1) {
           return ctrl.selectedImages.first();
         }
       }
@@ -377,9 +375,12 @@ module.controller('grImageMetadataCtrl', [
       function rawMetadata() {
         return selectedMetadata().map((values) => {
           switch (values.size) {
-            case 0:  return undefined;
-            case 1:  return values.first();
-            default: return Array.from(values);
+            case 0:
+              return undefined;
+            case 1:
+              return values.first();
+            default:
+              return Array.from(values);
           }
         }).toObject();
       }
@@ -387,8 +388,10 @@ module.controller('grImageMetadataCtrl', [
       function displayMetadata() {
         return selectedMetadata().map((values) => {
           switch (values.size) {
-            case 1:  return values.first();
-            default: return undefined;
+            case 1:
+              return values.first();
+            default:
+              return undefined;
           }
         }).toObject();
       }
@@ -398,9 +401,12 @@ module.controller('grImageMetadataCtrl', [
         const properties = imageList.getSetOfProperties(info);
         return properties.map((values) => {
           switch (values.size) {
-            case 0:  return undefined;
-            case 1:  return values.first();
-            default: return Array.from(values);
+            case 0:
+              return undefined;
+            case 1:
+              return values.first();
+            default:
+              return Array.from(values);
           }
         }).toObject();
       }
@@ -427,11 +433,11 @@ module.controller('grImageMetadataCtrl', [
       ctrl.removeImageFromCollection = (collection) => {
         ctrl.removingCollection = collection;
         collections.removeImageFromCollection(collection, ctrl.singleImage)
-            .then(() => ctrl.removingCollection = false);
+          .then(() => ctrl.removingCollection = false);
       };
 
-      $scope.$on('$destroy', function() {
-          freeUpdateListener();
+      $scope.$on('$destroy', function () {
+        freeUpdateListener();
       });
 
       ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leasesWithConfig) => {
@@ -504,44 +510,18 @@ module.controller('grImageMetadataCtrl', [
       };
 
       ctrl.isDomainMetadataEmpty = (key) => {
-        return ctrl.domainMetadata.find(obj => obj.name === key ).fields.every(field => field.value === undefined );
+        return ctrl.domainMetadata.find(obj => obj.name === key).fields.every(field => field.value === undefined);
       };
 
       ctrl.isAdditionalMetadataEmpty = () => {
         const totalAdditionalMetadataCount = Object.keys(ctrl.metadata).filter(key => ctrl.isUsefulMetadata(key)).length +
-        Object.keys(ctrl.additionalMetadata).length +
-        Object.keys(ctrl.identifiers).length;
+          Object.keys(ctrl.additionalMetadata).length +
+          Object.keys(ctrl.identifiers).length;
 
         return totalAdditionalMetadataCount == 0;
       };
 
-      function updateQueryWithModifiers(field, fieldValue, alt, shift, prevQuery) {
-        if (alt && prevQuery) {
-          return `${prevQuery} -${fieldFilter(field, fieldValue)}`;
-        }
-        if (alt) {
-          return `-${fieldFilter(field, fieldValue)}`;
-        }
-        if (shift && prevQuery) {
-          return `${prevQuery} ${fieldFilter(field, fieldValue)}`;
-        }
-        return fieldFilter(field, fieldValue);
-      }
-
-
-      ctrl.searchWithModifiers = ($event, fieldName, fieldValue) => {
-        const alt = event.getModifierState('Alt');
-        const shift = event.getModifierState('Shift');
-        if (alt || shift) {
-          $event.preventDefault();
-          const nonFree = ctrl.srefNonfree();
-
-          return $state.go('search.results', {
-            query: updateQueryWithModifiers(fieldName, fieldValue, alt, shift, $stateParams.query),
-            nonFree: nonFree
-          });
-        }
-      };
+      ctrl.searchWithModifiers = searchWithModifiers;
     };
   }
 ]);

--- a/kahuna/public/js/edits/list-editor-compact.html
+++ b/kahuna/public/js/edits/list-editor-compact.html
@@ -8,6 +8,7 @@
             <a class="element__value element__value--compact element__link"
                ng-if="!ctrl.disabled"
                ui-sref="search.results({query: (element | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})"
+               ng-click="ctrl.searchWithModifiers($event, 'label', element)"
                aria-label="Search images by {{element}} {{ctrl.elementName}}">
                 {{element}}
             </a>

--- a/kahuna/public/js/edits/list-editor-info-panel.html
+++ b/kahuna/public/js/edits/list-editor-info-panel.html
@@ -8,6 +8,7 @@
         <gr-icon>library_add</gr-icon>
     </button>
     <a ui-sref="search.results({query: (element.data | {{ctrl.queryFilter}}), nonFree: ctrl.srefNonfree()})" class="element__value"
+       ng-click="ctrl.searchWithModifiers($event, ctrl.elementName, element.data)"
        aria-label="Search images by {{element.data}} {{ctrl.elementName}}"
        ng-class="{'element__right-bit': !ctrl.isEditable}"
     >

--- a/kahuna/public/js/edits/list-editor.js
+++ b/kahuna/public/js/edits/list-editor.js
@@ -7,7 +7,6 @@ import '../services/image-list';
 import '../util/storage';
 
 import '../search/query-filter';
-import { fieldFilter} from '../search/query-filter';
 
 export var listEditor = angular.module('kahuna.edits.listEditor', [
     'kahuna.search.filters.query',
@@ -18,22 +17,20 @@ export var listEditor = angular.module('kahuna.edits.listEditor', [
 listEditor.controller('ListEditorCtrl', [
     '$rootScope',
     '$scope',
-    '$state',
-    '$stateParams',
     '$window',
     '$timeout',
     'imageLogic',
     'imageList',
     'storage',
+    'searchWithModifiers',
     function($rootScope,
             $scope,
-            $state,
-            $stateParams,
             $window,
             $timeout,
             imageLogic,
             imageList,
-            storage) {
+            storage,
+            searchWithModifiers) {
     var ctrl = this;
 
     ctrl.$onInit = () => {
@@ -152,34 +149,8 @@ listEditor.controller('ListEditorCtrl', [
       $scope.$on('$destroy', function() {
           updateListener();
       });
-      function updateQueryWithModifiers(field, fieldValue, alt, shift, prevQuery) {
-        if (alt && prevQuery) {
-          return `${prevQuery} -${fieldFilter(field, fieldValue)}`;
-        }
-        if (alt) {
-          return `-${fieldFilter(field, fieldValue)}`;
-        }
-        if (shift && prevQuery) {
-          return `${prevQuery} ${fieldFilter(field, fieldValue)}`;
-        }
-        return fieldFilter(field, fieldValue);
-      }
 
-
-      ctrl.searchWithModifiers = ($event, fieldName, fieldValue) => {
-        const alt = event.getModifierState('Alt');
-        const shift = event.getModifierState('Shift');
-        if (alt || shift) {
-          $event.preventDefault();
-          const nonFree = ctrl.srefNonfree();
-
-          return $state.go('search.results', {
-            query: updateQueryWithModifiers(fieldName, fieldValue, alt, shift, $stateParams.query),
-            nonFree: nonFree
-          });
-        }
-      };
-
+      ctrl.searchWithModifiers = searchWithModifiers;
     };
 }]);
 

--- a/kahuna/public/js/edits/list-editor.js
+++ b/kahuna/public/js/edits/list-editor.js
@@ -7,6 +7,7 @@ import '../services/image-list';
 import '../util/storage';
 
 import '../search/query-filter';
+import { fieldFilter} from '../search/query-filter';
 
 export var listEditor = angular.module('kahuna.edits.listEditor', [
     'kahuna.search.filters.query',
@@ -17,6 +18,8 @@ export var listEditor = angular.module('kahuna.edits.listEditor', [
 listEditor.controller('ListEditorCtrl', [
     '$rootScope',
     '$scope',
+    '$state',
+    '$stateParams',
     '$window',
     '$timeout',
     'imageLogic',
@@ -24,6 +27,8 @@ listEditor.controller('ListEditorCtrl', [
     'storage',
     function($rootScope,
             $scope,
+            $state,
+            $stateParams,
             $window,
             $timeout,
             imageLogic,
@@ -147,6 +152,34 @@ listEditor.controller('ListEditorCtrl', [
       $scope.$on('$destroy', function() {
           updateListener();
       });
+      function updateQueryWithModifiers(field, fieldValue, alt, shift, prevQuery) {
+        if (alt && prevQuery) {
+          return `${prevQuery} -${fieldFilter(field, fieldValue)}`;
+        }
+        if (alt) {
+          return `-${fieldFilter(field, fieldValue)}`;
+        }
+        if (shift && prevQuery) {
+          return `${prevQuery} ${fieldFilter(field, fieldValue)}`;
+        }
+        return fieldFilter(field, fieldValue);
+      }
+
+
+      ctrl.searchWithModifiers = ($event, fieldName, fieldValue) => {
+        const alt = event.getModifierState('Alt');
+        const shift = event.getModifierState('Shift');
+        if (alt || shift) {
+          $event.preventDefault();
+          const nonFree = ctrl.srefNonfree();
+
+          return $state.go('search.results', {
+            query: updateQueryWithModifiers(fieldName, fieldValue, alt, shift, $stateParams.query),
+            nonFree: nonFree
+          });
+        }
+      };
+
     };
 }]);
 

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -79,6 +79,7 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
                     gr-tooltip-position="top">
                     <a ui-sref="search.results({query: (collection.data.pathId | queryCollectionFilter), nonFree: ctrl.srefNonfree()})"
                        ng-attr-style="{{::ctrl.getCollectionStyle(collection)}}"
+                       ng-click="ctrl.searchWithModifiers($event, 'collection', collection.data.pathId)"
                        class="preview__collections__collection__value">
                         {{::collection.data.description}}
                     </a>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -17,7 +17,7 @@ import '../components/gr-add-label/gr-add-label';
 import '../components/gr-archiver-status/gr-archiver-status';
 import '../components/gr-syndication-icon/gr-syndication-icon';
 import {graphicImageBlurService} from "../services/graphic-image-blur";
-import { fieldFilter} from '../search/query-filter';
+import '../search/query-filter';
 
 export var image = angular.module('kahuna.preview.image', [
     'gr.image.service',
@@ -35,8 +35,6 @@ export var image = angular.module('kahuna.preview.image', [
 
 image.controller('uiPreviewImageCtrl', [
   '$scope',
-  '$state',
-  '$stateParams',
   'inject$',
   '$rootScope',
   '$window',
@@ -46,10 +44,9 @@ image.controller('uiPreviewImageCtrl', [
   'imageAccessor',
   'storage',
   'graphicImageBlurService',
+  'searchWithModifiers',
   function (
       $scope,
-      $state,
-      $stateParams,
       inject$,
       $rootScope,
       $window,
@@ -58,7 +55,8 @@ image.controller('uiPreviewImageCtrl', [
       labelService,
       imageAccessor,
       storage,
-      graphicImageBlurService) {
+      graphicImageBlurService,
+      searchWithModifiers) {
     var ctrl = this;
 
     ctrl.$onInit = () => {
@@ -137,33 +135,7 @@ image.controller('uiPreviewImageCtrl', [
         }
       };
 
-      function updateQueryWithModifiers(field, byline, alt, shift, prevQuery) {
-        if (alt && prevQuery) {
-          return `${prevQuery} -${fieldFilter(field, byline)}`;
-        }
-        if (alt) {
-          return `-${fieldFilter(field, byline)}`;
-        }
-        if (shift && prevQuery) {
-          return `${prevQuery} ${fieldFilter(field, byline)}`;
-        }
-        return fieldFilter(field, byline);
-      }
-
-
-      ctrl.searchWithModifiers = ($event, fieldName, fieldValue) => {
-        const alt = event.getModifierState('Alt');
-        const shift = event.getModifierState('Shift');
-        if (alt || shift) {
-          $event.preventDefault();
-          const nonFree = ctrl.srefNonfree();
-
-          return $state.go('search.results', {
-            query: updateQueryWithModifiers(fieldName, fieldValue, alt, shift, $stateParams.query),
-            nonFree: nonFree
-          });
-        }
-      };
+      ctrl.searchWithModifiers = searchWithModifiers;
     };
 }]);
 

--- a/kahuna/public/js/search/query-filter.js
+++ b/kahuna/public/js/search/query-filter.js
@@ -21,6 +21,37 @@ export function fieldFilter(field, value) {
     return `${field}:${valueMaybeQuoted}`;
 }
 
+queryFilters.factory('searchWithModifiers',
+  ['$state', '$stateParams', 'storage',
+  function($state, $stateParams, storage) {
+    function updateQueryWithModifiers(field, fieldValue, alt, shift, prevQuery) {
+      if (alt && prevQuery) {
+        return `${prevQuery} -${fieldFilter(field, fieldValue)}`;
+      }
+      if (alt) {
+        return `-${fieldFilter(field, fieldValue)}`;
+      }
+      if (shift && prevQuery) {
+        return `${prevQuery} ${fieldFilter(field, fieldValue)}`;
+      }
+      return fieldFilter(field, fieldValue);
+    }
+
+    return  ($event, fieldName, fieldValue) => {
+      const alt = $event.getModifierState('Alt');
+      const shift = $event.getModifierState('Shift');
+      if (alt || shift) {
+        $event.preventDefault();
+        const nonFree = storage.getJs("isNonFree", true) ? true : undefined;
+
+        return $state.go('search.results', {
+          query: updateQueryWithModifiers(fieldName, fieldValue, alt, shift, $stateParams.query),
+          nonFree: nonFree
+        });
+      }
+    };
+  }]);
+
 queryFilters.filter('queryFilter', function() {
     return (value, field) => fieldFilter(field, value);
 });

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -34,7 +34,8 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     DateConstraintMatch |
     DateRangeMatch ~> Match | AtMatch |
     FileTypeMatch ~> Match |
-    ScopedMatch ~> Match | HashMatch | CollectionRule |
+    CollectionRule |
+    ScopedMatch ~> Match | HashMatch |
     AnyMatch
   }
 
@@ -83,7 +84,7 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     )
   )}
 
-  def CollectionRule = rule { '~' ~ ExactMatchValue ~> (
+  def CollectionRule = rule { ("~" | "collection:") ~ ExactMatchValue ~> (
     collection => Match(
       HierarchyField,
       Phrase(collection.string.toLowerCase)
@@ -120,7 +121,6 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     "supplier" |
     "specialInstructions" |
     "title" |
-    "collection" |
     "keyword" |
     "label" |
     "croppedBy" |
@@ -134,7 +134,6 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     case "illustrator"         => "credit"
     case "uploader"            => "uploadedBy"
     case "label"               => "labels"
-    case "collection"          => "suppliersCollection"
     case "subject"             => "subjects"
     case "location"            => "subLocation"
     case "by" | "photographer" => "byline"


### PR DESCRIPTION
co-authored by: @andrew-nowak (proper code), @paperboyo (copypasta+logorrhea)

## A (sobbing) story [_(skip to content)_](#a-content)
Using metadata for searching is often an exercise in embarking on a journey of discovery too. You search for some text, you find an image, you click on one of it its metadata fields, you note the number of hits and if this number is large and you want to focus the search more, you try to exclude more and more things you don’t want. Or you want to add other metadata conditions to the current one(s). A proper filtering UI helps with the above immediately by displaying different values for multiple metadata fields dynamically in a reverse-popularity sort order, so it’s easy to discover the breakdown of the **specific** corpus you are looking at. It’s then easy to tell immediately how `subjects` for `Victor Hugo` are distributed and separate the writer from the MMA fighter. And the footballer. You can even tell when were they popular, more or less.
Lacking UI like that, my searches often involve opening multiple windows (to note the no. of hits for specific searches) and then copying and pasting parts of the query back to main search as exclusions (to find the ones I haven’t seen yet). This is very boring and manual work. Filters UI should make it a breeze.
But functionality in this PR will make it a bit easier now. It’s not at all discoverable, so is very much a power user level feature, which is sad, but at least it doesn’t interfere with anything else. It has zero visible UI. It uses keyboard shortcuts familiar from other applications.


## What does this change? <a href="#a-content" id="a-content"/>

This adds functionality for more focussed searches while clicking on metadata links and pills in the Info Panel and pills in image thumbnails: holding Alt will exclude, holding Shift will include (add to). In a browser, it adds and excludes from the **current running search**. In the Viewer, excluding just launches a new exclude search (one day, when the Viewer will just be a zoomed-in browser, we will fix that). It applies to:
- metadata values
- Additional metadata values
- Labels (also on thumbnails)
- Collections (also on thumbnails)
- Subjects, People, Keywords

![modifier search1](https://github.com/guardian/grid/assets/6032869/50b85c6e-d20d-4162-8192-6d605c5a9d20)

Also, while at it and to make it work, this PR fixes a longstanding confusion of `collection:` and `suppliersCollection:` searches. Now, both work correctly.

## How should a reviewer test this change?

Search for something, select an image, expand Info panel, click on any of the above holding Shift or Alt. Do the same from pills on thumbnails and from an image page (in the Viewer).

## How can success be measured?
Some tedious trawling of the corpus is a tad less so.

## Who should look at this?
@guardian/digital-cms 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment


TODO:
- [x] Add this to pills (subjects, people, labels, keywords) 
- [x] Add this to Additional metadata
- [x] Add this to Collections
- [x] learn how to remove all the code repetition (was told it’s fine, will await review later)
- [x] Domain metadata, shockingly, lacks links completely, so no support needed (sad)
- [x] figure out why excluding collections doesn’t work from viewer (image page): `collection:` does not enhance to `~:` like in other instances… ~possibly some suppliersCollection≠collection/~ malarkey~ (not that… but I bet something in `query-syntax.js`, weirdly an extra history step is created too…)