### PR TITLE
actually enforce that Guardian users have at `grid_access` permission

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -85,6 +85,5 @@ class Authorisation(provider: AuthorisationProvider, executionContext: Execution
     }
   }
 
-  def hasBasicAccessExplicitly(userEmail: String): Boolean = provider.hasBasicAccessExplicitly(userEmail)
-  def hasAtLeastBasicAccess(userEmail: String): Boolean = provider.hasAtLeastBasicAccess(userEmail)
+  def hasBasicAccess(userEmail: String): Boolean = provider.hasBasicAccess(userEmail)
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
@@ -31,6 +31,5 @@ trait AuthorisationProvider extends Provider {
     */
   def hasPermissionTo(permission: SimplePermission, principal: Principal): Boolean
 
-  def hasBasicAccessExplicitly(userEmail: String): Boolean = false // default implementation
-  def hasAtLeastBasicAccess(userEmail: String): Boolean = true // default implementation
+  def hasBasicAccess(userEmail: String): Boolean = true // default implementation
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -63,9 +63,6 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
   }
 
 
-  override def hasBasicAccessExplicitly(userEmail: String): Boolean =
+  override def hasBasicAccess(userEmail: String): Boolean =
     permissions.hasPermission(Permissions.GridAccess, userEmail)
-  override def hasAtLeastBasicAccess(userEmail: String): Boolean = permissions.listPermissions(userEmail).exists {
-    case (PermissionDefinition(_, app), isActive) => app == Permissions.app && isActive
-  }
 }


### PR DESCRIPTION
https://github.com/guardian/grid/pull/4270 added logging for users without any permission whilst we can get everybody's permissions in good shape. 

## What does this change?
This makes use of the `hasAnyGridPermission` val we created in #4270 for the result of the `validateUser` function. We also `override` the `showUnauthedMessage` function to return a more useful 403 response...
<img width="959" alt="image" src="https://github.com/guardian/grid/assets/19289579/aca05f25-dbc5-4e8d-8283-85eb91ad8f0c">

NOTE: as with  #4270 this should be no-op for other organisations using Grid (since they'll be [plugging](https://github.com/guardian/grid/pull/3131) their own `AuthorisationProvider` or relying on the default implementation of the key function `hasBasicAccess` which returns true).

## How should a reviewer test this change?
Assuming https://github.com/guardian/permissions/pull/186 is deployed to CODE then deploy this branch to TEST main (or run locally) and experiment accessing grid with and without some form of grid permission (incl. new `grid_access` permission), observe the logs and you should see something like the image above.

## How can success be measured?
adhering better to our security principles [guardian/recommendations@b4746d4/README.md#security-principles](https://github.com/guardian/recommendations/blob/b4746d4cbf0b53f5237980170dd61b5c6b7d8ee8/README.md#security-principles)

## Who should look at this?
@guardian/digital-cms @guardian/newsroom-resilience @RichardLe @AndyKilmory @Conalb97 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
