### PR TITLE
correct logic error in usable for all when restrictions are inferred from config

### DIFF
--- a/kahuna/public/js/components/gr-usagerights-summary/gr-usagerights-bbc.tsx
+++ b/kahuna/public/js/components/gr-usagerights-summary/gr-usagerights-bbc.tsx
@@ -46,6 +46,10 @@ const usableForAllClause = (image: any) : boolean => {
       image.data.cost.toString().toLowerCase() === "conditional")) {
     hasRestrictions = true;
   }
+  if (image.data.usageRights &&
+      image.data.usageRights.usageRestrictions) {
+    hasRestrictions = true;
+  }
   let bbcOwned = false;
   if (image.data.metadata.credit &&
       image.data.metadata.credit.toString().toLowerCase().includes("bbc")) {


### PR DESCRIPTION
## What does this change do?

Corrects BBC only logic for when the 'Usable for All' icon should appear in the metadata panel (not used by the Guardian)

![Screenshot 2024-07-18 at 15 46 25](https://github.com/user-attachments/assets/3e057d24-0a58-4d16-8d21-74f93980df3f)

## How should a reviewer test this change?

Check that only BBC specific logic is impacted

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
