### PR TITLE
T1804 restrict download modifications

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -301,8 +301,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     (source \ "usageRights" \ "category") match {
       case JsDefined(category) =>
         if (customUsageRestrictions.contains(category.as[String]) && !writePermissions) {
-          validityMap.updated("conditional_paid", ValidityCheck(true, validityMap("conditional_paid").overrideable, validityMap("conditional_paid").shouldOverride))
-                     .updated("paid", ValidityCheck(true, validityMap("paid").overrideable, validityMap("paid").shouldOverride))
+          validityMap.updated("conditional_paid", ValidityCheck(true, false, false))
+                     .updated("paid_image", ValidityCheck(true, false, false))
         } else {
           validityMap
         }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -91,9 +91,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     val valid = ImageExtras.isValid(validityMap)
     val invalidReasons = ImageExtras.invalidReasons(validityMap, config.customValidityDescription)
 
-    val downloadableMap = ImageExtras.downloadableMap(image, withWritePermission)
+    val downloadableMap = checkDownloadRestrictions(source, ImageExtras.downloadableMap(image, withWritePermission), withWritePermission)
     val isDownloadable = ImageExtras.isValid(downloadableMap)
-
 
     val persistenceReasons = imagePersistenceReasons(image)
     val isPersisted = persistenceReasons.nonEmpty
@@ -291,6 +290,19 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       case JsDefined(category) =>
         if (customUsageRestrictions.contains(category.as[String])) {
           validityMap.updated("conditional_paid", ValidityCheck(true, validityMap("conditional_paid").overrideable, validityMap("conditional_paid").shouldOverride))
+        } else {
+          validityMap
+        }
+      case _ => validityMap
+    }
+  }
+
+  private def checkDownloadRestrictions(source: JsValue, validityMap: Map[String, ValidityCheck], writePermissions: Boolean) : Map[String, ValidityCheck] = {
+    (source \ "usageRights" \ "category") match {
+      case JsDefined(category) =>
+        if (customUsageRestrictions.contains(category.as[String]) && !writePermissions) {
+          validityMap.updated("conditional_paid", ValidityCheck(true, validityMap("conditional_paid").overrideable, validityMap("conditional_paid").shouldOverride))
+                     .updated("paid", ValidityCheck(true, validityMap("paid").overrideable, validityMap("paid").shouldOverride))
         } else {
           validityMap
         }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -301,8 +301,8 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
     (source \ "usageRights" \ "category") match {
       case JsDefined(category) =>
         if (customUsageRestrictions.contains(category.as[String]) && !writePermissions) {
-          validityMap.updated("conditional_paid", ValidityCheck(true, false, false))
-                     .updated("paid_image", ValidityCheck(true, false, false))
+          validityMap.updated("conditional_paid", ValidityCheck(true, validityMap("conditional_paid").overrideable, validityMap("conditional_paid").shouldOverride))
+                     .updated("paid_image", ValidityCheck(true, validityMap("paid_image").overrideable, validityMap("paid_image").shouldOverride))
         } else {
           validityMap
         }


### PR DESCRIPTION
## What does this change?

This PR extends the 'Restrict Download' functionality which stops users who don't have write permissions from downloading images with restrictions attached. Image restrictions can now be inferred from the rights category allocated to the image if restrictions for that category have been defined in app config..

```
usageInstructions {
    programmes-organisation-owned = "This image is the copyright of the BBC, ensure the BBC is credited wherever practical. You must also make sure that any use meets the BBC's Editorial Guidelines including considering fairness to contributors and making sure that the use doesn't infringe anyone's rights, including privacy rights. Note that in some cases where the image includes a child or children, parental consent may be required, consult Editorial Policy for further advice. For any questions on usage please contact BBC Pictures."
    programmes-acquisitions = "This image can only be used for non-commercial BBC promotional activity of the programme from which it came. It can be published on any BBC platform or in any BBC branded social media activity (subject to editorial guidelines). See the allow lease for further details on how long the image can be used for. This image should not be re-used after this date without approval by the independent production company."
    programmes-independents = "This image can only be used for non-commercial BBC promotional activity of the programme from which it came. It can be published on any BBC platform or in any BBC branded social media activity (subject to editorial guidelines). See the allow lease for further details on how long the image can be used for. This image should not be re-used after this date without approval by the independent production company referenced in the credit. Contact them to get approval."
}
usageRestrictions {
    programmes-organisation-owned = "See the special instructions related to this image and consider if the use is editorially justified."
    programmes-acquisitions = "See the special instructions and lease details related to this image. It must only be used for the promotional activity of the programme from which it came."
    programmes-independents = "See the special instructions and lease details related to this image. It must only be used for the promotional activity of the programme from which it came."
}
```

If an image has inferred restrictions it should behave as if the restrictions were stored on the image with respect to download rules.

## How should a reviewer test this change?

Select appropriately configured images (with and without inferred restrictions) and test download behaviour from grid view and the image view.

![Screenshot 2024-07-30 at 10 48 20](https://github.com/user-attachments/assets/309b9921-0ecf-478b-b8c6-692517e9e586)

![Screenshot 2024-07-30 at 10 49 46](https://github.com/user-attachments/assets/59352171-8cbc-4db0-bd38-3dfce3edd694)

## How can success be measured?

Image download behaviour for images with inferred restrictions should match that for images with restrictions added directly to the image.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
