### PR TITLE
LOG Guardian users who access grid without any permission

### DIFF
--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -4,15 +4,14 @@ import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, UserPrincipal}
 import com.gu.mediaservice.lib.auth.Permissions.{DeleteImage, ShowPaid, UploadImages}
-import com.gu.mediaservice.lib.auth.provider.{AuthenticationProviders, LocalAuthenticationProvider}
+import com.gu.mediaservice.lib.auth.provider.AuthenticationProviders
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, Internal}
 import com.gu.mediaservice.lib.guardian.auth.PandaAuthenticationProvider
-import com.gu.pandomainauth.service.CookieUtils
 import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, Result}
+
 import java.net.URI
 import java.util.Date
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -1,10 +1,11 @@
 package com.gu.mediaservice.lib.auth
 
+import akka.stream.Materializer
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, Principal, Request, UserPrincipal}
 import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCropsOrUsages, PrincipalFilter, UploadImages}
 import com.gu.mediaservice.lib.auth.provider.AuthorisationProvider
-import play.api.mvc.{ActionFilter, Result, Results}
+import play.api.mvc.{ActionFilter, Filter, RequestHeader, Result, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -83,4 +84,6 @@ class Authorisation(provider: AuthorisationProvider, executionContext: Execution
       }
     }
   }
+
+  def hasAtLeastBasicAccess(userEmail: String): Boolean = provider.hasAtLeastBasicAccess(userEmail)
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -85,5 +85,6 @@ class Authorisation(provider: AuthorisationProvider, executionContext: Execution
     }
   }
 
+  def hasBasicAccessExplicitly(userEmail: String): Boolean = provider.hasBasicAccessExplicitly(userEmail)
   def hasAtLeastBasicAccess(userEmail: String): Boolean = provider.hasAtLeastBasicAccess(userEmail)
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Permissions.scala
@@ -13,6 +13,7 @@ object Permissions {
   /** A predicate that takes a principal and returns a boolean reflecting whether the principal has permission or not */
   type PrincipalFilter = Principal => Boolean
 
+  case object GridAccess extends SimplePermission
   case object EditMetadata extends SimplePermission
   case object DeleteImage extends SimplePermission
   case object DeleteCropsOrUsages extends SimplePermission

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationProvider.scala
@@ -2,6 +2,7 @@ package com.gu.mediaservice.lib.auth.provider
 
 import akka.actor.ActorSystem
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, Principal}
+import com.gu.mediaservice.lib.auth.Authorisation
 import com.gu.mediaservice.lib.auth.provider.AuthenticationProvider.RedirectUri
 import com.gu.mediaservice.lib.config.{CommonConfig, Provider}
 import play.api.libs.crypto.CookieSigner
@@ -18,10 +19,13 @@ import scala.concurrent.Future
   * @param wsClient a play WSClient for making API calls
   * @param controllerComponents play components, including the execution context for example
   */
-case class AuthenticationProviderResources(commonConfig: CommonConfig,
-                                           actorSystem: ActorSystem,
-                                           wsClient: WSClient,
-                                           controllerComponents: ControllerComponents)
+case class AuthenticationProviderResources(
+  commonConfig: CommonConfig,
+  actorSystem: ActorSystem,
+  wsClient: WSClient,
+  controllerComponents: ControllerComponents,
+  authorisation: Authorisation
+)
 
 sealed trait LoginLink
 case object BuiltInAuthService extends LoginLink

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
@@ -31,5 +31,6 @@ trait AuthorisationProvider extends Provider {
     */
   def hasPermissionTo(permission: SimplePermission, principal: Principal): Boolean
 
+  def hasBasicAccessExplicitly(userEmail: String): Boolean = false // default implementation
   def hasAtLeastBasicAccess(userEmail: String): Boolean = true // default implementation
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
@@ -30,4 +30,6 @@ trait AuthorisationProvider extends Provider {
     * @return true if the principal has permission, false otherwise
     */
   def hasPermissionTo(permission: SimplePermission, principal: Principal): Boolean
+
+  def hasAtLeastBasicAccess(userEmail: String): Boolean = true // default implementation
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
@@ -155,6 +155,7 @@ class PandaAuthenticationProvider(
   final override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     val isValid = PandaAuthenticationProvider.validateUser(authedUser, userValidationEmailDomain, multifactorChecker)
 
+    val hasBasicAccessExplicitly = resources.authorisation.hasBasicAccessExplicitly(authedUser.user.email)
     val hasAnyGridPermission = resources.authorisation.hasAtLeastBasicAccess(authedUser.user.email)
 
     if(!isValid) {
@@ -162,6 +163,9 @@ class PandaAuthenticationProvider(
     }
     else if (!hasAnyGridPermission) {
       logger.warn(s"User ${authedUser.user.email} does not have any grid permissions")
+    }
+    else if (!hasBasicAccessExplicitly) {
+      logger.warn(s"User ${authedUser.user.email} does not have grid_access permission but does have other grid permissions")
     }
 
     isValid

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/Permissions.scala
@@ -5,8 +5,10 @@ import com.gu.permissions.PermissionDefinition
 object Permissions {
   val app = "grid"
 
+  val GridAccess: PermissionDefinition = PermissionDefinition("grid_access", app)
   val EditMetadata: PermissionDefinition = PermissionDefinition("edit_metadata", app)
   val DeleteImage: PermissionDefinition = PermissionDefinition("delete_image", app)
+  //FIXME I think this needs to be renamed ot `delete_crops_or_usages` - see https://github.com/guardian/grid/pull/3416 and https://github.com/guardian/permissions/pull/138
   val DeleteCrops: PermissionDefinition = PermissionDefinition("delete_crops", app)
   val ShowPaid: PermissionDefinition = PermissionDefinition("show_paid", app)
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -51,6 +51,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       }
     }
     permissionContext match {
+      case GridAccess => hasPermission(Permissions.GridAccess)
       case EditMetadata => hasPermission(Permissions.EditMetadata)
       case DeleteImage => hasPermission(Permissions.DeleteImage)
       case DeleteCropsOrUsages => hasPermission(Permissions.DeleteCrops)
@@ -59,5 +60,9 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       case UploadImages => true
       case ArchiveImages => true
     }
+  }
+
+  override def hasAtLeastBasicAccess(userEmail: String): Boolean = permissions.listPermissions(userEmail).exists {
+    case (PermissionDefinition(_, app), isActive) => app == Permissions.app && isActive
   }
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -62,6 +62,9 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
     }
   }
 
+
+  override def hasBasicAccessExplicitly(userEmail: String): Boolean =
+    permissions.hasPermission(Permissions.GridAccess, userEmail)
   override def hasAtLeastBasicAccess(userEmail: String): Boolean = permissions.listPermissions(userEmail).exists {
     case (PermissionDefinition(_, app), isActive) => app == Permissions.app && isActive
   }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/GridComponents.scala
@@ -52,7 +52,8 @@ abstract class GridComponents[Config <: CommonConfig](context: Context, val load
     commonConfig = config,
     actorSystem = actorSystem,
     wsClient = wsClient,
-    controllerComponents = controllerComponents
+    controllerComponents = controllerComponents,
+    authorisation = authorisation
   )
 
   protected val providers: AuthenticationProviders = AuthenticationProviders(

--- a/rest-lib/src/test/scala/com/gu/mediaservice/lib/auth/ApiKeyAuthenticationProviderTest.scala
+++ b/rest-lib/src/test/scala/com/gu/mediaservice/lib/auth/ApiKeyAuthenticationProviderTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.Inside.inside
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.inject.ApplicationLifecycle
 import play.api.mvc.DefaultControllerComponents
 import play.api.test.{FakeRequest, WsTestClient}
@@ -32,7 +33,7 @@ class ApiKeyAuthenticationProviderTest extends AsyncFreeSpec with Matchers with 
   )){}
   private val providerConfig = Configuration.empty
   private val controllerComponents: DefaultControllerComponents = DefaultControllerComponents(null, null, null, null, null, global)
-  private val resources = AuthenticationProviderResources(config, actorSystem, wsClient, controllerComponents)
+  private val resources = AuthenticationProviderResources(config, actorSystem, wsClient, controllerComponents, mock[Authorisation])
   private val provider = new ApiKeyAuthenticationProvider(providerConfig, resources) {
     override def initialise(): Unit = { /* do nothing */ }
 


### PR DESCRIPTION
## What does this change?
Wires `Authorisation` into `AuthenticationProviderResources` so `PandaAuthenticationProvider` has access to it in order to verify all user interactions have some form of grid permission (incl. new `grid_access` permission added in https://github.com/guardian/permissions/pull/186) LOGGING ONLY for now. 

Regardless, this should be no-op for other organisations using Grid (since they'll be [plugging](https://github.com/guardian/grid/pull/3131) their own `AuthorisationProvider` or relying on the default implementation of the key function `hasAtLeastBasicAccess` which returns true).

## How should a reviewer test this change?
Assuming https://github.com/guardian/permissions/pull/186 is deployed to CODE then deploy this branch to TEST main (or run locally) and experiment accessing grid with and without some form of grid permission (incl. new `grid_access` permission), observe the logs and you should see something like this...
<img width="1271" alt="image" src="https://github.com/guardian/grid/assets/19289579/a3c04eb1-01b0-49b9-9e70-b536dc99f67b">

## How can success be measured?
adhering better to our security principles [guardian/recommendations@b4746d4/README.md#security-principles](https://github.com/guardian/recommendations/blob/b4746d4cbf0b53f5237980170dd61b5c6b7d8ee8/README.md#security-principles)

## Who should look at this?
@guardian/digital-cms @guardian/newsroom-resilience @RichardLe @AndyKilmory @Conalb97 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
