### PR TITLE
Stable content-disposition fallback filename field improves client side image caching

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
@@ -15,8 +15,8 @@ trait ContentDisposition extends GridLogging {
     }
     val extension: String = getExtension(image, asset)
     val filenameSuffix: String = s"(${image.id})$extension"
-    val baseFilename = getBaseFilename(image, filenameSuffix, shortenDownloadFilename)
-    getContentDisposition(baseFilename, image.id)
+    val filename = getBaseFilename(image, filenameSuffix, shortenDownloadFilename)
+    getContentDisposition(filename, fallbackLatin1Filename(image, extension))
   }
 
   def getContentDisposition(image: Image, crop: Crop, asset: Asset, shortenDownloadFilename: Boolean): String = {
@@ -24,9 +24,9 @@ trait ContentDisposition extends GridLogging {
     val extension: String = getExtension(image, asset)
     val dimensions: String = asset.dimensions.map(dims => s"(${dims.width} x ${dims.height})").getOrElse("")
     val filenameSuffix: String = s"(${image.id})$cropId$dimensions$extension"
-    val baseFilename = getBaseFilename(image, filenameSuffix, shortenDownloadFilename)
+    val filename = getBaseFilename(image, filenameSuffix, shortenDownloadFilename)
 
-    getContentDisposition(baseFilename, image.id)
+    getContentDisposition(filename, fallbackLatin1Filename(image, extension))
   }
 
   private def getExtension(image: Image, asset: Asset): String = asset.mimeType match {
@@ -41,6 +41,8 @@ trait ContentDisposition extends GridLogging {
     case Some(f) => s"${removeExtension(f)} $filenameSuffix"
     case _ => filenameSuffix
   }
+
+  private def fallbackLatin1Filename(image:Image, extension: String): String = image.id + extension
 
   private def getContentDisposition(filename: String, fallbackLatin1Filename: String): String = {
     // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
@@ -37,7 +37,7 @@ trait ContentDisposition extends GridLogging {
   }
 
   private def getBaseFilename(image: Image, filenameSuffix: String, shortenDownloadFilename: Boolean): String = image.uploadInfo.filename match {
-    case Some(_) if shortenDownloadFilename => s"$filenameSuffix".filter(!"()".contains(_))
+    case Some(_) if shortenDownloadFilename => filenameSuffix.filter(!"()".contains(_))
     case Some(f) => s"${removeExtension(f)} $filenameSuffix"
     case _ => filenameSuffix
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
@@ -1,0 +1,66 @@
+package com.gu.mediaservice.lib.aws
+
+import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.model._
+
+import java.net.URLEncoder
+
+trait ContentDisposition extends GridLogging {
+
+  def useShortenDownloadFilename: Boolean
+
+  def getContentDisposition(image: Image, imageType: ImageType): String = {
+    val asset = imageType match {
+      case Source => image.source
+      case Thumbnail => image.thumbnail.getOrElse(image.source)
+      case OptimisedPng => image.optimisedPng.getOrElse(image.source)
+    }
+    val extension: String = getExtension(image, asset)
+    val filenameSuffix: String = s"(${image.id})$extension"
+    val baseFilename = getBaseFilename(image, filenameSuffix)
+    getContentDisposition(baseFilename, image.id)
+  }
+
+  def getContentDisposition(image: Image, crop: Crop, asset: Asset): String = {
+    val cropId: String = crop.id.map(id => s"($id)").getOrElse("")
+    val extension: String = getExtension(image, asset)
+    val dimensions: String = asset.dimensions.map(dims => s"(${dims.width} x ${dims.height})").getOrElse("")
+    val filenameSuffix: String = s"(${image.id})$cropId$dimensions$extension"
+    val baseFilename = getBaseFilename(image, filenameSuffix)
+
+    getContentDisposition(baseFilename, image.id)
+  }
+
+  private def getExtension(image: Image, asset: Asset): String = asset.mimeType match {
+    case Some(mimeType) => mimeType.fileExtension
+    case _ =>
+      logger.warn(image.toLogMarker, "Unrecognised mime type")
+      ""
+  }
+
+  private def getBaseFilename(image: Image, filenameSuffix: String): String = image.uploadInfo.filename match {
+    case Some(_) if useShortenDownloadFilename => s"$filenameSuffix".filter(!"()".contains(_))
+    case Some(f) => s"${removeExtension(f)} $filenameSuffix"
+    case _ => filenameSuffix
+  }
+
+  private def getContentDisposition(filename: String, fallbackLatin1Filename: String): String = {
+    // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987
+    // they'll fallback to `filename`, which will be a UTF-8 string decoded as Latin-1 - this is a rubbish string, but only rubbish browsers don't support RFC 5987 (IE8 back)
+    // See http://tools.ietf.org/html/rfc6266#section-5
+    val filenameUTF8 = encodedUTF8Filename(filename)
+    s"""attachment; filename="$fallbackLatin1Filename"; filename*=UTF-8''$filenameUTF8"""
+  }
+
+  private def removeExtension(filename: String): String = {
+    val regex = """\.[a-zA-Z]{3,4}$""".r
+    regex.replaceAllIn(filename, "")
+  }
+
+  private def encodedUTF8Filename(filename: String): String = {
+      // URLEncoder converts ` ` to `+`, replace it with `%20`
+      // See http://docs.oracle.com/javase/6/docs/api/java/net/URLEncoder.html
+      URLEncoder.encode(filename, "UTF-8").replace("+", "%20")
+  }
+
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
@@ -7,9 +7,7 @@ import java.net.URLEncoder
 
 trait ContentDisposition extends GridLogging {
 
-  def useShortenDownloadFilename: Boolean
-
-  def getContentDisposition(image: Image, imageType: ImageType): String = {
+  def getContentDisposition(image: Image, imageType: ImageType, shortenDownloadFilename: Boolean): String = {
     val asset = imageType match {
       case Source => image.source
       case Thumbnail => image.thumbnail.getOrElse(image.source)
@@ -17,16 +15,16 @@ trait ContentDisposition extends GridLogging {
     }
     val extension: String = getExtension(image, asset)
     val filenameSuffix: String = s"(${image.id})$extension"
-    val baseFilename = getBaseFilename(image, filenameSuffix)
+    val baseFilename = getBaseFilename(image, filenameSuffix, shortenDownloadFilename)
     getContentDisposition(baseFilename, image.id)
   }
 
-  def getContentDisposition(image: Image, crop: Crop, asset: Asset): String = {
+  def getContentDisposition(image: Image, crop: Crop, asset: Asset, shortenDownloadFilename: Boolean): String = {
     val cropId: String = crop.id.map(id => s"($id)").getOrElse("")
     val extension: String = getExtension(image, asset)
     val dimensions: String = asset.dimensions.map(dims => s"(${dims.width} x ${dims.height})").getOrElse("")
     val filenameSuffix: String = s"(${image.id})$cropId$dimensions$extension"
-    val baseFilename = getBaseFilename(image, filenameSuffix)
+    val baseFilename = getBaseFilename(image, filenameSuffix, shortenDownloadFilename)
 
     getContentDisposition(baseFilename, image.id)
   }
@@ -38,8 +36,8 @@ trait ContentDisposition extends GridLogging {
       ""
   }
 
-  private def getBaseFilename(image: Image, filenameSuffix: String): String = image.uploadInfo.filename match {
-    case Some(_) if useShortenDownloadFilename => s"$filenameSuffix".filter(!"()".contains(_))
+  private def getBaseFilename(image: Image, filenameSuffix: String, shortenDownloadFilename: Boolean): String = image.uploadInfo.filename match {
+    case Some(_) if shortenDownloadFilename => s"$filenameSuffix".filter(!"()".contains(_))
     case Some(f) => s"${removeExtension(f)} $filenameSuffix"
     case _ => filenameSuffix
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -1,18 +1,16 @@
 package com.gu.mediaservice.lib.aws
 
-import java.io.File
-import java.net.{URI, URLEncoder}
-import java.nio.charset.{Charset, StandardCharsets}
-import com.amazonaws.{AmazonServiceException, ClientConfiguration}
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, model}
 import com.amazonaws.util.IOUtils
+import com.amazonaws.{AmazonServiceException, ClientConfiguration}
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, Stopwatch}
 import com.gu.mediaservice.model._
 import org.joda.time.{DateTime, Duration}
-import org.slf4j.LoggerFactory
 
+import java.io.File
+import java.net.URI
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -62,7 +60,7 @@ object S3Metadata {
 
 case class S3ObjectMetadata(contentType: Option[MimeType], cacheControl: Option[String], lastModified: Option[DateTime])
 
-class S3(config: CommonConfig) extends GridLogging {
+class S3(config: CommonConfig) extends GridLogging with ContentDisposition {
   type Bucket = String
   type Key = String
   type UserMetadata = Map[String, String]
@@ -71,69 +69,13 @@ class S3(config: CommonConfig) extends GridLogging {
   // also create a legacy client that uses v2 signatures for URL signing
   private lazy val legacySigningClient: AmazonS3 = S3Ops.buildS3Client(config, forceV2Sigs = true)
 
-  private def removeExtension(filename: String): String = {
-    val regex = """\.[a-zA-Z]{3,4}$""".r
-    regex.replaceAllIn(filename, "")
-  }
-
-  private def getExtension(image: Image, asset: Asset): String = asset.mimeType match {
-    case Some(mimeType) => mimeType.fileExtension
-    case _ =>
-      logger.warn(image.toLogMarker, "Unrecognised mime type")
-      ""
-  }
-
-  private def encodedFilename(charset: Charset, baseFilename: String): String = charset.displayName() match {
-      case "UTF-8" =>
-        // URLEncoder converts ` ` to `+`, replace it with `%20`
-        // See http://docs.oracle.com/javase/6/docs/api/java/net/URLEncoder.html
-        URLEncoder.encode(baseFilename, "UTF-8").replace("+", "%20")
-      case characterSet => baseFilename.getBytes(characterSet).toString
-    }
-
-  private def getBaseFilename(image: Image, filenameSuffix: String): String = image.uploadInfo.filename match {
-    case Some(_) if config.shortenDownloadFilename => s"$filenameSuffix".filter(!"()".contains(_))
-    case Some(f) => s"${removeExtension(f)} $filenameSuffix"
-    case _ => filenameSuffix
-  }
-
-  private def getContentDisposition(filename: String): String = {
-    // use both `filename` and `filename*` parameters for compatibility with user agents not implementing RFC 5987
-    // they'll fallback to `filename`, which will be a UTF-8 string decoded as Latin-1 - this is a rubbish string, but only rubbish browsers don't support RFC 5987 (IE8 back)
-    // See http://tools.ietf.org/html/rfc6266#section-5
-    val filenameISO = encodedFilename(StandardCharsets.ISO_8859_1, filename)
-    val filenameUTF8 = encodedFilename(StandardCharsets.UTF_8, filename)
-    s"""attachment; filename="$filenameISO"; filename*=UTF-8''$filenameUTF8"""
-  }
-
-  def getContentDisposition(image: Image, crop: Crop, asset: Asset): String = {
-    val cropId: String = crop.id.map(id => s"($id)").getOrElse("")
-    val extension: String = getExtension(image, asset)
-    val dimensions: String = asset.dimensions.map(dims => s"(${dims.width} x ${dims.height})").getOrElse("")
-    val filenameSuffix: String = s"(${image.id})$cropId$dimensions$extension"
-    val baseFilename = getBaseFilename(image, filenameSuffix)
-
-    getContentDisposition(baseFilename)
-  }
-
-  def getContentDisposition(image: Image, imageType: ImageType): String = {
-    val asset = imageType match {
-      case Source => image.source
-      case Thumbnail => image.thumbnail.getOrElse(image.source)
-      case OptimisedPng => image.optimisedPng.getOrElse(image.source)
-    }
-    val extension: String = getExtension(image, asset)
-    val filenameSuffix: String = s"(${image.id})$extension"
-    val baseFilename = getBaseFilename(image, filenameSuffix)
-
-    getContentDisposition(baseFilename)
-  }
-
   private def roundDateTime(t: DateTime, d: Duration): DateTime = t minus (t.getMillis - (t.getMillis.toDouble / d.getMillis).round * d.getMillis)
 
   // Round expiration time to try and hit the cache as much as possible
   // TODO: do we really need these expiration tokens? they kill our ability to cache...
   private def defaultExpiration: DateTime = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
+
+  def useShortenDownloadFilename: Boolean = config.shortenDownloadFilename
 
   def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = defaultExpiration, imageType: ImageType = Source): String = {
     // get path and remove leading `/`

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -75,13 +75,11 @@ class S3(config: CommonConfig) extends GridLogging with ContentDisposition {
   // TODO: do we really need these expiration tokens? they kill our ability to cache...
   private def defaultExpiration: DateTime = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
 
-  def useShortenDownloadFilename: Boolean = config.shortenDownloadFilename
-
   def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = defaultExpiration, imageType: ImageType = Source): String = {
     // get path and remove leading `/`
     val key: Key = url.getPath.drop(1)
 
-    val contentDisposition = getContentDisposition(image, imageType)
+    val contentDisposition = getContentDisposition(image, imageType, config.shortenDownloadFilename)
 
     val headers = new ResponseHeaderOverrides().withContentDisposition(contentDisposition)
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ContentDispositionTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ContentDispositionTest.scala
@@ -1,0 +1,28 @@
+package com.gu.mediaservice.lib.aws
+
+import com.gu.mediaservice.lib.elasticsearch.MappingTest
+import com.gu.mediaservice.model.Thumbnail
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class ContentDispositionTest extends AnyFunSuiteLike with ContentDisposition {
+
+  def useShortenDownloadFilename: Boolean = false
+
+  test("build content disposition header based on filename") {
+    val image = MappingTest.testImage
+
+    val header = getContentDisposition(image, Thumbnail)
+
+    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''filename%20%28abcdef1234567890%29.jpg"""
+  }
+
+  test("only use id for the latin1 fallback filename field") {
+    val image = MappingTest.testImage.copy(uploadInfo = MappingTest.testImage.uploadInfo.copy(filename = Some("©House of Commons_240508_MU_PMQs-09_42668.jpg")))
+
+    val header = getContentDisposition(image, Thumbnail)
+
+    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''%C2%A9House%20of%20Commons_240508_MU_PMQs-09_42668%20%28abcdef1234567890%29.jpg"""
+  }
+
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ContentDispositionTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ContentDispositionTest.scala
@@ -1,28 +1,37 @@
 package com.gu.mediaservice.lib.aws
 
 import com.gu.mediaservice.lib.elasticsearch.MappingTest
-import com.gu.mediaservice.model.Thumbnail
+import com.gu.mediaservice.model.{Image, Thumbnail}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 class ContentDispositionTest extends AnyFunSuiteLike with ContentDisposition {
 
-  def useShortenDownloadFilename: Boolean = false
-
   test("build content disposition header based on filename") {
-    val image = MappingTest.testImage
+    val image = withFilename(MappingTest.testImage, "imagefilename.jpg")
 
-    val header = getContentDisposition(image, Thumbnail)
+    val header = getContentDisposition(image, Thumbnail, shortenDownloadFilename = false)
 
-    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''filename%20%28abcdef1234567890%29.jpg"""
+    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''imagefilename%20%28abcdef1234567890%29.jpg"""
   }
 
   test("only use id for the latin1 fallback filename field") {
-    val image = MappingTest.testImage.copy(uploadInfo = MappingTest.testImage.uploadInfo.copy(filename = Some("©House of Commons_240508_MU_PMQs-09_42668.jpg")))
+    val image = withFilename(MappingTest.testImage, "©House of Commons_240508_MU_PMQs-09_42668.jpg")
 
-    val header = getContentDisposition(image, Thumbnail)
+    val header = getContentDisposition(image, Thumbnail, shortenDownloadFilename = false)
 
     header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''%C2%A9House%20of%20Commons_240508_MU_PMQs-09_42668%20%28abcdef1234567890%29.jpg"""
   }
 
+  test("use just the generated filename suffix as filename if short filenames are requested") {
+    val image = withFilename(MappingTest.testImage, "SOCCER_England_124275.jpg")
+
+    val header = getContentDisposition(image, Thumbnail, shortenDownloadFilename = true)
+
+    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''abcdef1234567890.jpg"""
+  }
+
+  private def withFilename(image: Image, filename: String) = {
+    image.copy(uploadInfo = MappingTest.testImage.uploadInfo.copy(filename = Some(filename)))
+  }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ContentDispositionTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/aws/ContentDispositionTest.scala
@@ -5,22 +5,37 @@ import com.gu.mediaservice.model.{Image, Thumbnail}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
+import java.net.URLDecoder
+
 class ContentDispositionTest extends AnyFunSuiteLike with ContentDisposition {
 
-  test("build content disposition header based on filename") {
+  test("build content disposition header based on filename, image id and asset extension") {
     val image = withFilename(MappingTest.testImage, "imagefilename.jpg")
 
     val header = getContentDisposition(image, Thumbnail, shortenDownloadFilename = false)
 
-    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''imagefilename%20%28abcdef1234567890%29.jpg"""
+    header shouldBe """attachment; filename="abcdef1234567890.jpg"; filename*=UTF-8''imagefilename%20%28abcdef1234567890%29.jpg"""
   }
 
-  test("only use id for the latin1 fallback filename field") {
+  test("use id with extension for the latin1 fallback filename field") {
     val image = withFilename(MappingTest.testImage, "©House of Commons_240508_MU_PMQs-09_42668.jpg")
 
     val header = getContentDisposition(image, Thumbnail, shortenDownloadFilename = false)
 
-    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''%C2%A9House%20of%20Commons_240508_MU_PMQs-09_42668%20%28abcdef1234567890%29.jpg"""
+    header shouldBe """attachment; filename="abcdef1234567890.jpg"; filename*=UTF-8''%C2%A9House%20of%20Commons_240508_MU_PMQs-09_42668%20%28abcdef1234567890%29.jpg"""
+  }
+
+  test("include crop id and dimensions in main crop asset filename") {
+    val image = withFilename(MappingTest.testImage, "imagefilename.jpg")
+    val crop = image.exports.head
+    val cropAsset = crop.assets.head
+    val header = getContentDisposition(image, crop, cropAsset, shortenDownloadFilename = false)
+
+    // Latin1 fallback wants to remain simple
+    header.contains("""filename="abcdef1234567890.jpg";""") shouldBe true
+
+    val decoded = URLDecoder.decode(header, "UTF-8")
+    decoded shouldBe """attachment; filename="abcdef1234567890.jpg"; filename*=UTF-8''imagefilename (abcdef1234567890)(1234567890987654321)(1000 x 2000).jpg"""
   }
 
   test("use just the generated filename suffix as filename if short filenames are requested") {
@@ -28,7 +43,7 @@ class ContentDispositionTest extends AnyFunSuiteLike with ContentDisposition {
 
     val header = getContentDisposition(image, Thumbnail, shortenDownloadFilename = true)
 
-    header shouldBe """attachment; filename="abcdef1234567890"; filename*=UTF-8''abcdef1234567890.jpg"""
+    header shouldBe """attachment; filename="abcdef1234567890.jpg"; filename*=UTF-8''abcdef1234567890.jpg"""
   }
 
   private def withFilename(image: Image, filename: String) = {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -2,14 +2,19 @@ package controllers
 
 import akka.stream.scaladsl.StreamConverters
 import com.google.common.net.HttpHeaders
+import com.gu.mediaservice.{GridClient, JsonDiff}
 import com.gu.mediaservice.lib.argo._
 import com.gu.mediaservice.lib.argo.model.{Action, _}
 import com.gu.mediaservice.lib.auth.Authentication._
 import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCropsOrUsages, EditMetadata, UploadImages, DeleteImage => DeleteImagePermission}
 import com.gu.mediaservice.lib.auth._
-import com.gu.mediaservice.lib.aws.{S3Metadata, ThrallMessageSender, UpdateMessage}
+import com.gu.mediaservice.lib.aws.{ContentDisposition, ThrallMessageSender, UpdateMessage}
+import com.gu.mediaservice.lib.config.Services
 import com.gu.mediaservice.lib.formatting.printDateTime
+import com.gu.mediaservice.lib.logging.MarkerMap
+import com.gu.mediaservice.lib.metadata.SoftDeletedMetadataTable
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.syntax.MessageSubjects
 import lib._
 import lib.elasticsearch._
 import org.apache.http.entity.ContentType
@@ -21,18 +26,8 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
-import java.net.{URI, URLDecoder}
-import java.util.concurrent.TimeUnit
-import com.gu.mediaservice.GridClient
-import com.gu.mediaservice.JsonDiff
-import com.gu.mediaservice.lib.config.{ServiceHosts, Services}
-import com.gu.mediaservice.lib.logging.MarkerMap
-import com.gu.mediaservice.lib.metadata.SoftDeletedMetadataTable
-import com.gu.mediaservice.syntax.MessageSubjects
-
-import java.util.Base64
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import java.net.URI
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 class MediaApi(
@@ -47,10 +42,11 @@ class MediaApi(
                 mediaApiMetrics: MediaApiMetrics,
                 ws: WSClient,
                 authorisation: Authorisation
-)(implicit val ec: ExecutionContext) extends BaseController with MessageSubjects with ArgoHelpers {
+)(implicit val ec: ExecutionContext) extends BaseController with MessageSubjects with ArgoHelpers with ContentDisposition {
 
   val services: Services = new Services(config.domainRoot, config.serviceHosts, Set.empty)
   val gridClient: GridClient = GridClient(services)(ws)
+  val useShortenDownloadFilename: Boolean = config.shortenDownloadFilename
 
   private val searchParamList = List(
     "q",
@@ -251,7 +247,7 @@ class MediaApi(
           s3Object <- Try(s3Client.getObject(config.imgPublishingBucket, asset.file)).toOption
           file = StreamConverters.fromInputStream(() => s3Object.getObjectContent)
           entity = HttpEntity.Streamed(file, asset.size, asset.mimeType.map(_.name))
-          result = Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> s3Client.getContentDisposition(source, export, asset))
+          result = Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> getContentDisposition(source, export, asset))
         } yield {
           if(config.recordDownloadAsUsage) {
             postToUsages(config.usageUri + "/usages/download", auth.getOnBehalfOfPrincipal(request.user), source.id, Authentication.getIdentity(request.user))
@@ -362,7 +358,7 @@ class MediaApi(
         }
 
           Future.successful(
-            Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> s3Client.getContentDisposition(image, Source))
+            Result(ResponseHeader(OK), entity).withHeaders("Content-Disposition" -> getContentDisposition(image, Source))
           )
       }
       case _ => Future.successful(ImageNotFound(id))


### PR DESCRIPTION
## What does this change?

Remove unintentional cache buster on the thumbnail and preview image urls (filename ByteArray.toString is different for every instance of ByteArray even if they contain the same value).

Improves the client side caching of preview images.

☠️ Uses Image.id as the fallback Latin1 filename.
Assumes that Image.id is a safe Latin1 string (it's a UUID in recent Grid installs).

No change on thumbnails for Grid installs which use CloudFront as they use a different URL scheme which does not include content-disposition.

![Screenshot 2024-08-06 at 13 50 15](https://github.com/user-attachments/assets/1c2c41f5-911f-46ea-bcd6-820c5fc06545)


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

Thumbnails and previews continue to render correctly.
File downloads continue to have sensible filenames.


Preview images begin to show client side cache hits for preview images (for up to 100 seconds).

Non CloudFront Grid installs begin to show client side cache hits for thumbnails.


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
