### PR TITLE
make transparency of crop gutters 50% to make them less 'opaque'

### DIFF
--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -54,6 +54,7 @@
   top: 0;
   bottom: 0;
   mix-blend-mode: difference;
+  opacity: 0.5;
 }
 .easel.vertical-warning-gutters .cropper-view-box::before { /* left gutter */
   left: 0;


### PR DESCRIPTION
#4331 added crop gutters under certain scenarios, and we've since been testing with a subset of users (see #4336) and have received the following feedback...

> I find the diagonal stripes obscure the sides of the image too much - I can't see what's underneath them to decide if I want to reduce my 5:3 crop

The stripes are white, but with `mix-blend-mode: difference` which attempts to invert the colour below, however depending on the colour/darkness below this can appear too 'opaque'...

**...so this PR is a quick fix to reduce the transparency to 50% (`opacity: 0.5`) - with hopefully a PR for configurable per-image transparency slider in https://github.com/guardian/grid/pull/4341  - proving a bit fiddly so want to get this one-liner improvement out first, it might even suffice (hehe @paperboyo)**

