### PR TITLE
add `seedCropId` optional query param for the `/crop` endpoint for an image and use the dimensions to set the starting point of the crop

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -78,12 +78,17 @@ crop.controller('ImageCropCtrl', [
       ctrl.maxInputY = () =>
         ctrl.originalHeight - ctrl.cropHeight();
 
+      const maybeSeedCropId = $stateParams.seedCropId;
+      const [maybeSeedX1, maybeSeedY1, maybeSeedX2, maybeSeedY2] = maybeSeedCropId?.split("_") || [];
+
+      // TODO attempt centering if seed crop dimensions don't fit
+
       ctrl.coords = {
-        x1: ctrl.inputX,
-        y1: ctrl.inputY,
+        x1: maybeSeedX1 || ctrl.inputX,
+        y1: maybeSeedY1 || ctrl.inputY,
         // fill the image with the selection
-        x2: ctrl.originalWidth,
-        y2: ctrl.originalHeight
+        x2: maybeSeedX2 || ctrl.originalWidth,
+        y2: maybeSeedY2 || ctrl.originalHeight
       };
 
       // If we have a square crop, remove any jitter introduced by client lib by using only one side


### PR DESCRIPTION
… 

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
