### PR TITLE
Fix issue that stopped Global Errors and Notification Banner displaying correctly simultaneously

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -122,7 +122,17 @@ usageRightsConfigProvider = {
 #   ...
 # ]
 # -----------------------------------------------------------------
-announcements = []
+announcements = [
+{
+announceId: "notification_banner",
+description: "A New Feature Notification Banner",
+endDate: "2025-03-31",
+url: "https://www.bbc.co.uk",
+urlText: "BBC Home Page",
+category: "announcement",
+lifespan: "persistent"
+}
+]
 
 domainMetadata.specifications = []
 

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -122,17 +122,7 @@ usageRightsConfigProvider = {
 #   ...
 # ]
 # -----------------------------------------------------------------
-announcements = [
-{
-announceId: "notification_banner",
-description: "A New Feature Notification Banner",
-endDate: "2025-03-31",
-url: "https://www.bbc.co.uk",
-urlText: "BBC Home Page",
-category: "announcement",
-lifespan: "persistent"
-}
-]
+announcements = []
 
 domainMetadata.specifications = []
 

--- a/docs/06-objects-of-interest/02-config.md
+++ b/docs/06-objects-of-interest/02-config.md
@@ -81,6 +81,13 @@ Service-specific configs. These will override all other config files.
     <td>boolean</td>
     <td>false</td>
   </tr>
+  <tr>
+    <td><code>announcements</code>
+    <br>Notifications and announcements to be sent to users<br>Format:<br>[ (array)<br>{ (json object)<br><i>announceId</i>: (string) the unique id of the announcement - should be unique among all active announcements<br><i>description</i>: (string) the main text to display in the notification<br><i>endDate</i>: (string, optional, format="yyyy-mm-dd") the date beyond which the announcement should not be seen, if not present set as today + 1 year<br><i>url</i>: (string, optional) a link to a page/document providing further details regarding announcement<br><i>urlText</i>: (string, optional) text to be included in a-tag hyperlink (will revert to default if not present)<br><i>category</i>: (string) the type of announcement - will control styling and display, Enum=announcement; information; warning; error; success<br><i>lifespan</i>: (string) the lifecycle behaviour Enum=transient (message disappears on any click etc); session (message must be acknowledged but action NOT stored in client cookie - used for current session messages); persistent (message must be acknowledged and action stored in client cookie - used for long-running announcements)<br>},<br>...<br>]</td>
+    <td>True</td>
+    <td>Json Object Array</td>
+    <td>[]</td>
+  </tr>
 </tbody>
 </table>
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -88,7 +88,10 @@
 
 <div ui-view></div>
 <ui-global-errors></ui-global-errors>
-<!--<ui-notifications></ui-notifications> IMAGEDAM-1712 - banner causes global errors not to display-->
+<div>
+    <ui-notifications></ui-notifications>
+</div>
+
 
 <script src="@routes.Assets.versioned("dist/build.js")"></script>
 

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -88,7 +88,7 @@
 
 <div ui-view></div>
 <ui-global-errors></ui-global-errors>
-<ui-notifications></ui-notifications>
+<!--<ui-notifications></ui-notifications> IMAGEDAM-1712 - banner causes global errors not to display-->
 
 <script src="@routes.Assets.versioned("dist/build.js")"></script>
 

--- a/kahuna/public/js/notifications/notifications.html
+++ b/kahuna/public/js/notifications/notifications.html
@@ -1,3 +1,3 @@
-<ng-messages ng-if="ctrl.hasNotifications" class="global-notifications">
+<div ng-if="notifctrl.hasNotifications" class="global-notifications">
     <notifications-banner class="notifications-banner"></notifications-banner>
-</ng-messages>
+</div>

--- a/kahuna/public/js/notifications/notifications.js
+++ b/kahuna/public/js/notifications/notifications.js
@@ -9,13 +9,13 @@ export var notifications = angular.module(
 
 notifications.controller('NotificationsCtrl',
   ['$window',
-    function ($window) {
+    function () {
       const notifctrl = this;
       notifctrl.$onInit = () => {
         notifctrl.notifications = window._clientConfig.announcements;
         notifctrl.hasNotifications = notifctrl.notifications.length > 0;
       };
-  }
+    }
 ]);
 
 notifications.directive('uiNotifications', [function() {

--- a/kahuna/public/js/notifications/notifications.js
+++ b/kahuna/public/js/notifications/notifications.js
@@ -2,24 +2,18 @@ import angular from 'angular';
 import template from './notifications.html';
 import '../components/gr-notifications-banner/gr-notifications-banner';
 
-import 'angular-messages';
-import 'pandular';
-import '../sentry/sentry';
-
 export var notifications = angular.module(
   'kahuna.notifications',
-  ['ngMessages', 'pandular.session', 'gr.notificationsBanner']
+  ['gr.notificationsBanner']
 );
 
 notifications.controller('NotificationsCtrl',
-  ['$location',
-    function ($location) {
-      const ctrl = this;
-
-      ctrl.$onInit = () => {
-        ctrl.getCurrentLocation = () => $location.url();
-        ctrl.notifications = window._clientConfig.announcements;
-        ctrl.hasNotifications = ctrl.notifications.length > 0;
+  ['$window',
+    function ($window) {
+      const notifctrl = this;
+      notifctrl.$onInit = () => {
+        notifctrl.notifications = window._clientConfig.announcements;
+        notifctrl.hasNotifications = notifctrl.notifications.length > 0;
       };
   }
 ]);
@@ -28,7 +22,7 @@ notifications.directive('uiNotifications', [function() {
   return {
     restrict: 'E',
     controller: 'NotificationsCtrl',
-    controllerAs: 'ctrl',
+    controllerAs: 'notifctrl',
     bindToController: true,
     template: template
   };

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -832,7 +832,7 @@ textarea.ng-invalid {
   left: 0;
   right: 0;
   top: 87px;
-  z-index: 40;
+  z-index: 39;
   text-align: left;
   max-width: 100%;
 }


### PR DESCRIPTION
## What does this change?

Fixes the problem identified with the Notification Banner control and its 'interaction' with the Global Errors control. It was found that the presence of the Notification Banner control in the main.scala.html file caused the Global Errors to fail to display - all code ran correctly and there were no console errors but the error messages and other user banners did not appear in the browser.

It was found that if the order of the controls was reversed in main.scala.html then the Error control worked correctly but the Notification Banner failed to display.

This was some complex cross interaction between the two components at an AngularJS level. The code has been simplified to ensure full separation of the two controls and the Notification Banner has been wrapped in its own div - this has resulted in the controls workig correctly together.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
