### PR TITLE
remove default implementation of `hasBasicAccess` to force organisations to specify in their implementation of `AuthorisationProvider`

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthorisationProvider.scala
@@ -31,5 +31,5 @@ trait AuthorisationProvider extends Provider {
     */
   def hasPermissionTo(permission: SimplePermission, principal: Principal): Boolean
 
-  def hasBasicAccess(userEmail: String): Boolean = true // default implementation
+  def hasBasicAccess(userEmail: String): Boolean
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/LocalAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/LocalAuthorisationProvider.scala
@@ -7,4 +7,5 @@ import com.typesafe.scalalogging.StrictLogging
 class LocalAuthorisationProvider extends AuthorisationProvider with StrictLogging {
   logger.warn("Authorisation set to local, every user will have permission for everything")
   override def hasPermissionTo(permission: SimplePermission, principal: Principal): Boolean = true
+  override def hasBasicAccess(userEmail: String): Boolean = true
 }


### PR DESCRIPTION
Small follow-up to https://github.com/guardian/grid/pull/4271 to address https://github.com/guardian/grid/pull/4271#discussion_r1611906264 and force other organisations to specify in their implementation of `AuthorisationProvider`.

FYI @RichardLe (in your case I think you'll want to return true, given your single-sign on auth solution already controls basic access, by virtue of who's allowed in in the first place) CC @AndyKilmory @Conalb97
