### PR TITLE
[GNM only] add gutters to 5:3 cropping box, to show what will be clipped if used in a 5:4 space (with explainer) - BEHIND FEATURE SWITCH FOR NOW

### DIFF
--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -112,7 +112,7 @@ function getKahunaConfig(config){
         |links.supportEmail="${config.links.supportEmail}"
         |security.cors.allowedOrigins="${getCorsAllowedOriginString(config)}"
         |security.frameAncestors="https://*.${config.DOMAIN}"
-        |security.imageSources=["https://*.newslabs.co/"]
+        |security.imageSources=["https://*.newslabs.co/", ]
         |metrics.request.enabled=false
         |usageRightsSummary=true
         |${permissionsConfig}

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, BaseControllerWithLoginRedirects}
-import lib.{ExampleSwitch, FeatureSwitches, KahunaConfig}
+import lib.{ExampleSwitch, FeatureSwitches, KahunaConfig, ShowCroppingGuttersSwitch}
 import play.api.mvc.ControllerComponents
 import play.api.libs.json._
 
@@ -38,7 +38,7 @@ class KahunaController(
 
     val isIFramed = request.headers.get("Sec-Fetch-Dest").contains("iframe")
     val featureSwitches = new FeatureSwitches(
-      List(ExampleSwitch)
+      List(if(config.staffPhotographerOrganisation == "GNM") ShowCroppingGuttersSwitch else ExampleSwitch)
     )
     val featureSwitchesWithClientValues = featureSwitches.getClientSwitchValues(featureSwitches.getFeatureSwitchCookies(request.cookies.get))
     val featureSwitchesJson = Json.stringify(Json.toJson(featureSwitches.getFeatureSwitchesToStringify(featureSwitchesWithClientValues)))

--- a/kahuna/app/lib/FeatureSwitch.scala
+++ b/kahuna/app/lib/FeatureSwitch.scala
@@ -10,6 +10,12 @@ object ExampleSwitch extends FeatureSwitch(
   default = false
 )
 
+object ShowCroppingGuttersSwitch extends FeatureSwitch(
+  key = "show-cropping-gutters-switch",
+  title = "Display gutters on 5:3 crops to show what would be clipped if used in a 5:4 space",
+  default = false
+)
+
 class FeatureSwitches(featureSwitches: List[FeatureSwitch]){
   // Feature switches are defined here, but updated by setting a cookie following the pattern e.g. "feature-switch-my-key"
   // for a switch called "my-key".

--- a/kahuna/public/js/components/gr-feature-switch-panel/gr-feature-switch-panel.module.css
+++ b/kahuna/public/js/components/gr-feature-switch-panel/gr-feature-switch-panel.module.css
@@ -40,7 +40,7 @@ th {
   position: fixed;
   top: 50px;
   right: 0px;
-  width: 400px;
+  width: 400px !important;
   background-color: #333;
   box-shadow: 2px 2px 10px rgba(0,0,0, 0.8);
 }

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -3,6 +3,8 @@ import angular from 'angular';
 import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
 import {radioList} from '../components/gr-radio-list/gr-radio-list';
 import {cropUtil} from "../util/crop";
+import {cropOptions} from "../util/constants/cropOptions";
+import {getFeatureSwitchActive} from "../components/gr-feature-switch-panel/gr-feature-switch-panel";
 
 const crop = angular.module('kahuna.crop.controller', [
   'gr.keyboardShortcut',
@@ -177,6 +179,12 @@ crop.controller('ImageCropCtrl', [
 
       $scope.$watch('ctrl.cropType', (newCropType, oldCropType) => {
         const isCropTypeDisabled = ctrl.cropOptions.find(_ => _.key === newCropType).disabled;
+
+        const maybeCropRatioIfStandard = cropOptions.find(_ => _.key === ctrl.cropType)?.ratioString;
+        ctrl.shouldShowVerticalWarningGutters =
+          getFeatureSwitchActive("show-cropping-gutters-switch")
+          && window._clientConfig.staffPhotographerOrganisation === "GNM"
+          && maybeCropRatioIfStandard === "5:3";
 
         if (isCropTypeDisabled) {
           ctrl.cropType = oldCropType;

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -101,7 +101,13 @@
     Please try to use a larger crop or an alternative image.
 </div>
 
-<div class="easel" role="main" aria-label="Image cropper">
+<div class="warning status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
+    Although this is a 5:3 crop, it might be used in a 5:4 space, so please ensure
+    there is nothing important in the striped sides as these might be clipped.
+</div>
+
+<div class="easel" role="main" aria-label="Image cropper"
+     ng-class="{'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters}">
     <div class="easel__canvas">
         <div class="easel__image-container" oncontextmenu="return false;">
             <img class="easel__image easel__image--cropper"

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -41,3 +41,28 @@
   background-position: 0 0, 10px 0, 10px -10px, 0px 10px;
 }
 
+
+
+/* GUTTERS to show what will be clipped if the 5:3 crop is used in 5:4 space */
+.easel.vertical-warning-gutters .cropper-view-box::before,
+.easel.vertical-warning-gutters .cropper-view-box::after {
+  display: block;
+  content: '';
+  position: absolute;
+  z-index: 999;
+  width: 12.5%;
+  top: 0;
+  bottom: 0;
+  mix-blend-mode: difference;
+}
+.easel.vertical-warning-gutters .cropper-view-box::before { /* left gutter */
+  left: 0;
+  background: repeating-linear-gradient(-45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
+}
+.easel.vertical-warning-gutters .cropper-view-box::after { /* right gutter */
+  right: 0;
+  background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
+}
+.easel.vertical-warning-gutters .easel__canvas {
+  height: calc(100vh - 115px);
+}

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -902,6 +902,10 @@ textarea.ng-invalid {
     background-color: orange;
 }
 
+.status--info {
+  background-color: #5E9ED6;
+}
+
 .status--valid {
     background-color: green;
 }


### PR DESCRIPTION
In some cases 5:3 crops need to be used in 5:4 spaces, and currently the sides are clipped off by platforms, sometimes undesirably. 

## What does this change?
This PR aims to reduce the likelihood that images displayed this way will need recropping, by presenting striped gutters on the left/right for landscape 5:3 crops. With explainer to suggest, not having anything important in the striped gutters when cropping 5:3 in anticipation of it being used in 5:4 space.

This is implemented using `::before` and `::after` CSS pseudo elements as this seemed the most pragmatic rather than attempting to do '_officially_' via jcrop (might have needed a major upgrade to accomplish) and the CSS selectors used seem sufficiently stable/simple.

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## Images
### 5:3
![image](https://github.com/user-attachments/assets/bcfeef30-20a6-4f7b-9187-57870465dec5)

### other ratios (e.g. 1:1 square crop)
note how there are no striped gutters / explainer
![image](https://github.com/user-attachments/assets/5cd5a27b-9e5e-41dc-8fc3-2289677e50ba)

### feature switch to enable
Using the lovely feature switch panel added in #3964 - Ctrl + Shift + F12 to activate the feature switch panel...
![image](https://github.com/user-attachments/assets/27493646-3ae9-4795-ba0c-4f1b0dd8f288)


<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?
We mitigate the need for more major efforts to support the 5:4 use case.

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
