### PR TITLE
Ensure scroll posotion resets to top when logo clicked

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -10,6 +10,7 @@ import './results';
 import '../preview/image';
 import '../lib/data-structure/list-factory';
 import '../lib/data-structure/ordered-set-factory';
+import '../services/scroll-position';
 import '../components/gr-top-bar/gr-top-bar';
 import '../components/gr-info-panel/gr-info-panel';
 import '../components/gr-collections-panel/gr-collections-panel';
@@ -35,6 +36,7 @@ export var search = angular.module('kahuna.search', [
     'kahuna.search.query',
     'kahuna.search.results',
     'kahuna.preview.image',
+    'kahuna.services.scroll-position',
     'data-structure.list-factory',
     'data-structure.ordered-set-factory',
     'gr.topBar',
@@ -85,9 +87,9 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         },
         controllerAs: 'ctrl',
         controller: [
-            '$scope', '$window', '$stateParams', 'panels', 'shortcutKeys', 'keyboardShortcut',
+            '$scope', '$window', '$stateParams', 'scrollPosition', 'panels', 'shortcutKeys', 'keyboardShortcut',
             'panelService', 'cropSettings', 'mediaApi', 'storage', '$state',
-            function($scope, $window, $stateParams, panels, shortcutKeys, keyboardShortcut,
+            function($scope, $window, $stateParams, scrollPosition, panels, shortcutKeys, keyboardShortcut,
                      panelService, cropSettings, mediaApi, storage, $state) {
 
             const ctrl = this;
@@ -115,6 +117,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
                   detail: {showPaid: defaultNonFreeFilter.isNonFree},
                   bubbles: true
                 }));
+                scrollPosition.resetToTop();
               });
             };
 

--- a/kahuna/public/js/services/scroll-position.js
+++ b/kahuna/public/js/services/scroll-position.js
@@ -12,6 +12,9 @@ scrollPosService.factory('scrollPosition',
     // The original context where the position was saved
     let originalContext;
 
+    // Enable reset to top on next save
+    let forceReset = false;
+
     function save(currentContext) {
         // deal with url ambiguity over nonFree parameter
         if (!currentContext.nonFree) {
@@ -19,7 +22,12 @@ scrollPosService.factory('scrollPosition',
         }
         originalContext = currentContext;
         // Accommodate Chrome & Firefox
-        positionTop = document.body.scrollTop || document.documentElement.scrollTop;
+        if (forceReset) {
+          forceReset = false;
+          positionTop = 0;
+        } else {
+          positionTop = document.body.scrollTop || document.documentElement.scrollTop;
+        }
     }
 
     function resume(currentContext) {
@@ -41,11 +49,16 @@ scrollPosService.factory('scrollPosition',
         originalContext = undefined;
     }
 
+    function resetToTop() {
+      forceReset = true;
+    }
+
     return {
         save,
         resume,
         getSaved,
-        clear
+        clear,
+        resetToTop
     };
 }]);
 


### PR DESCRIPTION
## What does this change?

This PR fixes a regression introduced through a combination of PRs that removed ambiguity regarding the 'nonFree' parameter in the current search context. Previously when the logo was clicked the search returned to the top of the page i.e. positionTop = 0 - the code was recording the position of the scroll when the logo was clicked but the setting of nonFree to undefined ensured that the contexts did not match and thus the scroll was no reset to its previous location.

The introduction of typescript react contros has made the use of nonFree = undefined problematic as typescript won't accept that value for a boolean so we have had to do introduce some code changes to ensure both scrolling and page navigation work correctly by removing the ambiguity of nonFree = false/undefined - in some areas the code relied on these being equivalent and in others it required them to be treated as different - e.g. resetting scroll position.

The recent PR to fix issues around page to page navigation and providing correct nonFree values to typescript controls removed further ambiguity around the nonFree parameter such that during logo click process the contexts evaluate as equal and thus the scroll position was reset to its previous value rather than being left at page-top.

The removal of the ambiguity around nonFree is required for other navigations to operate correctly with the typescript controls and so this PR introduces a new function for the scroll service to allow user to say 'reset to top' - this function is called during the logo click process and ensure that positionTop is set to 0 and thus when the contexts evaluate to equal the reset scroll position is now top.

## How should a reviewer test this change?

Ensure that on logo click the page resets to the top of the image list.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
