### PR TITLE
Play v3 migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,7 +165,10 @@ lazy val thrall = playProject("thrall", 9002)
     ),
     // amazon-kinesis-client 2.6.0 brings in a critically vulnerable version of apache avro,
     // but we cannot upgrade amazon-kinesis-client further without performing the v2->v3 upgrade https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html
-    dependencyOverrides += "org.apache.avro" % "avro" % "1.11.4"
+    dependencyOverrides ++= Seq(
+      "org.apache.avro" % "avro" % "1.11.4",
+      "org.apache.pekko" %% "pekko-stream" % "1.0.3"
+    )
   )
 
 lazy val usage = playProject("usage", 9009).settings(

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ val commonSettings = Seq(
   Test / testOptions ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports")),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test,
     "org.scalatestplus" %% "mockito-3-4" % "3.1.4.0" % Test,
     "org.mockito" % "mockito-core" % "2.18.0" % Test,
     "org.scalamock" %% "scalamock" % "5.1.0" % Test,
@@ -76,7 +76,7 @@ val maybeBBCLib: Option[sbt.ProjectReference] = if(bbcBuildProcess) Some(bbcProj
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "3.0.0",
-    "com.gu" %% "pan-domain-auth-play_2-9" % "7.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
@@ -103,7 +103,7 @@ lazy val commonLib = project("common-lib").settings(
     // i.e. to only log to disk in DEV
     // see: https://logback.qos.ch/setup.html#janino
     "org.codehaus.janino" % "janino" % "3.0.6",
-    "com.typesafe.play" %% "play-json-joda" % "2.10.2",
+    "org.playframework" %% "play-json-joda" % "3.0.4",
     "org.scanamo" %% "scanamo" % "2.0.0",
     // Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
     ws,
@@ -116,7 +116,7 @@ lazy val restLib = project("rest-lib").settings(
   libraryDependencies ++= Seq(
     playCore,
     filters,
-    akkaHttpServer,
+    pekkoHttpServer,
   ),
 ).dependsOn(commonLib % "compile->compile;test->test")
 
@@ -159,7 +159,7 @@ lazy val thrall = playProject("thrall", 9002)
       "org.codehaus.groovy" % "groovy-json" % "3.0.7",
       // TODO upgrading kcl to v3? check if you can remove avro override below
       "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.0",
-      "io.github.streetcontxt" %% "kcl-akka-stream" % "4.1.1",
+      "com.gu" %% "kcl-pekko-stream" % "0.1.0-PREVIEW.anprep-release.2025-01-16T1415.937816fd",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val thrall = playProject("thrall", 9002)
       "org.codehaus.groovy" % "groovy-json" % "3.0.7",
       // TODO upgrading kcl to v3? check if you can remove avro override below
       "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.0",
-      "com.gu" %% "kcl-pekko-stream" % "0.1.0-PREVIEW.anprep-release.2025-01-16T1415.937816fd",
+      "com.gu" %% "kcl-pekko-stream" % "0.1.0",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
     ),

--- a/collections/app/lib/CollectionsMetrics.scala
+++ b/collections/app/lib/CollectionsMetrics.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 import play.api.inject.ApplicationLifecycle
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/BaseStore.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib
 
-import akka.actor.{Cancellable, Scheduler}
+import org.apache.pekko.actor.{Cancellable, Scheduler}
 import com.gu.mediaservice.lib.aws.S3
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.GridLogging

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsViaSnsMessageConsumer.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/SqsViaSnsMessageConsumer.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executors
 
 import _root_.play.api.libs.functional.syntax._
 import _root_.play.api.libs.json._
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.model.Dimension
 import com.amazonaws.services.sqs.model.{Message => SQSMessage}
 import com.gu.mediaservice.lib.ImageId

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ImageProcessorResources.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ImageProcessorResources.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.cleanup
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.config.CommonConfig
 import play.api.Configuration
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ReapableEligibiltyResources.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/ReapableEligibiltyResources.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.cleanup
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.config.{CommonConfig, CommonConfigWithElastic}
 
 /**

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigResources.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/GridConfigResources.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.config
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/MigrationStatusProvider.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.elasticsearch
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.sksamuel.elastic4s.Index
 
 import java.util.concurrent.atomic.AtomicReference

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/metrics/CloudWatchMetrics.scala
@@ -1,8 +1,8 @@
 package com.gu.mediaservice.lib.metrics
 
-import akka.actor.{Actor, ActorSystem, Props, Timers}
-import akka.pattern.ask
-import akka.util.Timeout
+import org.apache.pekko.actor.{Actor, ActorSystem, Props, Timers}
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit, StatisticSet}
 import com.gu.mediaservice.lib.config.CommonConfig

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestMetricFilter.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestMetricFilter.scala
@@ -1,7 +1,7 @@
 package com.gu.mediaservice.lib.play
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 import play.api.inject.ApplicationLifecycle

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.cleanup
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}
 import com.gu.mediaservice.lib.guardian.GuardianUsageRightsConfig
 import com.gu.mediaservice.model._

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import akka.Done
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import org.apache.pekko.Done
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import com.amazonaws.services.cloudwatch.model.Dimension
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception

--- a/image-loader/app/controllers/ImageLoaderManagement.scala
+++ b/image-loader/app/controllers/ImageLoaderManagement.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.Done
+import org.apache.pekko.Done
 import com.gu.mediaservice.lib.aws.SimpleSqsMessageConsumer
 import com.gu.mediaservice.lib.management.{BuildInfo, Management}
 import play.api.libs.json.Json

--- a/image-loader/app/lib/BodyParsers.scala
+++ b/image-loader/app/lib/BodyParsers.scala
@@ -3,8 +3,8 @@ package lib
 import java.io.{File, FileOutputStream}
 import java.security.MessageDigest
 
-import akka.stream.scaladsl.Sink
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.util.ByteString
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.logging.GridLogging
 import play.api.libs.streams.Accumulator

--- a/image-loader/app/lib/ImageLoaderMetrics.scala
+++ b/image-loader/app/lib/ImageLoaderMetrics.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 import play.api.inject.ApplicationLifecycle
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.stream.scaladsl.StreamConverters
+import org.apache.pekko.stream.scaladsl.StreamConverters
 import com.google.common.net.HttpHeaders
 import com.gu.mediaservice.{GridClient, JsonDiff}
 import com.gu.mediaservice.lib.argo._

--- a/media-api/app/lib/MediaApiMetrics.scala
+++ b/media-api/app/lib/MediaApiMetrics.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.amazonaws.services.cloudwatch.model.Dimension
 import com.gu.mediaservice.lib.auth.{ApiAccessor, Syndication}
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics

--- a/media-api/app/lib/UsageQuota.scala
+++ b/media-api/app/lib/UsageQuota.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.FeatureToggle
 import com.gu.mediaservice.model.UsageRights
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.elasticsearch.filters
 import com.gu.mediaservice.lib.auth.Authentication.Principal

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import akka.actor.{ActorSystem, Scheduler}
+import org.apache.pekko.actor.{ActorSystem, Scheduler}
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Internal, ReadOnly, Syndication}
 import com.gu.mediaservice.lib.config.GridConfigResources

--- a/metadata-editor/app/lib/MetadataEditorMetrics.scala
+++ b/metadata-editor/app/lib/MetadataEditorMetrics.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 import play.api.inject.ApplicationLifecycle
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.5")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authorisation.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.auth
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, Principal, Request, UserPrincipal}
 import com.gu.mediaservice.lib.auth.Permissions.{ArchiveImages, DeleteCropsOrUsages, PrincipalFilter, UploadImages}

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationProvider.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.auth.provider
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, Principal}
 import com.gu.mediaservice.lib.auth.Authorisation
 import com.gu.mediaservice.lib.auth.provider.AuthenticationProvider.RedirectUri

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/ConnectionBrokenFilter.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/ConnectionBrokenFilter.scala
@@ -1,7 +1,7 @@
 package com.gu.mediaservice.lib.play
 
-import akka.http.scaladsl.model.EntityStreamException
-import akka.stream.Materializer
+import org.apache.pekko.http.scaladsl.model.EntityStreamException
+import org.apache.pekko.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import play.api.mvc.{Filter, RequestHeader, Result, Results}
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/RequestLoggingFilter.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.play
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gu.mediaservice.lib.auth.Authentication
 import com.gu.mediaservice.lib.auth.provider.InnerServiceAuthentication
 import net.logstash.logback.marker.Markers.appendEntries

--- a/rest-lib/src/test/scala/com/gu/mediaservice/lib/auth/ApiKeyAuthenticationProviderTest.scala
+++ b/rest-lib/src/test/scala/com/gu/mediaservice/lib/auth/ApiKeyAuthenticationProviderTest.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.auth
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.auth.Authentication.MachinePrincipal
 import com.gu.mediaservice.lib.auth.provider.{ApiKeyAuthenticationProvider, Authenticated, AuthenticationProviderResources, Invalid, NotAuthenticated, NotAuthorised}
 import com.gu.mediaservice.lib.config.{CommonConfig, GridConfigResources}

--- a/rest-lib/src/test/scala/com/gu/mediaservice/lib/auth/AuthenticationTest.scala
+++ b/rest-lib/src/test/scala/com/gu/mediaservice/lib/auth/AuthenticationTest.scala
@@ -1,7 +1,7 @@
 package com.gu.mediaservice.lib.auth
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
 import com.gu.mediaservice.lib.auth.Authentication.{MachinePrincipal, OnBehalfOfPrincipal, UserPrincipal}
 import com.gu.mediaservice.lib.auth.provider.AuthenticationProvider.RedirectUri
 import com.gu.mediaservice.lib.auth.provider._

--- a/thrall/app/ThrallComponents.scala
+++ b/thrall/app/ThrallComponents.scala
@@ -1,6 +1,6 @@
-import akka.Done
-import akka.stream.scaladsl.Source
-import com.contxt.kinesis.{KinesisRecord, KinesisSource, ConsumerConfig => KclAkkaStreamConfig}
+import org.apache.pekko.Done
+import org.apache.pekko.stream.scaladsl.Source
+import com.gu.kinesis.{KinesisRecord, KinesisSource, ConsumerConfig => KclPekkoStreamConfig}
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.config.Services
 import com.gu.mediaservice.lib.aws.{S3Ops, ThrallMessageSender}
@@ -48,8 +48,8 @@ class ThrallComponents(context: Context) extends GridComponents(context, new Thr
 
   val messageSender = new ThrallMessageSender(config.thrallKinesisStreamConfig)
 
-  val highPriorityKinesisConfig: KclAkkaStreamConfig = KinesisConfig.kinesisConfig(config.kinesisConfig)
-  val lowPriorityKinesisConfig: KclAkkaStreamConfig = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)
+  val highPriorityKinesisConfig: KclPekkoStreamConfig = KinesisConfig.kinesisConfig(config.kinesisConfig)
+  val lowPriorityKinesisConfig: KclPekkoStreamConfig = KinesisConfig.kinesisConfig(config.kinesisLowPriorityConfig)
 
   val uiSource: Source[KinesisRecord, Future[Done]] = KinesisSource(highPriorityKinesisConfig)
   val automationSource: Source[KinesisRecord, Future[Done]] = KinesisSource(lowPriorityKinesisConfig)

--- a/thrall/app/controllers/ReaperController.scala
+++ b/thrall/app/controllers/ReaperController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.{DateTimeUtils, ImageIngestOperations}
 import com.gu.mediaservice.lib.auth.Permissions.DeleteImage
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, BaseControllerWithLoginRedirects}

--- a/thrall/app/controllers/ThrallController.scala
+++ b/thrall/app/controllers/ThrallController.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.auth.{Authentication, BaseControllerWithLoginRedirects}
 import com.gu.mediaservice.lib.aws.ThrallMessageSender

--- a/thrall/app/lib/MigrationSourceWithSender.scala
+++ b/thrall/app/lib/MigrationSourceWithSender.scala
@@ -1,8 +1,8 @@
 package lib
 
-import akka.stream.scaladsl.Source
-import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
-import akka.{Done, NotUsed}
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.{Materializer, OverflowStrategy, QueueOfferResult}
+import org.apache.pekko.{Done, NotUsed}
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.elasticsearch.{InProgress, Paused}
 import com.gu.mediaservice.lib.logging.GridLogging
@@ -37,7 +37,7 @@ object MigrationSourceWithSender extends GridLogging {
       Source.repeat(())
         .throttle(1, per = 1.second)
         .statefulMapConcat(() => {
-          // This Akka-provided stage is explicitly provided as a way to safely wrap around mutable state.
+          // This Pekko-provided stage is explicitly provided as a way to safely wrap around mutable state.
           // Required here to keep a marker of the current search scroll. Scrolling prevents the
           // next search from picking up the same image ids and inserting them into the flow and
           // causing lots of version comparison failures.
@@ -47,7 +47,7 @@ object MigrationSourceWithSender extends GridLogging {
           //     difficult (or impossible?) to change the query value once the stream has been materialized.)
           // - Defining our own version of the ElasticSource using our desired library versions and a system to change
           //   the query value as desired.
-          // - Define an Akka actor to handle the querying and wrap around the state.
+          // - Define an Pekko actor to handle the querying and wrap around the state.
           var maybeScrollId: Option[String] = None
 
           def handleScrollResponse(resp: ScrolledSearchResults) = {

--- a/thrall/app/lib/RetryHandler.scala
+++ b/thrall/app/lib/RetryHandler.scala
@@ -1,8 +1,8 @@
 package lib
 
 
-import akka.actor.{ActorSystem, Scheduler}
-import akka.pattern.{after, retry}
+import org.apache.pekko.actor.{ActorSystem, Scheduler}
+import org.apache.pekko.pattern.{after, retry}
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap, combineMarkers}
 import play.api.{Logger, MarkerContext}
 

--- a/thrall/app/lib/SyncChecker.scala
+++ b/thrall/app/lib/SyncChecker.scala
@@ -1,9 +1,9 @@
 package lib
 
-import akka.Done
-import akka.actor.ActorSystem
-import akka.stream.{Materializer, RestartSettings}
-import akka.stream.scaladsl.{RestartSource, Source}
+import org.apache.pekko.Done
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{Materializer, RestartSettings}
+import org.apache.pekko.stream.scaladsl.{RestartSource, Source}
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsV2Request
 import com.gu.mediaservice.lib.elasticsearch.InProgress

--- a/thrall/app/lib/ThrallMetrics.scala
+++ b/thrall/app/lib/ThrallMetrics.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 import play.api.inject.ApplicationLifecycle
 

--- a/thrall/app/lib/ThrallStreamProcessor.scala
+++ b/thrall/app/lib/ThrallStreamProcessor.scala
@@ -1,11 +1,11 @@
 package lib
 
 import java.time.Instant
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{GraphDSL, MergePreferred, MergePrioritized, Source}
-import akka.stream.{Materializer, SourceShape}
-import akka.{Done, NotUsed}
-import com.contxt.kinesis.KinesisRecord
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{GraphDSL, MergePreferred, MergePrioritized, Source}
+import org.apache.pekko.stream.{Materializer, SourceShape}
+import org.apache.pekko.{Done, NotUsed}
+import com.gu.kinesis.KinesisRecord
 import com.gu.mediaservice.lib.DateTimeUtils
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.logging._

--- a/thrall/app/lib/elasticsearch/ElasticSearch.scala
+++ b/thrall/app/lib/elasticsearch/ElasticSearch.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.elasticsearch.filters
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchClient, ElasticSearchConfig, ElasticSearchExecutions, ReapableEligibility, Running}

--- a/thrall/app/lib/kinesis/KinesisConfig.scala
+++ b/thrall/app/lib/kinesis/KinesisConfig.scala
@@ -1,6 +1,6 @@
 package lib.kinesis
 
-import com.contxt.kinesis.ConsumerConfig
+import com.gu.kinesis.ConsumerConfig
 import com.gu.mediaservice.lib.logging.GridLogging
 import lib.KinesisReceiverConfig
 import software.amazon.kinesis.common.{InitialPositionInStream, InitialPositionInStreamExtended}

--- a/thrall/app/lib/kinesis/ThrallEventConsumer.scala
+++ b/thrall/app/lib/kinesis/ThrallEventConsumer.scala
@@ -1,6 +1,6 @@
 package lib.kinesis
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.json.{JsonByteArrayUtil, PlayJsonHelpers}
 import com.gu.mediaservice.lib.logging._

--- a/thrall/test/lib/ThrallStreamProcessorTest.scala
+++ b/thrall/test/lib/ThrallStreamProcessorTest.scala
@@ -1,11 +1,11 @@
 package lib
 
-import akka.Done
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, Materializer}
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
-import com.contxt.kinesis.KinesisRecord
+import org.apache.pekko.Done
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{ActorMaterializer, Materializer}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.ByteString
+import com.gu.kinesis.KinesisRecord
 import com.gu.mediaservice.GridClient
 import com.gu.mediaservice.lib.aws.UpdateMessage
 import com.gu.mediaservice.lib.json.JsonByteArrayUtil

--- a/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/thrall/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,6 +1,6 @@
 package lib.elasticsearch
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchAliases, ElasticSearchConfig}
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.testlib.ElasticSearchDockerBase

--- a/usage/app/lib/UsageMetrics.scala
+++ b/usage/app/lib/UsageMetrics.scala
@@ -1,6 +1,6 @@
 package lib
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.gu.mediaservice.lib.metrics.CloudWatchMetrics
 import play.api.inject.ApplicationLifecycle
 


### PR DESCRIPTION
## What does this change?

Upgrades Grid to Play v3.

The main changes include Grid's move from Akka to Pekko, which involves updating import paths but otherwise behaviour should be the same. To accommodate the move, we also switch from kcl-akka-stream to [kcl-pekko-stream](https://github.com/guardian/kcl-pekko-stream), which likewise involves updated import paths but should otherwise behave the same.

## How should a reviewer test this change?

Run locally or on the TEST environment, and see if the app continues to perform

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
