### PR TITLE
Fix test running in IntelliJ UI by resolving ScalaTest 3.1 vs 3.2 conflict

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val commonSettings = Seq(
   Test / testOptions ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports")),
   libraryDependencies ++= Seq(
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
-    "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
+    "org.scalatestplus" %% "mockito-3-4" % "3.1.4.0" % Test,
     "org.mockito" % "mockito-core" % "2.18.0" % Test,
     "org.scalamock" %% "scalamock" % "5.1.0" % Test,
   ),


### PR DESCRIPTION
## What does this change?

Fixes this error when trying to run a single test in the IntelliJ IDE:

<img width="900" alt="Screenshot 2024-06-09 at 18 43 03" src="https://github.com/guardian/grid/assets/150238/4a2c3de2-fe8d-4751-bff6-d238bf876a1e">


Downgrade "org.scalatestplus" %% "mockito-3-4" to 3.1 series to match the 3.1 ScalaTest pulled in by scalatestplus-play.

Resolves a scalac -deprecation snag which breaks running of tests in IntelliJ. Warns about a deprecation on .right.value but then doesn't know about the new method because ScalaTest 3.2 is not available on the IntelliJ classpath.

This commit works by pushing the transitive ScalaTest from "org.scalatestplus" %% "mockito-3-4" back down to 3.1 for compatibility with "scalatestplus-play".

Notably "scalatestplus-play" cannot be leveled to 6.0.0 / ScalaTest 3.2 without moving to Scala 2.13 because it has not been released for 2.12.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

Single tests can be run in the IDE. Faster feedback loop. Prevent the urban myth that you can't run tests in the IDE from taking hold.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
