### PR TITLE
Documentation fix; correct usageRightsConfigProvider class name for GuardianUsageRightsConfig

### DIFF
--- a/docs/07-extending/04-usage-rights.md
+++ b/docs/07-extending/04-usage-rights.md
@@ -16,7 +16,7 @@ implementations are provided out of the box in the Grid.
   below.
 
 ```hocon
-usageRightsConfigProvider = "com.gu.mediaservice.lib.guardian.GuardianUsageRightsConfig"
+usageRightsConfigProvider = "com.gu.mediaservice.lib.guardian.GuardianUsageRightsConfig$"
 ```
 
 * `RuntimeUsageRightsConfig` - that fetches the data from the application configuration. To use this provider and


### PR DESCRIPTION
## What does this change?

The canonical class name of `GuardianUsageRightsConfig` needs a trailing `$` in the configuration now that it's a Scala object.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
