### PR TITLE
Plugins clearout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,12 @@ import com.typesafe.sbt.packager.debian.JDebPackaging
 // Setting as a packageOption seems to bypass that problem, wherever it lies
 ThisBuild / packageOptions += FixedTimestamp(Package.keepTimestamps)
 
+// Currently multiple modules depend on scala-java8-compat, some on 0.8.x, 0.9.x and 1.x.y
+// These may be binary incompatible, but force the checker to accept them
+// In the future, check if this override can be removed
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
+
 val commonSettings = Seq(
   scalaVersion := "2.12.20",
   description := "grid",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
-
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")


### PR DESCRIPTION
## What does this change?

Remove some unused sbt plugins, notably the `sbt-coursier` plugin which has some bugs which interferes with sbt's own dependency resolution behaviours.

## How should a reviewer test this change?

Should be a no-op, with no change in behaviour when deployed

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
