### PR TITLE
trigger CI for `pr*` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'pr**'
+      - pr*
 jobs:
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `push-pr` workflow (added in https://github.com/guardian/grid/pull/4240) hasn't been triggering CI as it was created to do, this should fix it...
