### PR TITLE
T1811 - payable images bug

### DIFF
--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -84,7 +84,6 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   const [isChargeable, setIsChargeable] = useState(props.chargeable);
   const [selectedOption, setSelection] = useState(defPerms);
   const [currentIndex, setCurrentIndex] = useState(-1);
-  const [logoClick, setLogoClick] = useState<LogoClickProperties>({logoClick: false, showPaid:false});
 
   const autoHideListener = (event: any) => {
     if (event.type === "keydown" && event.key === "Escape") {
@@ -97,15 +96,8 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   };
 
   const handleLogoClick = (event: LogoClickEvent) => {
-    setLogoClick({logoClick: true, showPaid: event.detail.showPaid});
+    setIsChargeable(event.detail.showPaid);
   };
-
-  useEffect(() => {
-    if (logoClick.logoClick) {
-      setIsChargeable(logoClick.showPaid);
-      setLogoClick({logoClick: false, showPaid: logoClick.showPaid});
-    }
-  }, [logoClick]);
 
   const handleQueryChange = (event: QueryChangeEvent ) => {
     const newQuery = event.detail.query ? (" " + event.detail.query) : "";

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -87,10 +87,13 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
 
   const handleQueryChange = (e: any ) => {
     const newQuery = e.detail.query ? (" " + e.detail.query) : "";
+    const showPaid = e.detail.showPaid;
 
     //-check chargeable-
     const logoClick = window.sessionStorage.getItem("logoClick") ? window.sessionStorage.getItem("logoClick") : "";
     if (logoClick.includes("logoClick")) {
+      console.log("LogoClick : " + logoClick);
+      console.log("ShowPaid : " + showPaid);
       setIsChargeable(false);
       window.sessionStorage.setItem("logoClick", "");
     }

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -70,7 +70,6 @@ interface QueryChangeEvent extends CustomEvent<QueryChangeEventDetail> {optional
 //-- logo click event --
 interface LogoClickEventDetail { showPaid: boolean }
 interface LogoClickEvent extends CustomEvent<LogoClickEventDetail> {optional?: string}
-interface LogoClickProperties {logoClick: boolean, showPaid: boolean}
 
 //-- react control--
 const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -98,22 +98,17 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
 
   const handleLogoClick = (event: LogoClickEvent) => {
     setLogoClick({logoClick: true, showPaid: event.detail.showPaid});
-    console.log("**Handle Logo Click isNonFree=" + event.detail.showPaid);
   };
 
   useEffect(() => {
     if (logoClick.logoClick) {
       setIsChargeable(logoClick.showPaid);
       setLogoClick({logoClick: false, showPaid: logoClick.showPaid});
-      console.log("**Logo Click Follow Up**");
-      console.log("isNonFree=" + logoClick.showPaid);
     }
   }, [logoClick]);
 
   const handleQueryChange = (event: QueryChangeEvent ) => {
     const newQuery = event.detail.query ? (" " + event.detail.query) : "";
-    const showPaid = event.detail.showPaid;
-    console.log("**QUERY CHANGE** Query=" + newQuery + " ShowPaid=" + showPaid);
 
     if (propsRef.current.query !== newQuery) {
       propsRef.current.query = newQuery;

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -63,13 +63,13 @@ const hasClassInSelfOrParent = (node: Element | null, className: string): boolea
   return false;
 };
 
-//-- query change event --
+//-- query change event - adding optional param to avoid CI/CD check issue!--
 interface QueryChangeEventDetail { query: string, showPaid: boolean }
-interface QueryChangeEvent extends CustomEvent<QueryChangeEventDetail> {}
+interface QueryChangeEvent extends CustomEvent<QueryChangeEventDetail> {optional?: string}
 
 //-- logo click event --
 interface LogoClickEventDetail { showPaid: boolean }
-interface LogoClickEvent extends CustomEvent<LogoClickEventDetail> {}
+interface LogoClickEvent extends CustomEvent<LogoClickEventDetail> {optional?: string}
 interface LogoClickProperties {logoClick: boolean, showPaid: boolean}
 
 //-- react control--

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -110,7 +110,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                   isNonFree: showPaid ? showPaid : false
                 };
                 storage.setJs("defaultNonFreeFilter", defaultNonFreeFilter, true);
-                storage.setJs("logoClick","logoClick", true);
+                storage.setJs("logoClick",(showPaid ? "logoClickTrue" : "logoClickFalse"), true);
                 $state.go('search.results', {nonFree: defaultNonFreeFilter.isNonFree});
                 window.dispatchEvent(new CustomEvent("logoClick", {
                   detail: "logoClick",

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -103,6 +103,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             cropSettings.set($stateParams);
 
             ctrl.onLogoClick = () => {
+                console.log("***LOGO CLICK***");
                 mediaApi.getSession().then(session => {
                 const showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
                 const defaultNonFreeFilter = {
@@ -110,10 +111,9 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                   isNonFree: showPaid ? showPaid : false
                 };
                 storage.setJs("defaultNonFreeFilter", defaultNonFreeFilter, true);
-                storage.setJs("logoClick",(showPaid ? "logoClickTrue" : "logoClickFalse"), true);
                 $state.go('search.results', {nonFree: defaultNonFreeFilter.isNonFree});
                 window.dispatchEvent(new CustomEvent("logoClick", {
-                  detail: "logoClick",
+                  detail: {showPaid: defaultNonFreeFilter.isNonFree},
                   bubbles: true
                 }));
               });

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -103,7 +103,6 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             cropSettings.set($stateParams);
 
             ctrl.onLogoClick = () => {
-                console.log("***LOGO CLICK***");
                 mediaApi.getSession().then(session => {
                 const showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
                 const defaultNonFreeFilter = {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -97,9 +97,9 @@ query.controller('SearchQueryCtrl', [
       storage.setJs("isUploadedByMe", ctrl.filter.uploadedByMe, true);
     }
 
-    function raiseQueryChangeEvent(q, showPaid) {
+    function raiseQueryChangeEvent(q) {
       const customEvent = new CustomEvent('queryChangeEvent', {
-        detail: {query: q, showPaid: showPaid},
+        detail: {query: q},
         bubbles: true
       });
       window.dispatchEvent(customEvent);
@@ -111,7 +111,7 @@ query.controller('SearchQueryCtrl', [
 
       ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
       watchUploadedBy(filter, sender);
-      raiseQueryChangeEvent(ctrl.filter.query, showPaid);
+      raiseQueryChangeEvent(ctrl.filter.query);
 
       const defaultNonFreeFilter = storage.getJs("defaultNonFreeFilter", true);
       if (defaultNonFreeFilter && defaultNonFreeFilter.isDefault === true){

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -97,9 +97,9 @@ query.controller('SearchQueryCtrl', [
       storage.setJs("isUploadedByMe", ctrl.filter.uploadedByMe, true);
     }
 
-    function raiseQueryChangeEvent(q) {
+    function raiseQueryChangeEvent(q, showPaid) {
       const customEvent = new CustomEvent('queryChangeEvent', {
-        detail: {query: q},
+        detail: {query: q, showPaid: showPaid},
         bubbles: true
       });
       window.dispatchEvent(customEvent);
@@ -111,7 +111,7 @@ query.controller('SearchQueryCtrl', [
 
       ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
       watchUploadedBy(filter, sender);
-      raiseQueryChangeEvent(ctrl.filter.query);
+      raiseQueryChangeEvent(ctrl.filter.query, showPaid);
 
       const defaultNonFreeFilter = storage.getJs("defaultNonFreeFilter", true);
       if (defaultNonFreeFilter && defaultNonFreeFilter.isDefault === true){


### PR DESCRIPTION
## What does this change do?

There was a bug such that the 'Show Payable Images' checkbox control could get out of sync with the url nonFree value and the query results when clicking the Logo if the result of clicking the logo left the url in a state where it did not contain an entry for nonFree (true or false) - if that occurred and the user then started to type in the search bar they could in some instances see payable images in the results (and nonFree = true in url) but payable images control remained 'off'.

This PR corrects that bug and tidies up the way that the Logo click is conveyed to the interim filters control

## How should a reviewer test this change?

Ensure that the 'payable images' control is always in sync with the query url and search results when clicking the logo.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
