### PR TITLE
post empty images array with user hits escape

### DIFF
--- a/kahuna/public/js/main.js
+++ b/kahuna/public/js/main.js
@@ -303,6 +303,17 @@ kahuna.run(['$rootScope', '$window', '$q', 'getEntity',
         images
       }));
     });
+
+    // If the user hits Escape, emit an event representing
+    // "0 crops created". The embedding application (parent)
+    // can respond to the event by closing its Grid dialog.
+    document.addEventListener('keydown', (keyEvent) => {
+      if (keyEvent.code === 'Escape') {
+        postMessage({
+          images:[]
+        })
+      }
+    })
 }]);
 
 


### PR DESCRIPTION
## What does this change?

Adds an "key down" event listener to the document to post a message event to the parent window (IE, if the Grid is being used in an iframe, the window that has the iframe) representing an empty array of images when the user hits the "Escape" key.

The intent is to allow the Grid to communicate the event to the parent application in a way consistent with the messages posted to communicate the user selecting or creating one of more crops - there are currently different formats for data representing one crop (object with `image` and `crop` fields) and multiple crops (object with `images` field, which is an array of those objects ) - the "Escape" key event equates to "0x image crops selected".

Did consider haveing the parent application attach the listener, but because the parent application is not necessarily on the same domain as the Grid, it won't always be possible to for it to listen to event on the grid iframe's content window:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentWindow#description

## issues 
Some controls in the Grid use the escape key - if a user was using them within the Iframe and hit escape, it should only close the control, not the whole window. May need to look a way to check the UI state before emitting the 'close' event

## How should a reviewer test this change?

There should be no effect when the Grid is running in its own window the message will be posted, when the escape key is pressed, but not listened to.

TO DO - testing plan for embedding applications:
 - composer
 - facia-tool
 - media-atom-maker
 - atom-workshop.


## How can success be measured?

Embedding applications can react to the escape key when the Grid Iframe has focussed (usually by closing the dialog)

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
