### PR TITLE
Match on “Shutterstock Editorial” source

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -420,10 +420,11 @@ object RexParser extends ImageProcessor {
 
     (image.metadata.source, image.metadata.credit) match {
     // TODO: cleanup byline/credit
-    case (Some("Rex Features"), _)      => image.copy(usageRights = usageRights)
-    case (_, Some(SlashRex()))          => image.copy(usageRights = usageRights)
-    case (Some("REX/Shutterstock"), _)  => image.copy(usageRights = usageRights)
-    case (Some("Shutterstock"), _)      => image.copy(usageRights = usageRights)
+    case (Some("Rex Features"), _)            => image.copy(usageRights = usageRights)
+    case (_, Some(SlashRex()))                => image.copy(usageRights = usageRights)
+    case (Some("REX/Shutterstock"), _)        => image.copy(usageRights = usageRights)
+    case (Some("Shutterstock"), _)            => image.copy(usageRights = usageRights)
+    case (Some("Shutterstock Editorial"), _)  => image.copy(usageRights = usageRights)
     case _ => image
   }
   }


### PR DESCRIPTION
## What does this change?

Friends at Shutterstock changed `source` field of images at their portal to have a new value of `Shutterstock Editorial`, so manual uploads (only) weren’t matching and nobody told us. This corrects it. The matching, that is.

## How should a reviewer test this change?
Concoct an image with `source:Shutterstock Editorial` (or download from Shutterstock), upload and see if it’s recognised correctly.

## How can success be measured?
Editorial colleagues don’t need to manually assign rights.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
