### PR TITLE
Increase Panda grace period to 24 hours

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
@@ -17,6 +17,7 @@ import play.api.libs.typedmap.{TypedEntry, TypedKey, TypedMap}
 import play.api.libs.ws.{DefaultWSCookie, WSClient, WSRequest}
 import play.api.mvc.{ControllerComponents, Cookie, RequestHeader, Result}
 
+import scala.concurrent.duration.{Duration, HOURS}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -32,6 +33,8 @@ class PandaAuthenticationProvider(
   override lazy val panDomainSettings: PanDomainAuthSettingsRefresher = buildPandaSettings()
   override def wsClient: WSClient = resources.wsClient
   override def controllerComponents: ControllerComponents = resources.controllerComponents
+
+  override def apiGracePeriod: Long = Duration(24, HOURS).toMillis
 
   val loginLinks = List(
     Link("login", resources.commonConfig.services.loginUriTemplate)


### PR DESCRIPTION
## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?
### Integration with Composer alt text helper
- Change `grid.api.uri` in `~/.gu/flexible-composerbackend.properties` to https://api.media.local.dev-gutools.co.uk
- Run up Composer (main) and the Grid (this branch) locally
- Verify successful Grid API request by using alt text helper
- Check cookie expiry (should by one hour) by copying the `gutoolsAuth-assym` to the clipboard from Chrome Dev Tools and then doing
```
pbpaste | grep -o '^[^.]*' | base64 --decode | grep -o 'expires=[^&]*' | grep -o '\d*' | sed 's/...$//' | xargs -n1 date -r
```
- Wait for cookie expiry, and try alt text helper again

### Grid itself
- Run Grid (this branch) locally
- Check cookie expiry (should by one hour) by copying the `gutoolsAuth-assym` to the clipboard from Chrome Dev Tools and then doing
```
pbpaste | grep -o '^[^.]*' | base64 --decode | grep -o 'expires=[^&]*' | grep -o '\d*' | sed 's/...$//' | xargs -n1 date -r
```
- Wait for cookie expiry, then try something in the UI that requires an API call

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
