### PR TITLE
add defaultCropType param

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -50,6 +50,7 @@ crop.controller('ImageCropCtrl', [
       const allCropOptions = cropSettings.getCropOptions();
 
       const storageCropType = cropSettings.getCropType();
+      const storageDefaultCropType = cropSettings.getDefaultCropType();
 
       const cropOptionDisplayValue = cropOption => cropOption.ratioString
         ? `${cropOption.key} (${cropOption.ratioString})`
@@ -63,7 +64,7 @@ crop.controller('ImageCropCtrl', [
           disabled: storageCropType && storageCropType !== option.key
         }));
 
-      ctrl.cropType = storageCropType || defaultCrop.key;
+      ctrl.cropType = storageCropType || storageDefaultCropType ||defaultCrop.key;
 
       ctrl.image = image;
       ctrl.optimisedImageUri = optimisedImageUri;

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -64,7 +64,7 @@ crop.controller('ImageCropCtrl', [
           disabled: storageCropType && storageCropType !== option.key
         }));
 
-      ctrl.cropType = storageCropType || storageDefaultCropType ||defaultCrop.key;
+      ctrl.cropType = storageCropType || storageDefaultCropType || defaultCrop.key;
 
       ctrl.image = image;
       ctrl.optimisedImageUri = optimisedImageUri;

--- a/kahuna/public/js/crop/index.js
+++ b/kahuna/public/js/crop/index.js
@@ -18,7 +18,7 @@ crop.config(['$stateProvider',
              function($stateProvider) {
 
     $stateProvider.state('crop', {
-        url: '/images/:imageId/crop?cropType&customRatio&shouldShowCropGuttersIfApplicable',
+        url: '/images/:imageId/crop?cropType&customRatio&shouldShowCropGuttersIfApplicable&defaultCropType',
         template: cropTemplate,
         controller: 'ImageCropCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -23,7 +23,7 @@ image.config(['$stateProvider',
               function($stateProvider) {
 
     $stateProvider.state('image', {
-        url: '/images/:imageId?crop?cropType&customRatio&shouldShowCropGuttersIfApplicable',
+        url: '/images/:imageId?crop?cropType&customRatio&shouldShowCropGuttersIfApplicable&defaultCropType',
         template: imageTemplate,
         controller: 'ImageCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -73,7 +73,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     $stateProvider.state('search', {
         // FIXME [1]: This state should be abstract, but then we can't navigate to
         // it, which we need to do to access it's deeper / remembered chile state
-        url: '/?cropType&customRatio&shouldShowCropGuttersIfApplicable',
+        url: '/?cropType&customRatio&shouldShowCropGuttersIfApplicable&defaultCropType',
         template: searchTemplate,
         deepStateRedirect: {
             // Inject a transient $stateParams for the results state

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -90,7 +90,7 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     }
 
     if (defaultCropType) {
-      setDefaultCropType(defaultCropType)
+      setDefaultCropType(defaultCropType);
     }
 
     if (shouldShowCropGuttersIfApplicable) {

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -5,6 +5,7 @@ import { landscape, portrait, video, square, freeform, cropOptions } from './con
 const CROP_TYPE_STORAGE_KEY = 'cropType';
 const CUSTOM_CROP_STORAGE_KEY = 'customCrop';
 const SHOULD_SHOW_CROP_GUTTERS_IF_APPLICABLE_STORAGE_KEY = 'shouldShowCropGuttersIfApplicable';
+const CROP_DEFAULT_TYPE_STORAGE_KEY = 'defaultCropType';
 
 const customCrop = (label, xRatio, yRatio) => {
   return { key:label, ratio: xRatio / yRatio, ratioString: `${xRatio}:${yRatio}`};
@@ -53,6 +54,14 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     }
   };
 
+  const setDefaultCropType = (defaultCropType) => {
+    if (isValidCropType(defaultCropType)) {
+      storage.setJs(CROP_DEFAULT_TYPE_STORAGE_KEY, defaultCropType, true);
+    } else {
+      storage.clearJs(CROP_DEFAULT_TYPE_STORAGE_KEY);
+    }
+  };
+
   const setCustomCrop = customRatio => {
     const parsedRatio = parseRatio(customRatio);
     if (parsedRatio) {
@@ -70,7 +79,7 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     );
   };
 
-  function set({cropType, customRatio, shouldShowCropGuttersIfApplicable}) {
+  function set({cropType, customRatio, shouldShowCropGuttersIfApplicable, defaultCropType}) {
     // set customRatio first in case cropType relies on a custom crop
     if (customRatio) {
       setCustomCrop(customRatio);
@@ -78,6 +87,10 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
 
     if (cropType) {
       setCropType(cropType);
+    }
+
+    if (defaultCropType) {
+      setDefaultCropType(defaultCropType)
     }
 
     if (shouldShowCropGuttersIfApplicable) {
@@ -94,11 +107,19 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     }
   }
 
+  function getDefaultCropType() {
+    const defaultCropType = storage.getJs(CROP_DEFAULT_TYPE_STORAGE_KEY, true);
+
+    if (isValidCropType(defaultCropType)) {
+      return defaultCropType;
+    }
+  }
+
   function shouldShowCropGuttersIfApplicable() {
     return storage.getJs(SHOULD_SHOW_CROP_GUTTERS_IF_APPLICABLE_STORAGE_KEY, true);
   }
 
-  return { set, getCropType, getCropOptions, shouldShowCropGuttersIfApplicable };
+  return { set, getCropType, getCropOptions, shouldShowCropGuttersIfApplicable, getDefaultCropType };
 }]);
 
 cropUtil.filter('asCropType', function() {


### PR DESCRIPTION
## What does this change?

Adds a `defaultCropType` param to kahuna's search, image and crop pages and validates and stores it in the same way as the existing `cropType` param.

The `defaultCropType` is used to set what type of crop to initially set the on the crop window. If the param is not set, this will default to 'landscape', (being defined as `defaultCrop`) as currently

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

run locally, open:
https://media.local.dev-gutools.co.uk/search?nonFree=true&defaultCropType=freeform
choose an image, click the 'crop' button
the crop UI should have "freeform" selected instead of "landscape"

## How can success be measured?

The purpose is to allow application that use a Grid window to specify the "preferred" crop type, without preventing user selecting other crops.

In particular, the request is for Gallery Articles in composer - when adding images, they should default to freeform (which will start as a full frame crop), but users should be able to select other, existing crops if desired.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
