### PR TITLE
Fix issue that led to restrictions textarea in metadata editor to lose focus on data input

### DIFF
--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -42,7 +42,7 @@ usageRightsEditor.controller(
       const categories$ = usageRights$.combineLatest(filteredCategories$, allCategories$, (urs, filCats, allCats) => {
           const uniqueCats = getUniqueCats(urs);
           if (uniqueCats.length === 1) {
-              if(allCats.length === filCats.length) {
+              if (allCats.length === filCats.length) {
                 return allCats;
               }
               const mtchCats = filCats.filter(c => c.value === uniqueCats[0]);

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -53,7 +53,7 @@ usageRightsEditor.controller(
                 return filCats;
               }
           } else {
-              return [multiCat].concat(filCats);
+              return filCats;
           }
       });
 

--- a/kahuna/public/js/usage-rights/usage-rights-editor.js
+++ b/kahuna/public/js/usage-rights/usage-rights-editor.js
@@ -37,13 +37,14 @@ usageRightsEditor.controller(
       const usageRights$ = observe$($scope, () => ctrl.usageRights);
 
       // @return Stream.<Array.<Category>>
-      const categories$ = Rx.Observable.fromPromise(editsApi.getUsageRightsCategories());
+      const allCategories$ = Rx.Observable.fromPromise(editsApi.getUsageRightsCategories());
       const filteredCategories$ = Rx.Observable.fromPromise(editsApi.getFilteredUsageRightsCategories());
-
-      // @return Stream.<Array.<Category>>
-      const displayCategories$ = usageRights$.combineLatest(filteredCategories$, categories$, (urs, filCats, allCats) => {
+      const categories$ = usageRights$.combineLatest(filteredCategories$, allCategories$, (urs, filCats, allCats) => {
           const uniqueCats = getUniqueCats(urs);
           if (uniqueCats.length === 1) {
+              if(allCats.length === filCats.length) {
+                return allCats;
+              }
               const mtchCats = filCats.filter(c => c.value === uniqueCats[0]);
               const extraCats = allCats.filter(c => c.value === uniqueCats[0]);
               if (mtchCats.length === 0 && extraCats.length === 1) {
@@ -53,6 +54,16 @@ usageRightsEditor.controller(
               }
           } else {
               return [multiCat].concat(filCats);
+          }
+      });
+
+      // @return Stream.<Array.<Category>>
+      const displayCategories$ = usageRights$.combineLatest(categories$, (urs, cats) => {
+          const uniqueCats = getUniqueCats(urs);
+          if (uniqueCats.length === 1) {
+              return cats;
+          } else {
+              return [multiCat].concat(cats);
           }
       });
 


### PR DESCRIPTION
## What does this change do?

Following the introduction of the config variable 'usageRights.stdUserExcluded' which allowed administrators to add in a list of usage rights categories that standard users should not be able to select from we have identified a bug in the usage rights editor.

If the user selects the restrictions checkbox to add restrictions to the image and starts to type in the texarea field after they type a character the control loses focus (if the user click back into the control they can continue to enter text as normal - so no functionality is lost - but it is annoying and a bug).

The problem was traced to the AngluarJS state management performing a refresh on the control - hence the loss of focus - because of the way the list of display categories had been derived - it appears that deriving the displayCategories stream from a different set of observables from the category stream caused AngularJS to perform a refresh.

The fix was to build a composite stream that both subsequent streams could utilise - category and displayCategories - this stopped the unwanted refersh and the control behaves as expected.

## How should a reviewer test this change?

Ensure that when adding restrictions to an image on upload or in the metadata editor (grid view or image view) that the textarea does not lose focus when starting to input data.

Also ensure that the expected range of categories are available for both standard users and admin users.

Also ensure that the display of rights category is correct when selecting multiple images (either with the same rights category or with differing categories).

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
