### PR TITLE
shutdown metrics actors more gracefully

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
@@ -132,8 +132,11 @@ private class MetricsActor(namespace: String, client: AmazonCloudWatch) extends 
   }
 
   def receive: Receive = {
-    case AddMetrics(metrics) => become(queued(metrics))
-    case Shutdown => become(shutdown)
+    case AddMetrics(metrics) =>
+      become(queued(metrics))
+    case Shutdown =>
+      sender() ! ()
+      become(shutdown)
   }
   private def shutdown: Receive = {
     case message => logger.error(s"metrics actor has shut down, cannot respond to message $message")
@@ -144,6 +147,7 @@ private class MetricsActor(namespace: String, client: AmazonCloudWatch) extends 
       become(receive)
     case Shutdown =>
       putData(queuedMetrics)
+      sender() ! ()
       become(shutdown)
     case AddMetrics(metrics) =>
       become(queued(queuedMetrics ++ metrics))


### PR DESCRIPTION


## What does this change?

On shutdown, Play sends the metrics actors a shutdown message, but as it uses an 'ask', it waits for a response. When no response arrives, it assumes something has gone wrong and shuts down with a more severe error. Sometimes (possibly not always?) this can also interrupt Play's dev mode (recompiling and restarting the app on code changes).

In fact nothing has gone wrong (usually), we simply don't bother to send a response. Let's do that, both to be graceful, and to enable slightly faster shutdowns. The actual message sent is unimportant, as the requester does nothing with it, so send Unit.

## How should a reviewer test this change?

Run locally, then stop the app. Does the app finish faster? Do the logs contain fewer shutdown related errors. (Currently some will end with errors that an actor did not respond within 5 seconds).

## How can success be measured?

Faster shutdowns, fewer errors, more uninterrupted dev mode.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
