### PR TITLE
modifications to correct bug linked to clean cookie operation

### DIFF
--- a/kahuna/public/js/components/gr-notifications-banner/gr-notifications-banner.tsx
+++ b/kahuna/public/js/components/gr-notifications-banner/gr-notifications-banner.tsx
@@ -80,7 +80,11 @@ const todayStr = (): string => {
 const getCookie = (cookieName: string): string => {
   const decodedCookie = decodeURIComponent(document.cookie);
   const cookieArray = decodedCookie.split(';');
-  return cookieArray.find((cookie) => cookie.trim().startsWith(cookieName));
+  const temp = cookieArray.find((cookie) => cookie.trim().startsWith(cookieName));
+  if (temp) {
+    return temp.trim().replace((cookieName + "="), "");
+  }
+  return null;
 };
 
 const mergeArraysByKey = (array1: Notification[], array2: Notification[], key: keyof Notification): Notification[] => {
@@ -171,7 +175,7 @@ const NotificationsBanner: React.FC = () => {
       const current_notif_ids = announce.map(ann => ann.announceId).join(",");
       const notif_ids = notif_cookie.split(',');
       const new_notif_ids = notif_ids.filter(n_id => current_notif_ids.includes(n_id)).join(",");
-      document.cookie = (`${NOTIFICATION_COOKIE}=${new_notif_ids}; max-age=${cookie_age}`);
+      document.cookie = `${NOTIFICATION_COOKIE}=${new_notif_ids}; max-age=${cookie_age}`;
     }
 
     // Clean up the event listener when the component unmounts


### PR DESCRIPTION
## What does this change?

Code changes introduced to simplfy the getCookie operation within the notification banner introduced a bug linked to the clean cookie operation ran on initialisation which removes obselete notification/announcement ids from the cookie to stop it bloating over time. It incorrectly cleared some ids from the cookie. The change simply corrects this problem

## How should a reviewer test this change?

Ensure that once acknowledged announcements stay 'hidden' after browser refresh (refresh at least twice to be sure bug is not present)

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
