### PR TITLE
Add a fallback for when the upload limit is undefined

### DIFF
--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -85,7 +85,7 @@
           permissionsDefault: "@kahunaConfig.permissionsDefault",
           defaultShouldBlurGraphicImages: @kahunaConfig.defaultShouldBlurGraphicImages,
           shouldUploadStraightToBucket: @kahunaConfig.shouldUploadStraightToBucket,
-          maybeUploadLimitInBytes: @kahunaConfig.maybeUploadLimitInBytes,
+          maybeUploadLimitInBytes: @kahunaConfig.maybeUploadLimitInBytes.getOrElse(0),
           announcements: @Html(announcements),
           imageTypes: @Html(imageTypes),
         }


### PR DESCRIPTION


## What does this change?

0 is treated as falsy, ie. no limit is defined.
Without setting a fallback, the produced config object is invalid as the key has no value, meaning that the grid client cannot launch, and the seemingly optional config setting is not so optional.

## How should a reviewer test this change?

Run locally, checking that the `upload.limit.mb` config value is not present in your local config.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
