### PR TITLE
tell snyk workflow to run with updated python

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,6 +15,6 @@ jobs:
       SKIP_NODE: false
       SKIP_PYTHON: false
       PIP_REQUIREMENTS_FILES: quarantine-status/lambda/requirements.txt
-      PYTHON_VERSION: 3.7.13
+      PYTHON_VERSION: 3.13.1
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION


## What does this change?

the latest ubuntu image will not use this version of python any more. this version isnt used at runtime so lets update the workflow to a nice modern version, which should last a few more years

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
