### PR TITLE
Ensures that scroll position is reset to top when Logo is clicked when no search criteria are entered

### DIFF
--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -138,10 +138,8 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     if (sessionStorage) {
       const defNonFree = sessionStorage.getItem("defaultIsNonFree");
       const payEvent = sessionStorage.getItem("payableImagesEvent");
-      console.log("SessionStorage values defNonFree = " + defNonFree + " payEvent = " + payEvent);
       if ("true" == payEvent) {
-        console.log("Setting Chargeable by PayEvent");
-        sessionStorage.setItem("payableImagesEvent", "false");
+        sessionStorage.setItem("payableImagesEvent", 'false');
         setIsChargeable("true" == defNonFree);
       }
     }

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -135,6 +135,9 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     window.addEventListener('scroll', autoHideListener);
     window.addEventListener('keydown', autoHideListener);
     setSelection(defPerms);
+    if (sessionStorage && sessionStorage.getItem("defaultIsNonFree")) {
+      setIsChargeable("true" == sessionStorage.getItem("defaultIsNonFree"));
+    }
 
     // Clean up the event listener when the component unmounts
     return () => {

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -135,10 +135,14 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     window.addEventListener('scroll', autoHideListener);
     window.addEventListener('keydown', autoHideListener);
     setSelection(defPerms);
-    if (sessionStorage && sessionStorage.getItem("defaultIsNonFree") && sessionStorage.getItem("payableImagesEvent")) {
-      if ("true" == sessionStorage.getItem("payableImagesEvent")) {
+    if (sessionStorage) {
+      const defNonFree = sessionStorage.getItem("defaultIsNonFree");
+      const payEvent = sessionStorage.getItem("payableImagesEvent");
+      console.log("SessionStorage values defNonFree = " + defNonFree + " payEvent = " + payEvent);
+      if ("true" == payEvent) {
+        console.log("Setting Chargeable by PayEvent");
         sessionStorage.setItem("payableImagesEvent", "false");
-        setIsChargeable("true" == sessionStorage.getItem("defaultIsNonFree"));
+        setIsChargeable("true" == defNonFree);
       }
     }
 

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -135,14 +135,6 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     window.addEventListener('scroll', autoHideListener);
     window.addEventListener('keydown', autoHideListener);
     setSelection(defPerms);
-    if (sessionStorage) {
-      const defNonFree = sessionStorage.getItem("defaultIsNonFree");
-      const payEvent = sessionStorage.getItem("payableImagesEvent");
-      if ("true" == payEvent) {
-        sessionStorage.setItem("payableImagesEvent", 'false');
-        setIsChargeable("true" == defNonFree);
-      }
-    }
 
     // Clean up the event listener when the component unmounts
     return () => {

--- a/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
+++ b/kahuna/public/js/components/gr-permissions-filter/gr-permissions-filter.tsx
@@ -135,8 +135,11 @@ const PermissionsFilter: React.FC<PermissionsWrapperProps> = ({ props }) => {
     window.addEventListener('scroll', autoHideListener);
     window.addEventListener('keydown', autoHideListener);
     setSelection(defPerms);
-    if (sessionStorage && sessionStorage.getItem("defaultIsNonFree")) {
-      setIsChargeable("true" == sessionStorage.getItem("defaultIsNonFree"));
+    if (sessionStorage && sessionStorage.getItem("defaultIsNonFree") && sessionStorage.getItem("payableImagesEvent")) {
+      if ("true" == sessionStorage.getItem("payableImagesEvent")) {
+        sessionStorage.setItem("payableImagesEvent", "false");
+        setIsChargeable("true" == sessionStorage.getItem("defaultIsNonFree"));
+      }
     }
 
     // Clean up the event listener when the component unmounts

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 
 import '../util/rx';
 import '../services/image/usages';
+import '../services/scroll-position';
 import '../image/service';
 import '../edits/service';
 
@@ -30,6 +31,7 @@ import { List } from 'immutable';
 const image = angular.module('kahuna.image.controller', [
   'util.rx',
   'kahuna.edits.service',
+  'kahuna.services.scroll-position',
   'gr.image.service',
   'gr.image-usages.service',
 
@@ -74,6 +76,7 @@ image.controller('ImageCtrl', [
   'imageService',
   'imageUsagesService',
   'editsService',
+  'scrollPosition',
   'keyboardShortcut',
   'cropSettings',
   'globalErrors',
@@ -96,6 +99,7 @@ image.controller('ImageCtrl', [
             imageService,
             imageUsagesService,
             editsService,
+            scrollPosition,
             keyboardShortcut,
             cropSettings,
             globalErrors) {
@@ -212,6 +216,10 @@ image.controller('ImageCtrl', [
       // a bit nasty - but it updates the state of the page better than trying to do that in
       // the client.
       $state.go('image', {imageId: ctrl.image.data.id, crop: undefined}, {reload: true});
+    };
+
+    ctrl.onLogoClick = () => {
+      scrollPosition.resetToTop();
     };
 
     // TODO: move this to a more sensible place.

--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -30,6 +30,7 @@ import {cropUtil} from '../util/crop';
 import { List } from 'immutable';
 const image = angular.module('kahuna.image.controller', [
   'util.rx',
+  'util.storage',
   'kahuna.edits.service',
   'kahuna.services.scroll-position',
   'gr.image.service',
@@ -67,6 +68,7 @@ image.controller('ImageCtrl', [
   '$window',
   '$filter',
   'inject$',
+  'storage',
   'image',
   'mediaApi',
   'optimisedImageUri',
@@ -90,6 +92,7 @@ image.controller('ImageCtrl', [
             $window,
             $filter,
             inject$,
+            storage,
             image,
             mediaApi,
             optimisedImageUri,
@@ -219,7 +222,19 @@ image.controller('ImageCtrl', [
     };
 
     ctrl.onLogoClick = () => {
-      scrollPosition.resetToTop();
+      mediaApi.getSession().then(session => {
+        const showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
+        const defaultNonFreeFilter = {
+          isDefault: true,
+          isNonFree: showPaid ? showPaid : false
+        };
+        storage.setJs("defaultNonFreeFilter", defaultNonFreeFilter, true);
+        window.dispatchEvent(new CustomEvent("logoClick", {
+          detail: {showPaid: defaultNonFreeFilter.isNonFree},
+          bubbles: true
+        }));
+        scrollPosition.resetToTop();
+      });
     };
 
     // TODO: move this to a more sensible place.

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -400,7 +400,6 @@ query.controller('SearchQueryCtrl', [
         if (ctrl.usePermissionsFilter && !ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
           ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
-          //storage.setJs("payableImagesEvent", true, true);
         }
 
         const isNonFree = storage.getJs("isNonFree", true);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -152,6 +152,7 @@ query.controller('SearchQueryCtrl', [
             ctrl.filter.orgOwned = false;
           }
           Object.assign(ctrl.filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
+          console.log("(155) Assigning nonFree to " + newNonFree);
           raiseFilterChangeEvent(ctrl.filter);
         }
     }
@@ -200,6 +201,7 @@ query.controller('SearchQueryCtrl', [
         nonFreeCheck = undefined;
       }
       ctrl.filter.nonFree = nonFreeCheck;
+      console.log("(204) Setting nonFree to " + nonFreeCheck);
       raiseQueryChangeEvent(ctrl.filter.query);
 
       sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe);
@@ -239,11 +241,13 @@ query.controller('SearchQueryCtrl', [
       ctrl.permissionsProps.selectedOption = permissionsSel;
       ctrl.filter.query = updateFilterChips(permissionsSel, ctrl.filter.query);
       ctrl.filter.nonFree = showChargeable;
+      console.log("(244) Permissions Filter : Nonfree = " + showChargeable);
       watchSearchChange(ctrl.filter, "updatePermissionsChips");
     }
 
     function chargeableChange (showChargeable) {
       ctrl.filter.nonFree = showChargeable;
+      console.log("(250) Chargeable change : Nonfree = " + showChargeable);
       watchSearchChange(ctrl.filter, "chargeableChange");
     }
 
@@ -405,12 +409,14 @@ query.controller('SearchQueryCtrl', [
         const isNonFree = storage.getJs("isNonFree", true);
         if (isNonFree === null) {
           ctrl.filter.nonFree = $stateParams.nonFree;
+          console.log("(412) Setting nonFree from stateParams = " + $stateParams.nonFree);
           storage.setJs("isNonFree", ctrl.filter.nonFree ? ctrl.filter.nonFree : (ctrl.usePermissionsFilter ? "false" : undefined), true);
         }
         else if (isNonFree === true || isNonFree === "true") {
           ctrl.filter.nonFree = "true";
         } else {
           ctrl.filter.nonFree = (ctrl.usePermissionsFilter ? "false" : undefined);
+          console.log("(419) From isNonFree = false");
         }
 
         //-org owned-

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -404,6 +404,7 @@ query.controller('SearchQueryCtrl', [
         if (!ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
           ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
+          storage.setJs("payableImagesEvent", "true", true);
         }
 
         const isNonFree = storage.getJs("isNonFree", true);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -397,13 +397,10 @@ query.controller('SearchQueryCtrl', [
         //-default non free-
         const defNonFree = session.user.permissions ? session.user.permissions.showPaid : undefined;
         storage.setJs("defaultIsNonFree", defNonFree ? defNonFree : false, true);
-        if (!ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
+        if (ctrl.usePermissionsFilter && !ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
           ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
-          storage.setJs("payableImagesEvent", true, true);
-          if (!ctrl.usePermissionsFilter) {
-            storage.setJs("isNonFree", true, true);
-          }
+          //storage.setJs("payableImagesEvent", true, true);
         }
 
         const isNonFree = storage.getJs("isNonFree", true);
@@ -421,6 +418,7 @@ query.controller('SearchQueryCtrl', [
         const structuredQuery = structureQuery(ctrl.filter.query);
         const orgOwned = (structuredQuery.some(item => item.value === ctrl.maybeOrgOwnedValue));
         ctrl.filter.orgOwned = orgOwned;
+        watchSearchChange(ctrl.filter, "userPermissions");
     });
 
     function resetQuery() {

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -73,7 +73,7 @@ query.controller('SearchQueryCtrl', [
 
     ctrl.usePermissionsFilter = window._clientConfig.usePermissionsFilter;
     ctrl.filterMyUploads = false;
-    ctrl.initialShowPaidEvent = ($stateParams.nonFree === undefined) ? false : true;
+    ctrl.initialShowPaidEvent = ($stateParams.nonFree === undefined && ctrl.usePermissionsFilter) ? false : true;
 
     //--react - angular interop events--
     function raisePayableImagesEvent(showPaid) {
@@ -177,6 +177,11 @@ query.controller('SearchQueryCtrl', [
           structuredQuery.splice(orgOwnedIndexInQuery, 1);
           ctrl.filter.query = renderQuery(structuredQuery);
         }
+    }
+
+    function resetQuery() {
+        ctrl.filter.query = undefined;
+        ctrl.filter.orgOwned = false;
     }
 
     // eslint-disable-next-line complexity
@@ -397,7 +402,7 @@ query.controller('SearchQueryCtrl', [
         //-default non free-
         const defNonFree = session.user.permissions ? session.user.permissions.showPaid : undefined;
         storage.setJs("defaultIsNonFree", defNonFree ? defNonFree : false, true);
-        if (ctrl.usePermissionsFilter && !ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
+        if (!ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
           ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
         }
@@ -417,13 +422,11 @@ query.controller('SearchQueryCtrl', [
         const structuredQuery = structureQuery(ctrl.filter.query);
         const orgOwned = (structuredQuery.some(item => item.value === ctrl.maybeOrgOwnedValue));
         ctrl.filter.orgOwned = orgOwned;
+
         watchSearchChange(ctrl.filter, "userPermissions");
     });
 
-    function resetQuery() {
-        ctrl.filter.query = undefined;
-        ctrl.filter.orgOwned = false;
-    }
+
 
     const { nonFree, uploadedByMe } = ctrl.filter;
     sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -404,7 +404,7 @@ query.controller('SearchQueryCtrl', [
         if (!ctrl.initialShowPaidEvent && (defNonFree === true || defNonFree === "true")) {
           ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
-          storage.setJs("payableImagesEvent", "true", true);
+          storage.setJs("payableImagesEvent", true, true);
         }
 
         const isNonFree = storage.getJs("isNonFree", true);

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -152,7 +152,6 @@ query.controller('SearchQueryCtrl', [
             ctrl.filter.orgOwned = false;
           }
           Object.assign(ctrl.filter, {nonFree: newNonFree, uploadedByMe: false, uploadedBy: undefined});
-          console.log("(155) Assigning nonFree to " + newNonFree);
           raiseFilterChangeEvent(ctrl.filter);
         }
     }
@@ -201,7 +200,6 @@ query.controller('SearchQueryCtrl', [
         nonFreeCheck = undefined;
       }
       ctrl.filter.nonFree = nonFreeCheck;
-      console.log("(204) Setting nonFree to " + nonFreeCheck);
       raiseQueryChangeEvent(ctrl.filter.query);
 
       sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe);
@@ -241,13 +239,11 @@ query.controller('SearchQueryCtrl', [
       ctrl.permissionsProps.selectedOption = permissionsSel;
       ctrl.filter.query = updateFilterChips(permissionsSel, ctrl.filter.query);
       ctrl.filter.nonFree = showChargeable;
-      console.log("(244) Permissions Filter : Nonfree = " + showChargeable);
       watchSearchChange(ctrl.filter, "updatePermissionsChips");
     }
 
     function chargeableChange (showChargeable) {
       ctrl.filter.nonFree = showChargeable;
-      console.log("(250) Chargeable change : Nonfree = " + showChargeable);
       watchSearchChange(ctrl.filter, "chargeableChange");
     }
 
@@ -410,14 +406,12 @@ query.controller('SearchQueryCtrl', [
         const isNonFree = storage.getJs("isNonFree", true);
         if (isNonFree === null) {
           ctrl.filter.nonFree = $stateParams.nonFree;
-          console.log("(412) Setting nonFree from stateParams = " + $stateParams.nonFree);
           storage.setJs("isNonFree", ctrl.filter.nonFree ? ctrl.filter.nonFree : (ctrl.usePermissionsFilter ? "false" : undefined), true);
         }
         else if (isNonFree === true || isNonFree === "true") {
           ctrl.filter.nonFree = "true";
         } else {
           ctrl.filter.nonFree = (ctrl.usePermissionsFilter ? "false" : undefined);
-          console.log("(419) From isNonFree = false");
         }
 
         //-org owned-

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -401,6 +401,9 @@ query.controller('SearchQueryCtrl', [
           ctrl.initialShowPaidEvent = true;
           raisePayableImagesEvent(defNonFree);
           storage.setJs("payableImagesEvent", true, true);
+          if (!ctrl.usePermissionsFilter) {
+            storage.setJs("isNonFree", true, true);
+          }
         }
 
         const isNonFree = storage.getJs("isNonFree", true);

--- a/kahuna/public/js/services/scroll-position.js
+++ b/kahuna/public/js/services/scroll-position.js
@@ -22,18 +22,17 @@ scrollPosService.factory('scrollPosition',
         }
         originalContext = currentContext;
         // Accommodate Chrome & Firefox
-        if (forceReset) {
-          forceReset = false;
-          positionTop = 0;
-        } else {
-          positionTop = document.body.scrollTop || document.documentElement.scrollTop;
-        }
+        positionTop = document.body.scrollTop || document.documentElement.scrollTop;
     }
 
     function resume(currentContext) {
         // deal with url ambiguity over nonFree parameter
         if (!currentContext.nonFree) {
           currentContext.nonFree = "false";
+        }
+        if (forceReset) {
+          forceReset = false;
+          positionTop = 0;
         }
         if (angular.equals(currentContext, originalContext)) {
             $window.scrollTo(0, positionTop);

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -2,13 +2,15 @@ import angular from 'angular';
 import './controller.css';
 import './prompt/prompt';
 import './recent/recent-uploads';
+import '../services/scroll-position';
 
 var upload = angular.module('kahuna.upload.controller', [
     'kahuna.upload.prompt',
-    'kahuna.upload.recent'
+    'kahuna.upload.recent',
+    'kahuna.services.scroll-position'
 ]);
 
-upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', '$scope', function (uploadManager, mediaApi, $scope) {
+upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', 'scrollPosition', '$scope', function (uploadManager, mediaApi, scrollPosition, $scope) {
     var ctrl = this;
 
     const isOngoingUploadJobs = () => {
@@ -46,5 +48,9 @@ upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', '$scope', function
         }
         return "";
       }
+    };
+
+    ctrl.onLogoClick = () => {
+      scrollPosition.resetToTop();
     };
 }]);

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -1,9 +1,9 @@
 <gr-top-bar role="banner" aria-label="Top bar">
     <gr-top-bar-nav role="navigation" aria-label="Primary">
-        <a class="top-bar-item side-padded"
-           ng-href="/search" role="link"
-           aria-label="Go to image search"><gr-icon>search</gr-icon>
-           <span class="top-bar-item__label">Search</span></a>
+        <a class="top-bar-item side-padded clickable" ui-sref="search" title="Back to search"
+           aria-label="Go to image search">
+            <gr-icon-label gr-icon="youtube_searched_for">Back to search</gr-icon-label>
+        </a>
     </gr-top-bar-nav>
     <gr-top-bar-actions></gr-top-bar-actions>
 </gr-top-bar>


### PR DESCRIPTION
## What does this change?

When the Logo is clicked in the top left of the screen it is expected that all search criteria will be wiped out and you will return to the grid view with the scroll position set to zero. This was not happening in some cases when the user had navigated to the MyUploads or Image Edit pages without entering any search or filtering criteria having scrolled through the image list.

The problem was that the scroll position was getting set correctly when the user navigated away from the grid view but on return the original context and the new context were evaluating to equal which caused the scroll to reset to its previous position - this has come about due to changes in the handling of the nonFree parameter in the context to better support the BBC Specific Payable Images control and requirement for BBC users to be able to toggle the control on and off.

The change has introduced a new function in the scroll position control - resetToTop() - which is called in all instances where the logo is clicked. This ensures the scroll always resets.

In addition this PR also introduces a fix to a BBC specific edge case where the react control has not completely initialised on return to the Grid view and does not respond/consume the 'setPayableImages' event triggered in the AngularJS code. To support this case an alternate approach has been introduced to store the occurence of the payableImages event as a simple message in the sessionStorage which can be consumed when the React control initialisation does get processed. The event launch is retained to deal with the case where the 'race' does finish in the other order and the react control is initialised before the user permissions have been correctly assessed.

Minor changes have also been introduced on the MyUploads page to make the 'Back to Search' behave in the same way it does on the Image Edit page - making all such navigation consistent.

## How should a reviewer test this change?

Ensure that whenever the Logo is clicked the search and filtering criteria are reset to the default and the scroll position resett to the top of the screen

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
