### PR TITLE
fixing myUploads bugs

### DIFF
--- a/dev/nginx-mappings.yml.template
+++ b/dev/nginx-mappings.yml.template
@@ -22,7 +22,7 @@ mappings:
   - prefix: media-usage
     port: 9009
   - prefix: media-collections
-    port: 9010
+    port: 9013
   - prefix: media-auth
     port: 9011
   - prefix: media-leases

--- a/dev/nginx-mappings.yml.template
+++ b/dev/nginx-mappings.yml.template
@@ -22,7 +22,7 @@ mappings:
   - prefix: media-usage
     port: 9009
   - prefix: media-collections
-    port: 9013
+    port: 9010
   - prefix: media-auth
     port: 9011
   - prefix: media-leases

--- a/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
+++ b/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
@@ -44,9 +44,8 @@ const MyUploads: React.FC<MyUploadsWrapperProps> = ({ props }) => {
 
       //-- raise payable images event --
       const event = new CustomEvent<PayableImagesEventDetail>('setPayableImages', {
-        detail: {
-          showPaid: !prevChkd
-        }
+        detail: { showPaid: !prevChkd },
+        bubbles: true
       });
       window.dispatchEvent(event);
 

--- a/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
+++ b/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
@@ -67,18 +67,11 @@ const MyUploads: React.FC<MyUploadsWrapperProps> = ({ props }) => {
   };
 
   const handleFilterChange = (event: FilterChangeEvent) => {
-    console.log("***Control:MyUploads - Method:handleFilterChange***")
-    console.log("   uploadedByMe=" + event.detail.filter.uploadedByMe)
-
     setMyUploads(event.detail.filter.uploadedByMe);
   };
 
   const handleUploadedBy =  (event: UploadedByEvent) => {
     const matches: boolean = (event.detail.userEmail === event.detail.uploadedBy);
-
-    console.log("***Control:MyUploads - Method:handleUploadedBy***")
-    console.log("   matches=" + matches)
-
     setMyUploads(matches);
   };
 

--- a/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
+++ b/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
@@ -26,6 +26,10 @@ interface Filter { uploadedByMe: boolean }
 interface FilterChangeEventDetail { filter: Filter }
 interface FilterChangeEvent extends CustomEvent<FilterChangeEventDetail> {optional?: string}
 
+//-- uploadedBy check event --
+interface UploadedByEventDetail { userEmail: string, uploadedBy: string }
+interface UploadedByEvent extends CustomEvent<UploadedByEventDetail> {optional?: string}
+
 //-- payable images event --
 interface PayableImagesEventDetail { showPaid: boolean }
 
@@ -66,12 +70,19 @@ const MyUploads: React.FC<MyUploadsWrapperProps> = ({ props }) => {
     setMyUploads(event.detail.filter.uploadedByMe);
   };
 
+  const handleUploadedBy =  (event: UploadedByEvent) => {
+    const matches: boolean = (event.detail.userEmail === event.detail.uploadedBy);
+    setMyUploads(matches);
+  };
+
   useEffect(() => {
     window.addEventListener('logoClick', handleLogoClick);
     window.addEventListener('filterChangeEvent', handleFilterChange);
+    window.addEventListener('uploadedByEvent', handleUploadedBy);
     return () => {
       window.removeEventListener('logoClick', handleLogoClick);
       window.removeEventListener('filterChangeEvent', handleFilterChange);
+      window.removeEventListener('uploadedByEvent', handleUploadedBy);
     };
   }, []);
 

--- a/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
+++ b/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
@@ -96,7 +96,7 @@ const MyUploads: React.FC<MyUploadsWrapperProps> = ({ props }) => {
   return (
     <div className="my-uploads-container" tabIndex={0} aria-label={MY_UPLOADS} onKeyDown={handleKeyboard}>
       <label className="custom-checkbox">
-        <input type="checkbox" checked={myUploads} onChange={handleCheckboxClick}/>
+        <input type="checkbox" checked={myUploads} onClick={handleCheckboxClick}/>
         <div className="label-wrapper" >
           <span className="custom-span"></span>
           <span className="custom-label no-select">{MY_UPLOADS}</span>

--- a/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
+++ b/kahuna/public/js/components/gr-my-uploads/gr-my-uploads.tsx
@@ -67,11 +67,18 @@ const MyUploads: React.FC<MyUploadsWrapperProps> = ({ props }) => {
   };
 
   const handleFilterChange = (event: FilterChangeEvent) => {
+    console.log("***Control:MyUploads - Method:handleFilterChange***")
+    console.log("   uploadedByMe=" + event.detail.filter.uploadedByMe)
+
     setMyUploads(event.detail.filter.uploadedByMe);
   };
 
   const handleUploadedBy =  (event: UploadedByEvent) => {
     const matches: boolean = (event.detail.userEmail === event.detail.uploadedBy);
+
+    console.log("***Control:MyUploads - Method:handleUploadedBy***")
+    console.log("   matches=" + matches)
+
     setMyUploads(matches);
   };
 

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -103,20 +103,11 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   };
 
   const handleSetPayableImages = (event: PayableImagesEvent) => {
-    console.log("***Control:PermissionsFilter - Method:handleSetPayableImages***")
-    console.log("   showPaid=" + event.detail.showPaid + "(type=" + typeof(event.detail.showPaid) + ")")
     setIsChargeable(event.detail.showPaid);
   };
 
   const handleQueryChange = (event: QueryChangeEvent) => {
-    console.log("***Control:PermissionsFilter - Method:handleQueryChange***")
     const newQuery = event.detail.query ? (" " + event.detail.query) : "";
-    const showPaid =  event.detail.showPaid;
-    console.log("   showPaid=" + showPaid + "(type=" + typeof(showPaid) + ")")
-
-    //if (showPaid !== isChargeable) {
-    //  setIsChargeable(showPaid);
-    //}
 
     if (propsRef.current.query !== newQuery) {
       propsRef.current.query = newQuery;

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -106,8 +106,13 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     setIsChargeable(event.detail.showPaid);
   };
 
-  const handleQueryChange = (event: QueryChangeEvent ) => {
+  const handleQueryChange = (event: QueryChangeEvent) => {
     const newQuery = event.detail.query ? (" " + event.detail.query) : "";
+    const showPaid =  event.detail.showPaid;
+
+    if (showPaid !== isChargeable) {
+      setIsChargeable(showPaid);
+    }
 
     if (propsRef.current.query !== newQuery) {
       propsRef.current.query = newQuery;

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -103,12 +103,16 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   };
 
   const handleSetPayableImages = (event: PayableImagesEvent) => {
+    console.log("***Control:PermissionsFilter - Method:handleSetPayableImages***")
+    console.log("   showPaid=" + event.detail.showPaid + "(type=" + typeof(event.detail.showPaid) + ")")
     setIsChargeable(event.detail.showPaid);
   };
 
   const handleQueryChange = (event: QueryChangeEvent) => {
+    console.log("***Control:PermissionsFilter - Method:handleQueryChange***")
     const newQuery = event.detail.query ? (" " + event.detail.query) : "";
     const showPaid =  event.detail.showPaid;
+    console.log("   showPaid=" + showPaid + "(type=" + typeof(showPaid) + ")")
 
     if (showPaid !== isChargeable) {
       setIsChargeable(showPaid);

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -242,7 +242,7 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
         <div className="ts-toggle-container" tabIndex={0} aria-label={SHOW_CHARGEABLE + " " + (isChargeable ? SELECTED : NOT_SELECTED)} onKeyDown={handleKeyToggle} onClick={handleToggle}>
           <div className="ts-toggle-label no-select">{SHOW_CHARGEABLE}</div>
           <label className="ts-toggle-switch">
-            <input type="checkbox" checked={isChargeable} onChange={handleToggle}/>
+            <input type="checkbox" checked={isChargeable} onClick={handleToggle}/>
             <span className="ts-slider"></span>
           </label>
         </div>

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -63,6 +63,10 @@ const hasClassInSelfOrParent = (node: Element | null, className: string): boolea
   return false;
 };
 
+//-- payable images event (optional param to avoid CI check issues) --
+interface PayableImagesEventDetail { showPaid: boolean }
+interface PayableImagesEvent extends CustomEvent<PayableImagesEventDetail> {optional?: string}
+
 //-- query change event - adding optional param to avoid CI/CD check issue!--
 interface QueryChangeEventDetail { query: string, showPaid: boolean }
 interface QueryChangeEvent extends CustomEvent<QueryChangeEventDetail> {optional?: string}
@@ -98,6 +102,10 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     setIsChargeable(event.detail.showPaid);
   };
 
+  const handleSetPayableImages = (event: PayableImagesEvent) => {
+    setIsChargeable(event.detail.showPaid);
+  };
+
   const handleQueryChange = (event: QueryChangeEvent ) => {
     const newQuery = event.detail.query ? (" " + event.detail.query) : "";
 
@@ -122,6 +130,7 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   useEffect(() => {
     window.addEventListener('queryChangeEvent', handleQueryChange);
     window.addEventListener('logoClick', handleLogoClick);
+    window.addEventListener('setPayableImages', handleSetPayableImages);
     window.addEventListener('mouseup', autoHideListener);
     window.addEventListener('scroll', autoHideListener);
     window.addEventListener('keydown', autoHideListener);
@@ -132,9 +141,10 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
       setCurrentIndex(-1);
       window.removeEventListener('queryChangeEvent', handleQueryChange);
       window.removeEventListener('logoClick', handleLogoClick);
-      window.removeEventListener("mouseup", autoHideListener);
-      window.removeEventListener("scroll", autoHideListener);
-      window.removeEventListener("keydown", autoHideListener);
+      window.removeEventListener('setPayableImages', handleSetPayableImages);
+      window.removeEventListener('mouseup', autoHideListener);
+      window.removeEventListener('scroll', autoHideListener);
+      window.removeEventListener('keydown', autoHideListener);
     };
   }, []);
 

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -162,14 +162,10 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   };
 
   useEffect(() => {
-    console.log("*** Permissions Filter - useEffect-isChargeable ***")
-    console.log("   isChargeable=" + isChargeable)
     props.onChargeable(isChargeable);
   }, [isChargeable]);
 
   const handleToggle = () => {
-    console.log("*** Permissions Filter - handleToggle ***")
-    console.log("   current-toggle=" + isChargeable)
     setIsChargeable(prevState => !prevState);
   };
 

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -114,9 +114,9 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     const showPaid =  event.detail.showPaid;
     console.log("   showPaid=" + showPaid + "(type=" + typeof(showPaid) + ")")
 
-    if (showPaid !== isChargeable) {
-      setIsChargeable(showPaid);
-    }
+    //if (showPaid !== isChargeable) {
+    //  setIsChargeable(showPaid);
+    //}
 
     if (propsRef.current.query !== newQuery) {
       propsRef.current.query = newQuery;

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -244,7 +244,7 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
         </div>
         <div className="ts-toggle-container-short" tabIndex={0} aria-label={SHOW_CHARGEABLE + " " + (isChargeable ? SELECTED : NOT_SELECTED)} onKeyDown={handleToggle}>
           <label className="chargeable-checkbox">
-            <input type="checkbox" checked={isChargeable} onChange={handleToggle}/>
+            <input type="checkbox" checked={isChargeable} onClick={handleToggle}/>
             <div className="chargeable-label-wrapper" >
               <span className="chargeable-span"></span>
               <span className="chargeable-label no-select">{SHOW_CHARGEABLE_SHORT}</span>

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -171,10 +171,14 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
   };
 
   useEffect(() => {
+    console.log("*** Permissions Filter - useEffect-isChargeable ***")
+    console.log("   isChargeable=" + isChargeable)
     props.onChargeable(isChargeable);
   }, [isChargeable]);
 
   const handleToggle = () => {
+    console.log("*** Permissions Filter - handleToggle ***")
+    console.log("   current-toggle=" + isChargeable)
     setIsChargeable(prevState => !prevState);
   };
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -396,7 +396,7 @@ query.controller('SearchQueryCtrl', [
         //-default non free-
         const defNonFree = session.user.permissions ? session.user.permissions.showPaid : undefined;
         storage.setJs("defaultIsNonFree", defNonFree ? defNonFree : false, true);
-        if($stateParams.nonFree === undefined && (defNonFree === true || defNonFree === "true")) {
+        if ($stateParams.nonFree === undefined && (defNonFree === true || defNonFree === "true")) {
           raisePayableImagesEvent(defNonFree);
         }
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -346,18 +346,17 @@ query.controller('SearchQueryCtrl', [
           ctrl.filter.uploadedByMe = ctrl.filter.uploadedBy === ctrl.user.email;
           ctrl.filterMyUploads = ctrl.filter.uploadedByMe;
           storage.setJs("isUploadedByMe",ctrl.filter.uploadedByMe);
-          raiseFilterChangeEvent(ctrl.filter);
         } else {
           if ((ctrl.filter.uploadedBy === ctrl.user.email) && !isUploadedByMe ) {
             ctrl.filter.uploadedByMe = true;
             ctrl.filterMyUploads = ctrl.filter.uploadedByMe;
             storage.setJs("isUploadedByMe",ctrl.filter.uploadedByMe);
-            raiseFilterChangeEvent(ctrl.filter);
           } else {
             ctrl.filter.uploadedByMe = isUploadedByMe;
             ctrl.filterMyUploads = isUploadedByMe;
           }
         }
+        raiseFilterChangeEvent(ctrl.filter);
 
         if (isNonFree === null) {
           ctrl.filter.nonFree = $stateParams.nonFree;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -76,9 +76,7 @@ query.controller('SearchQueryCtrl', [
 
     //--react - angular interop events--
     function raiseQueryChangeEvent(query, showPaid) {
-      console.log("***Query - raiseQueryChangeEvent***")
       const boolShowPaid = (showPaid === true || showPaid === "true") ? true : false;
-      console.log("showPaid=" + boolShowPaid + "(type=" + typeof(boolShowPaid) + ")")
       const customEvent = new CustomEvent('queryChangeEvent', {
         detail: {query: query, showPaid: boolShowPaid},
         bubbles: true
@@ -174,9 +172,6 @@ query.controller('SearchQueryCtrl', [
 
     // eslint-disable-next-line complexity
     function watchSearchChange(newFilter, sender) {
-      console.log("***Query:watchSearchChange - Sender:" + sender + " ***")
-      console.log("   filter.nonFree=" + newFilter.nonFree)
-
       const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
       const showPaid = newFilter.nonFree ? newFilter.nonFree : false;
       storage.setJs("isNonFree", showPaid, true);
@@ -196,7 +191,7 @@ query.controller('SearchQueryCtrl', [
         nonFreeCheck = undefined;
       }
       ctrl.filter.nonFree = nonFreeCheck;
-      raiseQueryChangeEvent(ctrl.filter.query, nonFreeCheck);
+      raiseQueryChangeEvent(ctrl.filter.query);
 
       sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe);
       $state.go('search.results', ctrl.filter);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -75,10 +75,18 @@ query.controller('SearchQueryCtrl', [
     ctrl.filterMyUploads = false;
 
     //--react - angular interop events--
-    function raiseQueryChangeEvent(query, showPaid) {
+    function raisePayableImagesEvent(showPaid) {
       const boolShowPaid = (showPaid === true || showPaid === "true") ? true : false;
+      const customEvent = new CustomEvent('setPayableImages', {
+        detail: {showPaid: boolShowPaid},
+        bubbles: true
+      });
+      window.dispatchEvent(customEvent);
+    }
+
+    function raiseQueryChangeEvent(query) {
       const customEvent = new CustomEvent('queryChangeEvent', {
-        detail: {query: query, showPaid: boolShowPaid},
+        detail: {query: query},
         bubbles: true
       });
       window.dispatchEvent(customEvent);
@@ -388,6 +396,7 @@ query.controller('SearchQueryCtrl', [
         //-non free-
         const defNonFree = session.user.permissions ? session.user.permissions.showPaid : undefined;
         storage.setJs("defaultIsNonFree", defNonFree ? defNonFree : false, true);
+        raisePayableImagesEvent(defNonFree);
 
         const isNonFree = storage.getJs("isNonFree", true);
         if (isNonFree === null) {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -91,6 +91,16 @@ query.controller('SearchQueryCtrl', [
       window.dispatchEvent(customEvent);
     }
 
+    function raiseUploadedByCheckEvent() {
+      if (ctrl.user) {
+        const customEvent = new CustomEvent('uploadedByEvent', {
+          detail: { userEmail: ctrl.user.email, uploadedBy: $stateParams.uploadedBy },
+          bubbles: true
+        });
+        window.dispatchEvent(customEvent);
+      }
+    }
+
     function watchUploadedBy(filter, sender) {
       // Users should be able to follow URLs with uploadedBy set to another user's name, so only
       // overwrite if:
@@ -116,6 +126,7 @@ query.controller('SearchQueryCtrl', [
           }
           raiseFilterChangeEvent(ctrl.filter);
         }
+        raiseUploadedByCheckEvent();
       }
       storage.setJs("isUploadedByMe", ctrl.filter.uploadedByMe, true);
     }
@@ -361,7 +372,6 @@ query.controller('SearchQueryCtrl', [
             ctrl.filterMyUploads = isUploadedByMe;
           }
         }
-        //raiseFilterChangeEvent(ctrl.filter);
 
         //-non free-
         const isNonFree = storage.getJs("isNonFree", true);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -77,7 +77,6 @@ query.controller('SearchQueryCtrl', [
     //--react - angular interop events--
     function raiseQueryChangeEvent(query, showPaid) {
       console.log("***Query - raiseQueryChangeEvent***")
-
       const boolShowPaid = (showPaid === true || showPaid === "true") ? true : false;
       console.log("showPaid=" + boolShowPaid + "(type=" + typeof(boolShowPaid) + ")")
       const customEvent = new CustomEvent('queryChangeEvent', {
@@ -88,9 +87,6 @@ query.controller('SearchQueryCtrl', [
     }
 
     function raiseFilterChangeEvent(filter) {
-      console.log("***Query - raiseFilterChangeEvent***")
-      console.log("   filter.nonFree=" + filter.nonFree)
-
       const customEvent = new CustomEvent('filterChangeEvent', {
         detail: {filter: filter},
         bubbles: true
@@ -99,11 +95,7 @@ query.controller('SearchQueryCtrl', [
     }
 
     function raiseUploadedByCheckEvent() {
-      console.log("***Query - raiseUploadedByCheckEven***")
-
       if (ctrl.user) {
-        console.log("   userEmail : " + ctrl.user.email)
-        console.log("   uploadedBy : " + $stateParams.uploadedBy)
         const customEvent = new CustomEvent('uploadedByEvent', {
           detail: { userEmail: ctrl.user.email, uploadedBy: $stateParams.uploadedBy },
           bubbles: true

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -73,6 +73,7 @@ query.controller('SearchQueryCtrl', [
 
     ctrl.usePermissionsFilter = window._clientConfig.usePermissionsFilter;
     ctrl.filterMyUploads = false;
+    ctrl.initialShowPaidEvent = ($stateParams.nonFree === undefined) ? false : true;
 
     //--react - angular interop events--
     function raisePayableImagesEvent(showPaid) {
@@ -180,7 +181,6 @@ query.controller('SearchQueryCtrl', [
 
     // eslint-disable-next-line complexity
     function watchSearchChange(newFilter, sender) {
-      const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
       const showPaid = newFilter.nonFree ? newFilter.nonFree : false;
       storage.setJs("isNonFree", showPaid, true);
 
@@ -194,6 +194,7 @@ query.controller('SearchQueryCtrl', [
       const { nonFree, uploadedByMe } = ctrl.filter;
       let nonFreeCheck = nonFree;
       if (ctrl.usePermissionsFilter && nonFreeCheck === undefined) {
+        const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
         nonFreeCheck = defaultShowPaid;
       } else if (!ctrl.usePermissionsFilter && (nonFreeCheck === 'false' || nonFreeCheck === false)) {
         nonFreeCheck = undefined;
@@ -396,7 +397,8 @@ query.controller('SearchQueryCtrl', [
         //-default non free-
         const defNonFree = session.user.permissions ? session.user.permissions.showPaid : undefined;
         storage.setJs("defaultIsNonFree", defNonFree ? defNonFree : false, true);
-        if ($stateParams.nonFree === undefined && (defNonFree === true || defNonFree === "true")) {
+        if (!ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
+          ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
         }
 

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -74,8 +74,12 @@ query.controller('SearchQueryCtrl', [
     ctrl.usePermissionsFilter = window._clientConfig.usePermissionsFilter;
     ctrl.filterMyUploads = false;
 
+    //--react - angular interop events--
     function raiseQueryChangeEvent(query, showPaid) {
+      console.log("***Query - raiseQueryChangeEvent***")
+
       const boolShowPaid = (showPaid === true || showPaid === "true") ? true : false;
+      console.log("showPaid=" + boolShowPaid + "(type=" + typeof(boolShowPaid) + ")")
       const customEvent = new CustomEvent('queryChangeEvent', {
         detail: {query: query, showPaid: boolShowPaid},
         bubbles: true
@@ -84,6 +88,9 @@ query.controller('SearchQueryCtrl', [
     }
 
     function raiseFilterChangeEvent(filter) {
+      console.log("***Query - raiseFilterChangeEvent***")
+      console.log("   filter.nonFree=" + filter.nonFree)
+
       const customEvent = new CustomEvent('filterChangeEvent', {
         detail: {filter: filter},
         bubbles: true
@@ -92,7 +99,11 @@ query.controller('SearchQueryCtrl', [
     }
 
     function raiseUploadedByCheckEvent() {
+      console.log("***Query - raiseUploadedByCheckEven***")
+
       if (ctrl.user) {
+        console.log("   userEmail : " + ctrl.user.email)
+        console.log("   uploadedBy : " + $stateParams.uploadedBy)
         const customEvent = new CustomEvent('uploadedByEvent', {
           detail: { userEmail: ctrl.user.email, uploadedBy: $stateParams.uploadedBy },
           bubbles: true
@@ -171,13 +182,16 @@ query.controller('SearchQueryCtrl', [
 
     // eslint-disable-next-line complexity
     function watchSearchChange(newFilter, sender) {
+      console.log("***Query:watchSearchChange - Sender:" + sender + " ***")
+      console.log("   filter.nonFree=" + newFilter.nonFree)
+
       const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
       const showPaid = newFilter.nonFree ? newFilter.nonFree : false;
       storage.setJs("isNonFree", showPaid, true);
 
       ctrl.collectionSearch = newFilter.query ? newFilter.query.indexOf('~') === 0 : false;
 
-      //--update filter components--
+      //--update filter elements--
       manageUploadedBy(newFilter, sender);
       manageDefaultNonFree(newFilter);
       manageOrgOwnedSetting(newFilter);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -126,6 +126,7 @@ query.controller('SearchQueryCtrl', [
       ctrl.collectionSearch = ctrl.filter.query ? ctrl.filter.query.indexOf('~') === 0 : false;
       watchUploadedBy(filter, sender);
       raiseQueryChangeEvent(ctrl.filter.query);
+      raiseFilterChangeEvent(ctrl.filter);
 
       const defaultNonFreeFilter = storage.getJs("defaultNonFreeFilter", true);
       if (defaultNonFreeFilter && defaultNonFreeFilter.isDefault === true){

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -393,10 +393,12 @@ query.controller('SearchQueryCtrl', [
           }
         }
 
-        //-non free-
+        //-default non free-
         const defNonFree = session.user.permissions ? session.user.permissions.showPaid : undefined;
         storage.setJs("defaultIsNonFree", defNonFree ? defNonFree : false, true);
-        raisePayableImagesEvent(defNonFree);
+        if($stateParams.nonFree === undefined && (defNonFree === true || defNonFree === "true")) {
+          raisePayableImagesEvent(defNonFree);
+        }
 
         const isNonFree = storage.getJs("isNonFree", true);
         if (isNonFree === null) {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -128,7 +128,6 @@ query.controller('SearchQueryCtrl', [
 
       ctrl.collectionSearch = newFilter.query ? newFilter.query.indexOf('~') === 0 : false;
       watchUploadedBy(newFilter, sender);
-      raiseQueryChangeEvent(newFilter.query);
 
       const defaultNonFreeFilter = storage.getJs("defaultNonFreeFilter", true);
       if (defaultNonFreeFilter && defaultNonFreeFilter.isDefault === true){
@@ -140,7 +139,10 @@ query.controller('SearchQueryCtrl', [
           ctrl.filter.orgOwned = false;
         }
         Object.assign(ctrl.filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
+        raiseFilterChangeEvent(ctrl.filter);
       }
+
+      raiseQueryChangeEvent(ctrl.filter.query);
 
       const structuredQuery = structureQuery(newFilter.query) || [];
       const orgOwnedIndexInQuery = structuredQuery.findIndex(item => item.value === ctrl.maybeOrgOwnedValue);


### PR DESCRIPTION
## What does this change do?

The BBC introduced a new set of controls - permissions filter, show payable images, sort control and my uploads - written in react to display in a second tier toolbar at the top of the page when the kahuna config variable usePermissionsFilter is set yo true. It's been found that problems with the interop between AngularJS and React have introduced some regressions to the system functionality (along with some missed specifications). This PR corrects these regressions whilst ensuring continuing operation when permisisons filter is off.

Areas impacted:
- clicking the logo button should clear the filter and set the 'Show Payable Images' control in-line with user type - on for Archivists and off for standard users
- selecting My Uploads control show turn show payable images on so that any user uploaded images without a rights category are also shown. Unchecking the control should turn show payable images off (this was missed specification and so is new functionality)
- selecting 'View All Your Uploads' from the uploads page should return to the search page and set 'show payable images' to on along with the 'my uploads' control checked
- use of logo or search from uploads page should return to search page with clear search (this is the default url /search)
- use of back button from uploads page of image view should return to search page with search retained.
- when pasting urls into a browser tab all controls should be set to match the values in the url

View of permissions filter layout:
![Screenshot 2024-08-29 at 10 08 13](https://github.com/user-attachments/assets/687d6452-9172-4dd7-8682-cc83a2d3a845)

Behaviour of system with permissions filter off should be unaltered. View of permissions filter off;
![Screenshot 2024-08-29 at 10 13 56](https://github.com/user-attachments/assets/7c8639c1-741a-439d-8743-a3e763bc8a02)

## How should a reviewer test this change?

Ensure that all the impacted functional areas behave as expected and described.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
