### PR TITLE
upgrade to the latest version of tika 1.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val cropper = playProject("cropper", 9006)
 
 lazy val imageLoader = playProject("image-loader", 9003).settings {
   libraryDependencies ++= Seq(
-    "org.apache.tika" % "tika-core" % "1.20",
+    "org.apache.tika" % "tika-core" % "1.28.5",
     "com.drewnoakes" % "metadata-extractor" % "2.19.0"
   )
 }


### PR DESCRIPTION
there are 2.x and now 3.x versions, but i have not investigated the ease of migration, but this at least moves beyond the version with a high vulnerability warning

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
