### PR TITLE
Fixes UI infinite polling after image delete

### DIFF
--- a/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
+++ b/kahuna/public/js/components/gr-delete-image/gr-delete-image.js
@@ -14,12 +14,19 @@ deleteImage.controller('grDeleteImageCtrl', [
         this.$onInit = () => {
           function pollDeleted (image) {
               const findImage = () => mediaApi.find(image.data.id).then(
-                  () => $q.reject(),
+                  (r) => {
+                    if (r.data.softDeletedMetadata) {
+                      // resolve when image has been soft deleted.
+                      return $q.resolve();
+                    } else {
+                      return $q.reject();
+                    }
+                  },
                   // resolve when image cannot be found, i.e. image has been deleted.
                   () => $q.resolve()
               );
 
-              apiPoll(findImage);
+              return apiPoll(findImage);
           }
 
           ctrl.deleteImage = function (image) {


### PR DESCRIPTION
## What does this change?

After an image is deleted, Kahuna with poll endlessly looking for the deleted image to be removed from the API.
As soft deleted images do not disappear from the API, there is not way for this loop to end other than when the page is next reloaded.

Stopped the infinite polling by updating the polling function to recognise soft deleted as deleted.

Also returns the polling promise rather than void from `pollDeleted`.
The existing code appears to have been dropping straight instantly, without waiting for the poll to complete.

Delete from list view UI now behaves as expected; there is a noticeable pause then the image is removed from the view.

Delete from single image screen may be slightly better. 
This delete triggers a search refresh to remove the deleted image and is probably catching stale Elastic eventually consistent search results most of the time. The deleted image will still be visible in the search results most of the time as per what currently happens.

I think this PR is a net improvement.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
