### PR TITLE
add `displayCropGutterByDefaultTo` (optional Set[String]) config option to Kahuna

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -38,7 +38,14 @@ class KahunaController(
 
     val isIFramed = request.headers.get("Sec-Fetch-Dest").contains("iframe")
     val featureSwitches = new FeatureSwitches(
-      List(if(config.staffPhotographerOrganisation == "GNM") ShowCroppingGuttersSwitch else ExampleSwitch)
+      List(
+        if (maybeUser.map(_.accessor.identity).exists(config.displayCropGutterByDefaultTo.contains))
+          ShowCroppingGuttersSwitch.copy(default = true)
+        else if(config.staffPhotographerOrganisation == "GNM")
+          ShowCroppingGuttersSwitch
+        else
+          ExampleSwitch
+      )
     )
     val featureSwitchesWithClientValues = featureSwitches.getClientSwitchValues(featureSwitches.getFeatureSwitchCookies(request.cookies.get))
     val featureSwitchesJson = Json.stringify(Json.toJson(featureSwitches.getFeatureSwitchesToStringify(featureSwitchesWithClientValues)))

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -88,5 +88,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     .getOrElse("Not configured")
 
   val shouldUploadStraightToBucket: Boolean = maybeIngestBucket.isDefined
+
+  val displayCropGutterByDefaultTo: Set[String] = getStringSet("displayCropGutterByDefaultTo")
 }
 


### PR DESCRIPTION
…to set the crop gutters (#4331) feature flag to ON for the configured users.

Requires fix https://github.com/guardian/grid/pull/4337 to work.

## How should a reviewer test this change?
First, attempt to crop an image 5:3 and the gutters feature (#4331) shouldn't be enabled by default. Then, change the `displayCropGutterByDefaultTo` array in `kahuna.conf` and redeploy, now attempt cropping 5:3 again and you should see the gutters feature.

## How can success be measured?
We can remotely control a subset of users to have this feature turned on without them having to turn it on.

## Who should look at this?
@MaxWalker2010 @CDicksonG @paperboyo @guardian/newsroom-resilience @guardian/digital-cms 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
