### PR TITLE
Change label for 'Added to Collection' sort option

### DIFF
--- a/kahuna/public/js/components/gr-sort-control/gr-sort-control-config.ts
+++ b/kahuna/public/js/components/gr-sort-control/gr-sort-control-config.ts
@@ -32,7 +32,7 @@ export const SortOptions: SortDropdownOption[] = [
   },
   {
     value: "dateAddedToCollection",
-    label: "Added to Collection (recent 1st)",
+    label: "Added to Collection (new to old)",
     isCollection: true
   }
 ];


### PR DESCRIPTION
## What does this change?

Simple change to modify the label for the sort drop down option associated with the 'Added to Collection' option.

'(recent 1st)' has been replaced by '(new to old)'

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
