### PR TITLE
add in config options for image sources in content security policy.

### DIFF
--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -107,6 +107,7 @@ function getKahunaConfig(config){
         |links.supportEmail="${config.links.supportEmail}"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |security.frameAncestors="https://*.${config.DOMAIN}"
+        |security.imageSources=["https://*.newslabs.co/"]
         |metrics.request.enabled=false
         |${pinboardConfig}
         |`;

--- a/kahuna/app/KahunaComponents.scala
+++ b/kahuna/app/KahunaComponents.scala
@@ -51,7 +51,7 @@ object KahunaSecurityConfig {
       URI.ensureSecure("app.getsentry.com").toString,
       "https://*.googleusercontent.com",
       "'self'"
-    ).mkString(" ")}"
+    ).mkString(" ")} ${config.imageSources.mkString(" ")}"
 
     val fontSources = s"font-src data: 'self' ${config.fontSources.mkString(" ")}"
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -47,6 +47,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     else s"https://$ingestBucket.s3.$awsRegion.amazonaws.com"
   }
   val fontSources: Set[String] = getStringSet("security.fontSources")
+  val imageSources: Set[String] = getStringSet("security.imageSources")
 
   val scriptsToLoad: List[ScriptToLoad] = getConfigList("scriptsToLoad").map(entry => ScriptToLoad(
     host = entry.getString("host"),


### PR DESCRIPTION
## What does this change?

Adds in the ability to add to the image source section of the Content-Security-Policy header via configuration. Adding security.imageSources key to the config. It includes a set of strings.

## How should a reviewer test this change?

Ensure that any sources added to security.imagesSources in the config get incorporated into the Content-Security-Policy header.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
