### PR TITLE
Fix issues leading to scrollTo not working with interimFilters on. 

### DIFF
--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -702,7 +702,10 @@ results.controller('SearchResultsCtrl', [
         });
 
         $scope.$on('$destroy', () => {
-            scrollPosition.save($stateParams);
+            // only save scroll position if we're destroying grid scope (avoids issue regarding ng-if triggering scope refresh)
+            if (0 < $scope.ctrl.images.length) {
+              scrollPosition.save($stateParams);
+            }
             freeUpdatesListener();
             freeImageDeleteListener();
             scopeGone = true;

--- a/kahuna/public/js/services/scroll-position.js
+++ b/kahuna/public/js/services/scroll-position.js
@@ -13,12 +13,20 @@ scrollPosService.factory('scrollPosition',
     let originalContext;
 
     function save(currentContext) {
+        // deal with url ambiguity over nonFree parameter
+        if (!currentContext.nonFree) {
+          currentContext.nonFree = "false";
+        }
         originalContext = currentContext;
         // Accommodate Chrome & Firefox
         positionTop = document.body.scrollTop || document.documentElement.scrollTop;
     }
 
     function resume(currentContext) {
+        // deal with url ambiguity over nonFree parameter
+        if (!currentContext.nonFree) {
+          currentContext.nonFree = "false";
+        }
         if (angular.equals(currentContext, originalContext)) {
             $window.scrollTo(0, positionTop);
         }


### PR DESCRIPTION
## What does this change do?

With the introduction of the interim filters control and the second layer in the top-bar we introduced a bug such that the ability to return to the same scroll location in a list of images had been lost - when the user returns to the grid having opened the image detail view for an image they will be returned to the top of the view/list rather than the scroll location they had come from.

The problem has two elements to it;

1) The inclusion of 'ng-if' in the wrapper element for the interim filters causes the refresh of the $scope when we return to the grid view form the image view - which triggers a $destroy event - this in turn resets the topPosition in the scroll-position service to 0 which means the scroll never gets reset to the correct value.

2) The ambiguity surrounding the nonFree parameter in the context causes the currentContext to evaluate as different from the originalContext aas the interimFilters control includes the 'Payable Images' checkbox which forces a value onto the nonFree parameter. nonFree = undefined and nonFree = false both mean the same thing so new code ensures that they will evaluate as equivalent.

## How should a reviewer test this change?

Ensure that when a user scrolls down an image list (including seach options if required) and then selects an image - when they then return to the list view from the image view they should return to the same scroll location and the search parameters are retained.

All the main UI controls should continue to operate unaltered and all other screen transition should not be impacted (the navigation to 'My Uploads' and back to the list view should also retain the scroll location).

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
