### PR TITLE
add automatic image type detection

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageType.scala
@@ -6,7 +6,7 @@ import com.gu.mediaservice.model.Image
 
 // Note this is a Processor, not a Cleaner!
 // This really ought to live in the ImageMetadataConverter, but unfortunately
-// that cannot be configured to behave differently per deployer
+// that cannot be configured to behave differently per organisation
 object InsertGuardianImageType extends ImageProcessor with GridLogging {
 
   override def apply(image: Image): Image = {

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageType.scala
@@ -1,0 +1,92 @@
+package com.gu.mediaservice.lib.cleanup
+
+import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.model.Image
+
+
+// Note this is a Processor, not a Cleaner!
+// This really ought to live in the ImageMetadataConverter, but unfortunately
+// that cannot be configured to behave differently per deployer
+object InsertGuardianImageType extends ImageProcessor with GridLogging {
+
+  override def apply(image: Image): Image = {
+    image.fileMetadata.readXmpHeadStringProp("Iptc4xmpExt:DigitalSourceType") match {
+      case Some(dst) =>
+        val imageType = toImageType(dst)
+        val metadata = image.metadata.copy(imageType = imageType)
+        image.copy(metadata = metadata)
+      case None => image
+    }
+  }
+
+  def toImageType(digitalSourceType: String): Option[String] = {
+    val Photograph = Some("Photograph")
+    val Illustration = Some("Illustration")
+    val Composite = Some("Composite")
+    // https://cv.iptc.org/newscodes/digitalsourcetype/
+    digitalSourceType match {
+      // Digital capture sampled from real life
+      case DigitalSourceType("digitalCapture") => Photograph
+      // Multi-frame computational capture sampled from real life
+      case DigitalSourceType("computationalCapture") => Photograph
+      // Digitised from a transparent negative
+      case DigitalSourceType("negativeFilm") => Photograph
+      // Digitised from a transparent positive
+      case DigitalSourceType("positiveFilm") => Photograph
+      // Digitised from a non-transparent medium
+      case DigitalSourceType("print") => None
+      // RETIRED Original media with minor human edits
+      case DigitalSourceType("minorHumanEdits") => None
+      // Human-edited media
+      case DigitalSourceType("humanEdits") => None
+      // Edited using Generative AI
+      case DigitalSourceType("compositeWithTrainedAlgorithmicMedia") => Illustration
+      // Algorithmically-altered media
+      case DigitalSourceType("algorithmicallyEnhanced") => Illustration
+      // RETIRED The digital image was created by computer software
+      case DigitalSourceType("softwareImage") => Illustration
+      // RETIRED Media created by a human using digital tools
+      case DigitalSourceType("digitalArt") => Illustration
+      // Media created by a human using non-generative tools
+      case DigitalSourceType("digitalCreation") => Illustration
+      // Digital media representation of data via human programming or creativity
+      case DigitalSourceType("dataDrivenMedia") => Illustration
+      // Created using Generative AI
+      case DigitalSourceType("trainedAlgorithmicMedia") => Illustration
+      // Media created purely by an algorithm not based on any sampled training data
+      case DigitalSourceType("algorithmicMedia") => Illustration
+      // A capture of the contents of the screen of a computer or mobile device
+      case DigitalSourceType("screenCapture") => Illustration
+      // Live recording of virtual event based on Generative AI and/or captured elements
+      case DigitalSourceType("virtualRecording") => None
+      // Mix or composite of several elements, any of which may or may not be generative AI
+      case DigitalSourceType("composite") => Composite
+      // Mix or composite of several elements that are all captures of real life
+      case DigitalSourceType("compositeCapture") => Composite
+      // Mix or composite of several elements, at least one of which is Generative AI
+      case DigitalSourceType("compositeSynthetic") => Illustration
+      // unknown
+      case other =>
+        logger.warn(s"Unexpected Iptc4xmpExt:DigitalSourceType value: $other. Consider adding a case for this value to DigitalSourceType.scala")
+        None
+    }
+  }
+}
+
+
+object DigitalSourceType {
+  private val dstUri = "http://cv.iptc.org/newscodes/digitalsourcetype/"
+  def unapply(name: String): Option[String] = {
+    if (name.startsWith(dstUri)) {
+      Some(name.stripPrefix(dstUri))
+    } else {
+      None
+    }
+    /* TODO in scala 2.13:
+      name match {
+        case s"http://cv.iptc.org/newscodes/digitalsourcetype/$value" =>
+          Some(value)
+        case _ => None
+     */
+  }
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/MetadataCleaner.scala
@@ -28,7 +28,8 @@ class MetadataCleaners(resources: ImageProcessorResources)
     CapitaliseCity,
     CapitaliseSubLocation,
     DropRedundantTitle,
-    PhotographerRenamer
+    PhotographerRenamer,
+    InsertGuardianImageType
   )
 
 // By vague order of importance:

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageTypeTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageTypeTest.scala
@@ -1,0 +1,49 @@
+package com.gu.mediaservice.lib.cleanup
+
+import com.gu.mediaservice.model.{FileMetadata, Image}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.JsString
+
+class InsertGuardianImageTypeTest extends AnyFlatSpec with Matchers with OptionValues with MetadataHelper {
+  def imageWithDigitalSourceType(dst: String): Image = {
+    val base = createImageFromMetadata()
+    val fileMeta = FileMetadata(
+      xmp = Map("Iptc4xmpExt:DigitalSourceType" -> JsString(s"http://cv.iptc.org/newscodes/digitalsourcetype/$dst"))
+    )
+    base.copy(fileMetadata = fileMeta)
+  }
+
+  it should "insert image type Photograph from a 'digitalCapture'" in {
+    val img = imageWithDigitalSourceType("digitalCapture")
+
+    val inserted = InsertGuardianImageType(img)
+
+    inserted.metadata.imageType.value shouldBe "Photograph"
+  }
+
+  it should "insert image type Illustration from a 'digitalCreation'" in {
+    val img = imageWithDigitalSourceType("digitalCreation")
+
+    val inserted = InsertGuardianImageType(img)
+
+    inserted.metadata.imageType.value shouldBe "Illustration"
+  }
+
+  it should "insert image type Composite from a 'composite'" in {
+    val img = imageWithDigitalSourceType("composite")
+
+    val inserted = InsertGuardianImageType(img)
+
+    inserted.metadata.imageType.value shouldBe "Composite"
+  }
+
+  it should "not insert an image type from a 'print'" in {
+    val img = imageWithDigitalSourceType("print")
+
+    val inserted = InsertGuardianImageType(img)
+
+    inserted.metadata.imageType shouldBe None
+  }
+}


### PR DESCRIPTION
## What does this change?

Detect the image type (according to the Guardian vocabulary) from the Digital Source Type (IPTC vocab) when applicable.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
