### PR TITLE
pin github actions ubuntu version as 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   CI:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # required by aws-actions/configure-aws-credentials
       id-token: write


### PR DESCRIPTION

## What does this change?

`ubuntu-latest` is now `ubuntu-24.04`, which doesn't preinstall `sbt`, and we currently run this app on ubuntu 22, so pin to `ubuntu-22.04`
