### PR TITLE
upgrade v2 kcl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,14 +158,14 @@ lazy val thrall = playProject("thrall", 9002)
     pipelineStages := Seq(digest, gzip),
     libraryDependencies ++= Seq(
       "org.codehaus.groovy" % "groovy-json" % "3.0.7",
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.2",
+      // TODO upgrading kcl to v3? check if you can remove avro override below
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.0",
       "io.github.streetcontxt" %% "kcl-akka-stream" % "4.1.1",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
     ),
-    // amazon-kinesis-client 2.4.2 brings in a critically vulnerable version of apache avro,
-    // but we cannot upgrade amazon-kinesis-client further until we move into slf4j v2.
-    // TODO when upgrading kinesis-client - can we remove this override?
+    // amazon-kinesis-client 2.6.0 brings in a critically vulnerable version of apache avro,
+    // but we cannot upgrade amazon-kinesis-client further without performing the v2->v3 upgrade https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html
     dependencyOverrides += "org.apache.avro" % "avro" % "1.11.4"
   )
 


### PR DESCRIPTION
## What does this change?

The kinesis-client-library brings in a series of transitive dependencies with high vulnerability warnings. Upgrade to the latest in the v2 series to remove as many as possible with straightforward upgrades.

Further upgrades will be required in the near future, but we should follow the migration steps here https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html

## How should a reviewer test this change?

Deploy to TEST, and upload or edit an image - check that the updates flow through the update stream to thrall and are persisted into the ES cluster.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
