### PR TITLE
Is softDeleted clause might be able to run in 1/3 the time

### DIFF
--- a/media-api/app/lib/elasticsearch/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/IsQueryFilter.scala
@@ -64,7 +64,7 @@ case class IsUnderQuota(overQuotaAgencies: List[Agency]) extends IsQueryFilter {
 
 case class IsDeleted(isDeleted: Boolean) extends IsQueryFilter {
   override def query: Query = filters.or(
-    (filters.existsOrMissing("softDeletedMetadata", _))(isDeleted)
+    (filters.existsOrMissing("softDeletedMetadata.deletedTime", _))(isDeleted)
   )
 }
 


### PR DESCRIPTION
Raising in case anyone want's to try this on a real, large index.

Without blindly believing profilers, the profiler output suggests that a 2 way Boolean query might be able to replaced with a more targeted single field lookup.

When examined in the profile output, the exists `softDeletedMetadata` clause seems to get expanded into this: `"description" : "-ConstantScore(DocValuesFieldExistsQuery [field=softDeletedMetadata.deletedBy] DocValuesFieldExistsQuery [field=softDeletedMetadata.deleteTime]) #*:*",`

This probably means if any of the known indexed fields of `softDeletedMetadata` exist then so does `softDeletedMetadata`. If we assume that `softDeletedMetadata.deletedTime` exists for all softDeletedMetadata records then the profiled `time_in_nanos` drops to 1/3 of the original value.

Hard to show real world results in a dev machine where the index fits in a single node's RAM, but in theory this might speed up the expensive count all and find first page of all queries on the initial page load.

Given that the initial page load time is single digit seconds, this might have a real user facing impact.

Specifying a specific field name is more fragile than the current clause so the improvement needs to be worth it.

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
