### PR TITLE
explicitly trigger CI job after push-pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - pr*
 jobs:
   CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-pr.yml
+++ b/.github/workflows/push-pr.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: push-pr
@@ -25,3 +26,9 @@ jobs:
           echo "Pushing PR merge commit for ${PR} to remote pr${PR} branch"
           git fetch -f origin pull/${PR}/merge:pr${PR}
           git push -f origin pr${PR}:pr${PR}
+      - name: trigger CI
+        env:
+          PR: ${{ inputs.prNumber }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yml --ref pr${PR}
+


### PR DESCRIPTION
...since pushes using GITHUB_TOKEN don't trigger workflows as per https://github.com/orgs/community/discussions/25702

Explains why https://github.com/guardian/grid/pull/4240 and https://github.com/guardian/grid/pull/4260 weren't working as desired.

Looks to work nicely...
![image](https://github.com/guardian/grid/assets/19289579/70ad5205-c5d6-4a49-93e7-97926953b604)
...shows up in riff-raff...
![image](https://github.com/guardian/grid/assets/19289579/6b7214ce-0127-4bc5-ba25-bbd347e74a4d)

