### PR TITLE
remove the feature switch `show-cropping-gutters-switch` (still GNM only)

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, BaseControllerWithLoginRedirects}
-import lib.{ExampleSwitch, FeatureSwitches, KahunaConfig, ShowCroppingGuttersSwitch}
+import lib.{ExampleSwitch, FeatureSwitches, KahunaConfig}
 import play.api.mvc.ControllerComponents
 import play.api.libs.json._
 
@@ -38,14 +38,7 @@ class KahunaController(
 
     val isIFramed = request.headers.get("Sec-Fetch-Dest").contains("iframe")
     val featureSwitches = new FeatureSwitches(
-      List(
-        if (maybeUser.map(_.accessor.identity).exists(config.displayCropGutterByDefaultTo.contains))
-          ShowCroppingGuttersSwitch.copy(default = true)
-        else if(config.staffPhotographerOrganisation == "GNM")
-          ShowCroppingGuttersSwitch
-        else
-          ExampleSwitch
-      )
+      List(ExampleSwitch)
     )
     val featureSwitchesWithClientValues = featureSwitches.getClientSwitchValues(featureSwitches.getFeatureSwitchCookies(request.cookies.get))
     val featureSwitchesJson = Json.stringify(Json.toJson(featureSwitches.getFeatureSwitchesToStringify(featureSwitchesWithClientValues)))

--- a/kahuna/app/lib/FeatureSwitch.scala
+++ b/kahuna/app/lib/FeatureSwitch.scala
@@ -10,12 +10,6 @@ object ExampleSwitch extends FeatureSwitch(
   default = false
 )
 
-object ShowCroppingGuttersSwitch extends FeatureSwitch(
-  key = "show-cropping-gutters-switch",
-  title = "Display gutters on 5:3 crops to show what would be clipped if used in a 5:4 space",
-  default = false
-)
-
 class FeatureSwitches(featureSwitches: List[FeatureSwitch]){
   // Feature switches are defined here, but updated by setting a cookie following the pattern e.g. "feature-switch-my-key"
   // for a switch called "my-key".

--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -90,7 +90,5 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
     .getOrElse("Not configured")
 
   val shouldUploadStraightToBucket: Boolean = maybeIngestBucket.isDefined
-
-  val displayCropGutterByDefaultTo: Set[String] = getStringSet("displayCropGutterByDefaultTo")
 }
 

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -4,7 +4,6 @@ import '../components/gr-keyboard-shortcut/gr-keyboard-shortcut';
 import {radioList} from '../components/gr-radio-list/gr-radio-list';
 import {cropUtil} from "../util/crop";
 import {cropOptions} from "../util/constants/cropOptions";
-import {getFeatureSwitchActive} from "../components/gr-feature-switch-panel/gr-feature-switch-panel";
 
 const crop = angular.module('kahuna.crop.controller', [
   'gr.keyboardShortcut',
@@ -185,7 +184,6 @@ crop.controller('ImageCropCtrl', [
         ctrl.shouldShowVerticalWarningGutters =
           window._clientConfig.staffPhotographerOrganisation === "GNM"
           && cropSettings.shouldShowCropGuttersIfApplicable()
-          && getFeatureSwitchActive("show-cropping-gutters-switch")
           && maybeCropRatioIfStandard === "5:3";
 
         if (isCropTypeDisabled) {

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -101,9 +101,10 @@
     Please try to use a larger crop or an alternative image.
 </div>
 
-<div class="warning status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
+<div class="warning warning--multiline status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
     Although this is a 5:3 crop, it might be used in a 5:4 space, so please ensure
-    there is nothing important in the striped sides as these might be clipped.
+    there is nothing important in the striped sides as these might be clipped.<br/>
+    You can also suggest alternative crops for the trail image back in Composer.
 </div>
 
 <div class="easel" role="main" aria-label="Image cropper"

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -66,5 +66,5 @@
   background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
 }
 .easel.vertical-warning-gutters .easel__canvas {
-  height: calc(100vh - 115px);
+  height: calc(100vh - 138px);
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -882,7 +882,13 @@ textarea.ng-invalid {
     text-align: center;
 }
 .warning--small {
-    padding: 5px 10px;
+  padding: 5px 10px;
+}
+.warning--multiline {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
 }
 
 .full-error {


### PR DESCRIPTION
…so that all GNM users see the cropping gutters when cropping 5:3 which is now limited to only certain scenarios by query param `shouldShowCropGuttersIfApplicable` (thanks to https://github.com/guardian/grid/pull/4343 and temporarily also https://github.com/guardian/flexible-content/pull/5049). 

Also tweaked the wording in the blue banner to hint users can suggest alternatives back in composer (via https://github.com/guardian/pinboard/pull/312)...
![image](https://github.com/user-attachments/assets/acaf7a9d-c9ec-47b9-bde9-97c83553b94c)
