### PR TITLE
Update the validity warning message colour to change colour when leased

### DIFF
--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.html
@@ -24,21 +24,21 @@
 
                     <div ng-switch-when="pay"
                          class="image-notice image-info__group status cost cost--pay"
-                         style="{{ctrl.stylePercentageLeased(cost)}}"
+                         ng-style="ctrl.stylePercentageLeased(cost, 'red')"
                     >
                         {{cost.count}} paid
                     </div>
 
                     <div ng-switch-when="overquota"
                          class="image-notice image-info__group status cost cost--pay"
-                         style="{{ctrl.stylePercentageLeased(cost)}}"
+                         ng-style="ctrl.stylePercentageLeased(cost, 'red')"
                     >
                         {{cost.count}} over quota
                     </div>
 
                     <div ng-switch-when="conditional"
                          class="image-notice image-info__group cost cost--conditional"
-                         style="{{ctrl.stylePercentageLeased(cost)}}"
+                         ng-style="ctrl.stylePercentageLeased(cost, 'orange')"
                     >
                         {{cost.count}} restricted
                     </div>

--- a/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
+++ b/kahuna/public/js/components/gr-info-panel/gr-info-panel.js
@@ -26,30 +26,18 @@ export const grInfoPanel = angular.module('grInfoPanel', [
 ]);
 
 grInfoPanel.controller('GrInfoPanelCtrl', [
-  '$rootScope',
   '$scope',
-  '$window',
   '$q',
   'inject$',
-  'subscribe$',
-  'mediaApi',
-  'imageAccessor',
   'imageList',
   'selectedImagesList$',
-  'labelService',
   'editsService',
   function (
-    $rootScope,
     $scope,
-    $window,
     $q,
     inject$,
-    subscribe$,
-    mediaApi,
-    imageAccessor,
     imageList,
     selectedImagesList$,
-    labelService,
     editsService) {
 
     const ctrl = this;
@@ -70,10 +58,14 @@ grInfoPanel.controller('GrInfoPanelCtrl', [
         map(allEditable => allEditable.every(v => v === true));
       inject$($scope, selectionIsEditable$, ctrl, 'userCanEdit');
 
-      ctrl.stylePercentageLeased = cost => {
+      ctrl.stylePercentageLeased = (cost, alt) => {
         const imageIsOfThisTypeAndIsLeased = (img) => img.data.cost === cost.data && img.data?.leases?.data?.leases?.some(lease => lease.access === 'allow-use' && lease.active);
         const countLeased = ctrl.selectedImages.count(imageIsOfThisTypeAndIsLeased);
-        return `--pct-leased: ${Math.floor(100 * countLeased / cost.count)}`;
+        const percentageLeased = Math.floor(100 * countLeased / cost.count);
+
+        return {
+          'background-image': `linear-gradient(90deg, teal 0 ${percentageLeased}%, ${alt} ${percentageLeased}% 100%)`
+        };
       };
     };
   }

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,7 +1,7 @@
 <div
     ng-if="ctrl.showInvalidReasons"
     class="image-notice image-info__group validity validity--invalid validity--point-up"
-    ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning && !ctrl.isOverridden, 'validity--overridden': !ctrl.isStrongWarning && ctrl.isOverridden}"
+    ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning && !ctrl.hasActiveAllowLease, 'validity--leased': !ctrl.isStrongWarning && ctrl.hasActiveAllowLease}"
 >
     <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">{{ctrl.unusableTextHeader}}
         <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.html
@@ -1,7 +1,7 @@
 <div
     ng-if="ctrl.showInvalidReasons"
     class="image-notice image-info__group validity validity--invalid validity--point-up"
-    ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning}"
+    ng-class="{'validity--invalid': ctrl.isStrongWarning, 'validity--warning': !ctrl.isStrongWarning && !ctrl.isOverridden, 'validity--overridden': !ctrl.isStrongWarning && ctrl.isOverridden}"
 >
     <strong ng-if="!ctrl.isOverridden && !ctrl.isDeleted">{{ctrl.unusableTextHeader}}
         <gr-icon title="This image cannot be used in content, a lease is required.">help</gr-icon>
@@ -38,5 +38,5 @@
             {{ctrl.denySyndicationTextHeader}}
         </li>
     </ul>
-    
+
 </div>

--- a/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
+++ b/kahuna/public/js/components/gr-metadata-validity/gr-metadata-validity.js
@@ -24,6 +24,7 @@ module.controller('grMetadataValidityCtrl', [ '$rootScope', '$window', function 
             }
             ctrl.invalidReasons = image.data.invalidReasons;
             ctrl.isOverridden = ctrl.showInvalidReasons && image.data.valid;
+            ctrl.hasActiveAllowLease = ctrl.image.data.leases.data.leases.find(lease => lease.active && lease.access === 'allow-use');
             ctrl.isStrongWarning = ctrl.isDeleted || !ctrl.isOverridden || image.data.cost === "pay";
 
             ctrl.unusableTextHeader = $window._clientConfig.unusableTextHeader;

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1342,6 +1342,7 @@ textarea.ng-invalid {
 .cost--conditional {
     background-color: orange;
 }
+.validity--overridden,
 .cost--leased {
   background-color: teal;
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1380,6 +1380,9 @@ textarea.ng-invalid {
 .validity--warning::before {
     border-bottom-color: orange;
 }
+.validity--overridden::before {
+  border-bottom-color: teal;
+}
 
 /* ==========================================================================
    Results bar

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1349,18 +1349,6 @@ textarea.ng-invalid {
     background-color: green;
 }
 
-.image-notice {
-  --pct-leased: 0;
-}
-
-.image-notice.cost--pay {
-  background-image: linear-gradient(90deg, teal 0 calc(var(--pct-leased) * 1%), red calc(var(--pct-leased) * 1%) 100%);
-}
-
-.image-notice.cost--conditional {
-  background-image: linear-gradient(90deg, teal 0 calc(var(--pct-leased) * 1%), orange calc(var(--pct-leased) * 1%) 100%);
-}
-
 .costs li {
     display: inline-block;
 }

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1342,7 +1342,7 @@ textarea.ng-invalid {
 .cost--conditional {
     background-color: orange;
 }
-.validity--overridden,
+.validity--leased,
 .cost--leased {
   background-color: teal;
 }
@@ -1380,7 +1380,7 @@ textarea.ng-invalid {
 .validity--warning::before {
     border-bottom-color: orange;
 }
-.validity--overridden::before {
+.validity--leased::before {
   border-bottom-color: teal;
 }
 


### PR DESCRIPTION
## What does this change?

1. Fixes a bug in the indicator of what % of selected images have been leased (some problem with interpolating in a "style" attribute during webpack production mode; works fine locally but completely broken in production. Couldn't find the root cause, so switch to using `ng-style`)

2. Then, change the colour of the validity warning message which applies when the image has restrictions or is overquota etc. to teal, so that it is clearer that the warnings have been overridden and the image can be used (usually because a lease has been applied).

## How should a reviewer test this change?

Run on TEST, where I have configured getty to (almost certainly) be overquota - check the quotas screen to confirm. Ensure you have edit_metadata permission!

Then, open an overquota image (ie. search `+uploader:getty`). The warning message on the right should be coloured amber, like so: 
<img width="307" alt="image" src="https://github.com/user-attachments/assets/18fd34b6-4841-449a-9a81-dd34249d8cb0" />

Now add an allow-cropping lease to that image. The message should turn teal (which is the colour used in the search page to indicate "not free, but has been leased and can be used"):

<img width="306" alt="image" src="https://github.com/user-attachments/assets/eedbf55d-080d-4666-9863-cc279cc05293" />

## How can success be measured?

Hopefully less confusion about whether a leased image may be used.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
