### PR TITLE
Scalaz upgrade & simplifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,8 +86,6 @@ lazy val commonLib = project("common-lib").settings(
     "com.sksamuel.elastic4s" %% "elastic4s-domain" % elastic4sVersion,
     "com.gu" %% "thrift-serializer" % "5.0.2",
     "org.scalaz" %% "scalaz-core" % "7.3.8",
-//    "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
-
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,9 @@ lazy val commonLib = project("common-lib").settings(
     "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-domain" % elastic4sVersion,
     "com.gu" %% "thrift-serializer" % "5.0.2",
-    "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
+    "org.scalaz" %% "scalaz-core" % "7.3.8",
+//    "org.scalaz.stream" %% "scalaz-stream" % "0.8.6",
+
     "org.im4java" % "im4java" % "1.4.0",
     "com.gu" % "kinesis-logback-appender" % "1.4.4",
     "net.logstash.logback" % "logstash-logback-encoder" % "5.0",

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/filters.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/filters.scala
@@ -17,7 +17,7 @@ object filters {
   def or(queries: Query*): Query = should(queries)
 
   def or(queries: NonEmptyList[Query]): Query = {
-    should(queries.list: _*)
+    should(queries.toList: _*)
   }
 
   def boolTerm(field: String, value: Boolean): TermQuery = termQuery(field, value)
@@ -64,7 +64,7 @@ object filters {
   def term(field: String, term: Int): Query = termQuery(field, term)
 
   def terms(field: String, terms: NonEmptyList[String]): Query = {
-    termsQuery(field, terms.list)
+    termsQuery(field, terms.list.toList)
   }
 
   def existsOrMissing(field: String, exists: Boolean): Query = if (exists) {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ExifTool.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ExifTool.scala
@@ -5,20 +5,28 @@ import java.util.concurrent.Executors
 import java.io.File
 import scala.concurrent.{Future, ExecutionContext}
 import org.im4java.core.{ETOperation, ExiftoolCmd}
-import scalaz.syntax.id._
 
 
 object ExifTool {
   private implicit val ctx: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Config.imagingThreadPoolSize))
 
-  def tagSource(source: File) = (new ETOperation()) <| (_.addImage(source.getAbsolutePath))
-
-  def setTags(ops: ETOperation)(tags: Map[String, String]): ETOperation =  {
-    tags.foldLeft(ops) { case (ops, (key, value)) => ops <| (_.setTags(s"$key=$value")) }
+  def tagSource(source: File): ETOperation = {
+    val op = new ETOperation()
+    op.addImage(source.getAbsolutePath)
+    op
   }
 
-  def overwriteOriginal(ops: ETOperation): ETOperation = ops <| (_.overwrite_original())
+  def setTags(ops: ETOperation)(tags: Map[String, String]): ETOperation =  {
+    tags.foldLeft(ops) { case (ops, (key, value)) =>
+      ops.setTags(s"$key=$value")
+    }
+  }
+
+  def overwriteOriginal(ops: ETOperation): ETOperation = {
+    ops.overwrite_original()
+    ops
+  }
 
   def runExiftoolCmd(ops: ETOperation): Future[Unit] = {
     // Set overwrite original to ensure temporary file deletion

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/im4jwrapper/ImageMagick.scala
@@ -8,28 +8,78 @@ import org.im4java.process.ArrayListOutputConsumer
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import org.im4java.core.{ConvertCmd, IMOperation, IdentifyCmd}
-import scalaz.syntax.id._
 import com.gu.mediaservice.model.{Bounds, Dimensions}
+
+
 object ImageMagick extends GridLogging {
   implicit val ctx: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Config.imagingThreadPoolSize))
 
-  def addImage(source: File) = (new IMOperation()) <| { op => { op.addImage(source.getAbsolutePath) }}
-  def quality(op: IMOperation)(qual: Double) = op <| (_.quality(qual))
-  def unsharp(op: IMOperation)(radius: Double, sigma: Double, amount: Double) = op <| (_.unsharp(radius, sigma, amount))
-  def stripMeta(op: IMOperation) = op <| (_.strip())
-  def stripProfile(op: IMOperation)(profile: String) = op <| (_.p_profile(profile))
-  def addDestImage(op: IMOperation)(dest: File) = op <| (_.addImage(dest.getAbsolutePath))
-  def crop(op: IMOperation)(b: Bounds): IMOperation = op <| (_.crop(b.width, b.height, b.x, b.y))
-  def profile(op: IMOperation)(profileFileLocation: String): IMOperation = op <| (_.profile(profileFileLocation))
-  def thumbnail(op: IMOperation)(width: Int): IMOperation = op <| (_.thumbnail(width))
-  def resize(op: IMOperation)(maxSize: Int): IMOperation = op <| (_.resize(maxSize, maxSize))
-  def scale(op: IMOperation)(dimensions: Dimensions): IMOperation = op <| (_.scale(dimensions.width, dimensions.height))
-  def format(op: IMOperation)(definition: String): IMOperation = op <| (_.format(definition))
-  def depth(op: IMOperation)(depth: Int): IMOperation = op <| (_.depth(depth))
-  def interlace(op: IMOperation)(interlacedHow: String): IMOperation = op <| (_.interlace(interlacedHow))
-  def setBackgroundColour(op: IMOperation)(backgroundColour: String): IMOperation = op <| (_.background(backgroundColour))
-  def flatten(op: IMOperation): IMOperation = op <| (_.flatten())
+  def addImage(source: File): IMOperation = {
+    val op = new IMOperation
+    op.addImage(source.getAbsolutePath)
+    op
+  }
+  def quality(op: IMOperation)(qual: Double): IMOperation = {
+    op.quality(qual)
+    op
+  }
+  def unsharp(op: IMOperation)(radius: Double, sigma: Double, amount: Double): IMOperation = {
+    op.unsharp(radius, sigma, amount)
+    op
+  }
+  def stripMeta(op: IMOperation): IMOperation = {
+    op.strip()
+    op
+  }
+  def stripProfile(op: IMOperation)(profile: String): IMOperation = {
+    op.p_profile(profile)
+    op
+  }
+  def addDestImage(op: IMOperation)(dest: File): IMOperation = {
+    op.addImage(dest.getAbsolutePath)
+    op
+  }
+  def crop(op: IMOperation)(b: Bounds): IMOperation = {
+    op.crop(b.width, b.height, b.x, b.y)
+    op
+  }
+  def profile(op: IMOperation)(profileFileLocation: String): IMOperation = {
+    op.profile(profileFileLocation)
+    op
+  }
+  def thumbnail(op: IMOperation)(width: Int): IMOperation = {
+    op.thumbnail(width)
+    op
+  }
+  def resize(op: IMOperation)(maxSize: Int): IMOperation = {
+    op.resize(maxSize, maxSize)
+    op
+  }
+  def scale(op: IMOperation)(dimensions: Dimensions): IMOperation = {
+    op.scale(dimensions.width, dimensions.height)
+    op
+  }
+  def format(op: IMOperation)(definition: String): IMOperation = {
+    op.format(definition)
+    op
+  }
+  def depth(op: IMOperation)(depth: Int): IMOperation = {
+    op.depth(depth)
+    op
+  }
+  def interlace(op: IMOperation)(interlacedHow: String): IMOperation = {
+    op.interlace(interlacedHow)
+    op
+  }
+  def setBackgroundColour(op: IMOperation)(backgroundColour: String): IMOperation = {
+    op.background(backgroundColour)
+    op
+  }
+  def flatten(op: IMOperation): IMOperation = {
+    op.flatten()
+    op
+  }
 
   def runConvertCmd(op: IMOperation, useImageMagick: Boolean)(implicit logMarker: LogMarker): Future[Unit] = {
     logger.info(logMarker, s"Using ${if(useImageMagick) { "imagemagick" } else { "graphicsmagick" }} for imaging conversion operation $op")

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LogConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LogConfig.scala
@@ -14,7 +14,6 @@ import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.ApplicationLoader.Context
 import play.api.LoggerConfigurator
 import play.api.libs.json._
-import scalaz.syntax.id._
 
 import scala.util.Try
 
@@ -39,37 +38,45 @@ object LogConfig {
     )).toString()
   }
 
-  private def makeLayout(customFields: String) = new LogstashLayout() <| (_.setCustomFields(customFields))
+  private def makeLayout(customFields: String) = {
+    val layout = new LogstashLayout()
+    layout.setCustomFields(customFields)
+    layout
+  }
 
-  private def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig) =
-    new KinesisAppender[ILoggingEvent]() <| { a =>
-      a.setStreamName(appenderConfig.stream)
-      a.setRegion(appenderConfig.region)
-      a.setRoleToAssumeArn(appenderConfig.roleArn)
-      a.setBufferSize(appenderConfig.bufferSize)
+  private def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig): KinesisAppender[ILoggingEvent] = {
+    val appender = new KinesisAppender[ILoggingEvent]()
+    appender.setStreamName(appenderConfig.stream)
+    appender.setRegion(appenderConfig.region)
+    appender.setRoleToAssumeArn(appenderConfig.roleArn)
+    appender.setBufferSize(appenderConfig.bufferSize)
 
-      a.setContext(context)
-      a.setLayout(layout)
+    appender.setContext(context)
+    appender.setLayout(layout)
 
-      layout.start()
-      a.start()
+    layout.start()
+    appender.start()
+
+    appender
   }
 
   private def makeLogstashAppender(config: CommonConfig, context: LoggerContext): LogstashTcpSocketAppender = {
     val customFields = makeCustomFields(config)
 
-    new LogstashTcpSocketAppender() <| { appender =>
-      appender.setContext(context)
-      appender.addDestinations(new InetSocketAddress("localhost", 5000))
-      appender.setWriteBufferSize(BUFFER_SIZE)
+    val appender = new LogstashTcpSocketAppender()
 
-      appender.setEncoder(new LogstashEncoder() <| { encoder =>
-        encoder.setCustomFields(customFields)
-        encoder.start()
-      })
+    appender.setContext(context)
+    appender.addDestinations(new InetSocketAddress("localhost", 5000))
+    appender.setWriteBufferSize(BUFFER_SIZE)
 
-      appender.start()
-    }
+    val encoder = new LogstashEncoder
+    encoder.setCustomFields(customFields)
+    encoder.start()
+
+    appender.setEncoder(encoder)
+    appender.start()
+
+    appender
   }
 
   def initLocalLogShipping(config: CommonConfig): Unit = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.ConfigException.BadValue
 import com.typesafe.scalalogging.StrictLogging
 import play.api.ConfigLoader
 import play.api.libs.json._
+import scalaz.NonEmptyList
 
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.reflect.runtime.universe
@@ -52,9 +53,9 @@ object UsageRightsSpec extends StrictLogging {
 
 object UsageRights {
 
-  val photographer: List[UsageRightsSpec] = List(StaffPhotographer, ContractPhotographer, CommissionedPhotographer)
-  val illustrator: List[UsageRightsSpec] = List(StaffIllustrator, ContractIllustrator, CommissionedIllustrator)
-  val whollyOwned: List[UsageRightsSpec] = photographer ++ illustrator
+  val photographer: NonEmptyList[UsageRightsSpec] = NonEmptyList(StaffPhotographer, ContractPhotographer, CommissionedPhotographer)
+  val illustrator: NonEmptyList[UsageRightsSpec] = NonEmptyList(StaffIllustrator, ContractIllustrator, CommissionedIllustrator)
+  val whollyOwned: NonEmptyList[UsageRightsSpec] = photographer append illustrator
 
   // this is a convenience method so that we use the same formatting for all subtypes
   // i.e. use the standard `Json.writes`. I still can't find a not have to pass the `f:Format[T]`

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -477,8 +477,7 @@ class MediaApi(
     SearchParams.validate(searchParams).fold(
       // TODO: respondErrorCollection?
       errors => Future.successful(respondError(UnprocessableEntity, InvalidUriParams.errorKey,
-        // Annoyingly `NonEmptyList` and `IList` don't have `mkString`
-        errors.map(_.message).list.toList.mkString(", ")) //.reduce(_+ ", " +_), List(searchLink))
+        errors.map(_.message).mkString(", "))
       ),
       params => respondSuccess(params)
     )

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -478,7 +478,7 @@ class MediaApi(
       // TODO: respondErrorCollection?
       errors => Future.successful(respondError(UnprocessableEntity, InvalidUriParams.errorKey,
         // Annoyingly `NonEmptyList` and `IList` don't have `mkString`
-        errors.map(_.message).list.reduce(_+ ", " +_), List(searchLink))
+        errors.map(_.message).list.toList.mkString(", ")) //.reduce(_+ ", " +_), List(searchLink))
       ),
       params => respondSuccess(params)
     )

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -3,6 +3,7 @@ package lib
 import com.amazonaws.services.cloudfront.util.SignerUtils
 import com.gu.mediaservice.lib.config.{CommonConfigWithElastic, GridConfigResources}
 import org.joda.time.DateTime
+import scalaz.NonEmptyList
 
 import java.security.PrivateKey
 import scala.util.Try
@@ -43,7 +44,7 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val loginUriTemplate: String = services.loginUriTemplate
   val collectionsUri: String = services.collectionsBaseUri
 
-  val requiredMetadata = List("credit", "description", "usageRights")
+  val requiredMetadata = NonEmptyList("credit", "description", "usageRights")
 
   val syndicationStartDate: Option[DateTime] = Try {
     stringOpt("syndication.start").map(d => DateTime.parse(d).withTimeAtStartOfDay())

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -202,24 +202,25 @@ object SearchParams {
       case (acc, (_,   None))        => acc
     }
 
-  type SearchParamValidation = Validation[InvalidUriParams, SearchParams]
-  type SearchParamValidations = ValidationNel[InvalidUriParams, SearchParams]
-
   // Also adjust in gu-lazy-table.js
   val maxSize = 200
 
-  def validate(searchParams: SearchParams): SearchParamValidations = {
+  def validate(searchParams: SearchParams): Either[List[InvalidUriParams], SearchParams] = {
     // we just need to return the first `searchParams` as we don't need to manipulate them
-    // TODO: try reduce these
-    (validateLength(searchParams).toValidationNel |@| validateOffset(searchParams).toValidationNel)((s1, s2) => s1)
+    (validateLength(searchParams), validateOffset(searchParams)) match {
+      case (Right(_), Right(_)) => Right(searchParams)
+      case (Left(invalidLength), Left(invalidOffset)) => Left(List(invalidLength, invalidOffset))
+      case (Left(invalidLength), _) => Left(List(invalidLength))
+      case (_, Left(invalidOffset)) => Left(List(invalidOffset))
+    }
   }
 
-  def validateOffset(searchParams: SearchParams): SearchParamValidation = {
-    if (searchParams.offset < 0) InvalidUriParams("offset cannot be less than 0").failure else searchParams.success
+  def validateOffset(searchParams: SearchParams): Either[InvalidUriParams, SearchParams] = {
+    if (searchParams.offset < 0) Left(InvalidUriParams("offset cannot be less than 0")) else Right(searchParams)
   }
 
-  def validateLength(searchParams: SearchParams): SearchParamValidation = {
-    if (searchParams.length > maxSize) InvalidUriParams(s"length cannot exceed $maxSize").failure else searchParams.success
+  def validateLength(searchParams: SearchParams): Either[InvalidUriParams, SearchParams] = {
+    if (searchParams.length > maxSize) Left(InvalidUriParams(s"length cannot exceed $maxSize")) else Right(searchParams)
   }
 
 }

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -112,7 +112,7 @@ object PayType extends Enumeration {
 
 object SearchParams {
   def commasToList(s: String): List[String] = s.trim.split(',').toList
-  def listToCommas(list: List[String]): Option[String] = list.toNel.map(_.list.mkString(","))
+  def listToCommas(list: List[String]): Option[String] = list.toNel.map(_.list.toList.mkString(",")).toOption
 
   // TODO: return descriptive 400 error if invalid
   def parseIntFromQuery(s: String): Option[Int] = Try(s.toInt).toOption

--- a/media-api/app/lib/elasticsearch/IsQueryFilter.scala
+++ b/media-api/app/lib/elasticsearch/IsQueryFilter.scala
@@ -40,19 +40,19 @@ object IsQueryFilter {
 
 case class IsOwnedPhotograph(staffPhotographerOrg: String) extends IsQueryFilter {
   override def query: Query = filters.or(
-    filters.terms(usageRightsField("category"), UsageRights.photographer.toNel.get.map(_.category))
+    filters.terms(usageRightsField("category"), UsageRights.photographer.map(_.category))
   )
 }
 
 case class IsOwnedIllustration(staffPhotographerOrg: String) extends IsQueryFilter {
   override def query: Query = filters.or(
-    filters.terms(usageRightsField("category"), UsageRights.illustrator.toNel.get.map(_.category))
+    filters.terms(usageRightsField("category"), UsageRights.illustrator.map(_.category))
   )
 }
 
 case class IsOwnedImage(staffPhotographerOrg: String) extends IsQueryFilter {
   override def query: Query = filters.or(
-    filters.terms(usageRightsField("category"), UsageRights.whollyOwned.toNel.get.map(_.category))
+    filters.terms(usageRightsField("category"), UsageRights.whollyOwned.map(_.category))
   )
 }
 

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -173,7 +173,7 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
       val expected = UsageRights.photographer.map(_.category)
 
-      termQuery.values shouldEqual expected
+      termQuery.values shouldEqual expected.list.toList
     }
 
     it("should correctly construct an is owned illustration query") {
@@ -189,7 +189,7 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
       val expected = UsageRights.illustrator.map(_.category)
 
-      termQuery.values shouldEqual expected
+      termQuery.values shouldEqual expected.list.toList
     }
 
     it("should correctly construct an is owned image query") {
@@ -205,7 +205,7 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
       val expected = UsageRights.whollyOwned.map(_.category)
 
-      termQuery.values shouldEqual expected
+      termQuery.values shouldEqual expected.list.toList
     }
 
     it("should return the match none query on an invalid is query") {

--- a/usage/app/model/UsageRecord.scala
+++ b/usage/app/model/UsageRecord.scala
@@ -1,9 +1,8 @@
 package model
 
-import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
+import com.amazonaws.services.dynamodbv2.xspec.{ExpressionSpecBuilder, UpdateItemExpressionSpec}
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder.{M, N, S}
 import com.gu.mediaservice.model.usage._
-import scalaz.syntax.id._
 
 import scala.collection.JavaConverters._
 import org.joda.time.DateTime
@@ -29,27 +28,27 @@ case class UsageRecord(
   downloadUsageMetadata: Option[DownloadUsageMetadata] = None,
   dateAdded: Option[DateTime] = None
 ) {
-  def toXSpec = {
-    (new ExpressionSpecBuilder() <| (xspec => {
-      List(
-        mediaId.filter(_.nonEmpty).map(S("media_id").set(_)),
-        usageType.map(usageType => S("usage_type").set(usageType.toString)),
-        mediaType.filter(_.nonEmpty).map(S("media_type").set(_)),
-        lastModified.map(lastMod => N("last_modified").set(lastMod.getMillis)),
-        usageStatus.filter(_.nonEmpty).map(S("usage_status").set(_)),
-        printUsageMetadata.map(_.toMap).map(map => M("print_metadata").set(map.asJava)),
-        digitalUsageMetadata.map(_.toMap).map(map => M("digital_metadata").set(map.asJava)),
-        syndicationUsageMetadata.map(_.toMap).map(map => M("syndication_metadata").set(map.asJava)),
-        frontUsageMetadata.map(_.toMap).map(map => M("front_metadata").set(map.asJava)),
-        downloadUsageMetadata.map(_.toMap).map(map => M("download_metadata").set(map.asJava)),
-        dateAdded.map(dateAdd => N("date_added").set(dateAdd.getMillis)),
-        dateRemovedOperation match {
-          case ClearDateRemoved => Some(N("date_removed").remove)
-          case LeaveDateRemovedUntouched => None
-          case SetDateRemoved(dateRemoved) => Some(N("date_removed").set(dateRemoved.getMillis))
-        }
-      ).flatten.foreach(xspec.addUpdate)
-    })).buildForUpdate
+  def toXSpec: UpdateItemExpressionSpec = {
+    val specBuilder = new ExpressionSpecBuilder
+    List(
+      mediaId.filter(_.nonEmpty).map(S("media_id").set(_)),
+      usageType.map(usageType => S("usage_type").set(usageType.toString)),
+      mediaType.filter(_.nonEmpty).map(S("media_type").set(_)),
+      lastModified.map(lastMod => N("last_modified").set(lastMod.getMillis)),
+      usageStatus.filter(_.nonEmpty).map(S("usage_status").set(_)),
+      printUsageMetadata.map(_.toMap).map(map => M("print_metadata").set(map.asJava)),
+      digitalUsageMetadata.map(_.toMap).map(map => M("digital_metadata").set(map.asJava)),
+      syndicationUsageMetadata.map(_.toMap).map(map => M("syndication_metadata").set(map.asJava)),
+      frontUsageMetadata.map(_.toMap).map(map => M("front_metadata").set(map.asJava)),
+      downloadUsageMetadata.map(_.toMap).map(map => M("download_metadata").set(map.asJava)),
+      dateAdded.map(dateAdd => N("date_added").set(dateAdd.getMillis)),
+      dateRemovedOperation match {
+        case ClearDateRemoved => Some(N("date_removed").remove)
+        case LeaveDateRemovedUntouched => None
+        case SetDateRemoved(dateRemoved) => Some(N("date_removed").set(dateRemoved.getMillis))
+      }
+    ).flatten.foreach(specBuilder.addUpdate)
+    specBuilder.buildForUpdate
   }
 }
 


### PR DESCRIPTION
## What does this change?

Redo of #3671 - removing outdated scalaz syntaxes.

This time around I've left in the NonEmptyList usages - they are serving a purpose, although with updated scalaz they need some more explicit conversions, and there were a few places where I could simplify their usage.

## How should a reviewer test this change?

All tests pass, and grid continues to function as normal when deployed to TEST

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
