### PR TITLE
fix local auth option by add missing grid_access permission

### DIFF
--- a/dev/config/permissions.json.template
+++ b/dev/config/permissions.json.template
@@ -1,6 +1,19 @@
 [
   {
     "permission": {
+      "name": "grid_access",
+      "app": "grid",
+      "defaultValue": false
+    },
+    "overrides": [
+      {
+        "userId": "grid-demo-account@@EMAIL_DOMAIN",
+        "active": true
+      }
+    ]
+  },
+  {
+    "permission": {
       "name": "show_paid",
       "app": "grid",
       "defaultValue": false


### PR DESCRIPTION
## What does this change?

Adds missing grid_access permission to local auth permissions template.

This file is used to create a static version of the permissions data for the local-oidc-provider proejct to use when the grid is setup with the 'local auth' option.

Since https://github.com/guardian/grid/pull/4271, the application requires users to have the grid_access permission, but this was not the case when the local-auth option was set up.

## issues
Both on main and an this branch, have intermittently got this runtime error in the browser when running with local auth. 
[CookieSignatureInvalidException: cookie signature incorrect]
traced to:  rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala:23

Believe this may be an unrelated issue - haven't found a way to reliably reproduce.


## How should a reviewer test this change?


On this main 
- clear local auth cookies in your browser
- run `./dev/script/setup --clean --with-local-auth`
- run `./dev/script/start`
- go to https://media.local.dev-gutools.co.uk/ - you should be redirected to the local-auth ui
- enter the test user id, "grid-demo-account@guardian.co.uk" and any password
- click 'authorise' at the next screen
- shown to the error message: "You do not have permission to access the Grid. Please contact Central Production to request the permissions you need." 

On this branch 
- clear local auth cookies in your browser
- run `./dev/script/setup --clean --with-local-auth`
- run `./dev/script/start`
- go to https://media.local.dev-gutools.co.uk/ - you should be redirected to the local-auth ui
- enter the test user id, "grid-demo-account@guardian.co.uk" and any password
- click 'authorise' at the next screen
- should be given access and be redirected to the to local grid (https://media.local.dev-gutools.co.uk/). 

Note that the `--clean` option on setup removes and recreates your local infastructure, including the local grid DB, so the Grid UI will not have any images to display. 


## How can success be measured?

developers (including non-guardian) can use the local-auth option running locally

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
