### PR TITLE
Cloudfront rounded expires

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/RoundedExpiration.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/RoundedExpiration.scala
@@ -6,7 +6,7 @@ trait RoundedExpiration {
 
   // Round expiration time to try and hit the cache as much as possible
   // TODO: do we really need these expiration tokens? they kill our ability to cache...
-  def defaultExpiration: DateTime = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
+  def cachableExpiration: DateTime = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
 
   private def roundDateTime(t: DateTime, d: Duration): DateTime = t minus (t.getMillis - (t.getMillis.toDouble / d.getMillis).round * d.getMillis)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/RoundedExpiration.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/RoundedExpiration.scala
@@ -1,0 +1,13 @@
+package com.gu.mediaservice.lib.aws
+
+import org.joda.time.{DateTime, Duration}
+
+trait RoundedExpiration {
+
+  // Round expiration time to try and hit the cache as much as possible
+  // TODO: do we really need these expiration tokens? they kill our ability to cache...
+  def defaultExpiration: DateTime = roundDateTime(DateTime.now, Duration.standardMinutes(10)).plusMinutes(20)
+
+  private def roundDateTime(t: DateTime, d: Duration): DateTime = t minus (t.getMillis - (t.getMillis.toDouble / d.getMillis).round * d.getMillis)
+
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -69,7 +69,7 @@ class S3(config: CommonConfig) extends GridLogging with ContentDisposition with 
   // also create a legacy client that uses v2 signatures for URL signing
   private lazy val legacySigningClient: AmazonS3 = S3Ops.buildS3Client(config, forceV2Sigs = true)
 
-  def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = defaultExpiration, imageType: ImageType = Source): String = {
+  def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = cachableExpiration, imageType: ImageType = Source): String = {
     // get path and remove leading `/`
     val key: Key = url.getPath.drop(1)
 


### PR DESCRIPTION
## What does this change?

Round signed CloudFront URLs expires times to allow client side caching of CloudFront assets (ie. thumbnails and preview images).

The 1 second resolution of the `Expires` parameter in the CloudFront URLs has probably been acting as a cache buster.

When stacked on top of #4304 this PR should introduce some client side caching of thumbnails for Guardian users
which may make the UI appear more snappy.

This change does not change the current CloudFront to S3 origin behaviour.


Should cache:

- imgops preview image on single image view
  Immediate reload when revisiting a single image.

- thumbnails
   Should be most noticeable when clicking 'Back to search' after viewing a single image.

On the search view, this is a small incremental gain rather than a game changer.
It reduces the number of network fetches at the very end of the page render but that cluster is only 100 to 200ms in width to begin with.

<img width="2055" alt="Screenshot 2024-08-02 at 13 04 04" src="https://github.com/user-attachments/assets/ff67bfb1-6013-49bd-a9b4-adc26211c336">

<img width="2056" alt="Screenshot 2024-08-02 at 13 11 51" src="https://github.com/user-attachments/assets/5273724e-87c3-483a-bea9-16eabef3efe7">




## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
