### PR TITLE
minor js mods to fix sort control console error

### DIFF
--- a/kahuna/public/js/components/gr-sort-control/gr-sort-control.tsx
+++ b/kahuna/public/js/components/gr-sort-control/gr-sort-control.tsx
@@ -55,13 +55,13 @@ export interface SortWrapperProps {
 const checkForCollection = (query:string): boolean => /~"[a-zA-Z0-9 #-_.://]+"/.test(query);
 
 const hasClassInSelfOrParent = (node: Element | null, className: string): boolean => {
-  if (node !== null && node.classList.contains(className)) {
+  if (node !== null && node.classList && node.classList.contains(className)) {
     return true;
   }
 
   while (node && node.parentNode && node.parentNode !== document) {
     node = node.parentNode as Element;
-    if (node.classList.contains(className)) {
+    if (node.classList && node.classList.contains(className)) {
       return true;
     }
   }


### PR DESCRIPTION
minor js mods to fix sort control console error - checking if element classList is not null prior to checking for content.

## What does this change?

Currently there is an issue in the sort control code when assessing the class list for an element and its parents. This results in a console error (it does not impact the operation of the control). The error is;

![Screenshot 2024-04-30 at 16 01 37](https://github.com/guardian/grid/assets/128470622/0e7b40c1-faa8-45d1-bc08-b18fad236579)

This can be corrected by null checking against node.classList

## How should a reviewer test this change?

Enssure that when the user scrolls through the images pane a console error is not being generated.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
