### PR TITLE
FIX `getOptionalStringSet` in CommonConfig

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -209,9 +209,9 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
 
   final def getOptionalStringSet(key: String): Option[Set[String]] = Try {
     configuration.getOptional[Seq[String]](key)
-  }.recover {
-    case _:ConfigException.WrongType => configuration.getOptional[String](key).map(_.split(",").toSeq.map(_.trim))
-  }.toOption.flatten.map(_.toSet)
+  }.getOrElse(
+    configuration.getOptional[String](key).map(_.split(",").toSeq.map(_.trim))
+  ).map(_.toSet)
 
   final def getStringSet(key: String): Set[String] = getOptionalStringSet(key).getOrElse(Set.empty)
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/config/CommonConfigTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/config/CommonConfigTest.scala
@@ -1,0 +1,29 @@
+package com.gu.mediaservice.lib.config
+
+import org.mockito.Mockito.when
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+
+class CommonConfigTest extends AnyFunSuiteLike with MockitoSugar {
+
+  private val commonConf = mock[CommonConfig]
+  when(commonConf.configuration).thenReturn(Configuration(
+    "setAsCommaSepString" -> "a, b,c",
+    "setAsActualArray" -> Set("a", "b", "c")
+  ))
+
+  test("testGetOptionalStringSet") {
+      commonConf.getOptionalStringSet("doesnt.exist") shouldBe None
+      commonConf.getOptionalStringSet("setAsCommaSepString") shouldBe Some(Set("a", "b", "c"))
+      commonConf.getOptionalStringSet("setAsActualArray") shouldBe Some(Set("a", "b", "c"))
+  }
+
+  test("testGetStringSet") {
+    commonConf.getStringSet("doesnt.exist") shouldBe Set.empty
+    commonConf.getStringSet("setAsCommaSepString") shouldBe Set("a", "b", "c")
+    commonConf.getStringSet("setAsActualArray") shouldBe Set("a", "b", "c")
+  }
+
+}


### PR DESCRIPTION
We've had a report of https://github.com/guardian/editions-card-builder failing to upload to grid, looking at the console it's a CORS error, despite the URL being in the list in `security.cors.allowedOrigins` in `common.conf`. #4287 has very recently changed this config reading logic subtly (to support optional lists)... turns out `getOptional` with the wrong type results in a different exception than `get` does, so the recover block was not catching it and it was resulting in an empty list.

## What does this change?
The fix here is to catch all errors and attempt to read as `String` (rather than `Set[String]`) - rather than only catching `ConfigException.WrongType` which is thrown by `.get` but not `.getOptional`.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
