### PR TITLE
remove snakeyaml dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,6 @@ lazy val commonLib = project("common-lib").settings(
     "org.scanamo" %% "scanamo" % "2.0.0",
     // Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
     ws,
-    "org.yaml" % "snakeyaml" % "1.31",
     "org.testcontainers" % "elasticsearch" % "1.19.2" % Test
   ),
   dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test


### PR DESCRIPTION
## What does this change?

Removes the snakeyaml dependency

Dependabot has detected a high vulnerability in this dependency, but I can't see that we use it anywhere in the codebase. Let's just remove it from the dependency list.

## How should a reviewer test this change?

Does the project still compile and pass CI? That should be sufficient in this case.

## How can success be measured?

-1 high vuln reported.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
