### PR TITLE
expose aspect ratio and crop type on `asset-handle` elements (used by Pinboard)

### DIFF
--- a/kahuna/public/js/image/crop.html
+++ b/kahuna/public/js/image/crop.html
@@ -20,5 +20,7 @@
     data-source-type="crop"
     data-thumbnail="{{:: extremeAssets.smallest | assetFile}}"
     data-embeddable-url="{{:: ctrl.image.data.id | embeddableUrl:crop.id}}"
+    data-aspect-ratio="{{:: crop.specification.aspectRatio}}"
+    data-crop-type="{{:: crop.specification.aspectRatio | asCropType}}"
   ></asset-handle>
 </div>


### PR DESCRIPTION
To help with https://github.com/guardian/pinboard/pull/312 and https://github.com/guardian/facia-tool/pull/1680 we want to know in pinboard what ratio/type the shared crops are. The Pinboard payload is already built from all the data attributes of the `asset-handle` (see #3190, #3704, #3705, #3683 & #3705 for context) so this PR just surfaces `aspectRatio` and `cropType`.