### PR TITLE
FIX `getFeatureSwitchActive` to fallback to default value (not just cookie)

### DIFF
--- a/kahuna/public/js/components/gr-feature-switch-panel/gr-feature-switch-panel.tsx
+++ b/kahuna/public/js/components/gr-feature-switch-panel/gr-feature-switch-panel.tsx
@@ -18,7 +18,7 @@ export const getFeatureSwitchActive = (key: string): boolean => {
   if (match) {
     return match[2] === "true";
   }
-  return false;
+  return window._clientConfig.featureSwitches.find((featureSwitch) => featureSwitch.key === key)?.value === "true";
 };
 
 const CloseIcon = () =>


### PR DESCRIPTION
When working on #4336 I noticed the default wasn't pulling through to the client