### PR TITLE
Fixes uploadStatuses/ link advertised by image loader

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -100,7 +100,7 @@ class ImageLoaderController(auth: Authentication,
     val indexLinks = List(
       Link("prepare", s"${config.rootUri}/prepare"),
       Link("uploadStatus", s"${config.rootUri}/uploadStatus/{id}"),
-      Link("uploadStatuses", s"${config.rootUri}/uploadStatuses/"),
+      Link("uploadStatuses", s"${config.rootUri}/uploadStatuses"),
       Link("load", s"${config.rootUri}/images{?uploadedBy,identifiers,uploadTime,filename}"),
       Link("import", s"${config.rootUri}/imports{?uri,uploadedBy,identifiers,uploadTime,filename}")
     )


### PR DESCRIPTION
## What does this change?

Removing the trailing slash makes the link work. This is generally consistent with other Grid advertised links.

This list all end point looks to be unused; it does not appear in recent access logs and seems to be unreferenced in the client code.



## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

From api.media.(redacted PROD domain)
Follow the 'loader' link
Then follow the 'uploadStatuses' link.
Should get a non 404 JSON end point.


## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
