### PR TITLE
searchWithModifiers added to Collections panel

### DIFF
--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel-node.html
@@ -29,7 +29,8 @@
         <a data-cy="collection-child-link"
            ng-if="! ctrl.hasCustomSelect"
            class="node__name flex-spacer"
-           ui-sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId), nonFree: ctrl.srefNonfree()})">
+           ui-sref="search.results({query: ctrl.getCollectionQuery(node.data.data.pathId), nonFree: ctrl.srefNonfree()})"
+           ng-click="ctrl.searchWithModifiers($event, 'collection', node.data.data.pathId)">
             {{:: node.data.data.description}}
         </a>
 

--- a/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
+++ b/kahuna/public/js/components/gr-collections-panel/gr-collections-panel.js
@@ -12,6 +12,7 @@ import './gr-collections-panel.css';
 import {getCollection} from '../../search-query/query-syntax';
 import nodeTemplate from './gr-collections-panel-node.html';
 import '../../directives/gr-auto-focus';
+import '../../search/query-filter';
 
 export var grCollectionsPanel = angular.module('grCollectionsPanel', [
     'kahuna.services.panel',
@@ -92,8 +93,8 @@ grCollectionsPanel.controller('GrCollectionsPanelCtrl', [
 }]);
 
 grCollectionsPanel.controller('GrNodeCtrl',
-    ['$scope', 'collections', 'subscribe$', 'inject$', 'onValChange', 'collectionsTreeState', 'storage',
-    function($scope, collections, subscribe$, inject$, onValChange, collectionsTreeState, storage) {
+    ['$scope', 'collections', 'subscribe$', 'inject$', 'onValChange', 'collectionsTreeState', 'storage', 'searchWithModifiers',
+    function($scope, collections, subscribe$, inject$, onValChange, collectionsTreeState, storage, searchWithModifiers) {
 
     const ctrl = this;
 
@@ -186,6 +187,7 @@ grCollectionsPanel.controller('GrNodeCtrl',
 
 
       };
+      ctrl.searchWithModifiers = searchWithModifiers;
     };
 }]);
 


### PR DESCRIPTION
## What does this change?

Previously, in https://github.com/guardian/grid/pull/4252, Alt- and Shift- modifiers to exclude and add were added to Collection badges on thumbnails and on Collection info in Info Panel (which is broken and works only on single image). This PR adds the familiar functionality to the Collections panel. Lack of it was a surprise to a member of Editorial, which was a surprise to me. But a happy ne!

## How should a reviewer test this change?

Run a search. Hold Shift and click on a Collection in the panel. Hold Alt and do the same. Observe extra conditions in the searchbox.

## How can success be measured?

In our hearts. And minds.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
