### PR TITLE
override apache avro to 1.11.4 to avoid critical vuln

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,11 @@ lazy val thrall = playProject("thrall", 9002)
       "io.github.streetcontxt" %% "kcl-akka-stream" % "4.1.1",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
-    )
+    ),
+    // amazon-kinesis-client 2.4.2 brings in a critically vulnerable version of apache avro,
+    // but we cannot upgrade amazon-kinesis-client further until we move into slf4j v2.
+    // TODO when upgrading kinesis-client - can we remove this override?
+    dependencyOverrides += "org.apache.avro" % "avro" % "1.11.4"
   )
 
 lazy val usage = playProject("usage", 9009).settings(


### PR DESCRIPTION
## What does this change?

`amazon-kinesis-client 2.4.2` brings in a version of apache avro with a critical vulnerability - but that is the latest version of kcl that depends on a v1 of `slf4j` - easier to override the version of avro for now (if it works) than untangling the slf4j upgrade.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
