### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ val maybeBBCLib: Option[sbt.ProjectReference] = if(bbcBuildProcess) Some(bbcProj
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "3.0.0",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "7.0.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
@@ -49,7 +49,7 @@ class PandaAuthenticationProvider(
     val pandaStatus = extractAuth(request)
     val providerStatus = pandaStatus match {
       case PandaNotAuthenticated => NotAuthenticated
-      case PandaInvalidCookie(e) => Invalid("error checking user's auth, clear cookie and re-auth", Some(e))
+      case PandaInvalidCookie(e) => Invalid(s"error checking user's auth, clear cookie and re-auth (${e.getClass.getSimpleName})")
       case PandaExpired(authedUser) => Expired(gridUserFrom(authedUser.user, request))
       case PandaGracePeriod(authedUser) => Authenticated(gridUserFrom(authedUser.user, request))
       case PandaNotAuthorised(authedUser) => NotAuthorised(s"${authedUser.user.email} not authorised to use application")


### PR DESCRIPTION
This upgrades Panda from v5 to v7, allowing us to use key rotation as introduced with guardian/pan-domain-authentication#150.

This PR sits on top of:

* #4329  - because [Panda v7](https://github.com/guardian/pan-domain-authentication/releases/tag/v7.0.0) requires Java 11.

### Testing

Successfully [deployed](https://riffraff.gutools.co.uk/deployment/view/4d33116d-b01e-45f0-a56e-2c70cbae050a) to TEST at 8180d55af336f1113a5890e65d6bb075f2e328b6:

https://github.com/user-attachments/assets/bb174d3a-fa71-42d0-90ac-5b3c68f7cf49

