### PR TITLE
[reaper] retain all images in collections, if 'persisted collections' not specified

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -207,12 +207,13 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   private def getKinesisConfigForStream(streamName: String) = KinesisSenderConfig(awsRegion, awsCredentials, awsLocalEndpoint, isDev, streamName)
 
-  final def getStringSet(key: String): Set[String] = Try {
-    configuration.get[Seq[String]](key)
+  final def getOptionalStringSet(key: String): Option[Set[String]] = Try {
+    configuration.getOptional[Seq[String]](key)
   }.recover {
-    case _:ConfigException.WrongType => configuration.get[String](key).split(",").toSeq.map(_.trim)
-  }.map(_.toSet)
-   .getOrElse(Set.empty)
+    case _:ConfigException.WrongType => configuration.getOptional[String](key).map(_.split(",").toSeq.map(_.trim))
+  }.toOption.flatten.map(_.toSet)
+
+  final def getStringSet(key: String): Set[String] = getOptionalStringSet(key).getOrElse(Set.empty)
 
   def getConfigList(key:String): List[_ <: Config] =
     if (configuration.has(key)) configuration.underlying.getConfigList(key).asScala.toList

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfigWithElastic.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfigWithElastic.scala
@@ -17,8 +17,6 @@ class CommonConfigWithElastic(resources: GridConfigResources) extends CommonConf
   val persistenceIdentifier = string("persistence.identifier")
   val queriableIdentifiers = Seq(persistenceIdentifier)
 
-  val persistedRootCollections: List[String] = stringOpt("persistence.collections") match {
-    case Some(collections) => collections.split(',').toList
-    case None => List(s"${staffPhotographerOrganisation} Archive")
-  }
+  // note this will match any part of the collection path, e.g. "bar" will match "bar", "foo/bar", "bar/baz"
+  val maybePersistOnlyTheseCollections: Option[Set[String]] = getOptionalStringSet("persistence.onlyTheseCollections")
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ReapableEligibility.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ReapableEligibility.scala
@@ -12,7 +12,7 @@ trait ReapableEligibility extends Provider{
   def shutdown(): Future[Unit] = Future.successful(())
 
 
-  val persistedRootCollections: List[String] // typically from config
+  val maybePersistOnlyTheseCollections: Option[Set[String]] // typically from config
   val persistenceIdentifier: String // typically from config
 
   private def moreThanTwentyDaysOld =
@@ -30,7 +30,7 @@ trait ReapableEligibility extends Provider{
     PersistedQueries.hasLabels,
     PersistedQueries.hasLeases,
     PersistedQueries.existedPreGrid(persistenceIdentifier),
-    PersistedQueries.addedGNMArchiveOrPersistedCollections(persistedRootCollections)
+    PersistedQueries.isInPersistedCollection(maybePersistOnlyTheseCollections)
   )
 
   def query: Query = filters.and(

--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -61,6 +61,8 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
                 return 'categorised as agency commissioned';
             case 'persisted-collection':
                 return 'added to a persisted collection';
+              case 'collection':
+                return 'added to a collection';
             case 'photoshoot':
                 return 'added to a photoshoot';
             case 'leases':

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -43,7 +43,10 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   type MediaLeaseEntity = EmbeddedEntity[MediaLease]
   type MediaLeasesEntity = EmbeddedEntity[LeasesByMedia]
 
-  private val imgPersistenceReasons = ImagePersistenceReasons(config.persistedRootCollections, config.persistenceIdentifier)
+  private val imgPersistenceReasons = ImagePersistenceReasons(
+    config.maybePersistOnlyTheseCollections,
+    config.persistenceIdentifier
+  )
 
   def imagePersistenceReasons(image: Image): List[String] = imgPersistenceReasons.reasons(image)
 

--- a/media-api/app/lib/elasticsearch/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/IsQueryFilter.scala
@@ -32,7 +32,7 @@ object IsQueryFilter {
       case s if s == s"$organisation-owned" => Some(IsOwnedImage(organisation))
       case "under-quota" => Some(IsUnderQuota(overQuotaAgencies()))
       case "deleted" => Some(IsDeleted(true))
-      case "reapable" => Some(IsReapable(config.persistedRootCollections, config.persistenceIdentifier))
+      case "reapable" => Some(IsReapable(config.maybePersistOnlyTheseCollections, config.persistenceIdentifier))
       case _ => None
     }
   }
@@ -68,6 +68,6 @@ case class IsDeleted(isDeleted: Boolean) extends IsQueryFilter {
   )
 }
 
-case class IsReapable(persistedRootCollections: List[String], persistenceIdentifier: String)
+case class IsReapable(maybePersistOnlyTheseCollections: Option[Set[String]], persistenceIdentifier: String)
   extends IsQueryFilter with ReapableEligibility {
 }

--- a/media-api/app/lib/elasticsearch/SearchFilters.scala
+++ b/media-api/app/lib/elasticsearch/SearchFilters.scala
@@ -52,7 +52,7 @@ class SearchFilters(config: MediaApiConfig) extends ImageFields {
   lazy val freeToUseCategories: List[String] =
     usageRights.filter(ur => ur.defaultCost.exists(cost => cost == Free || cost == Conditional)).map(ur => ur.category)
 
-  val persistedReasons: List[PersistenceReason] = ImagePersistenceReasons(config.persistedRootCollections, config.persistenceIdentifier).allReasons
+  val persistedReasons: List[PersistenceReason] = ImagePersistenceReasons(config.maybePersistOnlyTheseCollections, config.persistenceIdentifier).allReasons
 
   val persistedFilter: Query = filters.or(persistedReasons.map(_.query): _*)
 

--- a/media-api/test/lib/ImagePersistenceReasonsTest.scala
+++ b/media-api/test/lib/ImagePersistenceReasonsTest.scala
@@ -14,8 +14,10 @@ class ImagePersistenceReasonsTest extends AnyFunSpec with Matchers {
     import TestUtils._
 
     val persistedIdentifier = "test-p-id"
-    val persistedRootCollections = List("coll1", "coll2", "coll3")
-    val imgPersistenceReasons = ImagePersistenceReasons(persistedRootCollections, persistedIdentifier)
+    val persistedCollections = Set("coll1", "coll2", "coll3")
+    val imgPersistenceReasons = ImagePersistenceReasons(Some(persistedCollections), persistedIdentifier)
+    val imagePersistenceReasonsWithEmptyListOfPersistedCollections = ImagePersistenceReasons(Some(Set.empty), persistedIdentifier)
+    val imagePersistenceReasonsWhichPersistsAllImagesInCollections = ImagePersistenceReasons(None, persistedIdentifier)
 
     imgPersistenceReasons.reasons(img) shouldBe Nil
     val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
@@ -34,8 +36,10 @@ class ImagePersistenceReasonsTest extends AnyFunSpec with Matchers {
     imgPersistenceReasons.reasons(imgWithAgencyCommissionedCategory) shouldBe List(CommissionedAgency.category)
     val imgWithLeases = img.copy(leases = LeasesByMedia.build(List(MediaLease(id = None, leasedBy = None, notes = None, mediaId = "test"))))
     imgPersistenceReasons.reasons(imgWithLeases) shouldBe List("leases")
-    val imgWithPersistedRootCollections = img.copy(collections = List(Collection.build(persistedRootCollections.tail, ActionData("testAuthor", now()))))
-    imgPersistenceReasons.reasons(imgWithPersistedRootCollections) shouldBe List("persisted-collection")
+    val imgInPersistedCollection = img.copy(collections = List(Collection.build(persistedCollections.headOption.toList, ActionData("testAuthor", now()))))
+    imgPersistenceReasons.reasons(imgInPersistedCollection) shouldBe List("persisted-collection")
+    imagePersistenceReasonsWithEmptyListOfPersistedCollections.reasons(imgInPersistedCollection) shouldBe List()
+    imagePersistenceReasonsWhichPersistsAllImagesInCollections.reasons(imgInPersistedCollection) shouldBe List("collection")
 
     val imgWithPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
     imgPersistenceReasons.reasons(imgWithPhotoshoot) shouldBe List("photoshoot")

--- a/thrall/app/controllers/ReaperController.scala
+++ b/thrall/app/controllers/ReaperController.scala
@@ -43,7 +43,7 @@ class ReaperController(
 
   private val isReapable = maybeCustomReapableEligibility getOrElse {
     new ReapableEligibility {
-      override val persistedRootCollections: List[String] = config.persistedRootCollections
+      override val maybePersistOnlyTheseCollections: Option[Set[String]] = config.maybePersistOnlyTheseCollections
       override val persistenceIdentifier: String = config.persistenceIdentifier
     }
   }


### PR DESCRIPTION
Since the reaper was reinstated in https://github.com/guardian/grid/pull/4145 - there have been a few user misunderstandings and work lost (actually only _almost_ lost, thanks to the additional 14days in soft-delete state 💡 😌) because people intuitively think putting something in a collection will protect it from deletion. In this PR we aim to match people's expectations (to prevent loss of work) whilst also ensuring it's still possibly to limit the collections which cause images to be retained/persisted.

## What does this change?
Replaces the config option `persistence.collections` with `persistence.onlyTheseCollections` to better reflect the new purpose, or rather the implication that if not set, all collections will be persisted (i.e. saved from the wrath of the reaper). The new config option now also supports using proper HOCON list/array (thanks for the suggestion @andrew-nowak). This is then modelled as `Option[Set[String]]` as it's passed around the codebase, to result in a new image persistence reason: `collection` (in addition to the existing `persisted-collection`) and results in the relevant ES query being executed, depending on whether the config option is defined or not.

## How should a reviewer test this change?
Before deploying this branch to TEST environment, PAUSE the reaper via the thrall dashboard. Find the oldest images which are surfaced via `+is:reapable` search, add some to a collection. RESUME the reaper. See that those images are retained (but more recent ones do get soft-deleted - findable via `+is:deleted`). 

To be thorough one could test configuring `persistence.onlyTheseCollections` but that works as `persistence.collections` did before the _rename_. 

One could also test specifying an empty list for `persistence.onlyTheseCollections` to not retain images based on collections at all.

✅  all the above have been tested in TEST by @twrichards 

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
