### PR TITLE
[reaper] remove the recently added persistence reason 'collection' as existing 'persisted-collection' reason is fine

### DIFF
--- a/docs/06-objects-of-interest/02-config.md
+++ b/docs/06-objects-of-interest/02-config.md
@@ -23,8 +23,6 @@ Anything that's specific to an organisation and to a stage, but is common across
 #### `<configRoot>/<stage>/<service>.conf`
 Service-specific configs. These will override all other config files.
 
-[Documentation](https://docs.google.com/document/d/1CSERbLwbu6nT_ggzzYxdUt9IHpfGUJLIYPnU_9MZbpc/edit) on the existing Grid config options
-
 ## Config documentation
 
 ### Common configuration
@@ -87,6 +85,25 @@ Service-specific configs. These will override all other config files.
     <td>True</td>
     <td>Json Object Array</td>
     <td>[]</td>
+  </tr>
+  <tr>
+    <td><b><code>persistence.identifier</code></b><br>Used by the reaper to retain images which have a particular identifier (e.g. <code>picdarUrn</code> for Guardian)</td>
+    <td>True</td>
+    <td>string</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><b><code>persistence.onlyTheseCollections</code></b><br>Used by the reaper…
+      <ol>
+        <li>If not specified, images in any collection are persisted</li>
+        <li>If specified, but empty array, images are not* persisted based on collection at all </li>
+        <li>If specified and non empty, images are persisted based on the listed collections only* (note that it matches any part of the collection path, but its not possible to match an entire nested collection path</li>
+      </ol>
+* but might be persisted based on other persistence criteria.
+</td>
+    <td>True (see 1.)</td>
+    <td>Array<string></td>
+    <td>None</td>
   </tr>
 </tbody>
 </table>
@@ -867,12 +884,6 @@ Service-specific configs. These will override all other config files.
     <td></td>
   </tr>
   <tr>
-    <td><code>persistence.identifier</code></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
     <td><code>es6.url</code></td>
     <td></td>
     <td></td>
@@ -1176,7 +1187,6 @@ Service-specific configs. These will override all other config files.
     <td></td>
   </tr>
   <tr>
-    <td><code>persistence.identifier</code></td>
     <td></td>
     <td></td>
     <td></td>

--- a/kahuna/public/js/services/image-logic.js
+++ b/kahuna/public/js/services/image-logic.js
@@ -61,8 +61,6 @@ imageLogic.factory('imageLogic', ['imageAccessor', function(imageAccessor) {
                 return 'categorised as agency commissioned';
             case 'persisted-collection':
                 return 'added to a persisted collection';
-              case 'collection':
-                return 'added to a collection';
             case 'photoshoot':
                 return 'added to a photoshoot';
             case 'leases':

--- a/media-api/app/lib/ImagePersistenceReasons.scala
+++ b/media-api/app/lib/ImagePersistenceReasons.scala
@@ -110,10 +110,7 @@ case class IsInPersistedCollection(maybePersistOnlyTheseCollections: Option[Set[
   }
 
   override val query: Query = PersistedQueries.isInPersistedCollection(maybePersistOnlyTheseCollections)
-  override val reason: String = maybePersistOnlyTheseCollections match {
-    case None => "collection"
-    case Some(_) => "persisted-collection"
-  }
+  override val reason: String = "persisted-collection"
 }
 
 object AddedToPhotoshoot extends PersistenceReason {

--- a/media-api/test/lib/ImagePersistenceReasonsTest.scala
+++ b/media-api/test/lib/ImagePersistenceReasonsTest.scala
@@ -17,7 +17,6 @@ class ImagePersistenceReasonsTest extends AnyFunSpec with Matchers {
     val persistedCollections = Set("coll1", "coll2", "coll3")
     val imgPersistenceReasons = ImagePersistenceReasons(Some(persistedCollections), persistedIdentifier)
     val imagePersistenceReasonsWithEmptyListOfPersistedCollections = ImagePersistenceReasons(Some(Set.empty), persistedIdentifier)
-    val imagePersistenceReasonsWhichPersistsAllImagesInCollections = ImagePersistenceReasons(None, persistedIdentifier)
 
     imgPersistenceReasons.reasons(img) shouldBe Nil
     val imgWithPersistenceIdentifier = img.copy(identifiers = Map(persistedIdentifier -> "test-id"))
@@ -39,7 +38,6 @@ class ImagePersistenceReasonsTest extends AnyFunSpec with Matchers {
     val imgInPersistedCollection = img.copy(collections = List(Collection.build(persistedCollections.headOption.toList, ActionData("testAuthor", now()))))
     imgPersistenceReasons.reasons(imgInPersistedCollection) shouldBe List("persisted-collection")
     imagePersistenceReasonsWithEmptyListOfPersistedCollections.reasons(imgInPersistedCollection) shouldBe List()
-    imagePersistenceReasonsWhichPersistsAllImagesInCollections.reasons(imgInPersistedCollection) shouldBe List("collection")
 
     val imgWithPhotoshoot = img.copy(userMetadata = Some(Edits(metadata = ImageMetadata.empty, photoshoot = Some(Photoshoot("test")))))
     imgPersistenceReasons.reasons(imgWithPhotoshoot) shouldBe List("photoshoot")


### PR DESCRIPTION
[reaper] remove the [recently added] (#4287) persistence reason 'collection' as it would require update to `grid-client` (and various consumers of the lib) for very little gain - existing 'persisted-collection' reason is fine

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
