### PR TITLE
upgrade to latest metadata-extractor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,7 @@ lazy val cropper = playProject("cropper", 9006)
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
     "org.apache.tika" % "tika-core" % "1.20",
-    "com.drewnoakes" % "metadata-extractor" % "2.17.0"
+    "com.drewnoakes" % "metadata-extractor" % "2.19.0"
   )
 }
 


### PR DESCRIPTION
## What does this change?

Upgrades to latest metadata-extractor. Get latest features and avoid high vulnerability https://github.com/advisories/GHSA-4v6p-cxf9-98rf

## How should a reviewer test this change?

Deploy to TEST and upload an image - check that metadata is extracted the same as currently

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
