### PR TITLE
IMAGEDAM-1675: Added to Photo Sales Chip

### DIFF
--- a/kahuna/public/js/search/structured-query/query-suggestions.js
+++ b/kahuna/public/js/search/structured-query/query-suggestions.js
@@ -180,6 +180,9 @@ querySuggestions.factory('querySuggestions', ['mediaApi', 'editsApi', function(m
       if (window._clientConfig.recordDownloadAsUsage === true) {
         suggestions.push('download');
       }
+      if (window._clientConfig.showSendToPhotoSales) {
+        suggestions.push('Added to Photo Sales');
+      }
 
       return suggestions;
     }

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -40,8 +40,13 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
       // Force AND operator else it will only require *any* of the words, not *all*
-      case Words(value) => matchQuery(resolveFieldPath(field), value).operator(Operator.AND)
-      case Phrase(value) => matchPhraseQuery(resolveFieldPath(field), value)
+      case Words(value) =>
+        matchQuery(resolveFieldPath(field), value).operator(Operator.AND)
+      case Phrase(value) => value match {
+        case "Added to Photo Sales" =>
+          matchPhraseQuery(resolveFieldPath(field), "syndication")
+        case _ => matchPhraseQuery(resolveFieldPath(field), value)
+      }
       case DateRange(start, end) => rangeQuery(resolveFieldPath(field)).gte(printDateTime(start)).lte(printDateTime(end))
       case e => throw InvalidQuery(s"Cannot do single field query on $e")
     }


### PR DESCRIPTION
## What does this change?

Note: this PR should be reviewed after https://github.com/guardian/grid/pull/4267 as it builds on the changes included in that PR

The relevant files for this PR are:

- kahuna/public/js/search/structured-query/query-suggestions.js
- media-api/app/lib/elasticsearch/QueryBuilder.scala

In order to filter for images that have been sent to photo sales, a new option had to be added to the 'usages@platform' chip - 'Added to Photo Sales'.

On the backend, this query had to be mapped to the 'syndication' platform, so that the filter could actually be carried out. So a similar approach as what is used for 'isQueries' was applied. A match is used in anticipation of a 'Removed from Photo Sales' option in the future.

The Photosales functionality is BBC specific, hence it is disabled by default via the showSendToPhotoSales feature flag.

## How should a reviewer test this change?

As a user with elevated permissions and with the showSendToPhotoSales flag set to true:

- Add a 'usage@platform' chip to the search bar
- 'Added to Photo Sales' should appear as an option in the dropdown menu
- Select the 'Added to Photo Sales' option 
- The query will be executed and the UI will refresh 

## How can success be measured?

- Confirm that 'Added to Photo Sales' appears as an option for a 'usages@platform' chip
- Confirm that the images returned by applying this chip have a 'Added to Photo Sales' usage

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
