### PR TITLE
Panda Auth takes domainRoot directly from commonConfig

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
@@ -141,11 +141,12 @@ class PandaAuthenticationProvider(
   }
 
   private def buildPandaSettings() = {
+    val domain = resources.commonConfig.domainRoot
     new PanDomainAuthSettingsRefresher(
-      domain = resources.commonConfig.services.domainRoot,
+      domain = domain,
       system = providerConfiguration.getOptional[String]("panda.system").getOrElse("media-service"),
       bucketName = providerConfiguration.getOptional[String]("panda.bucketName").getOrElse("pan-domain-auth-settings"),
-      settingsFileKey = providerConfiguration.getOptional[String]("panda.settingsFileKey").getOrElse(s"${resources.commonConfig.services.domainRoot}.settings"),
+      settingsFileKey = providerConfiguration.getOptional[String]("panda.settingsFileKey").getOrElse(s"$domain.settings"),
       s3Client = S3Ops.buildS3Client(resources.commonConfig, localstackAware=resources.commonConfig.useLocalAuth)
     )
   }


### PR DESCRIPTION
Rather than indirectly though `commonConfig.services.domainRoot`.


## What does this change?

Decouples this class from the implementation details of services.
Allows for service URL schemes which doesn't use domainRoot (such as a local Docker localhost + ports deployment).

Compiles locally.


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
