### PR TITLE
IMAGEDAM-1665: Generic React modal dialog and send to Photosales functionality

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -40,6 +40,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val useReaper: Option[Boolean] = booleanOpt("useReaper")
 
   val showDenySyndicationWarning: Option[Boolean] = booleanOpt("showDenySyndicationWarning")
+  val showSendToPhotoSales: Option[Boolean] = booleanOpt("showSendToPhotoSales")
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources") ++ maybeIngestBucket.map { ingestBucket =>

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -57,6 +57,7 @@
           systemName: "@Html(kahunaConfig.systemName)",
           canDownloadCrop: @kahunaConfig.canDownloadCrop,
           showDenySyndicationWarning: @kahunaConfig.showDenySyndicationWarning.getOrElse(false),
+          showSendToPhotoSales:@kahunaConfig.showSendToPhotoSales.getOrElse(false),
           domainMetadataSpecs: @Html(domainMetadataSpecs),
           recordDownloadAsUsage: @kahunaConfig.recordDownloadAsUsage,
           metadataTemplates: @Html(metadataTemplates),
@@ -88,6 +89,7 @@
 
 <div ui-view></div>
 <ui-global-errors></ui-global-errors>
+<confirmation-modal></confirmation-modal>
 <div>
     <ui-notifications></ui-notifications>
 </div>

--- a/kahuna/public/js/components/gr-confirmation-modal/gr-confirmation-modal.css
+++ b/kahuna/public/js/components/gr-confirmation-modal/gr-confirmation-modal.css
@@ -1,0 +1,75 @@
+.modalStyle {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 42;
+  background: #FFF;
+  padding: 20px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+.backdropStyle {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 41;
+}
+.modalTitle {
+  font-weight: bold;
+  font-size: 20px;
+  color: #262525;
+}
+.modalMessage {
+ padding-top: 44px;
+ padding-bottom: 44px;
+ color: #262525;
+}
+.buttonContainerStyle {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: auto;
+}
+.confirmButtonStyle {
+  padding: 7px 10px;
+  margin-top: 12px;
+  margin-left: 10px;
+  width: fit-content;
+  cursor: pointer;
+  border: none;
+  text-align: center;
+  background: #5a526b;
+  color: white;
+  font-size: 16px;
+}
+.closeButtonStyle {
+  padding: 6px 10px;
+  margin-top: 12px;
+  width: fit-content;
+  cursor: pointer;
+  border: 2px solid #b6b7b7;
+  text-align: center;
+  background: #FFF;
+  color: #1e1f1d;
+  font-size: 16px;
+}
+.closeIconStyle {
+  margin: 10px;
+  padding: 10px 20px;
+  position: absolute;
+  top:1px;
+  right: -10px;
+  font-size: 15px;
+  cursor: pointer;
+  border: none;
+  color: white;
+}
+.styledParagraph {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.confirmation-closed {
+  display: none;
+}

--- a/kahuna/public/js/components/gr-confirmation-modal/gr-confirmation-modal.tsx
+++ b/kahuna/public/js/components/gr-confirmation-modal/gr-confirmation-modal.tsx
@@ -1,0 +1,138 @@
+import * as React from "react";
+import * as angular from "angular";
+import { react2angular } from "react2angular";
+import "./gr-confirmation-modal.css";
+import {useEffect, useState, useRef} from "react";
+
+
+const crossIcon = () =>
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" fill="none" stroke="none"/>
+    <path d="M7 17L16.8995 7.10051" stroke="#000" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"/>
+    <path d="M7 7.00001L16.8995 16.8995" stroke="#000" strokeLinecap="round" strokeLinejoin="round"
+          strokeWidth="2"/>
+  </svg>;
+
+const confirmationModal: React.FC = () => {
+
+  const modalRef = useRef(null);
+  const firstInputRef = useRef(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [showSingleBtn, setShowSingleBtn] = useState(false);
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+  const [cancelBtnTxt, setCancelBtnTxt] = useState("");
+  const [confirmBtnTxt, setConfirmBtnTxt] = useState("");
+  const [okayFunction, setOkayFunction] = useState(() => () => {return;});
+
+  const onOkay = () => {
+    document.body.removeAttribute("aria-hidden");
+    setIsOpen(false);
+    setShowSingleBtn(false);
+    okayFunction();
+  };
+
+  const onCancel = () => {
+    document.body.removeAttribute("aria-hidden");
+    setShowSingleBtn(false);
+    setIsOpen(false);
+  };
+
+  const handleDisplay = (e: any) => {
+    document.body.setAttribute("aria-hidden", "true");
+    setOkayFunction(() => e.detail.okayFn);
+    setTitle(e.detail.title);
+    setMessage(e.detail.message);
+    setCancelBtnTxt(e.detail.cancelBtnTxt);
+    setConfirmBtnTxt(e.detail.confirmBtnTxt);
+    e.detail.showSingleBtn ? setShowSingleBtn(true) : showSingleBtn;
+    setIsOpen(true);
+  };
+
+  const processedMessage = message.includes(';') ? message.split(';')
+    .map((item, index) => <p key={index} className="styledParagraph">{item.trim()}</p>) : message;
+
+  useEffect(() => {
+    window.addEventListener('displayModal', handleDisplay);
+    return () => {
+      document.body.removeAttribute("aria-hidden");
+      window.removeEventListener('displayModal', handleDisplay);
+    };
+  },[]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: any) => {
+      if ((e.target.className === 'closeButtonStyle' || e.target.className === 'confirmButtonStyle') && (e.keyCode === 32 || e.keyCode === 13)) {
+        e.preventDefault();  // Prevent the default action to avoid scrolling when using Space
+        e.target.click();   // Trigger the button's onClick event
+      }
+      if (e.keyCode === 27) {
+        onCancel();  // Close on ESC
+      }
+    };
+    const trapTabKey = (e: any) => {
+      if (e.keyCode !== 9) {return;} // Listen for TAB key only
+      if (!modalRef.current) {return;}
+      // Collect focusable items inside the modal
+      const focusableModalElements = modalRef.current.querySelectorAll(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+      );
+      const firstElement = focusableModalElements[0];
+      const lastElement = focusableModalElements[focusableModalElements.length - 1];
+      // Trap focus inside modal
+      if (e.shiftKey) { // if SHIFT + TAB
+        if (document.activeElement === firstElement) { // loop focus back to last
+          lastElement.focus();
+          e.preventDefault();
+        }
+      } else { // if TAB
+        if (document.activeElement === lastElement) { // loop focus back to first
+          firstElement.focus();
+          e.preventDefault();
+        }
+      }
+    };
+    // Add event listeners
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keydown', trapTabKey);
+    // Set initial focus to the first input inside the modal
+    if (firstInputRef.current) {
+      firstInputRef.current.focus();
+    }
+    // Remove event listeners on cleanup
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keydown', trapTabKey);
+    };
+  }, [isOpen]);
+
+  return (
+    <div>
+      {isOpen && (
+        <div aria-label={title} ref={modalRef}>
+          <div className='backdropStyle'/>
+          <div className='modalStyle'>
+            <div className='modalTitle'>{title}</div>
+            <div className='modalMessage'>{processedMessage}</div>
+            <div className="closeIconStyle" aria-label={"Close"} onClick={() => {onCancel();}}>
+              {crossIcon()}
+            </div>
+              <div className="buttonContainerStyle">
+                {!showSingleBtn && (
+                  <div ref={firstInputRef} className='closeButtonStyle' aria-label={"Close"} tabIndex={0} onClick={() => {onCancel();}}>
+                    {cancelBtnTxt}
+                  </div>
+                )}
+                <div className='confirmButtonStyle' aria-label={"Confirm"} tabIndex={0} onClick={() => {onOkay();}}>
+                  {confirmBtnTxt}
+                </div>
+              </div>
+          </div>
+        </div>)}
+    </div>
+  );
+};
+
+export const ConfirmationModal = angular.module('gr.confirmationModal', [])
+  .component('confirmationModal', react2angular(confirmationModal));

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -81,6 +81,23 @@
                     <gr-icon-label gr-icon="share">Share with URL</gr-icon-label>
                 </a>
 
+                <div class="results-toolbar-item results-toolbar-item--right"
+                    tabindex="0"
+                    ng-if="ctrl.showSendToPhotoSales()">
+                    <a id="send-to"
+                       style="display: contents;"
+                       ng-class="{'batch-archive__button--disabled': ctrl.selectionCount >= 45}"
+                       ng-click="ctrl.selectionCount < 45 && ctrl.displayConfirmationModal()"
+                       ng-if="ctrl.selectionCount > 0"
+                       aria-label="{{ctrl.selectionCount >= 45 ? 'You can’t send all these images to Photosales at once, please reduce to 44 or less' : 'Send selected images'}}"
+                       gr-tooltip="{{ctrl.selectionCount >= 45 ? 'You can’t send all these images to Photosales at once, please reduce to 44 or less' : 'Send selected images'}}"
+                       gr-tooltip-position="bottom"
+                       gr-tooltip-updates>
+                        <gr-icon-label gr-icon="send">Send To Photo Sales</gr-icon-label>
+                    </a>
+                </div>
+
+
                 <gr-batch-export-original-images class="results-toolbar-item results-toolbar-item--right"
                   images="ctrl.selectedImages"
                   ng-if="ctrl.selectionCount > 0"></gr-batch-export-original-images>

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -419,7 +419,7 @@ results.controller('SearchResultsCtrl', [
       };
 
       ctrl.sendToPhotoSales = () => {
-        const [validImages] = validatePhotoSalesSelection(ctrl.selectedImages)[0];
+        const validImages = validatePhotoSalesSelection(ctrl.selectedImages)[0];
         validImages.map(image => {
           mediaApi.syndicateImage(image.data.id, "Capture", "true");
         });

--- a/kahuna/public/js/services/api/media-api.js
+++ b/kahuna/public/js/services/api/media-api.js
@@ -98,6 +98,10 @@ mediaApi.factory('mediaApi',
         return root.follow('undelete', {id: id}).put();
     }
 
+    function syndicateImage(mediaId, partner, pending) {
+      return root.follow('syndicate-image', {id: mediaId, partnerName: partner, startPending: pending}).post();
+    }
+
     function canUserArchive() {
         return root.getLink('archive').then(() => true, () => false);
     }
@@ -113,6 +117,7 @@ mediaApi.factory('mediaApi',
         delete: delete_,
         canUserUpload,
         canUserArchive,
-        undelete
+        undelete,
+        syndicateImage
     };
 }]);

--- a/kahuna/public/js/util/constants/sendToCapture-config.js
+++ b/kahuna/public/js/util/constants/sendToCapture-config.js
@@ -1,0 +1,9 @@
+export const sendToCaptureTitle = "Are you sure?";
+export const sendToCaptureAllValid = "Do you want to send these images to Photo Sales?";
+export const sendToCaptureMixed = "Do you want to send these images to Photo Sales?; #VALIDIMAGES# of these images will be sent through to Photo Sales; #INVALIDIMAGES# are already in Photo Sales and will not be sent again; Look out for the Photo Sales logo which will identify these images";
+export const sendToCaptureInvalid = "The image(s) selected are already in Photo Sales. If an image has the Photo Sales logo it already exists there";
+export const VALIDIMAGES = "#VALIDIMAGES#";
+export const INVALIDIMAGES = "#INVALIDIMAGES#";
+export const sendToCaptureCancelBtnTxt = "No";
+export const sendToCaptureConfirmBtnTxt = "Yes, send";
+export const sendToCaptureSingleBtnTxt = "Okay";

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -23,6 +23,7 @@ GET     /images/:imageId/export/:exportId/asset/:width/download     controllers.
 GET     /images/:imageId/export                                     controllers.MediaApi.getImageExports(imageId: String)
 GET     /images/:imageId/download                                   controllers.MediaApi.downloadOriginalImage(imageId: String)
 GET     /images/:imageId/downloadOptimised                          controllers.MediaApi.downloadOptimisedImage(imageId: String, width: Int, height: Int, quality: Int)
+POST    /images/:id/:partnerName/:startPending/syndicateImage       controllers.MediaApi.syndicateImage(id: String, partnerName: String, startPending:String)
 DELETE  /images/:id                                                 controllers.MediaApi.deleteImage(id: String)
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)

--- a/usage/app/model/SyndicationUsageRequest.scala
+++ b/usage/app/model/SyndicationUsageRequest.scala
@@ -7,12 +7,12 @@ import play.api.libs.json._
 case class SyndicationUsageRequest (
   partnerName: String,
   syndicatedBy: Option[String],
-  startPending: Option[Boolean],
+  startPending: Option[String],
   mediaId: String,
   dateAdded: DateTime
 ) {
   val status: UsageStatus = startPending match {
-    case Some(true) => PendingUsageStatus
+    case Some("true") => PendingUsageStatus
     case _ => SyndicatedUsageStatus
   }
   val metadata: SyndicationUsageMetadata = SyndicationUsageMetadata(partnerName, syndicatedBy)


### PR DESCRIPTION
## What does this change?
### Note, this PR builds on changes introduced in IMAGEDAM-1502 and so will replace that PR.

This PR introduces two new functionalities:
- The ability for a user to add a 'send to photosales' syndication usage to an image, via the 'Send to Photosales button' 
- A generic React modal component, used in this case as a confirmation dialog

As an archivist user of BBC Images, I want to be able to send certain images from BBC Images to BBC Photo Sales, through the Grid UI. This PR introduces this functionality, allowing a user to select a number of images and trigger the outbound photo sales process by clicking on the new 'Send to Photo Sales' button.

Upon doing this the confirmation dialog will pop up, asking the user to confirm their choice. The dialog will have different text and button options depending on if the images selected already exist in photosales or not. Once the user has confirmed their intention to send the image, a syndication usage (with a 'pending' usage status) is added to each of the selected image, which is the trigger for an AWS step function that carries out the majority of the outbound logic.

The Photosales functionality is BBC specific, hence it is disabled by default via the `showSendToPhotoSales` feature flag.

![image](https://github.com/guardian/grid/assets/129299738/352f9abd-db1c-4adb-b553-a228fae6adae)


## How should a reviewer test this change?

As a user with elevated permissions and with the showSendToPhotoSales flag set to true:

### No selected images already exist in Photosales
- Select a number of image thumbnails from the main grid view, ensure none of these images have already been sent to Photosales 
- Click the 'Send to Photo Sales Button' from the menu that appears
- A confirmation dialog will pop up
- Click 'Yes, send'

### The selected images contain a mixture of images that have and have not been sent to Photosales
- Select a number of image thumbnails from the main grid view, ensure that some of these images have already been sent to Photosales and some have not been sent
- Click the 'Send to Photo Sales Button' from the menu that appears
- A confirmation dialog will pop up
- Click 'Yes, send'

### All the selected images have already been sent to Photosales
- Select a number of image thumbnails from the main grid view, ensure that all of these images ahve already been sent to Photosales 
- Click the 'Send to Photo Sales Button' from the menu that appears
- A confirmation dialog, with one button will pop up
- Click 'Okay'

## How can success be measured?

### No selected images already exist in Photosales
- Confirm that a Pending Publication usage is visible in the usages section of the metadata panel, for the selected images
- Confirm that the confirmation dialog has the following appearance:
![Screenshot 2024-05-02 at 10 43 41](https://github.com/guardian/grid/assets/129299738/9d7fd34e-f715-481d-9c78-2eb5278b9b53)

### The selected images contain a mixture of images that have and have not been sent to Photosales
- Confirm that a Pending Publication usage is visible in the usages section of the metadata panel, for those selected images that had not already been sent to Photosales
- Confirm that the confirmation dialog has the following appearance:
![Screenshot 2024-05-02 at 10 43 24](https://github.com/guardian/grid/assets/129299738/1035d101-8e36-49f9-b1b8-e7ce67c93a4f)

### All the selected images have already been sent to Photosales
- Confirm that the confirmation dialog has the following appearance:
![Screenshot 2024-05-02 at 10 42 52](https://github.com/guardian/grid/assets/129299738/798962a5-4d97-4037-9b17-b5368a1b5bd8)


## Who should look at this?
@guardian/digital-cms

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
