### PR TITLE
logback vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,8 @@ lazy val commonLib = project("common-lib").settings(
     "org.yaml" % "snakeyaml" % "1.31",
     "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   ),
-  dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0"
+  dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0",
+  dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test
 )
 
 lazy val restLib = project("rest-lib").settings(

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,8 @@ lazy val commonLib = project("common-lib").settings(
     "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0",
-  dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test
+  dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,
+  dependencyOverrides += "com.typesafe.akka" % "akka-http-core_2.12" % "10.5.3"
 )
 
 lazy val restLib = project("rest-lib").settings(

--- a/build.sbt
+++ b/build.sbt
@@ -106,8 +106,7 @@ lazy val commonLib = project("common-lib").settings(
     "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   ),
   dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0",
-  dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,
-  dependencyOverrides += "com.typesafe.akka" % "akka-http-core_2.12" % "10.5.3"
+  dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test
 )
 
 lazy val restLib = project("rest-lib").settings(

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.gu" %% "thrift-serializer" % "5.0.2",
     "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
     "org.im4java" % "im4java" % "1.4.0",
-    "com.gu" % "kinesis-logback-appender" % "1.4.2",
+    "com.gu" % "kinesis-logback-appender" % "1.4.4",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
     "com.typesafe.play" %% "play-logback" % "2.8.20", // needed when running the scripts
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",


### PR DESCRIPTION
## What does this change?

Addresses vulnerabilities from ch.qos.logback:logback-classic:
 - adds dependency overrides to patch vulnerabilities in logback-classic
 - patches kinesis-logback-appender to 1.4.4 (did not upgrade to v2 as relies on awsSdk v2 - Grid currently using awsSdk v1)

## How should a reviewer test this change?

project should still compile, test and run - healthchecks for all services should pass.

## How can success be measured?

reduction in vulnerabilities

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
