### PR TITLE
remove S3 watcher deployment (only affects Guardian)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,4 @@ jobs:
             image-counter-lambda:
               - image-counter-lambda/dist/image-counter-lambda.zip
 
-            s3watcher:
-              - s3watcher/lambda/target/s3watcher.zip
-
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -119,14 +119,3 @@ deployments:
       fileName: image-counter-lambda.zip
       functionNames:
         - "image-counter-lambda-function-"
-
-  s3watcher:
-    type: aws-lambda
-    parameters:
-      functions:
-        TEST:
-          filename: s3watcher.zip
-          name: media-service-TEST-S3WatcherLamdbaFunction-1OZTI92QAHHU3
-        PROD:
-          filename: s3watcher.zip
-          name: media-service-PROD-S3WatcherLamdbaFunction-11VPCX7ETKU5O


### PR DESCRIPTION
Since we've had queue ingestion (see https://github.com/guardian/grid/pull/4201) running very successfully for almost a year we're removing all its infrastructure (see https://github.com/guardian/editorial-tools-platform/pull/828) and as such we ought to remove the guardian deployment steps relating to S3 watcher too.

This PR of course doesn't include actually removing 'S3 watcher' from this repo, although we'd very much like to, we're waiting on another user of the grid (CC @RichardLe @AndyKilmory).