### PR TITLE
fix dragging over cropping gutters

### DIFF
--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -55,6 +55,7 @@
   bottom: 0;
   mix-blend-mode: difference;
   opacity: 0.5;
+  pointer-events: none;
 }
 .easel.vertical-warning-gutters .cropper-view-box::before { /* left gutter */
   left: 0;


### PR DESCRIPTION
set `pointer-events: none` to ensure dragging the crop box isn't prevented when the mouse is over the gutters (introduced in https://github.com/guardian/grid/pull/4331). Thanks @paperboyo for the spot.
