### PR TITLE
Add custom error handler to collections API

### DIFF
--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -20,6 +20,6 @@ class CollectionsComponents(context: Context) extends GridComponents(context, ne
 
   override val router = new Routes(httpErrorHandler, collections, imageCollections, management, InnerServiceStatusCheckController)
 
-  override lazy val httpErrorHandler: HttpErrorHandler = customHttpErrorHandler
   val customHttpErrorHandler = new CustomHttpErrorHandler(HttpErrorConfig(), devContext.map(_.sourceMapper), Some(router))
+  override lazy val httpErrorHandler: HttpErrorHandler = customHttpErrorHandler
 }

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -20,6 +20,5 @@ class CollectionsComponents(context: Context) extends GridComponents(context, ne
 
   override val router = new Routes(httpErrorHandler, collections, imageCollections, management, InnerServiceStatusCheckController)
 
-  val customHttpErrorHandler = new CustomHttpErrorHandler(HttpErrorConfig(), devContext.map(_.sourceMapper), Some(router))
-  override lazy val httpErrorHandler: HttpErrorHandler = customHttpErrorHandler
+  override lazy val httpErrorHandler: HttpErrorHandler = new CustomHttpErrorHandler(HttpErrorConfig(), devContext.map(_.sourceMapper), Some(router))
 }

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -1,8 +1,9 @@
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{CollectionsController, ImageCollectionsController}
-import lib.{CollectionsConfig, CollectionsMetrics, Notifications}
+import lib.{CollectionsConfig, CollectionsMetrics, CustomHttpErrorHandler, Notifications}
 import play.api.ApplicationLoader.Context
+import play.api.http.{HttpErrorConfig, HttpErrorHandler}
 import router.Routes
 import store.CollectionsStore
 
@@ -17,6 +18,8 @@ class CollectionsComponents(context: Context) extends GridComponents(context, ne
   val imageCollections = new ImageCollectionsController(auth, config, notifications, controllerComponents)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
-
   override val router = new Routes(httpErrorHandler, collections, imageCollections, management, InnerServiceStatusCheckController)
+
+  override lazy val httpErrorHandler: HttpErrorHandler = customHttpErrorHandler
+  val customHttpErrorHandler = new CustomHttpErrorHandler(HttpErrorConfig(), devContext.map(_.sourceMapper), Some(router))
 }

--- a/collections/app/lib/CustomHttpErrorHandler.scala
+++ b/collections/app/lib/CustomHttpErrorHandler.scala
@@ -1,10 +1,8 @@
 package lib
 
 import com.gu.mediaservice.lib.logging.GridLogging
-
 import play.api.http.{DefaultHttpErrorHandler, HttpErrorConfig}
 import play.api.mvc._
-import play.api.mvc.Results._
 import play.api.routing.Router
 import play.core.SourceMapper
 
@@ -17,13 +15,12 @@ class CustomHttpErrorHandler (
 ) extends DefaultHttpErrorHandler(config, sourceMapper, router) with GridLogging {
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
-    if (statusCode >= 400 && statusCode < 500) {
-      logger.error(s"[Client error]: $statusCode - ${request.method} ${request.uri} $message")
-      Future.successful(Status(statusCode)("A client error occurred: " + message))
-    } else {
-      throw new IllegalArgumentException(
-        s"onClientError invoked with non client error status code $statusCode: $message"
-      )
-    }
+    logger.error(s"[CLIENT ERROR] $statusCode - ${request.method} ${request.uri} $message")
+    super.onClientError(request, statusCode, message)
+  }
+
+  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+    logger.error(s"[SERVER ERROR] ${request.method} ${request.uri} ${exception.getMessage}")
+    super.onServerError(request, exception)
   }
 }

--- a/collections/app/lib/CustomHttpErrorHandler.scala
+++ b/collections/app/lib/CustomHttpErrorHandler.scala
@@ -1,0 +1,29 @@
+package lib
+
+import com.gu.mediaservice.lib.logging.GridLogging
+
+import play.api.http.{DefaultHttpErrorHandler, HttpErrorConfig}
+import play.api.mvc._
+import play.api.mvc.Results._
+import play.api.routing.Router
+import play.core.SourceMapper
+
+import scala.concurrent._
+
+class CustomHttpErrorHandler (
+  config: HttpErrorConfig = HttpErrorConfig(),
+  sourceMapper: Option[SourceMapper] = None,
+  router: => Option[Router] = None
+) extends DefaultHttpErrorHandler(config, sourceMapper, router) with GridLogging {
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
+    if (statusCode >= 400 && statusCode < 500) {
+      logger.error(s"[Client error]: $statusCode - ${request.method} ${request.uri} $message")
+      Future.successful(Status(statusCode)("A client error occurred: " + message))
+    } else {
+      throw new IllegalArgumentException(
+        s"onClientError invoked with non client error status code $statusCode: $message"
+      )
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?
For now, this just adds some logging around the errors thrown in the collections API. Why are we doing this? We periodically receive malicious probing requests to this service looking for vulnerabilities and would like to increase our visibility of the errors these requests are throwing.

## How should a reviewer test this change?
This is a very small change and should be a no-op in production. It can be tested by hitting an unimplemented collections API endpoint and seeing a new client error appear in the logs.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
