### PR TITLE
some simpler upgrades blocking scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val mediaApi = playProject("media-api", 9001)
   .settings(
     libraryDependencies ++= Seq(
       "org.apache.commons" % "commons-email" % "1.5",
-      "org.parboiled" %% "parboiled" % "2.1.5",
+      "org.parboiled" %% "parboiled" % "2.1.7",
       "org.http4s" %% "http4s-core" % "0.23.17",
     )
   )
@@ -166,7 +166,7 @@ lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
     "com.gu" %% "content-api-client-default" % "19.0.4",
     "com.gu" %% "content-api-client-aws" % "0.7",
-    "io.reactivex" %% "rxscala" % "0.26.5",
+    "io.reactivex" %% "rxscala" % "0.27.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
     "com.google.protobuf" % "protobuf-java" % "3.19.6"
   )


### PR DESCRIPTION
## What does this change?

Upgrades rxscala and parboiled to versions with scala 2.13-compatible releases.

Currently these are the last remaining dependencies preventing an `sbt clean compile` on Scala 2.13, after that we're seeing compiler warnings from the new Scala version. (Though more may emerge as work continues)

## How should a reviewer test this change?

Deploy to TEST and check that grid continues to work as expected.

`parboiled` is used in the query parser: add some more complex chips and check that the search behaves as expected.
`rxscala` is used by usages: add an image to a composer piece, and check that the usage is recorded. (And removed when the image is removed from the piece, etc.etc.)

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
