### PR TITLE
Revert "Default Richard Saker to Guardian publication"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -73,6 +73,7 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Jonathan Lovekin",
       "Karen Robinson",
       "Katherine Anne Rose",
+      "Richard Saker",
       "Sophia Evans",
       "Suki Dhanda"
     )),
@@ -89,7 +90,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Martin Godwin",
       "Mike Bowers",
       "Murdo MacLeod",
-      "Richard Saker",
       "Sarah Lee",
       "Tom Jenkins",
       "Tristram Kenton",


### PR DESCRIPTION
Reverts guardian/grid#3655 at the request of Editorial. https://www.youtube.com/watch?v=90WD_ats6eE