### PR TITLE
Add new metadata field for imageType, and UI controls

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageFields.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/ImageFields.scala
@@ -20,7 +20,8 @@ trait ImageFields {
     "city",
     "state",
     "country",
-    "peopleInImage"
+    "peopleInImage",
+    "imageType"
   )
 
   val sourceFields = List("mimeType")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/ContentDisposition.scala
@@ -7,7 +7,7 @@ import java.net.URLEncoder
 
 trait ContentDisposition extends GridLogging {
 
-  def getContentDisposition(image: Image, imageType: ImageType, shortenDownloadFilename: Boolean): String = {
+  def getContentDisposition(image: Image, imageType: ImageFileType, shortenDownloadFilename: Boolean): String = {
     val asset = imageType match {
       case Source => image.source
       case Thumbnail => image.thumbnail.getOrElse(image.source)

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -69,7 +69,7 @@ class S3(config: CommonConfig) extends GridLogging with ContentDisposition with 
   // also create a legacy client that uses v2 signatures for URL signing
   private lazy val legacySigningClient: AmazonS3 = S3Ops.buildS3Client(config, forceV2Sigs = true)
 
-  def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = cachableExpiration(), imageType: ImageType = Source): String = {
+  def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = cachableExpiration(), imageType: ImageFileType = Source): String = {
     // get path and remove leading `/`
     val key: Key = url.getPath.drop(1)
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -36,7 +36,8 @@ case class UsageRightsToMetadataParser(resources: ImageProcessorResources) exten
       metadata = image.metadata.copy(
         byline = maybeNewMetadata.flatMap(_.byline) orElse image.metadata.byline,
         credit = maybeNewMetadata.flatMap(_.credit) orElse image.metadata.credit,
-        copyright = maybeNewMetadata.flatMap(_.copyright) orElse image.metadata.copyright
+        copyright = maybeNewMetadata.flatMap(_.copyright) orElse image.metadata.copyright,
+        imageType = maybeNewMetadata.flatMap(_.imageType) orElse image.metadata.imageType
       )
     )
   }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MappingTest.scala
@@ -47,7 +47,8 @@ object MappingTest {
         "foo" -> JsString("bar"),
         "size" -> JsNumber(12345)
       )
-    )
+    ),
+    imageType = Some("photograph")
   )
 
   private val testAsset: Asset = Asset(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/Mappings.scala
@@ -112,7 +112,8 @@ object Mappings {
     standardAnalysed("country").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     standardAnalysed("peopleInImage").copy(copyTo = Seq("metadata.englishAnalysedCatchAll")),
     sStemmerAnalysed("englishAnalysedCatchAll"),
-    dynamicObj("domainMetadata")
+    dynamicObj("domainMetadata"),
+    keywordField("imageType")
   ))
 
   def originalMetadataMapping(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(
@@ -134,7 +135,8 @@ object Mappings {
     standardAnalysed("state"),
     standardAnalysed("country"),
     standardAnalysed("peopleInImage"),
-    dynamicObj("domainMetadata")
+    dynamicObj("domainMetadata"),
+    keywordField("imageType")
   ))
 
   def usageRightsMapping(name: String): ObjectField = nonDynamicObjectField(name).copy(properties = Seq(

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/ImageMetadataConverter.scala
@@ -98,7 +98,8 @@ object ImageMetadataConverter extends GridLogging {
                             fileMetadata.readXmpHeadStringProp("Iptc4xmpCore:CountryCode") orElse
                             fileMetadata.iptc.get("Country/Primary Location Code"),
       subjects            = extractSubjects(fileMetadata),
-      peopleInImage       = extractPeople(fileMetadata)
+      peopleInImage       = extractPeople(fileMetadata),
+      imageType           = None // FIXME add extractor for imageType https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#digital-source-type
     )
   }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
@@ -1,11 +1,12 @@
 package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.ImageType._
 
 object UsageRightsMetadataMapper {
 
   def usageRightsToMetadata(usageRights: UsageRights, originalMetadata: ImageMetadata, staffPhotographerPublications: Set[String] = Set()): Option[ImageMetadata] = {
-    val toImageMetadata: PartialFunction[UsageRights, ImageMetadata] = (ur: UsageRights) => ur match {
+    val toImageMetadata: PartialFunction[UsageRights, ImageMetadata] = {
       case u: StaffPhotographer        =>
         val copyright: Option[String] = originalMetadata.copyright match {
           case None => Some(u.publication)
@@ -18,14 +19,20 @@ object UsageRightsMetadataMapper {
         ImageMetadata(
           byline = Some(u.photographer),
           credit = Some(u.publication),
-          copyright = copyright
+          copyright = copyright,
+          imageType = Some(Photograph)
         )
-      case u: ContractPhotographer     => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
-      case u: CommissionedPhotographer => ImageMetadata(byline = Some(u.photographer), credit = u.publication)
-      case u: ContractIllustrator      => ImageMetadata(byline = Some(u.creator),      credit = u.publication)
-      case u: StaffIllustrator         => ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator))
-      case u: CommissionedIllustrator  => ImageMetadata(byline = Some(u.creator),      credit = u.publication)
-      case u: Composite                => ImageMetadata(credit = Some(u.suppliers))
+      case u: ContractPhotographer     =>
+        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(Photograph))
+      case u: CommissionedPhotographer =>
+        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(Photograph))
+      case u: ContractIllustrator      =>
+        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(Illustration))
+      case u: StaffIllustrator         =>
+        ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator), imageType = Some(Illustration))
+      case u: CommissionedIllustrator  =>
+        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(Illustration))
+      case u: Composite                => ImageMetadata(credit = Some(u.suppliers), imageType = Some(Composite))
       case u: Screengrab               => ImageMetadata(credit = u.source)
     }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
@@ -1,7 +1,6 @@
 package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.model._
-import com.gu.mediaservice.model.ImageType._
 
 object UsageRightsMetadataMapper {
 
@@ -20,19 +19,19 @@ object UsageRightsMetadataMapper {
           byline = Some(u.photographer),
           credit = Some(u.publication),
           copyright = copyright,
-          imageType = Some(Photograph)
+          imageType = Some(ImageType.Photograph)
         )
       case u: ContractPhotographer     =>
-        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(Photograph))
+        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(ImageType.Photograph))
       case u: CommissionedPhotographer =>
-        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(Photograph))
+        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(ImageType.Photograph))
       case u: ContractIllustrator      =>
-        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(Illustration))
+        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(ImageType.Illustration))
       case u: StaffIllustrator         =>
-        ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator), imageType = Some(Illustration))
+        ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator), imageType = Some(ImageType.Illustration))
       case u: CommissionedIllustrator  =>
-        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(Illustration))
-      case u: Composite                => ImageMetadata(credit = Some(u.suppliers), imageType = Some(Composite))
+        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(ImageType.Illustration))
+      case u: Composite                => ImageMetadata(credit = Some(u.suppliers), imageType = Some(ImageType.Composite))
       case u: Screengrab               => ImageMetadata(credit = u.source)
     }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageFileType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageFileType.scala
@@ -1,0 +1,6 @@
+package com.gu.mediaservice.model
+
+sealed trait ImageFileType
+case object Source extends ImageFileType
+case object Thumbnail extends ImageFileType
+case object OptimisedPng extends ImageFileType

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageMetadata.scala
@@ -26,7 +26,8 @@ case class ImageMetadata(
   country:             Option[String]   = None,
   subjects:            Option[List[String]] = None,
   peopleInImage:       Option[Set[String]] = None,
-  domainMetadata:      Map[String, Map[String, JsValue]] = Map()
+  domainMetadata:      Map[String, Map[String, JsValue]] = Map(),
+  imageType:           Option[String]   = None,
 ) {
   def merge(that: ImageMetadata) = this.copy(
     dateTaken = that.dateTaken orElse this.dateTaken,
@@ -47,7 +48,8 @@ case class ImageMetadata(
     country = that.country orElse this.country,
     subjects = that.subjects orElse this.subjects,
     peopleInImage = that.peopleInImage orElse this.peopleInImage,
-    domainMetadata = that.domainMetadata ++ this.domainMetadata
+    domainMetadata = that.domainMetadata ++ this.domainMetadata,
+    imageType = that.imageType orElse this.imageType,
   )
 
 }
@@ -74,7 +76,8 @@ object ImageMetadata {
       (__ \ "country").readNullable[String] ~
       (__ \ "subjects").readNullable[List[String]] ~
       (__ \ "peopleInImage").readNullable[Set[String]] ~
-      (__ \ "domainMetadata").readNullable[Map[String, Map[String, JsValue]]].map(_ getOrElse Map())
+      (__ \ "domainMetadata").readNullable[Map[String, Map[String, JsValue]]].map(_ getOrElse Map()) ~
+      (__ \ "imageType").readNullable[String]
     )(ImageMetadata.apply _)
 
   implicit val IptcMetadataWrites: Writes[ImageMetadata] = (
@@ -96,7 +99,8 @@ object ImageMetadata {
       (__ \ "country").writeNullable[String] ~
       (__ \ "subjects").writeNullable[List[String]] ~
       (__ \ "peopleInImage").writeNullable[Set[String]] ~
-      (__ \ "domainMetadata").writeNullable[Map[String, Map[String, JsValue]]].contramap((l: Map[String, Map[String, JsValue]]) => if (l.isEmpty) None else Some(l))
+      (__ \ "domainMetadata").writeNullable[Map[String, Map[String, JsValue]]].contramap((l: Map[String, Map[String, JsValue]]) => if (l.isEmpty) None else Some(l)) ~
+      (__ \ "imageType").writeNullable[String]
     )(unlift(ImageMetadata.unapply))
 
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageType.scala
@@ -1,6 +1,0 @@
-package com.gu.mediaservice.model
-
-sealed trait ImageType
-case object Source extends ImageType
-case object Thumbnail extends ImageType
-case object OptimisedPng extends ImageType

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageType.scala
@@ -1,0 +1,8 @@
+package com.gu.mediaservice.model
+
+// The collection of valid values for the imageType metadata field
+object ImageType {
+  val Photograph = "Photograph"
+  val Illustration = "Illustration"
+  val Composite = "Composite"
+}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
@@ -1,6 +1,7 @@
 package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.ImageType._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -15,49 +16,49 @@ class UsageRightsMetadataMapperTest extends AnyFunSpec with Matchers {
     it("should convert StaffPhotographers adding copyright when original metadata doesn't have it") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian")))
+      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(Photograph)))
     }
 
     it ("should convert StaffPhotographers changing copyright when original copyright is a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC")) should be
-        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian")))
+        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(Photograph)))
     }
 
     it ("should convert StaffPhotographers keeping original copyright when original copyright is not a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC Studio")) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC")))
+      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some(Photograph)))
     }
 
     it ("should convert ContractPhotographers") {
       val ur = ContractPhotographer("Andy Hall", Some("The Observer"), None)
       usageRightsToMetadata(ur, metadataWithCopyright) should be
-        Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall")))
+        Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall"), imageType = Some(Photograph)))
     }
 
     it ("should convert CommissionedPhotographers") {
       val ur = CommissionedPhotographer("Mr. Photo", Some("Weekend Magazine"))
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo")))
+        Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo"), imageType = Some(Photograph)))
     }
 
     it ("should convert ContractIllustrators") {
       val ur = ContractIllustrator("First Dog on the Moon Institute")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute")))
+        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute"), imageType = Some(Illustration)))
     }
 
     it ("should convert CommissionedIllustrators") {
       val ur = CommissionedIllustrator("Roger Rabbit")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("Roger Rabit")))
+        Some(ImageMetadata(credit = Some("Roger Rabit"), imageType = Some(Illustration)))
     }
 
     it ("should convert Composites") {
       val ur = Composite("REX/Getty Images")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("REX/Getty Images")))
+        Some(ImageMetadata(credit = Some("REX/Getty Images"), imageType = Some(Composite)))
     }
 
     it ("should convert Screengrabs") {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
@@ -1,7 +1,6 @@
 package com.gu.mediaservice.lib.metadata
 
 import com.gu.mediaservice.model._
-import com.gu.mediaservice.model.ImageType._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -16,49 +15,49 @@ class UsageRightsMetadataMapperTest extends AnyFunSpec with Matchers {
     it("should convert StaffPhotographers adding copyright when original metadata doesn't have it") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(Photograph)))
+      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(ImageType.Photograph)))
     }
 
     it ("should convert StaffPhotographers changing copyright when original copyright is a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC")) should be
-        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(Photograph)))
+        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(ImageType.Photograph)))
     }
 
     it ("should convert StaffPhotographers keeping original copyright when original copyright is not a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC Studio")) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some(Photograph)))
+      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some(ImageType.Photograph)))
     }
 
     it ("should convert ContractPhotographers") {
       val ur = ContractPhotographer("Andy Hall", Some("The Observer"), None)
       usageRightsToMetadata(ur, metadataWithCopyright) should be
-        Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall"), imageType = Some(Photograph)))
+        Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall"), imageType = Some(ImageType.Photograph)))
     }
 
     it ("should convert CommissionedPhotographers") {
       val ur = CommissionedPhotographer("Mr. Photo", Some("Weekend Magazine"))
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo"), imageType = Some(Photograph)))
+        Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo"), imageType = Some(ImageType.Photograph)))
     }
 
     it ("should convert ContractIllustrators") {
       val ur = ContractIllustrator("First Dog on the Moon Institute")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute"), imageType = Some(Illustration)))
+        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute"), imageType = Some(ImageType.Illustration)))
     }
 
     it ("should convert CommissionedIllustrators") {
       val ur = CommissionedIllustrator("Roger Rabbit")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("Roger Rabit"), imageType = Some(Illustration)))
+        Some(ImageMetadata(credit = Some("Roger Rabit"), imageType = Some(ImageType.Illustration)))
     }
 
     it ("should convert Composites") {
       val ur = Composite("REX/Getty Images")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("REX/Getty Images"), imageType = Some(Composite)))
+        Some(ImageMetadata(credit = Some("REX/Getty Images"), imageType = Some(ImageType.Composite)))
     }
 
     it ("should convert Screengrabs") {

--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -70,6 +70,7 @@ class KahunaController(
         Html(s""""${config.staffPhotographerOrganisation}-owned"""")
       else
         Html("undefined")
+    val imageTypes = Json.toJson(config.imageTypes).toString()
 
     Ok(views.html.main(
       s"${config.authUri}/login?redirectUri=$returnUri",
@@ -84,7 +85,8 @@ class KahunaController(
       costFilterChargeable,
       maybeOrgOwnedValue,
       config,
-      featureSwitchesJson
+      featureSwitchesJson,
+      imageTypes
     ))
   }
 

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -70,6 +70,8 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
 
   val announcements: Seq[Announcement] = configuration.getOptional[Seq[Announcement]]("announcements").getOrElse(Seq.empty)
 
+  val imageTypes: Seq[String] = configuration.getOptional[Seq[String]]("imageTypes").getOrElse(Seq.empty)
+
   //BBC custom warning text
   val warningTextHeader: String = configuration.getOptional[String]("warningText.header")
     .getOrElse("This image can be used, but has warnings:")

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -15,6 +15,7 @@
   maybeOrgOwnedValueHtml: Html,
   kahunaConfig: KahunaConfig,
   featureSwitches: String,
+  imageTypes: String,
 )
 <!DOCTYPE html>
 <html>
@@ -85,6 +86,7 @@
           defaultShouldBlurGraphicImages: @kahunaConfig.defaultShouldBlurGraphicImages,
           shouldUploadStraightToBucket: @kahunaConfig.shouldUploadStraightToBucket,
           announcements: @Html(announcements),
+          imageTypes: @Html(imageTypes),
         }
     </script>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -46,7 +46,9 @@
         </dl>
     </div>
 
-    <div class="image-info__group" role="region" aria-label="Image type">
+    <div class="image-info__group" role="region" aria-label="Image type"
+         ng-if="ctrl.validImageTypes.length > 0"
+    >
         <dl class="image-info__wrap metadata-line image-info__image-type">
             <dt class="metadata-line__key">Image type</dt>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -50,31 +50,61 @@
         <dl class="image-info__wrap metadata-line image-info__image-type">
             <dt class="metadata-line__key">Image type</dt>
 
-            <button
-                data-cy="it-edit-image-type-button"
-                class="image-info__edit"
-                ng-click="imageTypeEditForm.$show()"
-                ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
-                ng-hide="imageTypeEditForm.$visible">✎</button>
+            <span ng-if="ctrl.metadataUpdatedByTemplate.includes('imageType')">
+                <div class="metadata-line__info">
+                    <dd class="image-info__image-type-preview">{{ctrl.metadata.imageType}}</dd>
+                </div>
+            </span>
 
-            <span class="image-info__image-type"
-                editable-select="ctrl.metadata.imageType"
-                e-placeholder="-- choose type --"
-                e-ng-options="option for option in ctrl.validImageTypes"
-                ng-hide="imageTypeEditForm.$visible"
-                onbeforesave="ctrl.updateMetadataField('imageType', $data)"
-                e:ng-class="{'image-info__editor--error': $error,
-                               'image-info__editor--saving': imageTypeEditForm.$waiting,
-                               'text-input': true}"
-                e:form="imageTypeEditForm">
+            <span ng-if="!ctrl.metadataUpdatedByTemplate.includes('imageType')">
+                <button
+                    data-cy="it-edit-image-type-button"
+                    class="image-info__edit"
+                    ng-click="imageTypeEditForm.$show()"
+                    ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
+                    ng-hide="imageTypeEditForm.$visible">✎</button>
 
-                <span ng-if="ctrl.metadata.imageType">
-                    {{ctrl.metadata.imageType}}
-                </span>
-                <span class="editable-empty" ng-if="!ctrl.metadata.imageType && ctrl.userCanEdit">
-                    Unknown (click ✎ to add)
+                <span class="image-info__image-type"
+                    editable-select="ctrl.metadata.imageType"
+                    e-placeholder="-- choose type --"
+                    e-ng-options="option for option in ctrl.validImageTypes"
+                    ng-hide="imageTypeEditForm.$visible"
+                    onbeforesave="ctrl.updateMetadataField('imageType', $data)"
+                    e:ng-class="{'image-info__editor--error': $error,
+                                   'image-info__editor--saving': imageTypeEditForm.$waiting,
+                                   'text-input': true}"
+                    e:form="imageTypeEditForm">
+
+                    <span ng-if="ctrl.userCanEdit">
+                        <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.imageType)"
+                            class="image-info__image-type"
+                        >
+                            Multiple image types (click ✎ to edit <strong>all</strong>)
+                        </dd>
+                        <dd ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.imageType)"
+                            class="image-info__image-type"
+                            ng-class="{'editable-empty': !ctrl.metadata.imageType}"
+                        >
+                            {{ctrl.metadata.imageType || "Unknown (click ✎ to add)"}}
+                        </dd>
+                    </span>
+
+                    <span ng-if="!ctrl.userCanEdit">
+                        <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.imageType)"
+                            class="image-info__image-type"
+                        >
+                            Multiple image types
+                        </dd>
+                        <dd ng-if="!ctrl.hasMultipleValues(ctrl.rawMetadata.imageType)"
+                            class="image-info__image-type"
+                            ng-class="{'editable-empty': !ctrl.metadata.imageType}"
+                        >
+                            {{ctrl.metadata.imageType || "Unknown"}}
+                        </dd>
+                    </span>
                 </span>
             </span>
+
         </dl>
     </div>
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -77,7 +77,7 @@
 
                     <span ng-if="ctrl.userCanEdit">
                         <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.imageType)"
-                            class="image-info__image-type"
+                            class="image-info__image-type image-info--multiple"
                         >
                             Multiple image types (click ✎ to edit <strong>all</strong>)
                         </dd>
@@ -91,7 +91,7 @@
 
                     <span ng-if="!ctrl.userCanEdit">
                         <dd ng-if="ctrl.hasMultipleValues(ctrl.rawMetadata.imageType)"
-                            class="image-info__image-type"
+                            class="image-info__image-type image-info--multiple"
                         >
                             Multiple image types
                         </dd>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -45,6 +45,39 @@
                 class="image-info__edit">✎</button>
         </dl>
     </div>
+
+    <div class="image-info__group" role="region" aria-label="Image type">
+        <dl class="image-info__wrap metadata-line image-info__image-type">
+            <dt class="metadata-line__key">Image type</dt>
+
+            <button
+                data-cy="it-edit-image-type-button"
+                class="image-info__edit"
+                ng-click="imageTypeEditForm.$show()"
+                ng-if="ctrl.userCanEdit && ctrl.metadataUpdatedByTemplate.length == 0"
+                ng-hide="imageTypeEditForm.$visible">✎</button>
+
+            <span class="image-info__image-type"
+                editable-select="ctrl.metadata.imageType"
+                e-placeholder="-- choose type --"
+                e-ng-options="option for option in ctrl.validImageTypes"
+                ng-hide="imageTypeEditForm.$visible"
+                onbeforesave="ctrl.updateMetadataField('imageType', $data)"
+                e:ng-class="{'image-info__editor--error': $error,
+                               'image-info__editor--saving': imageTypeEditForm.$waiting,
+                               'text-input': true}"
+                e:form="imageTypeEditForm">
+
+                <span ng-if="ctrl.metadata.imageType">
+                    {{ctrl.metadata.imageType}}
+                </span>
+                <span class="editable-empty" ng-if="!ctrl.metadata.imageType && ctrl.userCanEdit">
+                    Unknown (click ✎ to add)
+                </span>
+            </span>
+        </dl>
+    </div>
+
     <div class="image-info__group" ng-if="ctrl.displayLeases()" role="region" aria-label="Leases">
         <dl class="image-info__wrap image-info__leases">
             <div class="image-info__heading image-info__heading--lease"

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -15,7 +15,6 @@ import '../../services/label';
 import '../../search/query-filter';
 import '../gr-usagerights-summary/gr-usagerights-summary';
 import { List } from 'immutable';
-import { validImageTypes } from "../../util/constants/imageTypes";
 
 export const module = angular.module('gr.imageMetadata', [
     'gr.image.service',
@@ -64,7 +63,7 @@ module.controller('grImageMetadataCtrl', [
     ctrl.usageRightsSummary = window._clientConfig.usageRightsSummary;
     ctrl.metadataUpdatedByTemplate = [];
 
-    ctrl.validImageTypes = validImageTypes;
+    ctrl.validImageTypes = window._clientConfig.imageTypes || [];
 
     ctrl.$onInit = () => {
       $scope.$watchCollection('ctrl.selectedImages', function () {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -15,6 +15,7 @@ import '../../services/label';
 import '../../search/query-filter';
 import '../gr-usagerights-summary/gr-usagerights-summary';
 import { List } from 'immutable';
+import { validImageTypes } from "../../util/constants/imageTypes";
 
 export const module = angular.module('gr.imageMetadata', [
     'gr.image.service',
@@ -62,6 +63,8 @@ module.controller('grImageMetadataCtrl', [
     ctrl.showUsageRights = false;
     ctrl.usageRightsSummary = window._clientConfig.usageRightsSummary;
     ctrl.metadataUpdatedByTemplate = [];
+
+    ctrl.validImageTypes = validImageTypes;
 
     ctrl.$onInit = () => {
       $scope.$watchCollection('ctrl.selectedImages', function () {

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.js
@@ -330,7 +330,7 @@ module.controller('grImageMetadataCtrl', [
         'title', 'description', 'copyright', 'keywords', 'byline',
         'credit', 'subLocation', 'city', 'state', 'country',
         'dateTaken', 'specialInstructions', 'subjects', 'peopleInImage',
-        'domainMetadata', 'usageInstructions'
+        'domainMetadata', 'usageInstructions', 'imageType'
       ];
 
       function updateSingleImage() {

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -1,30 +1,32 @@
 <form class="job-editor" name="jobEditor" ng-submit="ctrl.save()"
       novalidate ng-class="{'job-editor__disabled': !ctrl.userCanEdit}"
       aria-label="Image metadata">
-    <div class="job-editor__inputs">
-        <label class="job-info--editor__field">
-            <div class="job-info--editor__label job-info--editor__multiline text-small">Image type</div>
-            <select
-                name="imageType"
-                ng-model="ctrl.metadata.imageType"
-                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
-                ng-change="ctrl.save()"
-                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.originalMetadata['imageType'] !== ctrl.metadata['imageType'] }"
-                ng-disabled="!ctrl.userCanEdit"
-                ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
-                ng-options="type for type in ctrl.validImageTypes"
-            >
-                <option value="">-- choose type --</option>
-            </select>
+    <div class="job-editor__ianputs">
+        <span ng-if="ctrl.validImageTypes.length > 0">
+            <label class="job-info--editor__field">
+                <div class="job-info--editor__label job-info--editor__multiline text-small">Image type</div>
+                <select
+                    name="imageType"
+                    ng-model="ctrl.metadata.imageType"
+                    ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                    ng-change="ctrl.save()"
+                    ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.originalMetadata['imageType'] !== ctrl.metadata['imageType'] }"
+                    ng-disabled="!ctrl.userCanEdit"
+                    ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
+                    ng-options="type for type in ctrl.validImageTypes"
+                >
+                    <option value="">-- choose type --</option>
+                </select>
 
-            <button
-                class="job-editor__apply-to-all"
-                title="Apply this image type to all your current uploads"
-                type="button"
-                ng-if="ctrl.withBatch && ctrl.userCanEdit && (ctrl.originalMetadata['imageType'] === ctrl.metadata['imageType'])"
-                ng-click="ctrl.batchApplyMetadata('imageType')"
-            >⇔</button>
-        </label>
+                <button
+                    class="job-editor__apply-to-all"
+                    title="Apply this image type to all your current uploads"
+                    type="button"
+                    ng-if="ctrl.withBatch && ctrl.userCanEdit && (ctrl.originalMetadata['imageType'] === ctrl.metadata['imageType'])"
+                    ng-click="ctrl.batchApplyMetadata('imageType')"
+                >⇔</button>
+            </label>
+        </span>
 
         <label class="job-info--editor__field">
             <div class="job-info--editor__label job-info--editor__multiline text-small">Description</div>

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.html
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.html
@@ -3,6 +3,30 @@
       aria-label="Image metadata">
     <div class="job-editor__inputs">
         <label class="job-info--editor__field">
+            <div class="job-info--editor__label job-info--editor__multiline text-small">Image type</div>
+            <select
+                name="imageType"
+                ng-model="ctrl.metadata.imageType"
+                ng-model-options="{updateOn: 'default blur', debounce: { default: ctrl.saveOnTime, blur: 0 }}"
+                ng-change="ctrl.save()"
+                ng-class="{ 'job-info--editor__input--with-batch': ctrl.withBatch, 'job-info--editor__input-preview': ctrl.originalMetadata['imageType'] !== ctrl.metadata['imageType'] }"
+                ng-disabled="!ctrl.userCanEdit"
+                ng-readonly="ctrl.metadataUpdatedByTemplate.length > 0"
+                ng-options="type for type in ctrl.validImageTypes"
+            >
+                <option value="">-- choose type --</option>
+            </select>
+
+            <button
+                class="job-editor__apply-to-all"
+                title="Apply this image type to all your current uploads"
+                type="button"
+                ng-if="ctrl.withBatch && ctrl.userCanEdit && (ctrl.originalMetadata['imageType'] === ctrl.metadata['imageType'])"
+                ng-click="ctrl.batchApplyMetadata('imageType')"
+            >⇔</button>
+        </label>
+
+        <label class="job-info--editor__field">
             <div class="job-info--editor__label job-info--editor__multiline text-small">Description</div>
             <textarea
                 name="description"

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -8,7 +8,6 @@ import '../../forms/datalist';
 import '../../components/gr-description-warning/gr-description-warning';
 
 import strings from '../../strings.json';
-import {validImageTypes} from "../../util/constants/imageTypes";
 
 export var jobs = angular.module('kahuna.upload.jobs.requiredMetadataEditor', [
     'kahuna.edits.service',
@@ -36,7 +35,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
       // if we set it to "".
       ctrl.copyrightWasInitiallyThere = !!ctrl.originalMetadata.copyright;
       ctrl.metadataUpdatedByTemplate = [];
-      ctrl.validImageTypes = validImageTypes;
+      ctrl.validImageTypes = window._clientConfig.imageTypes || [];
 
       ctrl.save = function() {
           ctrl.saving = true;

--- a/kahuna/public/js/upload/jobs/required-metadata-editor.js
+++ b/kahuna/public/js/upload/jobs/required-metadata-editor.js
@@ -8,6 +8,7 @@ import '../../forms/datalist';
 import '../../components/gr-description-warning/gr-description-warning';
 
 import strings from '../../strings.json';
+import {validImageTypes} from "../../util/constants/imageTypes";
 
 export var jobs = angular.module('kahuna.upload.jobs.requiredMetadataEditor', [
     'kahuna.edits.service',
@@ -35,6 +36,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
       // if we set it to "".
       ctrl.copyrightWasInitiallyThere = !!ctrl.originalMetadata.copyright;
       ctrl.metadataUpdatedByTemplate = [];
+      ctrl.validImageTypes = validImageTypes;
 
       ctrl.save = function() {
           ctrl.saving = true;
@@ -58,6 +60,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
               update(ctrl.resource, cleanMetadata, ctrl.image).
               then(resource => {
                   ctrl.resource = resource;
+                  setInterval(() => {console.log(ctrl.metadata);}, 5000);
               }).
               finally(() => ctrl.saving = false);
       };
@@ -67,6 +70,7 @@ jobs.controller('RequiredMetadataEditorCtrl',
               return resource.data.map(d => d.key);
           });
       };
+
 
       ctrl.currentMetadata = () => {
         let cleanMetadata = {};
@@ -125,7 +129,8 @@ jobs.controller('RequiredMetadataEditorCtrl',
               specialInstructions: originalMetadata.specialInstructions,
               description: originalMetadata.description,
               domainMetadata: originalMetadata.domainMetadata,
-              usageInstructions: originalMetadata.usageInstructions
+              usageInstructions: originalMetadata.usageInstructions,
+              imageType: originalMetadata.imageType
           };
       }
     };

--- a/kahuna/public/js/util/constants/imageTypes.ts
+++ b/kahuna/public/js/util/constants/imageTypes.ts
@@ -1,1 +1,0 @@
-export const validImageTypes = ['Photograph', 'Illustration', 'Composite'];

--- a/kahuna/public/js/util/constants/imageTypes.ts
+++ b/kahuna/public/js/util/constants/imageTypes.ts
@@ -1,0 +1,1 @@
+export const validImageTypes = ['Photograph', 'Illustration', 'Composite'];

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2212,6 +2212,7 @@ FIXME: what to do with touch devices
 
 .image-info--editor__input-preview,
 .image-info__description-preview,
+.image-info__image-type-preview
 .image-info__title-preview,
 .image-info__special-instructions-preview{
   border: 1px solid #ffbc01;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2186,6 +2186,9 @@ FIXME: what to do with touch devices
     margin-top: 0;
 }
 
+.image-info__image-type {
+  color: #eee;
+}
 .image-info__description,
 .image-info__special-instructions {
     /* respect newlines in text */

--- a/media-api/app/lib/elasticsearch/MatchFields.scala
+++ b/media-api/app/lib/elasticsearch/MatchFields.scala
@@ -10,7 +10,8 @@ trait MatchFields extends ImageFields {
   val matchFields: Seq[String] = Seq("id") ++ Seq("mimeType").map(sourceField) ++
     Seq("description", "title", "byline", "source", "credit", "keywords",
       "subLocation", "city", "state", "country", "suppliersReference",
-      "peopleInImage", "specialInstructions", "englishAnalysedCatchAll").map(metadataField) ++
+      "peopleInImage", "specialInstructions", "englishAnalysedCatchAll",
+      "imageType").map(metadataField) ++
     Seq("labels").map(editsField) ++
     config.queriableIdentifiers.map(identifierField) ++
     Seq("restrictions").map(usageRightsField)

--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -127,7 +127,8 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
     "filename" |
     "photoshoot" |
     "leasedBy" |
-    "person"
+    "person" |
+    "imageType"
   }
 
   def resolveNamedField(name: String): Field = (name match {

--- a/metadata-editor/app/controllers/EditsController.scala
+++ b/metadata-editor/app/controllers/EditsController.scala
@@ -184,7 +184,8 @@ class EditsController(
           val mergedMetadata = originalUserMetadata.copy(
             byline = metadata.byline orElse originalUserMetadata.byline,
             credit = metadata.credit orElse originalUserMetadata.credit,
-            copyright = metadata.copyright orElse originalUserMetadata.copyright
+            copyright = metadata.copyright orElse originalUserMetadata.copyright,
+            imageType = metadata.imageType orElse originalUserMetadata.imageType
           )
 
           editsStore.jsonAdd(id, Edits.Metadata, metadataAsMap(mergedMetadata))


### PR DESCRIPTION
## What does this change?

Adds a new metadata field named "image type" (or `imageType` in code responses), to designate an image as either "Photograph", "Illustration" or "Composite".

This has been requested by the Guardian's picture desk, so we can designate images into one of these categories and have that value pull through automatically into the content publishing tools.

<img width="290" alt="image" src="https://github.com/user-attachments/assets/d19febfb-ac2c-4442-9575-eabd1037c348">

Requires a mapping update (no migration necessary)

## How should a reviewer test this change?

Deploy to TEST, and try setting the value

## How can success be measured?
- we will finally be able to simplify Usage Rights (as they currently conflate type and rights)
- we will be able to listen to some external signals (mostly [DigitalSourceType](https://www.iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#digital-source-type), but maybe some weaker ones like signals in Description from agencies)
- we will be able to ask our partners to supply DigitalSourceType
- and, most importantly, we will be able to be more transparent with our audience about the nature of the image

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
