### PR TITLE
adding ability to filter usage rights categories for standard users - so they can only select from a subset when uploading and editing

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -83,6 +83,12 @@ usageRights.applicable = [
   "com.gu.mediaservice.model.PublicDomain"
 ]
 
+# ----------------------------------------------------------------------------------------
+# List of usage right categories standard users cannot select whilst uploading or editing
+# List of rights category ids - e.g.   "guardian-witness", "pool" or "crown-copyright"
+#-----------------------------------------------------------------------------------------
+usageRights.stdUserExcluded = []
+
 usageRightsConfigProvider = {
   className: "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig"
   config {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -204,6 +204,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientBui
    * and the singleton instance added to the list.
    */
   val applicableUsageRights: Seq[UsageRightsSpec] = configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
+  val stdUserExcludedUsageRights = getStringSet("usageRights.stdUserExcluded")
 
   private def getKinesisConfigForStream(streamName: String) = KinesisSenderConfig(awsRegion, awsCredentials, awsLocalEndpoint, isDev, streamName)
 

--- a/kahuna/public/js/services/api/edits-api.js
+++ b/kahuna/public/js/services/api/edits-api.js
@@ -9,6 +9,7 @@ editsApi.factory('editsApi', ['$q', 'mediaApi', function($q, mediaApi) {
 
     var root;
     var categories;
+    var filteredCategories;
 
     function getRoot() {
         return root || (root = mediaApi.root.follow('edits'));
@@ -18,7 +19,12 @@ editsApi.factory('editsApi', ['$q', 'mediaApi', function($q, mediaApi) {
         return categories || (categories = getRoot().follow('usage-rights-list').getData());
     }
 
+    function getFilteredUsageRightsCategories() {
+      return filteredCategories || (filteredCategories = getRoot().follow('filtered-usage-rights-list').getData());
+    }
+
     return {
-        getUsageRightsCategories
+        getUsageRightsCategories,
+        getFilteredUsageRightsCategories
     };
 }]);

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -38,14 +38,21 @@ usageRightsEditor.controller(
 
       // @return Stream.<Array.<Category>>
       const categories$ = Rx.Observable.fromPromise(editsApi.getUsageRightsCategories());
+      const filteredCategories$ = Rx.Observable.fromPromise(editsApi.getFilteredUsageRightsCategories());
 
       // @return Stream.<Array.<Category>>
-      const displayCategories$ = usageRights$.combineLatest(categories$, (urs, cats) => {
+      const displayCategories$ = usageRights$.combineLatest(filteredCategories$, categories$, (urs, filCats, allCats) => {
           const uniqueCats = getUniqueCats(urs);
           if (uniqueCats.length === 1) {
-              return cats;
+              const mtchCats = filCats.filter(c => c.value === uniqueCats[0]);
+              const extraCats = allCats.filter(c => c.value === uniqueCats[0]);
+              if (mtchCats.length === 0 && extraCats.length === 1) {
+                return extraCats.concat(filCats);
+              } else {
+                return filCats;
+              }
           } else {
-              return [multiCat].concat(cats);
+              return [multiCat].concat(filCats);
           }
       });
 

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -24,7 +24,7 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
 
   val editsController = new EditsController(auth, editsStore, notifications, config, wsClient, authorisation, controllerComponents)
   val syndicationController = new SyndicationController(auth, editsStore, syndicationStore, notifications, config, controllerComponents)
-  val controller = new EditsApi(auth, config, controllerComponents)
+  val controller = new EditsApi(auth, config, authorisation, controllerComponents)
   val InnerServiceStatusCheckController = new InnerServiceStatusCheckController(auth, controllerComponents, config.services, wsClient)
 
 

--- a/metadata-editor/conf/routes
+++ b/metadata-editor/conf/routes
@@ -1,5 +1,6 @@
 GET     /                                               controllers.EditsApi.index
 GET     /usage-rights/categories                        controllers.EditsApi.getUsageRights()
+GET     /usage-rights/filtered-categories               controllers.EditsApi.getFilteredUsageRights()
 
 # Image
 GET     /metadata/:id                                   controllers.EditsController.getAllMetadata(id: String)


### PR DESCRIPTION
## What does this change do?

It allows the range of rights categories that are available to stanard users during upload and edit to be filtered according to a list of exclusions added to the application config. The config setting is;

![Screenshot 2024-08-05 at 19 21 06](https://github.com/user-attachments/assets/d205cf54-396d-4571-8912-1ac042c633a1)

For a standard user this will limit the range of available categories in the drop down during upload and edit;

_Edit_
![Screenshot 2024-08-05 at 19 16 05](https://github.com/user-attachments/assets/8058d058-5844-473a-a4f2-40f817a56973)

_Upload_
![Screenshot 2024-08-05 at 19 16 33](https://github.com/user-attachments/assets/dd93c864-8458-45fe-b998-1418e301d53b)

For admin users these changes will have no impact;
![Screenshot 2024-08-05 at 19 17 26](https://github.com/user-attachments/assets/6c39ddb6-0754-4932-aa7a-dff146a0c496)

When searching by category via a search chip standard users will still be presented with the full list of available categories.

Also if the user is editing an image that is assigned to a category to which they do not usually have access this category will be added to the available list so that the drop down continues to operate in a consistent fashion.

The reason for this change to to try and restrict the number of images that get mis-classified by standard users during upload.

The list of restricted categories can be empty or can be left out of the config if it is not required and the system will continue to operate unaltered.

## How should a reviewer test this change?

Ensure that the correct range of rights categories is visible for admin and standard users in line with the configured values. Ensure that the dropdown lists for rights categories operates as expected under all circumstances including use of multi-select in grid view.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
