### PR TITLE
Fix usages stream for cartoons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,8 +171,8 @@ lazy val thrall = playProject("thrall", 9002)
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "19.0.4",
-    "com.gu" %% "content-api-client-aws" % "0.7",
+    "com.gu" %% "content-api-client-default" % "32.0.0",
+    "com.gu" %% "content-api-client-aws" % "0.7.6",
     "io.reactivex" %% "rxscala" % "0.27.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
     "com.google.protobuf" % "protobuf-java" % "3.19.6"

--- a/build.sbt
+++ b/build.sbt
@@ -171,8 +171,8 @@ lazy val thrall = playProject("thrall", 9002)
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "32.0.0",
-    "com.gu" %% "content-api-client-aws" % "0.7.6",
+    "com.gu" %% "content-api-client-default" % "32.0.0" exclude("org.slf4j","slf4j-api"), // slf4j exclusion can be removed when we upgrade to SLFJ v2
+    "com.gu" %% "content-api-client-aws" % "0.7.6" exclude("org.slf4j","slf4j-api"), // slf4j exclusion can be removed when we upgrade to SLFJ v2
     "io.reactivex" %% "rxscala" % "0.27.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
     "com.google.protobuf" % "protobuf-java" % "3.19.6"

--- a/build.sbt
+++ b/build.sbt
@@ -171,8 +171,8 @@ lazy val thrall = playProject("thrall", 9002)
 
 lazy val usage = playProject("usage", 9009).settings(
   libraryDependencies ++= Seq(
-    "com.gu" %% "content-api-client-default" % "32.0.0" exclude("org.slf4j","slf4j-api"), // slf4j exclusion can be removed when we upgrade to SLFJ v2
-    "com.gu" %% "content-api-client-aws" % "0.7.6" exclude("org.slf4j","slf4j-api"), // slf4j exclusion can be removed when we upgrade to SLFJ v2
+    "com.gu" %% "content-api-client-default" % "32.0.0",
+    "com.gu" %% "content-api-client-aws" % "0.7.6",
     "io.reactivex" %% "rxscala" % "0.27.0",
     "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
     "com.google.protobuf" % "protobuf-java" % "3.19.6"

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ val commonSettings = Seq(
     "org.mockito" % "mockito-core" % "2.18.0" % Test,
     "org.scalamock" %% "scalamock" % "5.1.0" % Test,
   ),
-  dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.3",
+  dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2",
 
   Compile / doc / sources := Seq.empty,
   Compile / packageDoc / publishArtifact := false

--- a/usage/app/lib/ContentApis.scala
+++ b/usage/app/lib/ContentApis.scala
@@ -16,7 +16,7 @@ abstract class UsageContentApiClient(config: UsageConfig)(implicit val executor:
   def usageQuery(contentId: String): ItemQuery = {
     ItemQuery(contentId)
       .showFields("firstPublicationDate,isLive,internalComposerCode")
-      .showElements("image")
+      .showElements("image,cartoon")
       .showAtoms("media")
   }
 }

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -207,23 +207,17 @@ class UsageGroupOps(config: UsageConfig, mediaWrapperOps: MediaWrapperOps)
     }
   }
 
-  private def extractCartoonUniqueMediaIds(content: Content): Set[String] = {
-    content.elements.toSeq.flatMap { elements =>
-      elements.filter(_.`type` == ElementType.Cartoon).flatMap { cartoonElement =>
-        cartoonElement.assets.flatMap { asset =>
-          asset.typeData.toSeq.flatMap { data =>
-            data.cartoonVariants.toSeq.flatMap { cartoonVariants =>
-              cartoonVariants.flatMap { cartoonVariant =>
-                cartoonVariant.images.flatMap { image =>
-                  image.mediaId
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }.toSet
+  private def extractCartoonUniqueMediaIds(content: Content): Set[String] = 
+    (for {
+      elements <- content.elements.toSeq
+      cartoonElement <- elements.filter(_.`type` == ElementType.Cartoon)
+      asset <- cartoonElement.assets.toSeq
+      data <- asset.typeData.toSeq
+      cartoonVariants <- data.cartoonVariants.toSeq
+      cartoonVariant <- cartoonVariants
+      image <- cartoonVariant.images
+      mediaId <- image.mediaId
+    } yield mediaId).toSet
 
   private def extractImageElements(
     content: Content, usageStatus: UsageStatus, isReindex: Boolean

--- a/usage/app/model/UsageGroup.scala
+++ b/usage/app/model/UsageGroup.scala
@@ -109,21 +109,26 @@ class UsageGroupOps(config: UsageConfig, mediaWrapperOps: MediaWrapperOps)
     val mediaAtomsUsages = extractMediaAtoms(content, usageStatus, isReindex)(extractJobLogMarkers).flatMap { atom =>
       getImageId(atom) match {
         case Some(id) =>
-          val mediaWrapper = mediaWrapperOps.build(id, contentWrapper, buildId(contentWrapper))
+          val mediaWrapper = mediaWrapperOps.build(mediaId = id, contentWrapper = contentWrapper, usageGroupId = buildId(contentWrapper))
           val usage = MediaUsageBuilder.build(mediaWrapper)
           Seq(createUsagesLogging(usage)(logMarker))
         case None => Seq.empty
       }
     }
     val imageElementUsages = extractImageElements(content, usageStatus, isReindex)(extractJobLogMarkers).map { element =>
-      val mediaWrapper = mediaWrapperOps.build(element.id, contentWrapper, buildId(contentWrapper))
+      val mediaWrapper = mediaWrapperOps.build(mediaId = element.id, contentWrapper = contentWrapper, usageGroupId = buildId(contentWrapper))
+      val usage = MediaUsageBuilder.build(mediaWrapper)
+      createUsagesLogging(usage)(logMarker)
+    }
+    val cartoonElementUsages = extractCartoonUniqueMediaIds(content).map { mediaId =>
+      val mediaWrapper = mediaWrapperOps.build(mediaId, contentWrapper = contentWrapper, usageGroupId = buildId(contentWrapper))
       val usage = MediaUsageBuilder.build(mediaWrapper)
       createUsagesLogging(usage)(logMarker)
     }
 
     // TODO capture images from interactive embeds
 
-    mediaAtomsUsages ++ imageElementUsages
+    mediaAtomsUsages ++ imageElementUsages ++ cartoonElementUsages
   }
 
   private def createUsagesLogging(usage: MediaUsage)(implicit logMarker: LogMarker) = {
@@ -201,6 +206,24 @@ class UsageGroupOps(config: UsageConfig, mediaWrapperOps: MediaWrapperOps)
       case e: ClassCastException => None
     }
   }
+
+  private def extractCartoonUniqueMediaIds(content: Content): Set[String] = {
+    content.elements.toSeq.flatMap { elements =>
+      elements.filter(_.`type` == ElementType.Cartoon).flatMap { cartoonElement =>
+        cartoonElement.assets.flatMap { asset =>
+          asset.typeData.toSeq.flatMap { data =>
+            data.cartoonVariants.toSeq.flatMap { cartoonVariants =>
+              cartoonVariants.flatMap { cartoonVariant =>
+                cartoonVariant.images.flatMap { image =>
+                  image.mediaId
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }.toSet
 
   private def extractImageElements(
     content: Content, usageStatus: UsageStatus, isReindex: Boolean


### PR DESCRIPTION
## What does this change?

Usages of images in cartoon elements were not being correctly recorded by the Grid. 

Usages are processed by the `usage-stream` service, which listens to events from CAPI then queries CAPI with the `'show-elements=image'` and `'show-atoms=media'` query params, extracting and building usage records accordingly. This wasn't happening for cartoons, as the images live inside the `cartoonVariants` field of the cartoon element. 

The fix was to add `'show-elements=cartoon'` to the CAPI query and look inside `cartoonVariants` for the images.

## How should a reviewer test this change?

It has already been tested on CODE. We created a cartoon in `composer.code.dev-gutools.co.uk` and verified the usage came through as expected in `media.test.dev-gutools.co.uk`

![Screenshot 2024-12-04 at 10 25 08](https://github.com/user-attachments/assets/cd0691a2-40fb-4181-9b36-475386844dc4)

## How can success be measured?

Image usages are correctly recorded for cartoons.

## Who should look at this?

@guardian/newsroom-resilience?

## Tested? Documented?

- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
