### PR TITLE
improves the error flow in updateUploadStatusTable

### DIFF
--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -444,17 +444,18 @@ class ImageLoaderController(auth: Authentication,
     }
   }
 
-  private def updateUploadStatusTable (
+  private def updateUploadStatusTable(
     uploadAttempt: Future[UploadStatusUri],
     digestedFile: DigestedFile
-  )(implicit logMarker:LogMarker): Future[Unit] = {
+  )(implicit logMarker: LogMarker): Future[Unit] = {
 
-    def reportFailure (error:Throwable): Unit = {
+    def reportFailure(error: Throwable): Unit = {
       val errorMessage = s"an error occurred while updating image upload status, error:$error"
       logger.error(logMarker, errorMessage, error)
       Future.failed(new Exception(errorMessage))
     }
-    def reportScanamoError (error:ScanamoError): Unit = {
+
+    def reportScanamoError(error: ScanamoError): Unit = {
       val errorMessage = error match {
         case ConditionNotMet(_) => s"ConditionNotMet error occurred while updating image upload status, image-id:${digestedFile.digest}, error:$error"
         case _ => s"an error occurred while updating image upload status, image-id:${digestedFile.digest}, error:$error"
@@ -463,34 +464,24 @@ class ImageLoaderController(auth: Authentication,
       Future.failed(new Exception(errorMessage))
     }
 
-    uploadAttempt
-      .recover {
-        case uploadFailure =>
-          uploadStatusTable.updateStatus(  //FIXME use set status to avoid potential ConditionNotMet (when status table rows have expired/TTL)
+    uploadAttempt.transformWith {
+        case Failure(uploadFailure) =>
+          uploadStatusTable.updateStatus( //FIXME use set status to avoid potential ConditionNotMet (when status table rows have expired/TTL)
             digestedFile.digest,
             UploadStatus(StatusType.Failed, Some(s"${uploadFailure.getClass.getName}: ${uploadFailure.getMessage}"))
           )
-            .recover {
-              case error => reportFailure(error)
-            }
-            .map {
-              case Left(error:ScanamoError) => reportScanamoError(error)
-              case Right => uploadFailure
-            }
-      }
-      .map {
-        case uploadStatusUri:UploadStatusUri =>
-          uploadStatusTable.updateStatus(  //FIXME use set status to avoid potential ConditionNotMet (when status table rows have expired/TTL)
+
+        case Success(_) =>
+          uploadStatusTable.updateStatus( //FIXME use set status to avoid potential ConditionNotMet (when status table rows have expired/TTL)
             digestedFile.digest,
             UploadStatus(StatusType.Completed, None)
           )
-            .recover {
-              case error => reportFailure(error)
-            }
-            .map {
-              case Left(error:ScanamoError) => reportScanamoError(error)
-              case Right => uploadStatusUri
-            }
+      }
+      .map {
+        case Left(error: ScanamoError) => reportScanamoError(error)
+        case Right(_) => ()
+      }.recover {
+        case error => reportFailure(error)
       }
   }
 


### PR DESCRIPTION


## What does this change?

Currently we recover from the uploadAttempt before we continue on the happy path, which means that the future is turned from a failure to a success, but holding the exception from the previous failure, which of course fails the pattern match, leaving us with a very confusing stack trace. Instead handle both success and failure cases by using a `transformWith`, which provides the bonus that we can handle the table update failure cases together

## How should a reviewer test this change?



## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
