### PR TITLE
IMAEGEDAM-1830: showPaid permission prevents standard users from accessing sendToPhotosales functionality

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -83,7 +83,7 @@
 
                 <div class="results-toolbar-item results-toolbar-item--right"
                     tabindex="0"
-                    ng-if="ctrl.showSendToPhotoSales()">
+                    ng-if="ctrl.showSendToPhotoSales() && ctrl.showPaid">
                     <a id="send-to"
                        style="display: contents;"
                        ng-class="{'batch-archive__button--disabled': ctrl.selectionCount >= 45}"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -418,6 +418,11 @@ results.controller('SearchResultsCtrl', [
         return [validImages, invalidImages];
       };
 
+      ctrl.showPaid = undefined;
+      mediaApi.getSession().then(session => {
+        ctrl.showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
+      });
+
       ctrl.sendToPhotoSales = () => {
         const validImages = validatePhotoSalesSelection(ctrl.selectedImages)[0];
         validImages.map(image => {


### PR DESCRIPTION

## What does this change?

This adds a layer of authorisation on top of the send to photosales functionality. Only users that have enhanced access rights (in the BBC case these would be archivists) can access the send to photosales feature.

## How should a reviewer test this change?

- Set the sendToPhotoSales feature flag to true. 
- Log in as a standard user and select an image. The 'send to photosales' button should not be present in the menu that appears.
- Log in as a user with enhanced access rights and select an image. The 'send to photosales' button should now be present in the menu that appears. 

## How can success be measured?

Only users with enhanced rights have access to the send to photosales functionality. 

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
