### PR TITLE
update docker-compose command to new-style "docker compose"

### DIFF
--- a/dev/imgops/README.md
+++ b/dev/imgops/README.md
@@ -13,7 +13,7 @@ Local version of the imgops service
 Imgops runs in a Docker container. It can be run using the command:
 
 ```bash
-docker-compose up -d imgops
+docker compose up -d imgops
 ```
 
 ## Is it running

--- a/dev/script/setup.sh
+++ b/dev/script/setup.sh
@@ -53,15 +53,15 @@ clean() {
   rm -rf "$ROOT_DIR/dev/.localstack"
   echo "  removed historical localstack data"
 
-  docker-compose down -v
+  docker compose down -v
   echo "  removed docker containers"
 
-  docker-compose build
+  docker compose build
   echo "  rebuilt docker containers"
 }
 
 startDocker() {
-  docker-compose up -d
+  docker compose up -d
 
   echo "waiting for localstack to launch on $LOCALSTACK_ENDPOINT"
   while ! curl -s $LOCALSTACK_ENDPOINT >/dev/null; do

--- a/dev/script/start.sh
+++ b/dev/script/start.sh
@@ -91,7 +91,7 @@ startDockerContainers() {
   EXISTING_TUNNELS=$(ps -ef | grep ssh | grep 9200 | grep -v grep || true)
   if [[ $USE_TEST == true ]]; then
     if (docker stats --no-stream &> /dev/null); then
-      docker-compose down
+      docker compose down
     fi
     if [[ -n $EXISTING_TUNNELS ]]; then
       echo "RE-USING EXISTING TUNNEL TO TEST ELASTICSEARCH (on port 9200)"
@@ -107,7 +107,7 @@ startDockerContainers() {
       # shellcheck disable=SC2046
       kill $(echo $EXISTING_TUNNELS | awk '{print $2}')
     fi
-    docker-compose up -d
+    docker compose up -d
   fi
 
 }


### PR DESCRIPTION
## What does this change?

The command has changed from `docker-compose` to `docker compose`, and newer versions of docker no longer seem to provide an alias. See more at https://docs.docker.com/compose/releases/migrate/#docker-compose-vs-docker-compose

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
