### PR TITLE
Remove the ImageType type

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapper.scala
@@ -19,19 +19,19 @@ object UsageRightsMetadataMapper {
           byline = Some(u.photographer),
           credit = Some(u.publication),
           copyright = copyright,
-          imageType = Some(ImageType.Photograph)
+          imageType = Some("Photograph")
         )
       case u: ContractPhotographer     =>
-        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(ImageType.Photograph))
+        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some("Photograph"))
       case u: CommissionedPhotographer =>
-        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some(ImageType.Photograph))
+        ImageMetadata(byline = Some(u.photographer), credit = u.publication, imageType = Some("Photograph"))
       case u: ContractIllustrator      =>
-        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(ImageType.Illustration))
+        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some("Illustration"))
       case u: StaffIllustrator         =>
-        ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator), imageType = Some(ImageType.Illustration))
+        ImageMetadata(byline = Some(u.creator),      credit = Some(u.creator), imageType = Some("Illustration"))
       case u: CommissionedIllustrator  =>
-        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some(ImageType.Illustration))
-      case u: Composite                => ImageMetadata(credit = Some(u.suppliers), imageType = Some(ImageType.Composite))
+        ImageMetadata(byline = Some(u.creator),      credit = u.publication, imageType = Some("Illustration"))
+      case u: Composite                => ImageMetadata(credit = Some(u.suppliers), imageType = Some("Composite"))
       case u: Screengrab               => ImageMetadata(credit = u.source)
     }
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/ImageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/ImageType.scala
@@ -1,8 +1,0 @@
-package com.gu.mediaservice.model
-
-// The collection of valid values for the imageType metadata field
-object ImageType {
-  val Photograph = "Photograph"
-  val Illustration = "Illustration"
-  val Composite = "Composite"
-}

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
@@ -15,49 +15,50 @@ class UsageRightsMetadataMapperTest extends AnyFunSpec with Matchers {
     it("should convert StaffPhotographers adding copyright when original metadata doesn't have it") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(ImageType.Photograph)))
+      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some("Photograph")))
     }
 
     it ("should convert StaffPhotographers changing copyright when original copyright is a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC")) should be
-        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some(ImageType.Photograph)))
+        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some("Photograph")))
     }
 
     it ("should convert StaffPhotographers keeping original copyright when original copyright is not a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
       usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC Studio")) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some(ImageType.Photograph)))
+      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some("Photograph")))
     }
 
     it ("should convert ContractPhotographers") {
       val ur = ContractPhotographer("Andy Hall", Some("The Observer"), None)
       usageRightsToMetadata(ur, metadataWithCopyright) should be
-        Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall"), imageType = Some(ImageType.Photograph)))
+        Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall"), imageType = Some("Photograph")))
     }
 
     it ("should convert CommissionedPhotographers") {
       val ur = CommissionedPhotographer("Mr. Photo", Some("Weekend Magazine"))
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo"), imageType = Some(ImageType.Photograph)))
+        Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo"), imageType = Some("Photograph")))
     }
 
     it ("should convert ContractIllustrators") {
       val ur = ContractIllustrator("First Dog on the Moon Institute")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute"), imageType = Some(ImageType.Illustration)))
+        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute"), imageType = Some("Illustration")))
     }
 
     it ("should convert CommissionedIllustrators") {
       val ur = CommissionedIllustrator("Roger Rabbit")
-      usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("Roger Rabit"), imageType = Some(ImageType.Illustration)))
+      usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
+        Some(ImageMetadata(credit = Some("Roger Rabit"), imageType = Some("Illustration"))))
+
     }
 
     it ("should convert Composites") {
       val ur = Composite("REX/Getty Images")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("REX/Getty Images"), imageType = Some(ImageType.Composite)))
+        Some(ImageMetadata(credit = Some("REX/Getty Images"), imageType = Some("Composite")))
     }
 
     it ("should convert Screengrabs") {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/metadata/UsageRightsMetadataMapperTest.scala
@@ -14,57 +14,66 @@ class UsageRightsMetadataMapperTest extends AnyFunSpec with Matchers {
 
     it("should convert StaffPhotographers adding copyright when original metadata doesn't have it") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
-      usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some("Photograph")))
+      usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
+        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some("Photograph")))
+      )
     }
 
     it ("should convert StaffPhotographers changing copyright when original copyright is a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
-      usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC")) should be
+      usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC")) should be (
         Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("The Guardian"), imageType = Some("Photograph")))
+      )
     }
 
     it ("should convert StaffPhotographers keeping original copyright when original copyright is not a publication") {
       val ur = StaffPhotographer("Alicia Canter", "The Guardian")
-      usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC Studio")) should be
-      Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some("Photograph")))
+      usageRightsToMetadata(ur, metadataWithCopyright, Set("The Observer", "BBC Studio")) should be (
+        Some(ImageMetadata(credit = Some("The Guardian"), byline = Some("Alicia Canter"), copyright = Some("BBC"), imageType = Some("Photograph")))
+      )
     }
 
     it ("should convert ContractPhotographers") {
       val ur = ContractPhotographer("Andy Hall", Some("The Observer"), None)
-      usageRightsToMetadata(ur, metadataWithCopyright) should be
+      usageRightsToMetadata(ur, metadataWithCopyright) should be (
         Some(ImageMetadata(credit = Some("The Observer"), byline = Some("Andy Hall"), imageType = Some("Photograph")))
+      )
     }
 
     it ("should convert CommissionedPhotographers") {
       val ur = CommissionedPhotographer("Mr. Photo", Some("Weekend Magazine"))
-      usageRightsToMetadata(ur, metadataWithoutCopyright) should be
+      usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
         Some(ImageMetadata(credit = Some("Weekend Magazine"), byline = Some("Mr. Photo"), imageType = Some("Photograph")))
+      )
     }
 
     it ("should convert ContractIllustrators") {
       val ur = ContractIllustrator("First Dog on the Moon Institute")
-      usageRightsToMetadata(ur, metadataWithoutCopyright) should be
-        Some(ImageMetadata(credit = Some("First Dog on the Moon Institute"), imageType = Some("Illustration")))
+      usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
+        Some(ImageMetadata(byline = Some("First Dog on the Moon Institute"), imageType = Some("Illustration")))
+      )
     }
 
     it ("should convert CommissionedIllustrators") {
       val ur = CommissionedIllustrator("Roger Rabbit")
       usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
-        Some(ImageMetadata(credit = Some("Roger Rabit"), imageType = Some("Illustration"))))
+        Some(ImageMetadata(byline = Some("Roger Rabbit"), imageType = Some("Illustration")))
+      )
 
     }
 
     it ("should convert Composites") {
       val ur = Composite("REX/Getty Images")
-      usageRightsToMetadata(ur, metadataWithoutCopyright) should be
+      usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
         Some(ImageMetadata(credit = Some("REX/Getty Images"), imageType = Some("Composite")))
+      )
     }
 
     it ("should convert Screengrabs") {
       val ur = Screengrab(Some("BBC News"))
-      usageRightsToMetadata(ur, metadataWithoutCopyright) should be
+      usageRightsToMetadata(ur, metadataWithoutCopyright) should be (
         Some(ImageMetadata(credit = Some("BBC News")))
+      )
     }
 
     it ("should not convert Agencies") {


### PR DESCRIPTION
## What does this change?

No-op change. The `ImageType` object contained a couple of hardcoded values for "Photograph" etc. - wrongly implying that these are the only valid values! Instead, remove this type and pass the used values directly.

While here, I noticed that a few of the tests were actually not running their assertions; the `be` function, with its argument on the trailing line was in a position that meant it was being _referenced_ rather than _invoked_. That revealed a couple of failing tests, that needed to be updated to match the current version of the code.

## How should a reviewer test this change?

Code review should be sufficient.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
