### PR TITLE
Upgrade to recent libthrift

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,8 +120,6 @@ lazy val restLib = project("rest-lib").settings(
     "com.typesafe.play" %% "filters-helpers" % "2.8.11",
     akkaHttpServer,
   ),
-
-  dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 ).dependsOn(commonLib % "compile->compile;test->test")
 
 lazy val auth = playProject("auth", 9011)

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,6 @@ lazy val commonLib = project("common-lib").settings(
     "org.yaml" % "snakeyaml" % "1.31",
     "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   ),
-  dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.13.0",
   dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test
 )
 


### PR DESCRIPTION
## What does this change?

Our dependencies now bring in recent versions of libthrift, so remove the dependencyOverrides which were keeping us stuck to older versions.

This PR should fix *3* "high" vulnerabilities on snyk.

## How should a reviewer test this change?

Deploy to TEST and check that all functionality performs as previously.

The only libthrift usage I'm aware of is in the Guardian-specific usage stream - content updates arriving from Crier will be in the thrift format, and we'll need to deserialize them. Try adding some images to draft Composer pieces, and ensure that the pending usage arrives, and is removed when removed from the Composer piece, etc.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
