### PR TITLE
IMAGEDAM-1667: Metadata panel displays send to photo sales usages

### DIFF
--- a/kahuna/public/js/components/gr-image-usage-photosales/gr-image-usage-photosales.css
+++ b/kahuna/public/js/components/gr-image-usage-photosales/gr-image-usage-photosales.css
@@ -1,0 +1,17 @@
+.usageNameStyle {
+  font-weight: bold;
+  color: #999;
+  vertical-align: top;
+  text-align: left;
+}
+.usageRecordStyle {
+  margin-bottom: 10px;
+  width: 90%;
+}
+.usageMoreInfoStyle {
+  position: relative;
+  top: 1px;
+}
+.usageDateAddedStyle {
+  font-size: 11px;
+}

--- a/kahuna/public/js/components/gr-image-usage-photosales/gr-image-usage-photosales.tsx
+++ b/kahuna/public/js/components/gr-image-usage-photosales/gr-image-usage-photosales.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import * as angular from "angular";
+import { react2angular } from "react2angular";
+import {useEffect, useState} from "react";
+import * as moment from 'moment';
+import "./gr-image-usage-photosales.css";
+
+export interface Usage {
+  title: string,
+  usageName: string,
+  usageType: string,
+  dateAdded: Date
+}
+
+export interface UsageProps {
+  usages: Usage[];
+}
+
+export interface UsagePropsWrapper {
+  props: UsageProps;
+}
+
+const ImageUsagePhotoSales: React.FC<UsagePropsWrapper> = ({ props }) => {
+  const [usages, setUsages] = useState(props.usages);
+  const [photoSalesUsage, setPhotoSalesUsage] = useState<Usage|null>(null);
+
+  const photoSalesIdentifier = "sendToPhotoSales";
+
+  const formatTimestamp = (timestamp: Date) => {
+    return moment(timestamp).fromNow();
+  };
+
+  useEffect(()=> {
+    const photoSalesUsage = usages.find(usage => usage.usageType === photoSalesIdentifier);
+    if (photoSalesUsage) {
+      setPhotoSalesUsage(photoSalesUsage);
+      setUsages(usages.filter(usage => usage.usageType !== photoSalesIdentifier));
+    } else {
+      setPhotoSalesUsage(null);
+    }
+  }, []);
+
+  return (
+    <div>
+      {photoSalesUsage && (
+        <div className="image-info__group">
+          <span className="usageNameStyle">
+            {photoSalesUsage.usageName}
+          </span>
+          <ul>
+            <li className="usageRecordStyle">
+
+              {photoSalesUsage.title}
+
+              <div className="usageMoreInfoStyle">
+                <span className="usageDateAddedStyle">{formatTimestamp(photoSalesUsage.dateAdded)}</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const imageUsagePhotoSales = angular.module('gr.imageUsagePhotoSales', [])
+  .component('imageUsagePhotoSales', react2angular(ImageUsagePhotoSales, ["props"]));

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
@@ -1,9 +1,18 @@
-<div ng-repeat="(type, usages) in ctrl.usages">
-  <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages"></gr-image-usage-list>
+<div ng-if="!ctrl.showSendToPhotoSales">
+    <div ng-repeat="(type, usages) in ctrl.usages">
+        <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages"></gr-image-usage-list>
+    </div>
+</div>
+<div ng-if="ctrl.showSendToPhotoSales">
+    <image-usage-photo-sales props="{'usages':ctrl.photoSalesUsages}"></image-usage-photo-sales>
+    <div ng-repeat="(type, usages) in ctrl.usages" ng-if="type ==='downloaded'">
+        <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages"></gr-image-usage-list>
+    </div>
 </div>
 
+
 <gr-delete-usages
-  ng-if="ctrl.usagesCount > 0"
+  ng-if="(ctrl.usagesCount > 0 && !(ctrl.showSendToPhotoSales && ctrl.hasSyndicationUsages))"
   gr-image="ctrl.image"
   gr-on-delete="ctrl.onUsagesDeleted()">
 </gr-delete-usages>

--- a/kahuna/public/js/util/constants/sendToCapture-config.js
+++ b/kahuna/public/js/util/constants/sendToCapture-config.js
@@ -10,3 +10,4 @@ export const INVALIDIMAGES = "#INVALIDIMAGES#";
 export const sendToCaptureCancelBtnTxt = "No";
 export const sendToCaptureConfirmBtnTxt = "Yes, send";
 export const sendToCaptureSingleBtnTxt = "Okay";
+export const sendToCaptureUsagePanelTxt = "Added to Photo Sales";


### PR DESCRIPTION
## What does this change?

Note: this PR should be reviewed after https://github.com/guardian/grid/pull/4267 as it builds on the changes included in that PR

The relevant files for this PR are:

- kahuna/public/js/components/gr-image-usage-photosales/gr-image-usage-photosales.css
- kahuna/public/js/components/gr-image-usage-photosales/gr-image-usage-photosales.css
- kahuna/public/js/components/gr-image-usage/gr-image-usage.html
- kahuna/public/js/components/gr-image-usage/gr-image-usage.js
- kahuna/public/js/util/constants/sendToCapture-config.js
- usage/app/controllers/UsageApi.scala

Previously, after the user had completed the process of adding a photo sales and they navigated to the usages panel the usage was presented as if it was a standard syndication usage. Now a custom photo sales 'usage' is rendered instead. Additionally, as deleting the usage from the image, does not cause the image to be deleted in photo sales, changes have been made to usagesAPI so that the 'Delete All' button does not delete a syndication usage when it has a partnerName = Capture (i.e. is a photo sales usage).

The Photosales functionality is BBC specific, hence it is disabled by default via the showSendToPhotoSales feature flag. 

## How should a reviewer test this change?

As a user with elevated permissions and with the showSendToPhotoSales flag set to true:

- Select a number of image thumbnails from the main grid view, ensure none of these images have already been sent to Photosales
- Click the 'Send to Photo Sales Button' from the menu that appears
- A confirmation dialog modal will pop up
- Click 'Yes, send'
- A green notification banner will pop up
- Navigate to the usages panel 
- A new 'Photo Sales' usage has been added
- Then, click the 'delete all button' and wait for the page to refresh

## How can success be measured?

Confirm that the added photo sales usage has the following appearance:

![Screenshot 2024-05-31 at 16 07 37](https://github.com/guardian/grid/assets/129299738/670dfb9b-5178-4aad-931a-93d3777d5253)

And confirm that after clicking the 'delete all button' the 'Added to Photo Sales' usage remains on the image.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
