### PR TITLE
Fixing bug where metadata-validity and image-cost-message controls don't update correctly when usage rights category is modified.

### DIFF
--- a/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
+++ b/kahuna/public/js/components/gr-image-cost-message/gr-image-cost-message.js
@@ -8,19 +8,30 @@ import './gr-image-cost-message.css';
 export const module = angular.module('gr.imageCostMessage', [imageService.name]);
 
 module.controller('grImageCostMessage', [
-  'imageService',
+  '$rootScope', 'imageService',
 
-  function (imageService) {
+  function ($rootScope, imageService) {
     let ctrl = this;
 
     ctrl.$onInit = () => {
-      const states = imageService(ctrl.image).states;
-      ctrl.messageState = (states.hasRestrictions) ? "conditional" : states.costState;
-      ctrl.restrictionsText = () => {
-        return restrictionsText(this.image);
+      function updateState() {
+        ctrl.image.get().then(image => {
+              const states = imageService(image).states;
+              ctrl.messageState = (states.hasRestrictions) ? "conditional" : states.costState;
+              ctrl.restrictionsText = () => {
+                return restrictionsText(image);
+              };
+        });
       };
 
+      $rootScope.$on('images-updated', () => {
+          updateState();
+      });
+
+      updateState();
+
     };
+
   }
 ]);
 

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -35,6 +35,10 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', '$window', function 
           updateState();
       });
 
+      $rootScope.$on('images-updated', () => {
+          updateState();
+      });
+
       updateState();
     };
 }]);


### PR DESCRIPTION
## What does this change do?

There is currently a bug such that if a user is viewing an image and updates the usage rights category in the metadata panel and adds some restrictions text to the image on save of the updates to the rights category the warning panels metadata-validity and image-cost-message do not display - i.e. they are not getting updated correctly on changes in usage rights category and restrictions. (refreshing the screen will correct the display). The same problem occurs in reverse - if restrictions are removed from an image the visibility of the restrictions panel and the warning panel above it does not update (ie they remain visibile when they should be hidden). 

This PR corrects this issue by 'listening' on $rootScope for the 'images-updated' message and updating both controls to relfect the new image information.

Initial state:
![Screenshot 2024-07-08 at 12 23 26](https://github.com/guardian/grid/assets/128470622/39175c77-2715-4a5f-b098-504476cb9dd3)

after restrictions removed and saved...

![Screenshot 2024-07-08 at 12 24 15](https://github.com/guardian/grid/assets/128470622/ad3d9b5d-1d77-4ded-ba65-56440a87bf8e)

after refresh...

![Screenshot 2024-07-08 at 12 26 44](https://github.com/guardian/grid/assets/128470622/d8293bbe-c607-45b7-ab3d-e397099df41a)


## How should a reviewer test this change?

Ensure that the correct restriction information is displayed in the metadata panel after the restrictions text linked to the image has either been added or removed.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
