### PR TITLE
Conal/imagedam 1502 send to capture handle user input

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -176,7 +176,7 @@ object MappingTest {
       )),
       syndicationUsageMetadata = Some(SyndicationUsageMetadata(
         partnerName = "friends of ours",
-        syndicatedBy = None
+        syndicatedBy = Some("Bob")
       )),
       frontUsageMetadata = Some(FrontUsageMetadata(
         addedBy = "me",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -175,7 +175,8 @@ object MappingTest {
         composerUrl = Some(new URI("https://composer/api/2345678987654321345678"))
       )),
       syndicationUsageMetadata = Some(SyndicationUsageMetadata(
-        partnerName = "friends of ours"
+        partnerName = "friends of ours",
+        syndicatedBy = None
       )),
       frontUsageMetadata = Some(FrontUsageMetadata(
         addedBy = "me",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -281,7 +281,8 @@ object Mappings {
   ))
 
   def syndicationUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
-    keywordField("partnerName")
+    keywordField("partnerName"),
+    keywordField("syndicatedBy")
   ))
 
   def frontUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -280,7 +280,7 @@ object Mappings {
     keywordField("composerUrl")
   ))
 
-  def syndicationUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
+  def syndicationUsageMetadata(name: String): ObjectField = dynamicObj(name).copy(properties = Seq(
     keywordField("partnerName"),
     keywordField("syndicatedBy")
   ))

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -294,7 +294,7 @@ object Mappings {
     keywordField("downloadedBy")
   ))
 
-  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy(properties = Seq(
+  def usagesMapping(name: String): NestedField = nestedField(name).copy(properties = Seq(
     keywordField("id"),
     sStemmerAnalysed("title"),
     usageReference("references"),
@@ -336,7 +336,6 @@ object Mappings {
   private def nonDynamicObjectField(name: String) = ObjectField(name = name, dynamic = Some("strict"))
 
   private def nestedField(name: String) = NestedField(name).dynamic("strict") // ES1 include_in_parent needs to be emulated with field bby field copy_tos
-  private def nestedFieldDynamic(name: String) = nestedField(name).copy(dynamic = Some("true"))
 
   private def dynamicObj(name: String) = objectField(name).copy(dynamic = Some("true"))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -280,7 +280,7 @@ object Mappings {
     keywordField("composerUrl")
   ))
 
-  def syndicationUsageMetadata(name: String): ObjectField = dynamicObj(name).copy(properties = Seq(
+  def syndicationUsageMetadata(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
     keywordField("partnerName"),
     keywordField("syndicatedBy")
   ))
@@ -294,7 +294,7 @@ object Mappings {
     keywordField("downloadedBy")
   ))
 
-  def usagesMapping(name: String): NestedField = nestedField(name).copy( properties = Seq(
+  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy( properties = Seq(
     keywordField("id"),
     sStemmerAnalysed("title"),
     usageReference("references"),
@@ -336,6 +336,7 @@ object Mappings {
   private def nonDynamicObjectField(name: String) = ObjectField(name = name, dynamic = Some("strict"))
 
   private def nestedField(name: String) = NestedField(name).dynamic("strict") // ES1 include_in_parent needs to be emulated with field bby field copy_tos
+  private def nestedFieldDynamic(name: String) = NestedField(name).dynamic("true")
 
   private def dynamicObj(name: String) = objectField(name).copy(dynamic = Some("true"))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -294,7 +294,7 @@ object Mappings {
     keywordField("downloadedBy")
   ))
 
-  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy( properties = Seq(
+  def usagesMapping(name: String): NestedField = nestedFieldDynamic(name).copy(properties = Seq(
     keywordField("id"),
     sStemmerAnalysed("title"),
     usageReference("references"),
@@ -336,7 +336,7 @@ object Mappings {
   private def nonDynamicObjectField(name: String) = ObjectField(name = name, dynamic = Some("strict"))
 
   private def nestedField(name: String) = NestedField(name).dynamic("strict") // ES1 include_in_parent needs to be emulated with field bby field copy_tos
-  private def nestedFieldDynamic(name: String) = NestedField(name).dynamic("true")
+  private def nestedFieldDynamic(name: String) = nestedField(name).copy(dynamic = Some("true"))
 
   private def dynamicObj(name: String) = objectField(name).copy(dynamic = Some("true"))
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
@@ -52,7 +52,7 @@ object ItemToMediaUsage {
     Try {
       SyndicationUsageMetadata(
         metadataMap("partnerName").asInstanceOf[String],
-        None
+        metadataMap.get("syndicatedBy").map(x => x.asInstanceOf[String])
       )
     }.toOption
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/ItemToMediaUsage.scala
@@ -1,7 +1,6 @@
 package com.gu.mediaservice.lib.usage
 
 import java.net.URI
-
 import com.amazonaws.services.dynamodbv2.document.Item
 import com.gu.mediaservice.model.usage._
 import org.joda.time.DateTime
@@ -52,7 +51,8 @@ object ItemToMediaUsage {
   private def buildSyndication(metadataMap: Map[String, Any]): Option[SyndicationUsageMetadata] = {
     Try {
       SyndicationUsageMetadata(
-        metadataMap("partnerName").asInstanceOf[String]
+        metadataMap("partnerName").asInstanceOf[String],
+        None
       )
     }.toOption
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -64,7 +64,7 @@ object UsageBuilder {
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(
       UsageReference(
-        SyndicationUsageReference, None, Some(metadata.partnerName)
+        SyndicationUsageReference, None, Some(List(metadata.partnerName, metadata.syndicatedBy).mkString(", "))
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -64,7 +64,7 @@ object UsageBuilder {
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(
       UsageReference(
-        SyndicationUsageReference, None, metadata.syndicatedBy.map(_ => s"${metadata.partnerName}, ${metadata.syndicatedBy}").orElse(Some(metadata.partnerName))
+        SyndicationUsageReference, None, metadata.syndicatedBy.map(_ => s"${metadata.partnerName}, ${metadata.syndicatedBy.get}").orElse(Some(metadata.partnerName))
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/usage/UsageBuilder.scala
@@ -64,7 +64,7 @@ object UsageBuilder {
   private def buildSyndicationUsageReference(usage: MediaUsage): List[UsageReference] = usage.syndicationUsageMetadata.map (metadata => {
     List(
       UsageReference(
-        SyndicationUsageReference, None, Some(List(metadata.partnerName, metadata.syndicatedBy).mkString(", "))
+        SyndicationUsageReference, None, metadata.syndicatedBy.map(_ => s"${metadata.partnerName}, ${metadata.syndicatedBy}").orElse(Some(metadata.partnerName))
       )
     )
   }).getOrElse(

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -124,6 +124,8 @@ case class DeleteSingleUsageMessage(id: String, lastModified: DateTime, usageId:
 
 case class DeleteUsagesMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 
+case class UpdateSingleUsageMessage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime) extends ExternalThrallMessage
+
 object DeleteUsagesMessage {
   implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))
   implicit val yourJodaDateWrites = JodaWrites.JodaDateTimeWrites

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -76,6 +76,7 @@ object ExternalThrallMessage{
   implicit val updateImagePhotoshootMetadataMessage = Json.format[UpdateImagePhotoshootMetadataMessage]
   implicit val deleteUsagesMessage = Json.format[DeleteUsagesMessage]
   implicit val deleteSingleUsageMessage = Json.format[DeleteSingleUsageMessage]
+  implicit val updateSingleUsageMessage = Json.format[UpdateSingleUsageMessage]
   implicit val updateImageUsagesMessage = Json.format[UpdateImageUsagesMessage]
   implicit val addImageLeaseMessage = Json.format[AddImageLeaseMessage]
   implicit val removeImageLeaseMessage = Json.format[RemoveImageLeaseMessage]

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ThrallMessage.scala
@@ -76,7 +76,7 @@ object ExternalThrallMessage{
   implicit val updateImagePhotoshootMetadataMessage = Json.format[UpdateImagePhotoshootMetadataMessage]
   implicit val deleteUsagesMessage = Json.format[DeleteUsagesMessage]
   implicit val deleteSingleUsageMessage = Json.format[DeleteSingleUsageMessage]
-  implicit val updateSingleUsageMessage = Json.format[UpdateSingleUsageMessage]
+  implicit val updateUsageStatusMessage = Json.format[UpdateUsageStatusMessage]
   implicit val updateImageUsagesMessage = Json.format[UpdateImageUsagesMessage]
   implicit val addImageLeaseMessage = Json.format[AddImageLeaseMessage]
   implicit val removeImageLeaseMessage = Json.format[RemoveImageLeaseMessage]
@@ -125,7 +125,7 @@ case class DeleteSingleUsageMessage(id: String, lastModified: DateTime, usageId:
 
 case class DeleteUsagesMessage(id: String, lastModified: DateTime) extends ExternalThrallMessage
 
-case class UpdateSingleUsageMessage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime) extends ExternalThrallMessage
+case class UpdateUsageStatusMessage(id: String, usageNotice: UsageNotice, lastModified: DateTime) extends ExternalThrallMessage
 
 object DeleteUsagesMessage {
   implicit val yourJodaDateReads = JodaReads.DefaultJodaDateTimeReads.map(d => d.withZone(DateTimeZone.UTC))

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
@@ -4,14 +4,11 @@ import play.api.libs.json._
 
 case class SyndicationUsageMetadata(
   partnerName: String,
-  syndicatedBy: Option[String]
+  syndicatedBy: Option[String] = None
 ) extends UsageMetadata {
-  override def toMap: Map[String, Any] = {
-    syndicatedBy match {
-      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user) // why isn't this working?
-      case None       => Map("partnerName" -> partnerName)
-    }
-  }
+  override def toMap: Map[String, Any] = Map(
+    "partnerName" -> partnerName
+  ) ++ syndicatedBy.map("syndicatedBy" -> _)
 }
 
 object SyndicationUsageMetadata {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
@@ -8,7 +8,7 @@ case class SyndicationUsageMetadata(
 ) extends UsageMetadata {
   override def toMap: Map[String, Any] = {
     syndicatedBy match {
-      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user)
+      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user) // why isn't this working?
       case None       => Map("partnerName" -> partnerName)
     }
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/SyndicationUsageMetadata.scala
@@ -3,11 +3,15 @@ package com.gu.mediaservice.model.usage
 import play.api.libs.json._
 
 case class SyndicationUsageMetadata(
-  partnerName: String
+  partnerName: String,
+  syndicatedBy: Option[String]
 ) extends UsageMetadata {
-  override def toMap: Map[String, Any] = Map(
-    "partnerName" -> partnerName
-  )
+  override def toMap: Map[String, Any] = {
+    syndicatedBy match {
+      case Some(user) => Map("partnerName" -> partnerName, "syndicatedBy" -> user)
+      case None       => Map("partnerName" -> partnerName)
+    }
+  }
 }
 
 object SyndicationUsageMetadata {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
@@ -5,8 +5,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, JsArray, JsObject, Json}
 
 case class UsageNotice(mediaId: String, usageJson: JsArray) {
-  def toJson =
-    Json.obj(
+  def toJson = Json.obj(
     "id" -> mediaId,
     "data" -> usageJson,
     "lastModified" -> printDateTime(DateTime.now())

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageNotice.scala
@@ -5,7 +5,8 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JodaWrites, JsArray, JsObject, Json}
 
 case class UsageNotice(mediaId: String, usageJson: JsArray) {
-  def toJson = Json.obj(
+  def toJson =
+    Json.obj(
     "id" -> mediaId,
     "data" -> usageJson,
     "lastModified" -> printDateTime(DateTime.now())

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/usage/UsageStatus.scala
@@ -9,6 +9,7 @@ sealed trait UsageStatus {
     case RemovedUsageStatus => "removed"
     case SyndicatedUsageStatus => "syndicated"
     case DownloadedUsageStatus => "downloaded"
+    case FailedUsageStatus => "failed"
     case UnknownUsageStatus => "unknown"
   }
 }
@@ -20,7 +21,9 @@ object UsageStatus {
     case "removed" => RemovedUsageStatus
     case "syndicated" => SyndicatedUsageStatus
     case "downloaded" => DownloadedUsageStatus
+    case "failed" => FailedUsageStatus
     case "unknown" => UnknownUsageStatus
+    case _ => throw new IllegalArgumentException("Invalid usage status")
   }
 
   implicit val reads: Reads[UsageStatus] = JsPath.read[String].map(UsageStatus(_))
@@ -35,6 +38,7 @@ object PublishedUsageStatus extends UsageStatus
 object RemovedUsageStatus extends UsageStatus
 object SyndicatedUsageStatus extends UsageStatus
 object DownloadedUsageStatus extends UsageStatus
+object FailedUsageStatus extends UsageStatus
 
 // For Fronts usages as we don't know if a front is in draft or is live
 // TODO remove this once we do!

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -16,6 +16,7 @@ trait MessageSubjects {
   val AddImageLease = "add-image-lease"
   val RemoveImageLease = "remove-image-lease"
   val SetImageCollections = "set-image-collections"
+  val UpdateUsageStatus = "update-usage-status"
   val DeleteUsages = "delete-usages"
   val DeleteSingleUsage = "delete-single-usage"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -16,7 +16,7 @@ trait MessageSubjects {
   val AddImageLease = "add-image-lease"
   val RemoveImageLease = "remove-image-lease"
   val SetImageCollections = "set-image-collections"
-  val UpdateUsageStatus = "update-usage-status"
+  val UpdateSingleUsage = "update-single-usage"
   val DeleteUsages = "delete-usages"
   val DeleteSingleUsage = "delete-single-usage"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"

--- a/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/syntax/MessageSubjects.scala
@@ -16,7 +16,7 @@ trait MessageSubjects {
   val AddImageLease = "add-image-lease"
   val RemoveImageLease = "remove-image-lease"
   val SetImageCollections = "set-image-collections"
-  val UpdateSingleUsage = "update-single-usage"
+  val UpdateUsageStatus = "update-usage-status"
   val DeleteUsages = "delete-usages"
   val DeleteSingleUsage = "delete-single-usage"
   val UpdateImageSyndicationMetadata = "update-image-syndication-metadata"

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -40,6 +40,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val useReaper: Option[Boolean] = booleanOpt("useReaper")
 
   val showDenySyndicationWarning: Option[Boolean] = booleanOpt("showDenySyndicationWarning")
+  val showSendToPhotoSales: Option[Boolean] = booleanOpt("showSendToPhotoSales")
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources") ++ maybeIngestBucket.map { ingestBucket =>

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -56,6 +56,7 @@
           systemName: "@Html(kahunaConfig.systemName)",
           canDownloadCrop: @kahunaConfig.canDownloadCrop,
           showDenySyndicationWarning: @kahunaConfig.showDenySyndicationWarning.getOrElse(false),
+          showSendToPhotoSales:@kahunaConfig.showSendToPhotoSales.getOrElse(false),
           domainMetadataSpecs: @Html(domainMetadataSpecs),
           recordDownloadAsUsage: @kahunaConfig.recordDownloadAsUsage,
           metadataTemplates: @Html(metadataTemplates),

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -81,6 +81,18 @@
                     <gr-icon-label gr-icon="share">Share with URL</gr-icon-label>
                 </a>
 
+                <a id="send-to" class="results-toolbar-item results-toolbar-item--right"
+                   style="display: flex;"
+                   ng-class="{'batch-archive__button--disabled': ctrl.selectionCount >= 45}"
+                   ng-click="ctrl.selectionCount < 45 && ctrl.sendToCapture()"
+                   ng-if="ctrl.selectionCount > 0"
+                   aria-label="{{ctrl.selectionCount >= 45 ? 'You can’t share all these images at once, please reduce to 44 or less' : 'Share selected images'}}"
+                   gr-tooltip="{{ctrl.selectionCount >= 45 ? 'You can’t share all these images at once, please reduce to 44 or less' : 'Share selected images'}}"
+                   gr-tooltip-position="bottom"
+                   gr-tooltip-updates>
+                    <gr-icon-label gr-icon="send">Send To Capture</gr-icon-label>
+                </a>
+
                 <gr-batch-export-original-images class="results-toolbar-item results-toolbar-item--right"
                   images="ctrl.selectedImages"
                   ng-if="ctrl.selectionCount > 0"></gr-batch-export-original-images>

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -81,17 +81,21 @@
                     <gr-icon-label gr-icon="share">Share with URL</gr-icon-label>
                 </a>
 
-                <a id="send-to" class="results-toolbar-item results-toolbar-item--right"
-                   style="display: flex;"
-                   ng-class="{'batch-archive__button--disabled': ctrl.selectionCount >= 45}"
-                   ng-click="ctrl.selectionCount < 45 && ctrl.sendToCapture()"
-                   ng-if="ctrl.selectionCount > 0"
-                   aria-label="{{ctrl.selectionCount >= 45 ? 'You can’t share all these images at once, please reduce to 44 or less' : 'Share selected images'}}"
-                   gr-tooltip="{{ctrl.selectionCount >= 45 ? 'You can’t share all these images at once, please reduce to 44 or less' : 'Share selected images'}}"
-                   gr-tooltip-position="bottom"
-                   gr-tooltip-updates>
-                    <gr-icon-label gr-icon="send">Send To Capture</gr-icon-label>
-                </a>
+                <div class="results-toolbar-item results-toolbar-item--right"
+                    ng-if="ctrl.showSendToPhotoSales()">
+                    <a id="send-to"
+                       style="display: flex;"
+                       ng-class="{'batch-archive__button--disabled': ctrl.selectionCount >= 45}"
+                       ng-click="ctrl.selectionCount < 45 && ctrl.sendToPhotoSales()"
+                       ng-if="ctrl.selectionCount > 0"
+                       aria-label="{{ctrl.selectionCount >= 45 ? 'You can’t share all these images at once, please reduce to 44 or less' : 'Share selected images'}}"
+                       gr-tooltip="{{ctrl.selectionCount >= 45 ? 'You can’t share all these images at once, please reduce to 44 or less' : 'Share selected images'}}"
+                       gr-tooltip-position="bottom"
+                       gr-tooltip-updates>
+                        <gr-icon-label gr-icon="send">Send To Photo Sales</gr-icon-label>
+                    </a>
+                </div>
+
 
                 <gr-batch-export-original-images class="results-toolbar-item results-toolbar-item--right"
                   images="ctrl.selectedImages"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -387,7 +387,7 @@ results.controller('SearchResultsCtrl', [
       ctrl.sendToCapture = () => {
         ctrl.selectedImages.map(image => {
           console.log("map image: ", image.data.id)
-          mediaApi.sendToCapture(image.data.id)
+          mediaApi.syndicateImage(image.data.id, "Capture", "true")
           // image.data.uploadTime = moment(image.data.uploadTime).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
           // return image;
         });

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -96,8 +96,8 @@ results.controller('SearchResultsCtrl', [
         const ctrl = this;
 
         ctrl.$onInit = () => {
-          ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales
-        }
+          ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales;
+        };
 
         // Panel control
         ctrl.metadataPanel    = panels.metadataPanel;
@@ -390,13 +390,13 @@ results.controller('SearchResultsCtrl', [
 
       ctrl.sendToPhotoSales = () => {
         ctrl.selectedImages.map(image => {
-          console.log("map image: ", image.data.id)
-          mediaApi.syndicateImage(image.data.id, "Capture", "true")
+          console.log("map image: ", image.data.id);
+          mediaApi.syndicateImage(image.data.id, "Capture", "true");
         });
         const sharedImagesIds = ctrl.selectedImages.map( image => image.data.id);
-        console.log("images ids: ", sharedImagesIds)
-        console.log("ctrl.image: ", ctrl.image)
-        console.log("images ids join : ", sharedImagesIds.join(','))
+        console.log("images ids: ", sharedImagesIds);
+        console.log("ctrl.image: ", ctrl.image);
+        console.log("images ids join : ", sharedImagesIds.join(','));
       };
 
         const inSelectionMode$ = selection.isEmpty$.map(isEmpty => ! isEmpty);

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -95,6 +95,10 @@ results.controller('SearchResultsCtrl', [
 
         const ctrl = this;
 
+        ctrl.$onInit = () => {
+          ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales
+        }
+
         // Panel control
         ctrl.metadataPanel    = panels.metadataPanel;
         ctrl.collectionsPanel = panels.collectionsPanel;
@@ -384,7 +388,7 @@ results.controller('SearchResultsCtrl', [
             globalErrors.trigger('clipboard', sharedUrl);
         };
 
-      ctrl.sendToCapture = () => {
+      ctrl.sendToPhotoSales = () => {
         ctrl.selectedImages.map(image => {
           console.log("map image: ", image.data.id)
           mediaApi.syndicateImage(image.data.id, "Capture", "true")

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -384,6 +384,22 @@ results.controller('SearchResultsCtrl', [
             globalErrors.trigger('clipboard', sharedUrl);
         };
 
+      ctrl.sendToCapture = () => {
+        ctrl.selectedImages.map(image => {
+          console.log("map image: ", image.data.id)
+          mediaApi.sendToCapture(image.data.id)
+          // image.data.uploadTime = moment(image.data.uploadTime).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+          // return image;
+        });
+        const sharedImagesIds = ctrl.selectedImages.map( image => image.data.id);
+        console.log("images ids: ", sharedImagesIds)
+        console.log("ctrl.image: ", ctrl.image)
+        console.log("images ids join : ", sharedImagesIds.join(','))
+        // mediaApi.sendToCapture(sharedImagesIds).then(sent => {
+        //         console.log("sent to capture", sent)
+        //     });
+      };
+
         const inSelectionMode$ = selection.isEmpty$.map(isEmpty => ! isEmpty);
         inject$($scope, inSelectionMode$, ctrl, 'inSelectionMode');
         inject$($scope, selection.count$, ctrl, 'selectionCount');

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -388,16 +388,11 @@ results.controller('SearchResultsCtrl', [
         ctrl.selectedImages.map(image => {
           console.log("map image: ", image.data.id)
           mediaApi.syndicateImage(image.data.id, "Capture", "true")
-          // image.data.uploadTime = moment(image.data.uploadTime).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-          // return image;
         });
         const sharedImagesIds = ctrl.selectedImages.map( image => image.data.id);
         console.log("images ids: ", sharedImagesIds)
         console.log("ctrl.image: ", ctrl.image)
         console.log("images ids join : ", sharedImagesIds.join(','))
-        // mediaApi.sendToCapture(sharedImagesIds).then(sent => {
-        //         console.log("sent to capture", sent)
-        //     });
       };
 
         const inSelectionMode$ = selection.isEmpty$.map(isEmpty => ! isEmpty);

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -98,6 +98,11 @@ mediaApi.factory('mediaApi',
         return root.follow('undelete', {id: id}).put();
     }
 
+    function sendToCapture(id) {
+      console.log("send to capture: ",id)
+      return root.follow('send-to-capture', {id: id}).post();
+    }
+
     function canUserArchive() {
         return root.getLink('archive').then(() => true, () => false);
     }
@@ -113,6 +118,7 @@ mediaApi.factory('mediaApi',
         delete: delete_,
         canUserUpload,
         canUserArchive,
-        undelete
+        undelete,
+        sendToCapture
     };
 }]);

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -98,9 +98,9 @@ mediaApi.factory('mediaApi',
         return root.follow('undelete', {id: id}).put();
     }
 
-    function sendToCapture(id) {
-      console.log("send to capture: ",id)
-      return root.follow('send-to-capture', {id: id}).post();
+    function syndicateImage(id, partnerName, startPending) {
+      console.log("syndicate image: ",id)
+      return root.follow('syndicate image').post({id, partnerName, startPending});
     }
 
     function canUserArchive() {
@@ -119,6 +119,6 @@ mediaApi.factory('mediaApi',
         canUserUpload,
         canUserArchive,
         undelete,
-        sendToCapture
+        syndicateImage
     };
 }]);

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -98,9 +98,8 @@ mediaApi.factory('mediaApi',
         return root.follow('undelete', {id: id}).put();
     }
 
-    function syndicateImage(id, partnerName, startPending) {
-      console.log("syndicate image: ",id)
-      return root.follow('syndicate image').post({id, partnerName, startPending});
+    function syndicateImage(mediaId, partner, pending) {
+      return root.follow('syndicate-image', {id: mediaId, partnerName: partner, startPending: pending}).post();
     }
 
     function canUserArchive() {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -375,20 +375,11 @@ class MediaApi(
     elasticSearch.getImageById(id) flatMap {
       case Some(image) if hasPermission(request.user, image) => {
         val apiKey = request.user.accessor
-        logger.info(s"set capture usage, image: $id from user: ${Authentication.getIdentity(request.user)}", apiKey, id)
-        println(s"set capture usage, image: $id from user: ${Authentication.getIdentity(request.user)}", apiKey, id)
-        //        mediaApiMetrics.incrementImageDownload(apiKey, mediaApiMetrics.OriginalDownloadType)
-        // val s3Object = s3Client.getObject(config.imageBucket, image.source.file)
-        // val file = StreamConverters.fromInputStream(() => s3Object.getObjectContent)
-        // val entity = HttpEntity.Streamed(file, image.source.size, image.source.mimeType.map(_.name))
+        logger.info(s"Syndicate image: $id from user: ${Authentication.getIdentity(request.user)}", apiKey, id, partnerName, startPending)
 
-        postToUsages(config.usageUri + "/usages/capture", auth.getOnBehalfOfPrincipal(request.user), id, Authentication.getIdentity(request.user), Option(partnerName), startPending)
-        println("done send to usages...............................")
+        postToUsages(config.usageUri + "/usages/syndication", auth.getOnBehalfOfPrincipal(request.user), id, Authentication.getIdentity(request.user), Option(partnerName), startPending)
 
         Future.successful(Ok)
-        // Future.successful(
-        //   Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> s3Client.getContentDisposition(image, Source))
-        // )
       }
       case _ => Future.successful(ImageNotFound(id))
     }

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -371,15 +371,9 @@ class MediaApi(
 
   def syndicateImage(id: String, partnerName: String, startPending: String) = auth.async { request =>
     implicit val r = request
-    println(id)
-
-    //partnerName: String, startPending: String)
-
-    println("media syndication endpoint has been triggered")
 
     elasticSearch.getImageById(id) flatMap {
       case Some(image) if hasPermission(request.user, image) => {
-        println(s"Found image by id from: https://api.media.local.dev-gutools.co.uk/images/$id/$partnerName/$startPending/syndicateImage")
         val apiKey = request.user.accessor
         logger.info(s"Syndicate image: $id from user: ${Authentication.getIdentity(request.user)}", apiKey,
           id, partnerName, startPending)
@@ -390,7 +384,6 @@ class MediaApi(
         Future.successful(Ok)
       }
       case _ => {
-        println(s"NO image by id from: https://api.media.local.dev-gutools.co.uk/images/$id/$partnerName/$startPending/syndicateImage")
         Future.successful(ImageNotFound(id))}
     }
   }
@@ -425,8 +418,6 @@ class MediaApi(
   def postToUsages(uri: String, onBehalfOfPrincipal: Authentication.OnBehalfOfPrincipal, mediaId: String, user: String,
                    partnerName: Option[String] = None, startPending: Option[String] = None) = {
 
-    println(s"Making a request to: $uri, with mediaId:$mediaId, partnerName: $partnerName, startPending: $startPending")
-
     val baseRequest = ws.url(uri)
       .withHttpHeaders(Authentication.originalServiceHeaderName -> config.appName,
         HttpHeaders.ORIGIN -> config.rootUri,
@@ -446,7 +437,6 @@ class MediaApi(
           throw new IllegalArgumentException("partnerName required for SyndicationUsageRequest"))
       )
     }
-    println(s"data on body: $usagesMetadata")
     logger.info(s"Making usages request to $uri")
     request.post(Json.toJson(Map("data" -> usagesMetadata))) //fire and forget
   }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -26,6 +26,7 @@ GET     /images/:imageId/downloadOptimised                          controllers.
 DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
+POST     /images/:id/sendToCapture                                  controllers.MediaApi.setCaptureUsage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch
 
 # completion

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -23,7 +23,7 @@ GET     /images/:imageId/export/:exportId/asset/:width/download     controllers.
 GET     /images/:imageId/export                                     controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                                   controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
-POST    /images/:id/:partnerName/:startPending                      controllers.MediaApi.syndicateImage(id: String, partnerName: String, startPending:Option[String])
+POST    /images/:id/:partnerName/:startPending/syndicateImage       controllers.MediaApi.syndicateImage(id: String, partnerName: String, startPending:String)
 DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -23,10 +23,10 @@ GET     /images/:imageId/export/:exportId/asset/:width/download     controllers.
 GET     /images/:imageId/export                                     controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                                   controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
+POST    /images/:id/:partnerName/:startPending                      controllers.MediaApi.syndicateImage(id: String, partnerName: String, startPending:Option[String])
 DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
-POST     /images/:id/sendToCapture                                  controllers.MediaApi.setCaptureUsage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch
 
 # completion

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -509,8 +509,8 @@ class ElasticSearch(
 
     val updateSingleUsageScript = s"""
          |ctx._source.usages.stream().filter(usage ->
-         |usage.id == params.usageParameter.usageId).forEach(usage ->
-         |{ usage.status = params.usageParameter.status;})
+         |usage.id == params.usagesParameter.usageId).forEach(usage ->
+         |{ usage.status = params.usagesParameter.status;})
          |""".stripMargin // need to update the script for all values not just status
 
     val usagesParameter = usageNotice.usageJson.value.flatMap(jsValue => asNestedMap(jsValue)).toMap //should be an option/have .orNull like metadata/syndication update?

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -8,7 +8,7 @@ import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.MediaLease
-import com.gu.mediaservice.model.usage.Usage
+import com.gu.mediaservice.model.usage.{Usage, UsageNotice}
 import com.gu.mediaservice.syntax._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.script.Script
@@ -501,6 +501,11 @@ class ElasticSearch(
       }
       ElasticSearchUpdateResponse()
     }))
+  }
+
+  def updateSingleUsage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime)
+                       (implicit ex: ExecutionContext, logMarker: LogMarker): List[Future[ElasticSearchUpdateResponse]] = {
+
   }
 
   def deleteSyndicationRights(id: String, lastModified: DateTime)

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -509,12 +509,12 @@ class ElasticSearch(
 
   val updateUsageStatusScript =
     s"""
-       |
+       | def lastUpdatedDate = ctx._source.usagesLastModified != null ? Date.from(Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(ctx._source.usagesLastModified))) : null;
        | for(int i = 0; i < ctx._source.usages.size(); i++) {
-       |    int dummy = ctx._source.usages.size();
-       |    if(ctx._source.usages[i].id == params.usage.id) {
+       |    if(lastUpdatedDate == null || modificationDate.after(lastUpdatedDate) && ctx._source.usages[i].id == params.usage.id) {
        |        ctx._source.usages[i].status = params.usage.status;
        |        ctx._source.usages[i].lastModified = params.lastModified;
+       |        ctx._source.usagesLastModified = params.lastModified;
        |    }
        | }
        |""".stripMargin

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -509,9 +509,8 @@ class ElasticSearch(
 
   val updateUsageStatusScript =
     s"""
-       | def lastUpdatedDate = ctx._source.usagesLastModified != null ? Date.from(Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(ctx._source.usagesLastModified))) : null;
        | for(int i = 0; i < ctx._source.usages.size(); i++) {
-       |    if(lastUpdatedDate == null || modificationDate.after(lastUpdatedDate) && ctx._source.usages[i].id == params.usage.id) {
+       |    if(ctx._source.usages[i].id == params.usage.id) {
        |        ctx._source.usages[i].status = params.usage.status;
        |        ctx._source.usages[i].lastModified = params.lastModified;
        |        ctx._source.usagesLastModified = params.lastModified;

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -504,21 +504,38 @@ class ElasticSearch(
     }))
   }
 
-  def updateSingleUsage(id: String, usageId: String, usageNotice: UsageNotice, lastModified: DateTime)
+  def updateSingleUsage(id: String, usageId: String, usages: Seq[Usage], lastModified: DateTime)
                        (implicit ex: ExecutionContext, logMarker: LogMarker): List[Future[ElasticSearchUpdateResponse]] = {
+//    implicit val unw: Writes[UsageNotice] = Json.writes[UsageNotice]
+//    implicit val unr: Reads[UsageNotice] = Json.reads[UsageNotice]
     // like in the case of leases it might be that I need to use 'usages' instead of 'usage'
     // further, instead of using the approach of streaming the source, I may simplify and assume a single usage
     val updateSingleUsageScript = s"""
          |
          | for(int i = 0; i < ctx._source.usages.size(); i++) {
          |    int dummy = ctx._source.usages.size();
-         |    if(ctx._source.usages[i].id == "syndication/1defb893fd70ac054f212ddbe2aab485_1e54245a8a937e66d03d7abafa8048f3") {
-         |        ctx._source.usages[i].status = params.status;
+         |    if(ctx._source.usages[i].id == params.id) {
+         |        ctx._source.usages[i].status = "foo";
          |    }
          | }
          |""".stripMargin // need to update the script for all values not just status
 
-    val usagesParameter = usageNotice.usageJson.value.flatMap(jsValue => asNestedMap(jsValue)).toMap //should be an option/have .orNull like metadata/syndication update?
+    //val usagesParameter = usageNotice.usageJson.value.flatMap(jsValue => asNestedMap(jsValue)).toMap
+    val usagesParameter = JsDefined(Json.toJson(usages)).toOption.map(_.as[Usage]).map(i => asNestedMap(Json.toJson(i))).orNull
+
+//      .map{
+//      case (key, value: Option[_]) => key -> value.getOrElse("default")
+//      case (key, value) => key -> value
+//    }
+
+//      .filterKeys(key => key == "id" || key == "status")
+//      .mapValues {
+//        case Some(value: String) => value
+//        case None => "default"
+//        case other => other.toString
+//      }
+
+    //should be an option/have .orNull like metadata/syndication update?
 //    val processedParameters: Map[String, Any] = usagesParameter.collect {
 //      case (key, Some(value)) => value
 //      case (key, value) if value != None => key -> value
@@ -527,7 +544,25 @@ class ElasticSearch(
     // how will 'prepareUpdateRequest' take two params: usageId & usagesParameters? Can just get from usage params (esp if use sequence of usageNotice) so two not required
     println(s"Usage parameters are: $usagesParameter")
     println(s"usage id from params is: ${usagesParameter.get("id")}")
-    println(s"status from params is: ${usagesParameter.get("status")}")
+    println(s"status frm params is: ${usagesParameter.get("status")}")
+
+//    val unwrappedMap: Map[String, Any] = usagesParameter.flatMap {
+//      case (key, Some(value)) => Some(key -> value)
+//      case (key, value) if value != None => Some(key -> value)
+//      case _ => None
+//    }
+//    println(s"unwrapped parameters are: $unwrappedMap")
+//    println(s"unwrapped id is: ${unwrappedMap.getOrElse("id","default")}")
+//    println(s"unwrapped references is: ${unwrappedMap.getOrElse("references","default")}")
+
+//    val testId = usagesParameter.get("id")
+//    val stringId = testId.getOrElse("default")
+//
+//    println(s"*****String id is: $stringId")
+//
+//    usagesParameter.foreach { case (key, value) =>
+//      println(s"Key: $key, Value Type: ${value.getClass.getName}")
+//    }
     val scriptSource = loadUpdatingModificationPainless(updateSingleUsageScript)
 
     List(migrationAwareUpdater(

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -514,6 +514,7 @@ class ElasticSearch(
        |    int dummy = ctx._source.usages.size();
        |    if(ctx._source.usages[i].id == params.usage.id) {
        |        ctx._source.usages[i].status = params.usage.status;
+       |        ctx._source.usages[i].lastModified = params.lastModified;
        |    }
        | }
        |""".stripMargin

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -49,6 +49,7 @@ class MessageProcessor(
       case message: CreateMigrationIndexMessage => createMigrationIndex(message, logMarker)
       case message: MigrateImageMessage => migrateImage(message, logMarker)
       case message: UpsertFromProjectionMessage => upsertImageFromProjection(message, logMarker)
+      case message: UpdateSingleUsageMessage => updateSingleUsage(message, logMarker)
       case _: CompleteMigrationMessage => completeMigration(logMarker)
     }
   }
@@ -181,6 +182,9 @@ class MessageProcessor(
   private def deleteSingleUsage(message: DeleteSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) = {
     Future.sequence(es.deleteSingleImageUsage(message.id, message.usageId, message.lastModified)(ec, logMarker))
   }
+
+  private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
+    Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
 
   def upsertSyndicationRightsOnly(message: UpdateImageSyndicationMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     implicit val marker: LogMarker = logMarker ++ imageIdMarker(ImageId(message.id))

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -184,12 +184,13 @@ class MessageProcessor(
   }
 
   private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[List[ElasticSearchUpdateResponse]] = {
-    Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
-//    implicit val lm: LogMarker = combineMarkers(message, logMarker)
-//    val usages = message.usageNotice.usageJson.as[Seq[Usage]]
-//    Future.traverse(es.updateImageUsages(message.id, usages, message.lastModified))(_.recoverWith {
-//      case ElasticNotFoundException => Future.successful(ElasticSearchUpdateResponse())
-//    })
+//    Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
+      implicit val unw: OWrites[UsageNotice] = Json.writes[UsageNotice]
+      implicit val lm: LogMarker = combineMarkers(message, logMarker)
+      val usages = message.usageNotice.usageJson.as[Seq[Usage]]
+      Future.traverse(es.updateSingleUsage(message.id, message.usageId, usages, message.lastModified ))(_.recoverWith {
+        case ElasticNotFoundException => Future.successful(ElasticSearchUpdateResponse())
+    })
   }
 
   def upsertSyndicationRightsOnly(message: UpdateImageSyndicationMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {

--- a/thrall/app/lib/kinesis/MessageProcessor.scala
+++ b/thrall/app/lib/kinesis/MessageProcessor.scala
@@ -183,8 +183,14 @@ class MessageProcessor(
     Future.sequence(es.deleteSingleImageUsage(message.id, message.usageId, message.lastModified)(ec, logMarker))
   }
 
-  private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext) =
+  private def updateSingleUsage(message: UpdateSingleUsageMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[List[ElasticSearchUpdateResponse]] = {
     Future.sequence(es.updateSingleUsage(message.id, message.usageId, message.usageNotice, message.lastModified)(ec, logMarker))
+//    implicit val lm: LogMarker = combineMarkers(message, logMarker)
+//    val usages = message.usageNotice.usageJson.as[Seq[Usage]]
+//    Future.traverse(es.updateImageUsages(message.id, usages, message.lastModified))(_.recoverWith {
+//      case ElasticNotFoundException => Future.successful(ElasticSearchUpdateResponse())
+//    })
+  }
 
   def upsertSyndicationRightsOnly(message: UpdateImageSyndicationMetadataMessage, logMarker: LogMarker)(implicit ec: ExecutionContext): Future[Any] = {
     implicit val marker: LogMarker = logMarker ++ imageIdMarker(ImageId(message.id))

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -73,6 +73,10 @@ object MessageTranslator extends GridLogging {
         case (Some(id), Some(edits)) => Right(UpdateImagePhotoshootMetadataMessage(id, updateMessage.lastModified, edits))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
+      case UpdateSingleUsage => (updateMessage.id, updateMessage.usageId, updateMessage.usageNotice ) match {
+        case (Some(id), Some(usageId), Some(usageNotice)) => Right(UpdateSingleUsageMessage(id, usageId, usageNotice, updateMessage.lastModified))
+        case _ => Left(MissingFieldsException(updateMessage.subject))
+      }
       case _ => Left(ProcessorNotFoundException(updateMessage.subject))
     }
   }

--- a/thrall/app/lib/kinesis/MessageTranslator.scala
+++ b/thrall/app/lib/kinesis/MessageTranslator.scala
@@ -73,8 +73,8 @@ object MessageTranslator extends GridLogging {
         case (Some(id), Some(edits)) => Right(UpdateImagePhotoshootMetadataMessage(id, updateMessage.lastModified, edits))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
-      case UpdateSingleUsage => (updateMessage.id, updateMessage.usageId, updateMessage.usageNotice ) match {
-        case (Some(id), Some(usageId), Some(usageNotice)) => Right(UpdateSingleUsageMessage(id, usageId, usageNotice, updateMessage.lastModified))
+      case UpdateUsageStatus => (updateMessage.id, updateMessage.usageNotice ) match {
+        case (Some(id), Some(usageNotice)) => Right(UpdateUsageStatusMessage(id, usageNotice, updateMessage.lastModified))
         case _ => Left(MissingFieldsException(updateMessage.subject))
       }
       case _ => Left(ProcessorNotFoundException(updateMessage.subject))

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -9,7 +9,7 @@ import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import com.gu.mediaservice.lib.usage.UsageBuilder
-import com.gu.mediaservice.model.usage.{MediaUsage, Usage}
+import com.gu.mediaservice.model.usage.{MediaUsage, Usage, UsageStatus}
 import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
 import model._
@@ -252,6 +252,39 @@ class UsageApi(
         val group = usageGroupOps.build(usageRequest)
         usageApiSubject.onNext(WithLogMarker.includeUsageGroup(group))
         Accepted
+      }
+    )
+  }}
+
+  def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
+    print(mediaId, usageId)
+    val request = (req.body \ "data").validate[UsageStatus]
+    request.fold(
+      e => respondError(
+        BadRequest,
+        errorKey = "update-image-usage-status-failed",
+        errorMessage = JsError.toJson(e).toString()
+      ),
+      usageStatusRequest => {
+        implicit val logMarker: LogMarker = MarkerMap(
+          "requestType" -> "update-usage-status",
+          "requestId" -> RequestLoggingFilter.getRequestId(req),
+          "usageStatus" -> usageStatusRequest.toString,
+          "image-id" -> mediaId,
+          "usage-id" -> usageId,
+        ) ++ apiKeyMarkers(req.user.accessor)
+        logger.info(logMarker, "recording usage status update")
+        usageTable.queryByUsageId(usageId).map {
+          case Some(mediaUsage) =>
+            mediaUsage.copy(status = UsageStatus("some string")) // this will need to change
+            usageTable.update(mediaUsage)
+            val updateMessage = UpdateMessage(subject = UpdateUsageStatus, id = Some(mediaId), usageId = Some(usageId))
+            notifications.publish(updateMessage)
+            Ok
+          case None =>
+            NotFound
+        }
+        Ok // this will need to change
       }
     )
   }}

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -255,7 +255,7 @@ class UsageApi(
       }
     )
   }}
-
+  // Might need to rename to updateSingleUsage -> will involve further changes
   def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
     val request = (req.body \ "data").validate[UsageStatus]
     request.fold(

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -257,7 +257,6 @@ class UsageApi(
   }}
 
   def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
-    println(s"mediaid is: $mediaId, usageid is: $usageId")
     val request = (req.body \ "data").validate[UsageStatus]
     request.fold(
       e => respondError(

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -255,7 +255,7 @@ class UsageApi(
       }
     )
   }}
-  // Might need to rename to updateSingleUsage -> will involve further changes
+
   def updateUsageStatus(mediaId: String, usageId: String) = auth(parse.json) {req => {
     val request = (req.body \ "data").validate[UsageStatus]
     request.fold(
@@ -280,15 +280,15 @@ class UsageApi(
             val usageNotice = UsageNotice(mediaId,
               JsArray(Seq(Json.toJson(UsageBuilder.build(updatedStatusMediaUsage)))))
             val updateMessage = UpdateMessage(
-              subject = UpdateSingleUsage, id = Some(mediaId),
-              usageId = Some(usageId), usageNotice = Some(usageNotice)
+              subject = UpdateUsageStatus, id = Some(mediaId),
+              usageNotice = Some(usageNotice)
             )
             notifications.publish(updateMessage)
             Ok
           case None =>
             NotFound
         }
-        Ok // this will need to change
+        Ok
       }
     )
   }}

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -14,7 +14,7 @@ case class SyndicationUsageRequest (
     case "Capture" => PendingUsageStatus
     case _ => SyndicatedUsageStatus
   }
-  val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName)
+  val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName, syndicatedBy)
 }
 object SyndicationUsageRequest {
   import JodaWrites._

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -7,12 +7,12 @@ import play.api.libs.json._
 case class SyndicationUsageRequest (
   partnerName: String,
   syndicatedBy: Option[String],
-  startPending: Option[Boolean],
+  startPending: Option[String],
   mediaId: String,
   dateAdded: DateTime
 ) {
   val status: UsageStatus = startPending match {
-    case Some(true) => PendingUsageStatus
+    case Some("true") => PendingUsageStatus
     case _ => SyndicatedUsageStatus
   }
   val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName, syndicatedBy)

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -1,15 +1,19 @@
 package model
 
-import com.gu.mediaservice.model.usage.{SyndicatedUsageStatus, SyndicationUsageMetadata, UsageStatus}
+import com.gu.mediaservice.model.usage.{PendingUsageStatus, SyndicatedUsageStatus, SyndicationUsageMetadata, UsageStatus}
 import org.joda.time.DateTime
 import play.api.libs.json._
 
 case class SyndicationUsageRequest (
   partnerName: String,
+  syndicatedBy: Option[String],
   mediaId: String,
   dateAdded: DateTime
 ) {
-  val status: UsageStatus = SyndicatedUsageStatus
+  val status: UsageStatus = partnerName match {
+    case "Capture" => PendingUsageStatus
+    case _ => SyndicatedUsageStatus
+  }
   val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName)
 }
 object SyndicationUsageRequest {

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -7,11 +7,12 @@ import play.api.libs.json._
 case class SyndicationUsageRequest (
   partnerName: String,
   syndicatedBy: Option[String],
+  startPending: Option[Boolean],
   mediaId: String,
   dateAdded: DateTime
 ) {
-  val status: UsageStatus = partnerName match {
-    case "Capture" => PendingUsageStatus
+  val status: UsageStatus = startPending match {
+    case Some(true) => PendingUsageStatus
     case _ => SyndicatedUsageStatus
   }
   val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName, syndicatedBy)

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -29,6 +29,7 @@ class UsageGroupOps(config: UsageConfig, mediaWrapperOps: MediaWrapperOps)
   def buildId(syndicationUsageRequest: SyndicationUsageRequest): String = s"syndication/${
     MD5.hash(List(
       syndicationUsageRequest.metadata.partnerName,
+      syndicationUsageRequest.metadata.syndicatedBy,
       syndicationUsageRequest.mediaId
     ).mkString("_"))
   }"

--- a/usage/app/model/UsageIdBuilder.scala
+++ b/usage/app/model/UsageIdBuilder.scala
@@ -23,6 +23,7 @@ object UsageIdBuilder {
   def build(syndicationUsageRequest: SyndicationUsageRequest) = buildId(List(
     Some(syndicationUsageRequest.mediaId),
     Some(syndicationUsageRequest.metadata.partnerName),
+    Some(syndicationUsageRequest.metadata.syndicatedBy),
     Some(syndicationUsageRequest.status)
   ))
 

--- a/usage/app/model/UsageIdBuilder.scala
+++ b/usage/app/model/UsageIdBuilder.scala
@@ -23,7 +23,7 @@ object UsageIdBuilder {
   def build(syndicationUsageRequest: SyndicationUsageRequest) = buildId(List(
     Some(syndicationUsageRequest.mediaId),
     Some(syndicationUsageRequest.metadata.partnerName),
-    Some(syndicationUsageRequest.metadata.syndicatedBy),
+    syndicationUsageRequest.metadata.syndicatedBy,
     Some(syndicationUsageRequest.status)
   ))
 

--- a/usage/conf/routes
+++ b/usage/conf/routes
@@ -8,7 +8,7 @@ POST    /usages/print                                   controllers.UsageApi.set
 POST    /usages/syndication                             controllers.UsageApi.setSyndicationUsages
 POST    /usages/front                                   controllers.UsageApi.setFrontUsages
 POST    /usages/download                                controllers.UsageApi.setDownloadUsages
-
+PUT     /usages/status/update/:mediaId/*usageId         controllers.UsageApi.updateUsageStatus(mediaId: String, usageId: String)
 GET     /usages/digital/content/*contentId/reindex      controllers.UsageApi.reindexForContent(contentId: String)
 
 # Management


### PR DESCRIPTION
## What does this change?

As an archivist user of BBC Images, I want to be able to send certain images from BBC Images to BBC Photo Sales, through the Grid UI. This PR introduces this functionality, allowing a user to select a number of images and trigger the outbound photo sales process by clicking on the new 'Send to Photo Sales' button. By doing this, a syndication usage (with a 'pending' usage status) is added to each of the selected image, which is the trigger for an AWS step function that carries out the majority of the outbound logic.  

This PR is only concerned with the ability of a user to select images and add a syndication usage through the frontend, future PRs will handle additional features such as confirmation dialogs, restrictions on what images can be sent, success/failure notifications and changes to the metadata panel.

As this is BBC specific functionality, it is disabled by default via the `showSendToPhotoSales` feature flag.

![Screenshot 2024-03-20 at 16 56 07](https://github.com/guardian/grid/assets/129299738/eb16a5ff-550f-4857-9557-c67fad33266e)

Note: this PR has been developed on top of the changes introduced in https://github.com/guardian/grid/pull/4244, which is still to be merged. As such there are additional files inlcuded in the PR that are outside its scope. The only files that need to be reviewed as part of this PR are:

- kahuna/app/lib/KahunaConfig.scala
- kahuna/app/views/main.scala.html
- kahuna/public/js/search/results.html
- kahuna/public/js/search/results.js
- kahuna/public/js/services/api/media-api.js
- media-api/app/controllers/MediaApi.scala
- media-api/conf/routes

## How should a reviewer test this change?

As a user with elevated permissions and with the `showSendToPhotoSales` flag set to true:

- Select a number of image thumbnails from the main grid view
- Click the 'Send to Photo Sales Button' from the menu that appears

## How can success be measured?
- Confirm that a Pending Publication usage is visible in the usages section of the metadata panel, for the selected images

## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
