### PR TITLE
Remove unused fields from components

### DIFF
--- a/auth/app/auth/AuthConfig.scala
+++ b/auth/app/auth/AuthConfig.scala
@@ -5,5 +5,4 @@ import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 class AuthConfig(resources: GridConfigResources) extends CommonConfig(resources) {
   val rootUri: String = services.authBaseUri
   val mediaApiUri: String = services.apiBaseUri
-  val kahunaUri = services.kahunaBaseUri
 }

--- a/collections/app/lib/CollectionsConfig.scala
+++ b/collections/app/lib/CollectionsConfig.scala
@@ -8,6 +8,4 @@ class CollectionsConfig(resources: GridConfigResources) extends CommonConfig(res
   val imageCollectionsTable = string("dynamo.table.imageCollections")
 
   val rootUri = services.collectionsBaseUri
-  val kahunaUri = services.kahunaBaseUri
-  val loginUriTemplate = services.loginUriTemplate
 }

--- a/cropper/app/lib/CropStore.scala
+++ b/cropper/app/lib/CropStore.scala
@@ -55,7 +55,7 @@ class CropStore(config: CropperConfig) extends S3ImageStorage(config) {
       crops.foldLeft(Map[String, Crop]()) {
         case (map, (s3Object)) => {
           val filename::containingFolder::_ = s3Object.uri.getPath.split("/").reverse.toList
-          var isMaster       = containingFolder == "master"
+          val isMaster = containingFolder == "master"
           val userMetadata   = s3Object.metadata.userMetadata
           val objectMetadata = s3Object.metadata.objectMetadata
 

--- a/cropper/app/lib/CropperConfig.scala
+++ b/cropper/app/lib/CropperConfig.scala
@@ -16,8 +16,6 @@ class CropperConfig(resources: GridConfigResources) extends CommonConfig(resourc
 
   val rootUri = services.cropperBaseUri
   val apiUri = services.apiBaseUri
-  val kahunaUri = services.kahunaBaseUri
-  val loginUriTemplate = services.loginUriTemplate
 
   val tempDir: File = new File(stringDefault("crop.output.tmp.dir", "/tmp"))
 

--- a/leases/app/lib/LeasesConfig.scala
+++ b/leases/app/lib/LeasesConfig.scala
@@ -10,8 +10,6 @@ class LeasesConfig(resources: GridConfigResources) extends CommonConfig(resource
   val leasesTable = string("dynamo.tablename.leasesTable")
 
   val rootUri: String = services.leasesBaseUri
-  val kahunaUri: String = services.kahunaBaseUri
-  val loginUriTemplate: String = services.loginUriTemplate
 
   private def uri(u: String) = URI.create(u)
 

--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -1,5 +1,4 @@
 import com.gu.mediaservice.lib.aws.ThrallMessageSender
-import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.management.{ElasticSearchHealthCheck, InnerServiceStatusCheckController, Management}
 import com.gu.mediaservice.lib.metadata.SoftDeletedMetadataTable
 import com.gu.mediaservice.lib.play.GridComponents
@@ -13,8 +12,6 @@ import scala.concurrent.Future
 
 class MediaApiComponents(context: Context) extends GridComponents(context, new MediaApiConfig(_)) {
   final override val buildInfo = utils.buildinfo.BuildInfo
-
-  val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val messageSender = new ThrallMessageSender(config.thrallKinesisStreamConfig)
   val mediaApiMetrics = new MediaApiMetrics(config, actorSystem, applicationLifecycle)

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -256,10 +256,6 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   def makeImgopsUri(uri: URI): String =
     config.imgopsUri + List(uri.getPath, uri.getRawQuery).mkString("?") + "{&w,h,q}"
 
-  def makeOptimisedPngImageopsUri(uri: URI): String = {
-    config.imgopsUri + List(uri.getPath, uri.getRawQuery).mkString("?") + "{&w, h, q}"
-  }
-
   private def updateCustomSpecialInstructions(source: JsValue): Reads[JsObject] = {
      (source \ "usageRights" \ "category") match {
         case JsDefined(category) =>

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -34,13 +34,11 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
   val kahunaUri: String = services.kahunaBaseUri
   val cropperUri: String = services.cropperBaseUri
   val loaderUri: String = services.loaderBaseUri
-  val projectionUri: String = services.projectionBaseUri
   val metadataUri: String = services.metadataBaseUri
   val imgopsUri: String = services.imgopsBaseUri
   val usageUri: String = services.usageBaseUri
   val leasesUri: String = services.leasesBaseUri
   val authUri: String = services.authBaseUri
-  val loginUriTemplate: String = services.loginUriTemplate
   val collectionsUri: String = services.collectionsBaseUri
 
   val requiredMetadata = List("credit", "description", "usageRights")

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,4 +1,3 @@
-import com.gu.mediaservice.lib.imaging.ImageOperations
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{EditsApi, EditsController, SyndicationController}
@@ -12,7 +11,6 @@ class MetadataEditorComponents(context: Context) extends GridComponents(context,
   val editsStore = new EditsStore(config)
   val syndicationStore = new SyndicationStore(config)
   val notifications = new Notifications(config)
-  val imageOperations = new ImageOperations(context.environment.rootPath.getAbsolutePath)
 
   val metrics = new MetadataEditorMetrics(config, actorSystem, applicationLifecycle)
   val messageConsumer = new MetadataSqsMessageConsumer(config, metrics, editsStore)

--- a/metadata-editor/app/lib/EditsConfig.scala
+++ b/metadata-editor/app/lib/EditsConfig.scala
@@ -1,14 +1,9 @@
 package lib
 
-import com.amazonaws.regions.{Region, RegionUtils}
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 
 
 class EditsConfig(resources: GridConfigResources) extends CommonConfig(resources) {
-  val dynamoRegion: Region = RegionUtils.getRegion(string("aws.region"))
-
-  val collectionsBucket: String = string("s3.collections.bucket")
-
   val editsTable = string("dynamo.table.edits")
   val editsTablePhotoshootIndex = string("dynamo.globalsecondaryindex.edits.photoshoots")
   val syndicationTable = string("dynamo.table.syndication")

--- a/usage/app/lib/UsageConfig.scala
+++ b/usage/app/lib/UsageConfig.scala
@@ -1,6 +1,5 @@
 package lib
 
-import com.amazonaws.regions.{Region, RegionUtils}
 import com.amazonaws.services.identitymanagement._
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import com.gu.mediaservice.lib.logging.GridLogging
@@ -12,13 +11,9 @@ import scala.util.Try
 case class KinesisReaderConfig(streamName: String, arn: String, appName: String)
 
 class UsageConfig(resources: GridConfigResources) extends CommonConfig(resources) with GridLogging {
-  val rootUri: String = services.metadataBaseUri
-  val kahunaUri: String = services.kahunaBaseUri
   val usageUri: String = services.usageBaseUri
   val apiUri: String = services.apiBaseUri
-  val loginUriTemplate: String = services.loginUriTemplate
 
-  val defaultPageSize = 100
   val defaultMaxRetries = 4
   val defaultMaxPrintRequestSizeInKb = 500
   val defaultDateLimit = "2016-01-01T00:00:00+00:00"
@@ -29,7 +24,6 @@ class UsageConfig(resources: GridConfigResources) extends CommonConfig(resources
   val capiPreviewUrl = string("capi.preview.url")
   val capiPreviewRole = stringOpt("capi.preview.role")
   val capiApiKey = string("capi.apiKey")
-  val capiPageSize: Int = intDefault("capi.page.size", defaultPageSize)
   val capiMaxRetries: Int = intDefault("capi.maxRetries", defaultMaxRetries)
 
   val usageDateLimit: String = stringDefault("usage.dateLimit", defaultDateLimit)
@@ -41,7 +35,6 @@ class UsageConfig(resources: GridConfigResources) extends CommonConfig(resources
 
   val usageRecordTable = string("dynamo.tablename.usageRecordTable")
 
-  val dynamoRegion: Region = RegionUtils.getRegion(string("aws.region"))
   val awsRegionName = string("aws.region")
 
   private val iamClient: AmazonIdentityManagement = withAWSCredentials(AmazonIdentityManagementClientBuilder.standard()).build()


### PR DESCRIPTION
## What does this change?

Remove various apparently unused fields from components. 

- Unused service URL references (simplifies configuration and clarifies which services talk to each other)
- Image operations (clarifies no special base image requirements).

As a new developer approaching the Grid, removing these unused mentions helps to clarify the mental map of "what services does this service talk too?" and also helps to reduce the size of the minimum viable configuration.

These are straight deletions so the complier should be giving a strong signal as if this is safe or not.


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
