### PR TITLE
Adapt info panel height based on usePermissionsFilter config setting

### DIFF
--- a/kahuna/public/js/components/gr-panels/gr-panels.css
+++ b/kahuna/public/js/components/gr-panels/gr-panels.css
@@ -58,6 +58,12 @@
     margin-top: 36px;
 }
 
-.gr-panel-height {
-    height: calc(100vh - 86px); /* 50px search bar, 36px toolbar */
+.gr-panel-height--single {
+    top: 86px; /* 50px single search bar, 36px toolbar */
+    bottom: 0;
+}
+
+.gr-panel-height--double {
+  top: 136px; /* 100px double search bar, 36px toolbar */
+  bottom: 0;
 }

--- a/kahuna/public/js/components/gr-panels/gr-panels.js
+++ b/kahuna/public/js/components/gr-panels/gr-panels.js
@@ -40,11 +40,13 @@ panels.directive('grPanel', ['$timeout', '$window', 'inject$', 'subscribe$',
         },
         template:
             `<div class="gr-panel" ng:class="{'gr-panel--locked': state.locked}">
-                <div class="gr-panel__content gr-panel-height"
+                <div class="gr-panel__content"
                      ng:class="{
                         'gr-panel__content--hidden': state.hidden,
                         'gr-panel__content--left': left,
-                        'gr-panel__content--right': right
+                        'gr-panel__content--right': right,
+                        'gr-panel-height--single' : !usePermissionsFilter,
+                        'gr-panel-height--double' : usePermissionsFilter
                      }"
                      gr:remember-scroll-top="rememberScroll">
                     <ng:transclude></ng:transclude>
@@ -52,6 +54,7 @@ panels.directive('grPanel', ['$timeout', '$window', 'inject$', 'subscribe$',
             </div>`,
         link: function(scope) {
             const panel = scope.panel;
+            scope.usePermissionsFilter = $window._clientConfig.usePermissionsFilter;
             const winScroll$ = Rx.DOM.fromEvent($window, 'scroll');
 
             inject$(scope, panel.state$, scope, 'state');


### PR DESCRIPTION
The usePermissionsFilter kahuna config setting (true/false default:false) introduces a second tier top bar into the UI to hold the new permissions filter control (along other controls). When the second tier top bar is visible the height of the info-panel was found to be set incorrectly causing the lower section of the panel to be inaccessible (e.g. the keywords portion). This change corrects that fault by setting the height of the info-panel based on the presence of the second tier top bar

## How should a reviewer test this change?

Ensure that the whole of the info-panel is visible and accessible when the second tier top bar is displayed and also ensure that the info-panel is vertically aligned correctly when the second tier top bar is not visible

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
