### PR TITLE
file size limit for upload/ingest (optional and configurable)

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -54,6 +54,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientV1B
   val maybeIngestBucket: Option[String] = stringOpt("s3.ingest.bucket")
   val maybeFailBucket: Option[String] = stringOpt("s3.fail.bucket")
 
+  val maybeUploadLimitInBytes: Option[Int] = intOpt("upload.limit.mb").map(_ * 1_000_000)
+
   // Note: had to make these lazy to avoid init order problems ;_;
   val domainRoot: String = string("domain.root")
   val domainRootOverride: Option[String] = stringOpt("domain.root-override")

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -150,6 +150,7 @@ class ImageLoaderController(auth: Authentication,
               imageId, UploadStatus(StatusType.Failed, Some(errorMessage))
             )
           }
+          metrics.failedIngestsFromQueue.incrementBothWithAndWithoutDimensions(metricDimensions)
           Future.unit
         }
         else if (approximateReceiveCount > 2) {

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -141,8 +141,8 @@ class ImageLoaderController(auth: Authentication,
 
         val approximateReceiveCount = getApproximateReceiveCount(sqsMessage)
 
-        if(s3IngestObject.contentLength > 500000000){ // 500MB
-          val errorMessage = s"File size exceeds the maximum allowed size (500MB). Moving to fail bucket."
+        if(config.maybeUploadLimitInBytes.exists(_ < s3IngestObject.contentLength)){
+          val errorMessage = s"File size exceeds the maximum allowed size (${config.maybeUploadLimitInBytes.get / 1_000_000}MB). Moving to fail bucket."
           logger.warn(logMarker, errorMessage)
           store.moveObjectToFailedBucket(s3IngestObject.key)
           s3IngestObject.maybeMediaIdFromUiUpload foreach { imageId =>

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -85,6 +85,7 @@
           permissionsDefault: "@kahunaConfig.permissionsDefault",
           defaultShouldBlurGraphicImages: @kahunaConfig.defaultShouldBlurGraphicImages,
           shouldUploadStraightToBucket: @kahunaConfig.shouldUploadStraightToBucket,
+          maybeUploadLimitInBytes: @kahunaConfig.maybeUploadLimitInBytes,
           announcements: @Html(announcements),
           imageTypes: @Html(imageTypes),
         }

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -33,15 +33,18 @@ upload.factory('uploadManager',
 
     async function createJobItems(_files){
 
-      const filesAboveSizeLimit = _files.filter(file => file.size > 500000000); // 500MB
+      const maybeUploadLimitInBytes = window._clientConfig.maybeUploadLimitInBytes;
+      const maybeFilesAboveSizeLimit = maybeUploadLimitInBytes && _files.filter(file => file.size > maybeUploadLimitInBytes);
 
-      if (filesAboveSizeLimit.length > 0){
-        alert(`The following files will be skipped as they are above the size limit of 500MB:\n ${
-          filesAboveSizeLimit.map(file => file.name).join("\n")
+      if (maybeFilesAboveSizeLimit && maybeFilesAboveSizeLimit.length > 0){
+        alert(`The following files will be skipped as they are above the size limit of ${maybeUploadLimitInBytes / 1_000_000}MB:\n${
+          maybeFilesAboveSizeLimit.map(file => file.name).join("\n")
         }`);
       }
 
-      const files = _files.filter(file => !filesAboveSizeLimit.includes(file));
+      const files = maybeFilesAboveSizeLimit && maybeFilesAboveSizeLimit.length > 0
+        ? _files.filter(file => !maybeFilesAboveSizeLimit.includes(file))
+        : _files;
 
       if (window._clientConfig.shouldUploadStraightToBucket) {
         const mediaIdToFileMap = Object.fromEntries(

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -34,7 +34,7 @@ upload.factory('uploadManager',
     async function createJobItems(_files){
 
       const maybeUploadLimitInBytes = window._clientConfig.maybeUploadLimitInBytes;
-      const maybeFilesAboveSizeLimit = maybeUploadLimitInBytes && _files.filter(file => file.size > maybeUploadLimitInBytes);
+      const maybeFilesAboveSizeLimit = !!maybeUploadLimitInBytes && _files.filter(file => file.size > maybeUploadLimitInBytes);
 
       if (maybeFilesAboveSizeLimit && maybeFilesAboveSizeLimit.length > 0){
         alert(`The following files will be skipped as they are above the size limit of ${maybeUploadLimitInBytes / 1_000_000}MB:\n${

--- a/kahuna/public/js/upload/manager.js
+++ b/kahuna/public/js/upload/manager.js
@@ -31,7 +31,18 @@ upload.factory('uploadManager',
         };
     }
 
-    async function createJobItems(files){
+    async function createJobItems(_files){
+
+      const filesAboveSizeLimit = _files.filter(file => file.size > 500000000); // 500MB
+
+      if (filesAboveSizeLimit.length > 0){
+        alert(`The following files will be skipped as they are above the size limit of 500MB:\n ${
+          filesAboveSizeLimit.map(file => file.name).join("\n")
+        }`);
+      }
+
+      const files = _files.filter(file => !filesAboveSizeLimit.includes(file));
+
       if (window._clientConfig.shouldUploadStraightToBucket) {
         const mediaIdToFileMap = Object.fromEntries(
           await Promise.all(


### PR DESCRIPTION
Recently the image-loader boxes got completely choked up and the queue grew in size. This was down to multiple whopping great images (e.g. 1GB), this was in the sweet spot (or rather not-so-sweet spot) between being small enough to successfully process and so big that it causes OoM and the box falls over and is recycled (still not great, but at least eventually self-healing) whereas the boxes stayed alive (passing healthcheck) but ultimately not completing the processing of the images.

## What does this change?
**This PR introduces an optional limit via a new config option `upload.limit.mb` (in common.conf, as it's used by both `kahuna` and `image-loader`.**

This limit is imposed in two places...

- As it picks an item off the ingest queue in `image-loader` - so as to guard against images from any source (agency, photographer over FTP ~or UI upload~) - which means we retain a copy of the offending image in the fail bucket for closer inspection.

- For UI uploads (`kahuna`), to avoid burning the planet by wastefully sending all those bytes to S3 only to have the server tell us the file is too big, we can alert the user promptly in the client, like so...
<img width="463" alt="image" src="https://github.com/user-attachments/assets/4b935796-3595-4ceb-be27-42dba2f7b3dc" />

## How should a reviewer test this change?

Try dropping an image over 500MB (e.g. download https://media.gutools.co.uk/images/25287e288b9254437e65209b541aa8e8895d571e) into the ingest queue bucket (in a dir with your name on it) and you should see this in the logs (as it's not a UI upload...
<img width="572" alt="image" src="https://github.com/user-attachments/assets/fe409862-6d5a-4bab-bc80-ed32c98d6231" /> 
...and the file should end up in the fail bucket.

Try uploading the same file to the UI and you should see a much prompter failure.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
