### PR TITLE
remove unused "elasticsearch-action-updatebyquery" dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,6 @@ lazy val thrall = playProject("thrall", 9002)
     pipelineStages := Seq(digest, gzip),
     libraryDependencies ++= Seq(
       "org.codehaus.groovy" % "groovy-json" % "3.0.7",
-      "com.yakaz.elasticsearch.plugins" % "elasticsearch-action-updatebyquery" % "2.2.0",
       "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"


### PR DESCRIPTION
This old dependency brings in an old version of the elasticsearch rest client. Remove it to remove the old, vulnerable dependency

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
