### PR TITLE
IMAGEDAM-1982: Prevent the resend of capture images and restrict icons

### DIFF
--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -192,7 +192,7 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
 
         <span class="bottom-bar__meta-item preview__has-syndication-usages preview__bottom-icons-align-right"
               title="This image exists in BBC Photo Sales"
-              ng-if="ctrl.hasSyndicationUsages && ctrl.showSendToPhotoSales()">
+              ng-if="(ctrl.hasSyndicationUsages || ctrl.uploadedByCapture) && ctrl.showSendToPhotoSales() && ctrl.showPaid">
               <gr-sent-to-photosales-icon class="gr-sent-to-photosales-icon"></gr-sent-to-photosales-icon>
         </span>
     </div>

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -67,8 +67,7 @@ image.controller('uiPreviewImageCtrl', [
       });
 
       ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales;
-      ctrl.uploadedByCapture = (ctrl) => ctrl.image.data.uploadedBy === "Capture_AutoIngest";
-      ctrl.showPaid = undefined;
+      ctrl.uploadedByCapture = ctrl.image.data.uploadedBy === "Capture_AutoIngest"
       mediaApi.getSession().then(session => {
         ctrl.showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
       });

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -67,7 +67,7 @@ image.controller('uiPreviewImageCtrl', [
       });
 
       ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales;
-      ctrl.uploadedByCapture = ctrl.image.data.uploadedBy === "Capture_AutoIngest"
+      ctrl.uploadedByCapture = ctrl.image.data.uploadedBy === "Capture_AutoIngest";
       mediaApi.getSession().then(session => {
         ctrl.showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
       });

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -67,7 +67,7 @@ image.controller('uiPreviewImageCtrl', [
       });
 
       ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales;
-      ctrl.uploadedByCapture = (ctrl) => ctrl?.image?.data?.uploadedBy === "Capture_AutoIngest";
+      ctrl.uploadedByCapture = (ctrl) => ctrl.image.data.uploadedBy === "Capture_AutoIngest";
       ctrl.showPaid = undefined;
       mediaApi.getSession().then(session => {
         ctrl.showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -38,6 +38,7 @@ image.controller('uiPreviewImageCtrl', [
   'inject$',
   '$rootScope',
   '$window',
+  'mediaApi',
   'imageService',
   'imageUsagesService',
   'labelService',
@@ -50,6 +51,7 @@ image.controller('uiPreviewImageCtrl', [
       inject$,
       $rootScope,
       $window,
+      mediaApi,
       imageService,
       imageUsagesService,
       labelService,
@@ -65,6 +67,11 @@ image.controller('uiPreviewImageCtrl', [
       });
 
       ctrl.showSendToPhotoSales = () => $window._clientConfig.showSendToPhotoSales;
+      ctrl.uploadedByCapture = (ctrl) => ctrl?.image?.data?.uploadedBy === "Capture_AutoIngest";
+      ctrl.showPaid = undefined;
+      mediaApi.getSession().then(session => {
+        ctrl.showPaid = session.user.permissions.showPaid ? session.user.permissions.showPaid : undefined;
+      });
 
       ctrl.addLabelToImages = labelService.batchAdd;
       ctrl.removeLabelFromImages = labelService.batchRemove;

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -428,26 +428,6 @@ results.controller('SearchResultsCtrl', [
           }
           (syndicationExists === true ? invalidImages : validImages).push(image);
         });
-        //
-        //
-        // images.forEach( (image) => {
-        //   if (image.data.uploadedBy === "Capture_AutoIngest") {
-        //     invalidImages.push(image);
-        //   } else {
-        //     if (image.data.usages.data.length === 0) {
-        //       validImages.push(image);
-        //     } else {
-        //       let syndicationExists = false;
-        //       for (const usage of image.data.usages.data) {
-        //         if (usage.data.platform === "syndication") {
-        //           syndicationExists = true;
-        //           break;
-        //         }
-        //       }
-        //       (syndicationExists === true ? invalidImages : validImages).push(image);
-        //     }
-        //   }
-        // });
         return [validImages, invalidImages];
       };
 

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -400,26 +400,54 @@ results.controller('SearchResultsCtrl', [
         };
 
       const validatePhotoSalesSelection = (images) => {
-        let validImages = [];
-        let invalidImages = [];
-        images.forEach( (image) => {
-          if (image.data.uploadedBy === "Capture_AutoIngest") {
-            invalidImages.push(image);
-          } else {
+        const validImages = [];
+        const invalidImages = [];
+
+        const filteredImages = images
+          .filter(image => {
+            if (image.data.uploadedBy === "Capture_AutoIngest") {
+              invalidImages.push(image);
+              return false;
+            }
+            return true;
+          })
+          .filter(image => {
             if (image.data.usages.data.length === 0) {
               validImages.push(image);
-            } else {
-              let syndicationExists = false;
-              for (const usage of image.data.usages.data) {
-                if (usage.data.platform === "syndication") {
-                  syndicationExists = true;
-                  break;
-                }
-              }
-              (syndicationExists === true ? invalidImages : validImages).push(image);
+              return false;
+            }
+            return true;
+          });
+        filteredImages.forEach((image) => {
+          let syndicationExists = false;
+          for (const usage of image.data.usages.data) {
+            if (usage.data.platform === "syndication") {
+              syndicationExists = true;
+              break;
             }
           }
+          (syndicationExists === true ? invalidImages : validImages).push(image);
         });
+        //
+        //
+        // images.forEach( (image) => {
+        //   if (image.data.uploadedBy === "Capture_AutoIngest") {
+        //     invalidImages.push(image);
+        //   } else {
+        //     if (image.data.usages.data.length === 0) {
+        //       validImages.push(image);
+        //     } else {
+        //       let syndicationExists = false;
+        //       for (const usage of image.data.usages.data) {
+        //         if (usage.data.platform === "syndication") {
+        //           syndicationExists = true;
+        //           break;
+        //         }
+        //       }
+        //       (syndicationExists === true ? invalidImages : validImages).push(image);
+        //     }
+        //   }
+        // });
         return [validImages, invalidImages];
       };
 

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -399,37 +399,27 @@ results.controller('SearchResultsCtrl', [
             globalErrors.trigger('clipboard', sharedUrl);
         };
 
+      const imageHasSyndicationUsage = (image) => {
+        return image.data.usages.data.some(usage =>
+          usage.data.platform === 'syndication'
+        );
+      };
+
       const validatePhotoSalesSelection = (images) => {
         const validImages = [];
         const invalidImages = [];
 
-        const filteredImages = images
-          .filter(image => {
-            if (image.data.uploadedBy === "Capture_AutoIngest") {
-              invalidImages.push(image);
-              return false;
-            }
-            return true;
-          })
-          .filter(image => {
-            if (image.data.usages.data.length === 0) {
-              validImages.push(image);
-              return false;
-            }
-            return true;
-          });
-        filteredImages.forEach((image) => {
-          let syndicationExists = false;
-          for (const usage of image.data.usages.data) {
-            if (usage.data.platform === "syndication") {
-              syndicationExists = true;
-              break;
-            }
+        images.forEach(image => {
+          if (image.data.uploadedBy === 'Capture_AutoIngest' || imageHasSyndicationUsage(image)) {
+            invalidImages.push(image);
+          } else {
+            validImages.push(image);
           }
-          (syndicationExists === true ? invalidImages : validImages).push(image);
         });
+
         return [validImages, invalidImages];
       };
+
 
       ctrl.showPaid = undefined;
       mediaApi.getSession().then(session => {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -403,17 +403,21 @@ results.controller('SearchResultsCtrl', [
         let validImages = [];
         let invalidImages = [];
         images.forEach( (image) => {
-          if (image.data.usages.data.length === 0) {
-            validImages.push(image);
+          if (image.data.uploadedBy === "Capture_AutoIngest") {
+            invalidImages.push(image);
           } else {
-            let syndicationExists = false;
-            for (const usage of image.data.usages.data) {
-              if (usage.data.platform === "syndication") {
-                syndicationExists = true;
-                break;
+            if (image.data.usages.data.length === 0) {
+              validImages.push(image);
+            } else {
+              let syndicationExists = false;
+              for (const usage of image.data.usages.data) {
+                if (usage.data.platform === "syndication") {
+                  syndicationExists = true;
+                  break;
+                }
               }
+              (syndicationExists === true ? invalidImages : validImages).push(image);
             }
-            (syndicationExists === true ? invalidImages : validImages).push(image);
           }
         });
         return [validImages, invalidImages];


### PR DESCRIPTION
## What does this change?

This change prevents users from sending images that were received from Photo Sales **back** to Photo Sales - this is enabled through the same modal/notification mechanism that is already applied to images that have an 'Added to Photo Sales' usage. Additionally, the 'sales' icon (for BBC Photo Sales) will now also display for images **received** from Photo Sales, whereas before it was only present for images that were **sent** to Photo Sales. Finally it ensures that only archivist users will be able to see the sales icon, standard users will not be able to. 

## How should a reviewer test this change?

As a user with elevated permissions and with the showSendToPhotoSales flag set to true:
### Users can not send images back to BBC Photo Sales:
- Apply the 'uploader' chip and enter 'Capture_AutoIngest'
- The query will be executed and the UI will refresh
- Select an image from the returned images 
- Select the 'Send to Photo Sales' button
- A notification banner appears informing the user that the image cannot be sent as it already exists in BBC Photo Sales

### The sales icon is present for images received from Photo Sales:
- Apply the 'uploader' chip and enter 'Capture_AutoIngest'
- The query will be executed and the UI will refresh
- Confirm that the sales icon is present on the returned images

As a user without elevated permissions and with the showSendToPhotoSales flag set to true:
### The sales icon is not present on any images:
- Apply the 'uploader' chip and enter 'Capture_AutoIngest'
- The query will be executed and the UI will refresh
- Confirm that the sales icon is not present on any images
- Remove the chip
- Apply the 'usage@platform' chip and select 'Added to Photo Sales'
- The query will be executed and the UI will refresh
- Confirm that the sales icon is not present on any images

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
