### PR TITLE
t1535 - Adds functionality that allows some restrictions text and special instructions text to be defined in config against the rights category and then displayed accordingly in metadata panel

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -104,6 +104,24 @@ usageRightsConfigProvider = {
   }
 }
 
+# ------------------------------------------------------
+# Rights Category Special Instructions and Restrictions
+# Variables usageInstructions and usageRestrictions define the rights derived special instructions and restrictions that
+# will be displayed along with the metadata for an image but are dervied from the selected rights category
+# They are json objects keyed by the rights category key and with the required text as a string variable;
+# usageInstructions {
+#   <<rights category key>> = "<<required text>>"
+# }
+# usageRestrictions {
+#  <<rights category key>> = "<<required text>>"
+# }
+# can be left blank or excluded if not required
+# -------------------------------------------------------
+usageInstructions {
+}
+usageRestrictions {
+}
+
 # -------------------------------------------------------------
 # Announcements - notifications to be seen by users
 # Format:

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -219,7 +219,7 @@ object Agency extends UsageRightsSpec {
   val defaultCost = None
   def name(commonConfig: CommonConfig) = "Agency - subscription"
   def description(commonConfig: CommonConfig) =
-    "Agencies such as Getty, Reuters, Press Association, etc. where subscription fees are paid to access and use pictures."
+    "Agencies such as Reuters, Press Association, etc. where subscription fees are paid to access and use pictures."
 
   implicit val formats: Format[Agency] =
     UsageRights.subtypeFormat(Agency.category)(Json.format[Agency])
@@ -318,7 +318,7 @@ object OriginalSource extends UsageRightsSpec {
   val defaultCost = Some(Free)
   def name(commonConfig: CommonConfig) = "Original Source"
   def description(commonConfig: CommonConfig) =
-    "Images provided by members of the public to be shared with Journalist who is out collecting material for stories"
+    "Images provided by members of the public to be shared with a journalist who is out collecting material for stories."
 
   implicit val formats: Format[OriginalSource] =
     UsageRights.subtypeFormat(OriginalSource.category)(Json.format[OriginalSource])
@@ -524,7 +524,7 @@ object Composite extends UsageRightsSpec {
   val defaultCost = Some(Free)
   def name(commonConfig: CommonConfig) = "Composite"
   def description(commonConfig: CommonConfig) =
-    "Any restricted images within the composite must be identified."
+    "A composite is an image made from the combination of a variety of stills. Any images within the composite must be listed within the suppliers field."
 
   override val caution = Some("All images should be free to use, or restrictions applied")
 
@@ -542,7 +542,7 @@ object PublicDomain extends UsageRightsSpec {
   def description(commonConfig: CommonConfig) =
     "Images out of copyright or bequeathed to the public."
 
-  override val caution = Some("ONLY use if out of copyright or bequeathed to public")
+  override val caution = Some("ONLY use if you are certain the image is out of copyright or bequeathed to public")
 
   implicit val formats: Format[PublicDomain] =
     UsageRights.subtypeFormat(PublicDomain.category)(Json.format[PublicDomain])
@@ -554,9 +554,9 @@ final case class ProgramPromotional(restrictions: Option[String] = None) extends
 object ProgramPromotional extends UsageRightsSpec {
   val category = "program-promotional"
   val defaultCost = Some(Pay)
-  def name(commonConfig: CommonConfig) = "Program Promotional"
+  def name(commonConfig: CommonConfig) = "Programme Promotional"
   def description(commonConfig: CommonConfig) =
-    "Images supplied for the Promotion of Public broadcast programs"
+    "Images supplied for the promotion of public broadcast programmes."
 
   implicit val formats: Format[ProgramPromotional] =
     UsageRights.subtypeFormat(ProgramPromotional.category)(Json.format[ProgramPromotional])

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.html
@@ -1,7 +1,7 @@
-<div ng-switch="messageState">
+<div ng-switch="ctrl.messageState">
     <div ng-switch-when="conditional"
          class="image-notice image-info__group cost cost--conditional"
          title="This image can be used but only within certain restrictions">
-        <b>Restricted use:</b> {{image.data.usageRights.restrictions}}
+        <b>Restricted use:</b> {{ctrl.restrictionsText()}}
     </div>
 </div>

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
@@ -17,11 +17,11 @@ module.controller('grImageCostMessage', [
       ctrl.messageState = (states.hasRestrictions) ? "conditional" : states.costState;
 
       ctrl.restrictionsText = () => {
-        if (!this.image.data.usageRights) {
-          return "";
-        }
         let rtxt = "";
-        if (this.image.data.usageRights.usageRestrictions && this.image.data.usageRights.usageRestrictions.length > 0) {
+        if (!this.image.data.usageRights) {
+          return rtxt;
+        }
+        if (this.image.data.usageRights.usageRestrictions) {
           rtxt = this.image.data.usageRights.usageRestrictions;
         }
         rtxt = rtxt.trim();

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
@@ -1,21 +1,55 @@
 import angular from 'angular';
+import {imageService} from '../../image/service';
 
 import template from './gr-image-cost-message.html';
 import './gr-image-cost-message.css';
 
-export const module = angular.module('gr.imageCostMessage', []);
+export const module = angular.module('gr.imageCostMessage', [imageService.name]);
 
-module.directive('grImageCostMessage', ['imageService', function (imageService) {
+module.controller('grImageCostMessage', [
+  'imageService',
+
+  function (imageService) {
+    let ctrl = this;
+
+    ctrl.$onInit = () => {
+      const states = imageService(ctrl.image).states;
+      ctrl.messageState = (states.hasRestrictions) ? "conditional" : states.costState;
+
+      ctrl.restrictionsText = () => {
+        if (!this.image.data.usageRights) {
+          return "";
+        }
+        let rtxt = "";
+        if (this.image.data.usageRights.usageRestrictions && this.image.data.usageRights.usageRestrictions.length > 0) {
+          rtxt = this.image.data.usageRights.usageRestrictions;
+        }
+        rtxt = rtxt.trim();
+        if (rtxt.length > 0 && rtxt[rtxt.length - 1] != ".") {
+          rtxt = rtxt + ". ";
+        } else {
+          rtxt = rtxt + " ";
+        }
+        if (this.image.data.usageRights.restrictions) {
+          rtxt = rtxt + this.image.data.usageRights.restrictions;
+        }
+        return rtxt;
+      };
+
+    };
+  }
+]);
+
+module.directive('grImageCostMessage', [function () {
     return {
         restrict: 'E',
         template: template,
         transclude: true,
-        link: scope => {
-            const { states } = imageService(scope.image);
-            scope.messageState = states.costState;
-        },
         scope: {
             image: '=grImage'
-        }
+        },
+        controller: 'grImageCostMessage',
+        controllerAs: 'ctrl',
+        bindToController: true
     };
 }]);

--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import {imageService} from '../../image/service';
+import {restrictionsText} from '../../util/rights-categories';
 
 import template from './gr-image-cost-message.html';
 import './gr-image-cost-message.css';
@@ -15,25 +16,8 @@ module.controller('grImageCostMessage', [
     ctrl.$onInit = () => {
       const states = imageService(ctrl.image).states;
       ctrl.messageState = (states.hasRestrictions) ? "conditional" : states.costState;
-
       ctrl.restrictionsText = () => {
-        let rtxt = "";
-        if (!this.image.data.usageRights) {
-          return rtxt;
-        }
-        if (this.image.data.usageRights.usageRestrictions) {
-          rtxt = this.image.data.usageRights.usageRestrictions;
-        }
-        rtxt = rtxt.trim();
-        if (rtxt.length > 0 && rtxt[rtxt.length - 1] != ".") {
-          rtxt = rtxt + ". ";
-        } else {
-          rtxt = rtxt + " ";
-        }
-        if (this.image.data.usageRights.restrictions) {
-          rtxt = rtxt + this.image.data.usageRights.restrictions;
-        }
-        return rtxt;
+        return restrictionsText(this.image);
       };
 
     };

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -206,17 +206,15 @@
     </dl>
     </div>
 
-    <div class="image-info__group" role="region" aria-label="Special instructions">
+    <div data-cy="metadata-specialInstructions" role="region" class="image-info__group" aria-label="Special instructions">
         <dl class="image-info__wrap">
             <dt class="metadata-line metadata-line__key">Special instructions</dt>
             <span ng-if="ctrl.metadata.usageInstructions">
-                <div class="metadata-line__info">
-                    <dd>{{ctrl.metadata.usageInstructions}}</dd>
-                </div>
+                <span class="metadata-line__info">{{ctrl.metadata.usageInstructions}}</span>
             </span>
             <span ng-if="ctrl.metadataUpdatedByTemplate.includes('specialInstructions')">
                 <div class="metadata-line__info">
-                    <dd class="image-info__special-instructions-preview">{{ctrl.metadata.specialInstructions}}</dd>
+                    <dd class="image-info__description-preview">{{ctrl.metadata.specialInstructions}}</dd>
                 </div>
             </span>
             <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('specialInstructions')">
@@ -224,42 +222,70 @@
                         ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
                         ng-click="specialInstructionsEditForm.$show()"
                         ng-hide="specialInstructionsEditForm.$visible">✎</button>
-                <div class="metadata-line__info" ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)}"
-                     editable-textarea="ctrl.metadata.specialInstructions"
-                     ng-hide="specialInstructionsEditForm.$visible"
-                     onbeforesave="ctrl.updateMetadataField('specialInstructions', $data)"
-                     e:msd-elastic
-                     e:form="specialInstructionsEditForm"
-                     e:ng-class="{'image-info__editor--error': $error,
-                         'image-info__editor--saving': specialInstructionsEditForm.$waiting,
-                         'text-input': true}">
+                <form editable-form name="specialInstructionsEditForm"
+                      onaftersave="ctrl.updateMetadataField('specialInstructions', $data)">
+                    <div ng-hide="specialInstructionsEditForm.$visible"
+                         ng-class="{'image-info--multiple': ctrl.hasMultipleSpecialInstructions()}">
 
-                    <div ng-if="ctrl.userCanEdit">
-                        <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                            class="image-info__special-instructions"
-                        >Multiple special instructions (click ✎ to edit <strong>all</strong>)
-                        </dd>
+                        <div ng-if="ctrl.userCanEdit">
+                            <dd class="image-info__special-instructions"
+                                ng-if="ctrl.hasMultipleSpecialInstructions()"
+                            >Multiple special instructions (click ✎ to edit <strong>all</strong>)
+                            </dd>
 
-                        <dd ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                            class="image-info__special-instructions"
-                        >{{ctrl.metadata.specialInstructions}}
-                        </dd>
+                            <dd class="image-info__special-instructions"
+                                ng-class="{'editable-empty': !ctrl.metadata.specialInstructions}"
+                                ng-if="!ctrl.hasMultipleSpecialInstructions() && !ctrl.metadata.usageInstructions"
+                            >{{ctrl.metadata.specialInstructions || "Unknown (click ✎ to add)"}}
+                            </dd>
+
+                            <dd class="image-info__special-instructions"
+                                ng-class="{'editable-empty': !ctrl.metadata.specialInstructions}"
+                                ng-if="!ctrl.hasMultipleSpecialInstructions() && ctrl.metadata.usageInstructions"
+                            >{{ctrl.metadata.specialInstructions || "Click ✎ to add further instructions"}}
+                            </dd>
+                        </div>
+
+                        <div ng-if="!ctrl.userCanEdit">
+                            <dd class="image-info__special-instructions"
+                                ng-if="ctrl.hasMultipleSpecialInstructions()"
+                            >Multiple special instructions
+                            </dd>
+
+                            <dd class="image-info__special-instructions"
+                                ng-class="{'editable-empty': !ctrl.metadata.specialInstructions}"
+                                ng-if="!ctrl.hasMultipleSpecialInstructions() && ctrl.metadata.usageInstructions"
+                            >{{ctrl.metadata.specialInstructions || ""}}
+                            </dd>
+
+                            <dd class="image-info__special-instructions"
+                                ng-class="{'editable-empty': !ctrl.metadata.specialInstructions}"
+                                ng-if="!ctrl.hasMultipleSpecialInstructions() && !ctrl.metadata.usageInstructions"
+                            >{{ctrl.metadata.specialInstructions || "Unknown"}}
+                            </dd>
+                        </div>
                     </div>
-
-                    <div ng-if="!ctrl.userCanEdit">
-                        <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                            class="image-info__special-instructions"
-                        >Multiple special instructions
-                        </dd>
-
-                        <dd ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.specialInstructions)"
-                            class="image-info__special-instructions"
-                        >{{ctrl.metadata.specialInstructions}}
-                        </dd>
+                    <div
+                        class="metadata-line__info"
+                        editable-textarea="ctrl.metadata.specialInstructions"
+                        ng-hide="descriptionEditForm.$visible"
+                        e:msd-elastic
+                        e:ng-class="{'image-info__editor--error': $error,
+                                     'image-info__editor--saving': specialInstructionsEditForm.$waiting,
+                                     'text-input': true}"
+                    >
                     </div>
-               </div>
+                    <div ng-if="ctrl.userCanEdit && specialInstructionsEditForm.$visible" class="editable-buttons">
+                        <button class="button-cancel" type="button" ng-click="specialInstructionsEditForm.$cancel()">
+                            <gr-icon-label gr-icon="close">Cancel</gr-icon-label>
+                        </button>
+                        <button class="button-save" type="submit">
+                            <gr-icon-label gr-icon="check">Save</gr-icon-label>
+                        </button>
+                    </div>
+                </form>
             </span>
-       </dl>
+        </dl>
     </div>
 
     <div class="image-info__group" role="region" aria-label="Image metadata">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -206,7 +206,7 @@
     </dl>
     </div>
 
-    <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions || ctrl.rawMetadata.usageInstructions" role="region" aria-label="Special instructions">
+    <div class="image-info__group" role="region" aria-label="Special instructions">
         <dl class="image-info__wrap">
             <dt class="metadata-line metadata-line__key">Special instructions</dt>
             <span ng-if="ctrl.metadata.usageInstructions">

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -223,7 +223,7 @@
                         ng-click="specialInstructionsEditForm.$show()"
                         ng-hide="specialInstructionsEditForm.$visible">✎</button>
                 <form editable-form name="specialInstructionsEditForm"
-                      onaftersave="ctrl.updateMetadataField('specialInstructions', $data)">
+                      onaftersave="ctrl.updateSpecialInstructionsField()">
                     <div ng-hide="specialInstructionsEditForm.$visible"
                          ng-class="{'image-info--multiple': ctrl.hasMultipleSpecialInstructions()}">
 
@@ -268,7 +268,7 @@
                     <div
                         class="metadata-line__info"
                         editable-textarea="ctrl.metadata.specialInstructions"
-                        ng-hide="descriptionEditForm.$visible"
+                        ng-hide="specialInstructionsEditForm.$visible"
                         e:msd-elastic
                         e:ng-class="{'image-info__editor--error': $error,
                                      'image-info__editor--saving': specialInstructionsEditForm.$waiting,

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -206,9 +206,14 @@
     </dl>
     </div>
 
-    <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions" role="region" aria-label="Special instructions">
+    <div class="image-info__group" ng-if="ctrl.rawMetadata.specialInstructions || ctrl.rawMetadata.usageInstructions" role="region" aria-label="Special instructions">
         <dl class="image-info__wrap">
             <dt class="metadata-line metadata-line__key">Special instructions</dt>
+            <span ng-if="ctrl.metadata.usageInstructions">
+                <div class="metadata-line__info">
+                    <dd>{{ctrl.metadata.usageInstructions}}</dd>
+                </div>
+            </span>
             <span ng-if="ctrl.metadataUpdatedByTemplate.includes('specialInstructions')">
                 <div class="metadata-line__info">
                     <dd class="image-info__special-instructions-preview">{{ctrl.metadata.specialInstructions}}</dd>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -140,7 +140,7 @@
                     <button data-cy="it-edit-description-button"
                             class="image-info__edit"
                             ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
-                            ng-click="descriptionEditForm.$show()"
+                            ng-click="descriptionEditForm.$show(); ctrl.checkDescriptionLength();"
                             ng-hide="descriptionEditForm.$visible">✎</button>
                     <form editable-form name="descriptionEditForm" onaftersave="ctrl.updateDescriptionField('description', $data)">
                         <div ng-hide="descriptionEditForm.$visible" ng-class="{'image-info--multiple': ctrl.hasMultipleValues(ctrl.rawMetadata.description)}">
@@ -220,10 +220,9 @@
             <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('specialInstructions')">
                 <button class="image-info__edit"
                         ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
-                        ng-click="specialInstructionsEditForm.$show()"
+                        ng-click="specialInstructionsEditForm.$show(); ctrl.checkSpecialInstructionsLength();"
                         ng-hide="specialInstructionsEditForm.$visible">✎</button>
-                <form editable-form name="specialInstructionsEditForm"
-                      onaftersave="ctrl.updateSpecialInstructionsField()">
+                <form editable-form name="specialInstructionsEditForm" onaftersave="ctrl.updateSpecialInstructionsField()">
                     <div ng-hide="specialInstructionsEditForm.$visible"
                          ng-class="{'image-info--multiple': ctrl.hasMultipleSpecialInstructions()}">
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -26,8 +26,8 @@
                 gr-usage-rights-updated-by-template="ctrl.usageRightsUpdatedByTemplate">
             </gr-usage-rights-editor>
 
-            <dd class="image-info__title" ng-if="! ctrl.showUsageRights">
-                <dd ng-if="! ctrl.usageRightsSummary">
+            <div class="image-info__title" ng-if="!ctrl.showUsageRights">
+                <dd ng-if="!ctrl.usageRightsSummary">
                     {{ctrl.usageCategory || 'None'}}
                 </dd>
                 <dd ng-if="ctrl.usageRightsSummary">
@@ -36,7 +36,7 @@
                         props="{'images':ctrl.selectedImages, 'categoryCallback':ctrl.callbackUsageCategory}">
                     </usage-rights-summary>
                 </dd>
-            </dd>
+            </div>
 
             <button
                 data-cy="it-edit-usage-rights-button"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -81,21 +81,22 @@ module.controller('grImageMetadataCtrl', [
 
       });
 
-      $document.on('keydown', keydownListener);
+      $document.on('keydown', textareaKeydownListener);
 
-      function keydownListener(evt) {
+      function textareaKeydownListener(evt) {
         if (evt.isDefaultPrevented()
             || evt.target.type !== 'textarea'
             || !evt.target.form) {
           return evt;
         }
 
+        const effectiveForms = ["specialInstructionsEditForm", "descriptionEditForm"];
         switch (evt.key) {
           case 'Escape':
-            return cancelEditForm(evt);
+            return formButtonClick(evt, 'button-cancel', effectiveForms);
           case 'Enter':
             if (evt.ctrlKey || evt.metaKey) {
-              return submitEditForm(evt);
+              return formButtonClick(evt, 'button-save', effectiveForms);
             } else {
               return evt;
             }
@@ -104,32 +105,16 @@ module.controller('grImageMetadataCtrl', [
         }
       };
 
-      function cancelEditForm(evt) {
+      function formButtonClick(evt, buttonClass, forms) {
         const form = evt.target.form;
-        const cancelableForms = ["specialInstructionsEditForm", "descriptionEditForm"];
-        if (!cancelableForms.includes(form.name)) {
+        if (!forms.includes(form.name)) {
           return evt;
         }
-        const cancelBtns = Array.from(form.elements).filter(function(element) {
-          return element.classList.contains('button-cancel');
+        const buttons = Array.from(form.elements).filter(function(element) {
+          return element.classList.contains(buttonClass);
         });
-        if (cancelBtns.length > 0) {
-          cancelBtns[0].click();
-        }
-        return;
-      };
-
-      function submitEditForm(evt) {
-        const form = evt.target.form;
-        const submittableForms = ["specialInstructionsEditForm", "descriptionEditForm"];
-        if (!submittableForms.includes(form.name)) {
-          return evt;
-        }
-        const saveBtns = Array.from(form.elements).filter(function(element) {
-          return element.classList.contains('button-save');
-        });
-        if (saveBtns.length > 0) {
-          saveBtns[0].click();
+        if (buttons.length > 0) {
+          buttons[0].click();
         }
         return;
       };

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -234,7 +234,7 @@ module.controller('grImageMetadataCtrl', [
         'title', 'description', 'copyright', 'keywords', 'byline',
         'credit', 'subLocation', 'city', 'state', 'country',
         'dateTaken', 'specialInstructions', 'subjects', 'peopleInImage',
-        'domainMetadata'
+        'domainMetadata', 'usageInstructions'
       ];
 
       function updateSingleImage() {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -90,7 +90,7 @@ module.controller('grImageMetadataCtrl', [
           return evt;
         }
 
-        switch(evt.key) {
+        switch (evt.key) {
           case 'Escape':
             return cancelEditForm(evt);
           case 'Enter':

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -546,7 +546,7 @@ module.controller('grImageMetadataCtrl', [
 
       $scope.$on('$destroy', function () {
         freeUpdateListener();
-        $document.off('keydown', keydownListener);
+        $document.off('keydown', textareaKeydownListener);
       });
 
       ctrl.onMetadataTemplateSelected = (metadata, usageRights, collection, leasesWithConfig) => {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -120,6 +120,10 @@ module.controller('grImageMetadataCtrl', [
         ctrl.updateMetadataField('description', ctrl.metadata.description);
       };
 
+      ctrl.updateSpecialInstructionsField = function () {
+        ctrl.updateMetadataField('specialInstructions', ctrl.metadata.specialInstructions);
+      };
+
       ctrl.updateLocationField = function (data, value) {
         Object.keys(value).forEach(key => {
           if (value[key] === undefined) {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -86,6 +86,12 @@ module.controller('grImageMetadataCtrl', [
         ctrl.selectedImages = new List(updatedImages);
       };
 
+      ctrl.hasMultipleSpecialInstructions = function () {
+        const val = ctrl.rawMetadata.specialInstructions;
+        const val2 = ctrl.rawMetadata.usageInstructions;
+        return ((Array.isArray(val) && val.length > 1) || (Array.isArray(val2) && val2.length > 1));
+      };
+
       ctrl.hasMultipleValues = (val) => Array.isArray(val) && val.length > 1;
 
       ctrl.displayDateTakenMetadata = function () {

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -14,17 +14,18 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', '$window', function 
             let showDenySyndicationWarning = $window._clientConfig.showDenySyndicationWarning;
             ctrl.showDenySyndication = image.data.leases.data.leases.some(lease => (lease.access === 'deny-syndication' && lease.active != false)) && showDenySyndicationWarning;
             ctrl.isDeleted = image.data.softDeletedMetadata !== undefined;
-            ctrl.showInvalidReasons = Object.keys(image.data.invalidReasons).length !== 0 || ctrl.isDeleted;
+            const hasUsageRights = Object.keys(image.data.usageRights).length > 0;
+            if (!hasUsageRights) {
+              ctrl.warningTextHeader = $window._clientConfig.warningTextHeaderNoRights;
+              ctrl.showInvalidReasons = Object.keys(image.data.invalidReasons).length !== 0 || ctrl.isDeleted;
+            } else {
+              ctrl.warningTextHeader = $window._clientConfig.warningTextHeader;
+              ctrl.showInvalidReasons = Object.keys(image.data.invalidReasons).length !== 0 || ctrl.isDeleted || image.data.usageRights.usageRestrictions;
+            }
             ctrl.invalidReasons = image.data.invalidReasons;
             ctrl.isOverridden = ctrl.showInvalidReasons && image.data.valid;
             ctrl.isStrongWarning = ctrl.isDeleted || !ctrl.isOverridden || image.data.cost === "pay";
 
-            const hasUsageRights = Object.keys(image.data.usageRights).length > 0;
-            if (!hasUsageRights) {
-              ctrl.warningTextHeader = $window._clientConfig.warningTextHeaderNoRights;
-            } else {
-              ctrl.warningTextHeader = $window._clientConfig.warningTextHeader;
-            }
             ctrl.unusableTextHeader = $window._clientConfig.unusableTextHeader;
             ctrl.denySyndicationTextHeader = $window._clientConfig.denySyndicationTextHeader;
         });

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -136,7 +136,7 @@
     <div class="result-editor__editor">
 
         <section aria-label="Image usage rights">
-            <h1>Image Rights</h1>
+            <h1 class="results-editor__top-heading">Image Rights</h1>
             <div class="result-editor__field-container image-info__wrap">
                 <span class="result-editor__field-label flex-no-shrink text-small">
                     Rights &amp; restrictions
@@ -190,7 +190,7 @@
 
         <section aria-label="Image metadata">
             <span class="edit_metadata__warning" ng-if="!ctrl.userCanEdit">WARNING: This image is already in {{ctrl.systemName}}. Since you're not the original uploader, you are not allowed to edit its metadata.</span>
-            <h1 ng-class="{'section__disabled': !ctrl.userCanEdit}">Image Metadata</h1>
+            <h1 ng-class="{'section__disabled': !ctrl.userCanEdit}" class="results-editor__heading">Image Metadata</h1>
             <ui-required-metadata-editor
                 class="result-editor__metadata-editor"
                 resource="ctrl.image.data.userMetadata.data.metadata"
@@ -202,7 +202,7 @@
         </section>
 
         <section aria-label="Organisation and grouping">
-            <h1>Organisation and Grouping</h1>
+            <h1 class="results-editor__heading">Organisation and Grouping</h1>
             <div class="result-editor__field-container flex-container flex-center">
                 <span class="result-editor__field-label  flex-no-shrink text-small">
                     Collections
@@ -318,7 +318,7 @@
         </section>
 
         <section aria-label="File information">
-            <h1>File information</h1>
+            <h1 class="results-editor__heading">File information</h1>
             <div class="result-editor__field-container" ng-if=":: ctrl.image.data.uploadInfo.filename">
                 <div class="result-editor__field-label text-small">File name</div>
                 <div class="result-editor__field-value">{{:: ctrl.image.data.uploadInfo.filename}}</div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -53,7 +53,7 @@
 
         <div class="result-editor__info">
             <div class="result-editor__info-item result-editor__info-item--first"
-                 ng-switch="ctrl.image.data.cost">
+                 ng-switch="ctrl.image.data.usageRights.usageRestrictions ? 'conditional' : ctrl.image.data.cost">
                 <span class="result-editor__status status status--invalid"
                       ng-switch-when="pay">Pay to use</span>
 

--- a/kahuna/public/js/image/service.js
+++ b/kahuna/public/js/image/service.js
@@ -23,11 +23,13 @@ imageService.factory('imageService', ['imageLogic', function(imageLogic) {
 
     function getStates(image) {
       const hasRights = !(Object.keys(image.data.usageRights).length === 0);
+      const hasRestrictions = hasRights && Object.keys(image.data.usageRights).includes('usageRestrictions');
       const cost = image.data.cost;
         return {
             cost,
             hasCrops: image.data.exports && image.data.exports.length > 0,
             hasRights,
+            hasRestrictions,
             costState: hasRights ? cost : "no_rights",
             isValid: image.data.valid,
             canDelete: imageLogic.canBeDeleted(image),

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -172,7 +172,7 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
             <div ng-switch-when="conditional"
                  class="cost bottom-bar__action bottom-bar__action--cost preview__cost preview__bottom-icons-align-right"
                  ng-class="{'cost--conditional': !ctrl.hasActiveAllowLease, 'cost--leased': ctrl.hasActiveAllowLease}"
-                 title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Restrictions: {{ctrl.image.data.usageRights.restrictions}}">
+                 title="{{ctrl.hasActiveAllowLease ? 'Leased, but: ' : ''}}Restrictions: {{ctrl.restrictionsText()}}">
                  <!-- As `conditional` can only be set with usageRights, let's
                  just assume it's here. We might need to revisit this. -->
                 <gr-icon>flag</gr-icon>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -3,7 +3,7 @@ import Rx from 'rx';
 
 import '../util/rx';
 import '../util/storage';
-
+import {restrictionsText} from '../util/rights-categories';
 
 import template from './image.html';
 import templateLarge from './image-large.html';
@@ -138,23 +138,7 @@ image.controller('uiPreviewImageCtrl', [
       ctrl.searchWithModifiers = searchWithModifiers;
 
       ctrl.restrictionsText = () => {
-        let rtxt = "";
-        if (!this.image.data.usageRights) {
-          return rtxt;
-        }
-        if (this.image.data.usageRights.usageRestrictions) {
-          rtxt = this.image.data.usageRights.usageRestrictions;
-        }
-        rtxt = rtxt.trim();
-        if (rtxt.length > 0 && rtxt[rtxt.length - 1] != ".") {
-          rtxt = rtxt + ". ";
-        } else {
-          rtxt = rtxt + " ";
-        }
-        if (this.image.data.usageRights.restrictions) {
-          rtxt = rtxt + this.image.data.usageRights.restrictions;
-        }
-        return rtxt;
+        return restrictionsText(this.image);
       };
 
     };

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -91,7 +91,7 @@ image.controller('uiPreviewImageCtrl', [
 
       ctrl.image.isPotentiallyGraphic = graphicImageBlurService.isPotentiallyGraphic(ctrl.image);
 
-      ctrl.flagState = ctrl.states.costState;
+      ctrl.flagState = (ctrl.states.hasRestrictions) ? "conditional" : ctrl.states.costState;
 
       const hasPrintUsages$ =
           imageUsagesService.getUsages(ctrl.image).hasPrintUsages$;
@@ -118,7 +118,7 @@ image.controller('uiPreviewImageCtrl', [
       ctrl.hasActiveAllowLease = ctrl.image.data.leases.data.leases.find(lease => lease.active && lease.access === 'allow-use');
 
       ctrl.showAlertOverlay = () => Object.keys(ctrl.image.data.invalidReasons).length > 0 && Object.keys(ctrl.image.data.invalidReasons).find(key => key !== 'conditional_paid') !== undefined ;
-      ctrl.showWarningOverlay = () => ctrl.image.data.cost === 'conditional' && ctrl.hasActiveAllowLease === undefined;
+      ctrl.showWarningOverlay = () => ctrl.flagState === 'conditional' && ctrl.hasActiveAllowLease === undefined;
       ctrl.showActiveAllowLeaseOverlay = () => !ctrl.showAlertOverlay() && ctrl.hasActiveAllowLease !== undefined;
 
       ctrl.showOverlay = () => $window._clientConfig.enableWarningFlags && ctrl.isSelected && (ctrl.showAlertOverlay() || ctrl.showWarningOverlay() || ctrl.showActiveAllowLeaseOverlay() );
@@ -136,6 +136,27 @@ image.controller('uiPreviewImageCtrl', [
       };
 
       ctrl.searchWithModifiers = searchWithModifiers;
+
+      ctrl.restrictionsText = () => {
+        if (!this.image.data.usageRights) {
+          return "";
+        }
+        let rtxt = "";
+        if (this.image.data.usageRights.usageRestrictions && this.image.data.usageRights.usageRestrictions.length > 0) {
+          rtxt = this.image.data.usageRights.usageRestrictions;
+        }
+        rtxt = rtxt.trim();
+        if (rtxt.length > 0 && rtxt[rtxt.length - 1] != ".") {
+          rtxt = rtxt + ". ";
+        } else {
+          rtxt = rtxt + " ";
+        }
+        if (this.image.data.usageRights.restrictions) {
+          rtxt = rtxt + this.image.data.usageRights.restrictions;
+        }
+        return rtxt;
+      };
+
     };
 }]);
 

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -138,11 +138,11 @@ image.controller('uiPreviewImageCtrl', [
       ctrl.searchWithModifiers = searchWithModifiers;
 
       ctrl.restrictionsText = () => {
-        if (!this.image.data.usageRights) {
-          return "";
-        }
         let rtxt = "";
-        if (this.image.data.usageRights.usageRestrictions && this.image.data.usageRights.usageRestrictions.length > 0) {
+        if (!this.image.data.usageRights) {
+          return rtxt;
+        }
+        if (this.image.data.usageRights.usageRestrictions) {
           rtxt = this.image.data.usageRights.usageRestrictions;
         }
         rtxt = rtxt.trim();

--- a/kahuna/public/js/services/image-list.js
+++ b/kahuna/public/js/services/image-list.js
@@ -31,7 +31,7 @@ imageList.factory("imageList", [
     }
 
     function getCostState(images) {
-        return images.map(img => imageService(img).states.costState);
+        return images.map(img => imageService(img).states.hasRestrictions ? "conditional" : imageService(img).states.costState);
     }
 
     function getLabels(images) {

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -12,8 +12,9 @@
 
 .job-usage-instructions {
   border: 1px solid #ffbc01;
-  padding: 2px;
+  padding: 2px 4px;
   line-height: 24px;
+  background-color: #444;
 }
 
 .job-additional-special-instructions {

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -13,7 +13,7 @@
 .job-usage-instructions {
   border: 1px solid #ffbc01;
   padding: 2px 4px;
-  line-height: 24px;
+  line-height: 19.5px;
   background-color: #444;
 }
 

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -6,9 +6,14 @@
   border: 1px solid #ffbc01;
 }
 
+.job-info--editor__multiline {
+  padding-top: 6px;
+}
+
 .job-usage-instructions {
-  border: 1px solid yellow;
+  border: 1px solid #ffbc01;
   padding: 2px;
+  line-height: 24px;
 }
 
 .job-additional-special-instructions {

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -5,3 +5,10 @@
 .job-info--editor__input-preview {
   border: 1px solid #ffbc01;
 }
+
+.job-usage-instructions {
+  border: 1px solid yellow;
+  padding: 2px;
+  margin-left: 28px;
+  width: 100%;
+}

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -9,6 +9,13 @@
 .job-usage-instructions {
   border: 1px solid yellow;
   padding: 2px;
-  margin-left: 28px;
-  width: 100%;
+}
+
+.job-additional-special-instructions {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+.job-additional-special-instructions-label {
+  min-width: 130px;
 }

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.css
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.css
@@ -21,7 +21,3 @@
   padding-top: 2px;
   padding-bottom: 2px;
 }
-
-.job-additional-special-instructions-label {
-  min-width: 130px;
-}

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -130,6 +130,12 @@
                 ng-click="ctrl.batchApplyMetadata('specialInstructions')"
             >⇔</button>
         </label>
+
+        <div class="job-info--editor__field flex-center" ng-if="!!ctrl.metadata.usageInstructions">
+            <div class="job-info--editor__label text-small">&nbsp;</div>
+            <div class="job-info--editor__label text-small job-usage-instructions" style="width:100%;">{{ctrl.metadata.usageInstructions}}</div>
+        </div>
+
     </div>
     <!-- Angular doesn't submit a form without a submit element, bonza!
     see: https://docs.angularjs.org/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action -->

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -109,7 +109,33 @@
         </label>
 
         <label class="job-info--editor__field flex-center">
-            <div class="job-info--editor__label text-small">Special Instructions</div>
+            <div class="job-info--editor__label text-small job-additional-special-instructions-label">Special Instructions</div>
+
+            <div ng-if="!!ctrl.metadata.usageInstructions">
+                <div class="text-small job-usage-instructions">{{ctrl.metadata.usageInstructions}}</div>
+                <div class="text-small job-additional-special-instructions">Add further special instructions</div>
+                <div class="job-info--editor__field flex-center">
+                    <input
+                        type="text"
+                        name="special-instructions"
+                        class="text-input job-info--editor__input"
+                        ng-model="ctrl.metadata.specialInstructions"
+                        ng-change="ctrl.save()"
+                        ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                        ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('specialInstructions') }"
+                        ng-disabled="!ctrl.userCanEdit"
+                        ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
+                    />
+                    <button
+                        class="job-editor__apply-to-all"
+                        title="Apply these instructions to all your current uploads"
+                        type="button"
+                        ng-if="ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('specialInstructions')"
+                        ng-click="ctrl.batchApplyMetadata('specialInstructions')"
+                    >⇔</button>
+                </div>
+            </div>
+
             <input
                 type="text"
                 name="special-instructions"
@@ -119,6 +145,7 @@
                 ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
                 ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.metadataUpdatedByTemplate.includes('specialInstructions') }"
                 ng-disabled="!ctrl.userCanEdit"
+                ng-if="!!!ctrl.metadata.usageInstructions"
                 ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
             />
 
@@ -126,15 +153,10 @@
                 class="job-editor__apply-to-all"
                 title="Apply these instructions to all your current uploads"
                 type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('specialInstructions')"
+                ng-if="!!!ctrl.metadata.usageInstructions && ctrl.withBatch && ctrl.userCanEdit && !ctrl.metadataUpdatedByTemplate.includes('specialInstructions')"
                 ng-click="ctrl.batchApplyMetadata('specialInstructions')"
             >⇔</button>
         </label>
-
-        <div class="job-info--editor__field flex-center" ng-if="!!ctrl.metadata.usageInstructions">
-            <div class="job-info--editor__label text-small">&nbsp;</div>
-            <div class="job-info--editor__label text-small job-usage-instructions" style="width:100%;">{{ctrl.metadata.usageInstructions}}</div>
-        </div>
 
     </div>
     <!-- Angular doesn't submit a form without a submit element, bonza!

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -2,8 +2,8 @@
       novalidate ng-class="{'job-editor__disabled': !ctrl.userCanEdit}"
       aria-label="Image metadata">
     <div class="job-editor__inputs">
-        <label class="job-info--editor__field flex-center">
-            <div class="job-info--editor__label job-info--editor__label flex-center text-small">Description</div>
+        <label class="job-info--editor__field">
+            <div class="job-info--editor__label job-info--editor__multiline text-small">Description</div>
             <textarea
                 name="description"
                 placeholder="eg {{funnyDescription}}…"
@@ -108,12 +108,12 @@
             >⇔</button>
         </label>
 
-        <label class="job-info--editor__field flex-center">
-            <div class="job-info--editor__label text-small job-additional-special-instructions-label">Special Instructions</div>
+        <label class="job-info--editor__field">
+            <div class="job-info--editor__label job-info--editor__multiline text-small">Special Instructions</div>
 
-            <div ng-if="!!ctrl.metadata.usageInstructions">
+            <div ng-if="!!ctrl.metadata.usageInstructions" style="flex:1;">
                 <div class="text-small job-usage-instructions">{{ctrl.metadata.usageInstructions}}</div>
-                <div class="text-small job-additional-special-instructions">Add further special instructions</div>
+                <div class="text-small job-additional-special-instructions">Add further instructions</div>
                 <div class="job-info--editor__field flex-center">
                     <input
                         type="text"

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -124,7 +124,8 @@ jobs.controller('RequiredMetadataEditorCtrl',
               copyright: originalMetadata.copyright,
               specialInstructions: originalMetadata.specialInstructions,
               description: originalMetadata.description,
-              domainMetadata: originalMetadata.domainMetadata
+              domainMetadata: originalMetadata.domainMetadata,
+              usageInstructions: originalMetadata.usageInstructions
           };
       }
     };

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -45,18 +45,28 @@
             </gr-icon>
         </div>
 
-        <div
-            class="form-property"
-            ng-repeat="property in ctrl.category.properties"
-            ng-class="{ 'form-property--last': $last }">
+        <div class="form-property"
+             ng-repeat="property in ctrl.category.properties"
+             ng-class="{ 'form-property--last': $last }">
 
-            <!-- TODO: potentially pull restrictions out from the server request and add it to all properties -->
-            <div ng-if="property.name === 'restrictions' && !!ctrl.category.usageRestrictions && ctrl.usageRights.length == 1">
-                <span>
+            <div ng-if="property.name === 'restrictions' && !!ctrl.category.usageRestrictions">
+                <span ng-if="ctrl.usageRights.length == 1">
                     This rights category requires a restriction to the image and the following wording will be applied:
                 </span>
+                <span ng-if="1 != ctrl.usageRights.length">
+                    Restricted
+                </span>
                 <div class="ure__caution warning warning--small">
-                    {{ctrl.category.usageRestrictions}}
+                    {{console.log("Usage Rights Length = " + ctrl.usageRights.length); ctrl.category.usageRestrictions}}
+                </div>
+            </div>
+
+            <div ng-if="property.name === 'restrictions' && ctrl.category.usageRestrictions && ctrl.category.usageSpecialInstructions && ctrl.usageRights.length == 1">
+                <span class="ure__description">
+                    Rights special instructions
+                </span>
+                <div class="ure__description">
+                    {{ctrl.category.usageSpecialInstructions}}
                 </div>
             </div>
 
@@ -69,7 +79,7 @@
                         Restricted
                     </span>
                     <span ng-if="!!ctrl.category.usageRestrictions">
-                        I want to add further restrictions
+                        Add further restrictions
                     </span>
                 </label>
 
@@ -84,15 +94,16 @@
                         ng-switch-when="true"
                         ng-model="ctrl.model[property.name]"
                         ng-required="ctrl.showRestrictions"
-                        ng-readonly="ctrl.usageRightsUpdatedByTemplate"></textarea>
+                        ng-readonly="ctrl.usageRightsUpdatedByTemplate">
+                    </textarea>
 
                     <textarea
                         class="text-input form-input-text"
                         disabled="disabled"
-                        ng-switch-default>{{ctrl.category.defaultRestrictions}}</textarea>
-
+                        ng-switch-default>
+                        {{ctrl.category.defaultRestrictions}}
+                    </textarea>
                 </div>
-
             </div>
 
             <div ng-if="property.name !== 'restrictions'"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -50,22 +50,19 @@
              ng-class="{ 'form-property--last': $last }">
 
             <div ng-if="property.name === 'restrictions' && !!ctrl.category.usageRestrictions">
-                <span ng-if="ctrl.usageRights.length == 1">
-                    This rights category requires a restriction to the image and the following wording will be applied:
-                </span>
-                <span ng-if="1 != ctrl.usageRights.length">
-                    Restricted
+                <span>
+                    This rights category requires a restriction and the following wording will be applied:
                 </span>
                 <div class="ure__caution warning warning--small">
                     {{console.log("Usage Rights Length = " + ctrl.usageRights.length); ctrl.category.usageRestrictions}}
                 </div>
             </div>
 
-            <div ng-if="property.name === 'restrictions' && ctrl.category.usageRestrictions && ctrl.category.usageSpecialInstructions && ctrl.usageRights.length == 1">
+            <div ng-if="property.name === 'restrictions' && ctrl.category.usageRestrictions && ctrl.category.usageSpecialInstructions">
                 <span class="ure__description">
-                    Rights special instructions
+                    the special instructions will be:
                 </span>
-                <div class="ure__description">
+                <div class="ure__description job-usage-instructions">
                     {{ctrl.category.usageSpecialInstructions}}
                 </div>
             </div>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -45,12 +45,6 @@
             </gr-icon>
         </div>
 
-        <div class="form-property" ng-if="!!ctrl.category.usageRestrictions && ctrl.usageRights.length == 1">
-            <div class="ure__caution warning warning--small">
-                {{ctrl.category.usageRestrictions}}
-            </div>
-        </div>
-
         <div
             class="form-property"
             ng-repeat="property in ctrl.category.properties"
@@ -58,12 +52,26 @@
 
             <!-- TODO: potentially pull restrictions out from the
             server request and add it to all properties -->
+            <div ng-if="property.name === 'restrictions' && !!ctrl.category.usageRestrictions && ctrl.usageRights.length == 1">
+                <label>
+                    This rights category requires a restriction to the image and the following wording will be applied:
+                </label>
+                <div class="ure__caution warning warning--small">
+                    {{ctrl.category.usageRestrictions}}
+                </div>
+            </div>
+
             <div ng-if="property.name === 'restrictions'">
                 <label>
                     <input type="checkbox"
                            ng-model="ctrl.showRestrictions"
                            ng-disabled="ctrl.forceRestrictions" />
-                    Restricted
+                    <span ng-if="!!!ctrl.category.usageRestrictions">
+                        Restricted
+                    </span>
+                    <span ng-if="!!ctrl.category.usageRestrictions">
+                        I want to add further restrictions
+                    </span>
                 </label>
 
                 <div ng-if="ctrl.showRestrictions"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -45,6 +45,12 @@
             </gr-icon>
         </div>
 
+        <div class="form-property" ng-if="!!ctrl.category.usageRestrictions && ctrl.usageRights.length == 1">
+            <div class="ure__caution warning warning--small">
+                {{ctrl.category.usageRestrictions}}
+            </div>
+        </div>
+
         <div
             class="form-property"
             ng-repeat="property in ctrl.category.properties"
@@ -79,6 +85,7 @@
                         ng-switch-default>{{ctrl.category.defaultRestrictions}}</textarea>
 
                 </div>
+
             </div>
 
             <div ng-if="property.name !== 'restrictions'"

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -65,7 +65,7 @@
                     <input type="checkbox"
                            ng-model="ctrl.showRestrictions"
                            ng-disabled="ctrl.forceRestrictions" />
-                    <span ng-if="!!!ctrl.category.usageRestrictions">
+                    <span ng-if="!ctrl.category.usageRestrictions">
                         Restricted
                     </span>
                     <span ng-if="!!ctrl.category.usageRestrictions">

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -50,12 +50,11 @@
             ng-repeat="property in ctrl.category.properties"
             ng-class="{ 'form-property--last': $last }">
 
-            <!-- TODO: potentially pull restrictions out from the
-            server request and add it to all properties -->
+            <!-- TODO: potentially pull restrictions out from the server request and add it to all properties -->
             <div ng-if="property.name === 'restrictions' && !!ctrl.category.usageRestrictions && ctrl.usageRights.length == 1">
-                <label>
+                <span>
                     This rights category requires a restriction to the image and the following wording will be applied:
-                </label>
+                </span>
                 <div class="ure__caution warning warning--small">
                     {{ctrl.category.usageRestrictions}}
                 </div>

--- a/kahuna/public/js/usage-rights/usage-rights-editor.html
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.html
@@ -58,9 +58,12 @@
                 </div>
             </div>
 
-            <div ng-if="property.name === 'restrictions' && ctrl.category.usageRestrictions && ctrl.category.usageSpecialInstructions">
-                <span class="ure__description">
-                    the special instructions will be:
+            <div ng-if="property.name === 'restrictions' && ctrl.category.usageSpecialInstructions">
+                <span ng-if="ctrl.category.usageRestrictions" class="ure__description">
+                    The special instructions will be:
+                </span>
+                <span ng-if="!ctrl.category.usageRestrictions" class="ure__description">
+                    This rights category requires special instructions and the following wording will be applied:
                 </span>
                 <div class="ure__description job-usage-instructions">
                     {{ctrl.category.usageSpecialInstructions}}

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -125,7 +125,7 @@ usageRightsEditor.controller(
           if (property.required) {
               return options;
           } else {
-              return [{key: 'None', value: null}].concat(options);
+              return [{key: 'Other', value: null}].concat(options);
           }
       };
       ctrl.getOptionsMapFor = property => {

--- a/kahuna/public/js/util/rights-categories.js
+++ b/kahuna/public/js/util/rights-categories.js
@@ -1,0 +1,27 @@
+/* ********************************************
+The restrictions text that should be displayed
+to accompany the image that comprises the
+restrictions stored on the image and any
+added by virtue of the rights category
+*********************************************** */
+const restrictionsText = (image) => {
+    let restrictText = "";
+    if (!image.data.usageRights) {
+      return restrictText;
+    }
+    if (image.data.usageRights.usageRestrictions) {
+      restrictText = image.data.usageRights.usageRestrictions;
+    }
+    restrictText = restrictText.trim();
+    if (restrictText.length > 0 && restrictText[restrictText.length - 1] != ".") {
+      restrictText = restrictText + ". ";
+    } else {
+      restrictText = restrictText + " ";
+    }
+    if (image.data.usageRights.restrictions) {
+      restrictText = restrictText + image.data.usageRights.restrictions;
+    }
+    return restrictText;
+}
+
+export { restrictionsText };

--- a/kahuna/public/js/util/rights-categories.js
+++ b/kahuna/public/js/util/rights-categories.js
@@ -22,6 +22,6 @@ const restrictionsText = (image) => {
       restrictText = restrictText + image.data.usageRights.restrictions;
     }
     return restrictText;
-}
+};
 
 export { restrictionsText };

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1900,6 +1900,15 @@ FIXME: what to do with touch devices
     font-size: 1.4rem;
 }
 
+.results-editor__top-heading {
+  margin-bottom: 15px;
+}
+
+.results-editor__heading {
+  margin-bottom: 15px;
+  margin-top: 15px;
+}
+
 .result-editor__info-item--png-warning {
     position: absolute;
     top: 0px;

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -54,6 +54,12 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val customValidityDescription: Map[String, String] =
     configuration.getOptional[Map[String, String]]("warningText.validityDescription").getOrElse(Map.empty)
 
+  val customSpecialInstructions: Map[String, String] =
+    configuration.getOptional[Map[String, String]]("usageInstructions").getOrElse(Map.empty)
+
+  val customUsageRestrictions: Map[String, String] =
+    configuration.getOptional[Map[String, String]]("usageRestrictions").getOrElse(Map.empty)
+
   val restrictDownload: Boolean = boolean("restrictDownload")
 
 }

--- a/metadata-editor/app/controllers/EditsApi.scala
+++ b/metadata-editor/app/controllers/EditsApi.scala
@@ -52,21 +52,25 @@ case class CategoryResponse(
   description: String,
   defaultRestrictions: Option[String],
   caution: Option[String],
-  properties: List[UsageRightsProperty] = List()
+  properties: List[UsageRightsProperty] = List(),
+  usageRestrictions: Option[String],
+  usageSpecialInstructions: Option[String]
 )
 object CategoryResponse {
   // I'd like to have an override of the `apply`, but who knows how you do that
   // with the JSON parsing stuff
-  def fromUsageRights(u: UsageRightsSpec, config: EditsConfig): CategoryResponse =
-    CategoryResponse(
-      value               = u.category,
-      name                = u.name(config),
-      cost                = u.defaultCost.getOrElse(Pay).toString,
-      description         = u.description(config),
+
+  def fromUsageRights(u: UsageRightsSpec, config: EditsConfig) = CategoryResponse (
+      value = u.category,
+      name = u.name(config),
+      cost = u.defaultCost.getOrElse(Pay).toString,
+      description = u.description(config),
       defaultRestrictions = u.defaultRestrictions,
-      caution             = u.caution,
-      properties          = UsageRightsProperty.getPropertiesForSpec(u, config.usageRightsConfig)
-    )
+      caution = u.caution,
+      properties = UsageRightsProperty.getPropertiesForSpec(u, config.usageRightsConfig),
+      usageRestrictions = config.customUsageRestrictions.get(u.category),
+      usageSpecialInstructions = config.customSpecialInstructions.get(u.category)
+  )
 
   implicit val categoryResponseWrites: Writes[CategoryResponse] = Json.writes[CategoryResponse]
 

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -18,4 +18,11 @@ class EditsConfig(resources: GridConfigResources) extends CommonConfig(resources
   val rootUri: String = services.metadataBaseUri
   val kahunaUri: String = services.kahunaBaseUri
   val loginUriTemplate: String = services.loginUriTemplate
+
+  val customSpecialInstructions: Map[String, String] =
+    configuration.getOptional[Map[String, String]]("usageInstructions").getOrElse(Map.empty)
+
+  val customUsageRestrictions: Map[String, String] =
+    configuration.getOptional[Map[String, String]]("usageRestrictions").getOrElse(Map.empty)
+
 }

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -81,10 +81,10 @@ object UsageRightsProperty {
       requiredStringField("supplier", "Supplier", Some(sortList(p.freeSuppliers))),
       UsageRightsProperty(
         "suppliersCollection", "Collection", "string", required = false,
-        examples = Some("AFP, FilmMagic, WireImage"))
+        examples = Some("News"))
     )
 
-    case CommissionedAgency => List(requiredStringField("supplier", "Supplier", examples = Some("Demotix")))
+    case CommissionedAgency => List(requiredStringField("supplier", "Supplier", examples = Some("Corbis")))
 
     case StaffPhotographer => List(
       publicationField(required = true, optionsFromPublicationList(p.staffPhotographers)),


### PR DESCRIPTION
## What does this change do?

**Summary**
This change allows some Restrictions text and Special Instructions text to be defined in the Application level config agianst specific Rights Categories. This information will then be displayed in the metadata and info panels when the image is selected (either as part of a set of images or individually). The information will displayed alongside any restrictions or special intructions that are added by the user and are specific to the image in question.

The configuration derived restrictions and special instructions will not be editable by the user in either the info panel or the metadata panel. If the rights category is updated then the any restrictions and special instructions derived from configuration will be displayed in place of those associated with the prior rights category.

Configuration derived restrictions and special instructions will also be displayed on the Upload page during the editing of the image metadata during the upload process. Thus the uploader will be able to see which restrictions and special instructions will be displayed with this image due to the selected rights category.

It also changes the behaviour of the Special Instructions group in the info panel and metadata editor - previously if an image didn't have any special instructions this section was not visible - this made it hard to add special instructions to an image that had not got any. This PR changes that behaviour so that the Special Instruction group is visible even if the image does not contain any value in that field. The behaviour now closely mirrors that of other metadata fields like Description wherer the User if told the value is unknown and given the option to edit if they have edit rights - see below...

![Screenshot 2024-07-01 at 10 36 33](https://github.com/guardian/grid/assets/128470622/3edcf324-fba7-499a-a25f-2a5cc816fac1)


**Defining Special Intructions and Restrictions in Config**
The rights category Special Instructions and Restrictions should be defined in the application configuration as json objects according to the patterns;

usageInstructions {
  {{rights category key}} = "{{rights derived special instructions}}"
}

usageRestrictions {
  {{rights category key}} = "{{rights derived restrictions}}"
}

for example;

usageInstructions {
    staff-photographer = "You must also make sure that any use meets BBC’s Editorial Guidelines."
    contract-photographer = "This image can only be used for non-commercial BBC promotional activity of the programme from which it came."
}

usageRestrictions {
    staff-photographer = "See the special instructions related to this image and consider if the use is editorially justified"
    contract-photographer = "See the special instructions and lease details related to this image."
    obituary = "Only to be used in conjunction with named person."
}  

If the _usageInstructions_ and _usageRestrictions_ objects are empty or absent from the configuration then the code will continue to operate as normal with no additional information displayed in conjunction with the images.

**Display of information in grid and image views**
In main image grid the additional information will appear as follows;

![Screenshot 2024-06-05 at 10 42 04](https://github.com/guardian/grid/assets/128470622/78cfc204-9259-4781-865f-5c92d7540dd1)

When an image is selected the information will appear as;

![Screenshot 2024-06-05 at 10 43 56](https://github.com/guardian/grid/assets/128470622/e1d0771d-28ff-450b-8c2b-b34860eafe3f)

Note: This image also shows how the user is able to add further special instructions that are image specific in addition to those derived from the rights category.

**Display on Uploads Page**
On the uploads page the config declared rights restrictions and special instructions will appear as;

![Screenshot 2024-06-05 at 10 49 23](https://github.com/guardian/grid/assets/128470622/ce2941ce-2254-474e-aa0b-256eced0a4fc)

This eaxmple shows both restrictions and special instructions drawn from config. Note the special instructions element will only be updated and displayed once the new usage rights category has been saved.


## How should a reviewer test this change?

Testing should ensure that;

- Any restrictions and special instructions defined in configuration display in the grid view, image view and upload page as expected for the correct rights category and that all other rights categories are unaffected.
- Any additional restrictions and special instructions defined against an image are added to the diaply after the config derived restrictions and special instructions
- Editing of the rights category for an image results in the corret config derived infomration displaying.
- The behaviour of the uploads page is correct and shows the correct restrictions and special instructions as required and that upload continue to operate as required.
- No other functionality is affected by these changes

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x ] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
