### PR TITLE
Delete unused authorisedForDeleteImageOrUploader method on MediaAPI

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -82,10 +82,6 @@ class MediaApi(
   private val searchLink = Link("search", searchLinkHref)
 
 
-  private def getUploader(imageId: String, user: Principal): Future[Option[String]] = elasticSearch.getImageUploaderById(imageId)
-
-  private def authorisedForDeleteImageOrUploader(imageId: String) = authorisation.actionFilterForUploaderOr(imageId, DeleteImagePermission, getUploader)
-
   private def indexResponse(user: Principal) = {
     val indexData = Json.obj(
       "description" -> "This is the Media API"


### PR DESCRIPTION
## What does this change?

Delete 2 unused private methods.

Looks like this is from before the generic auth changes. private methods which do not look like overrides and the application compiles without then.

Complies and tests pass.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

Should have zero impact; removes a piece redundant code and makes this class slightly easier to alter.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
