### PR TITLE
update image flag colour when leased

### DIFF
--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -81,6 +81,7 @@ image.controller('uiPreviewImageCtrl', [
         ctrl.states = imageService(updatedImage).states;
         ctrl.image = updatedImage;
         ctrl.flagState = ctrl.states.costState;
+        ctrl.hasActiveAllowLease = ctrl.image.data.leases.data.leases.find(lease => lease.active && lease.access === 'allow-use');
         ctrl.imageAsArray = [updatedImage];
       };
 


### PR DESCRIPTION
## What does this change?

Follow on from #4404 - update the image's flag immediately when it's been leased. This was an oversight when the colouring was first added - we set it when the image is loaded, but don't reset when it's been updated. We now correct this mistake.

## How should a reviewer test this change?

Deploy to TEST. From the search page, select an image (without _entering_ it - use the tickbox and open up the info panel on the right). Set it to some usage rights such as social media, so the image is _restricted_ but not blocked. Add a lease. Does the image's flag turn the leased teal colour, without having to reload the page?

<img width="147" alt="image" src="https://github.com/user-attachments/assets/0bffc0fb-fc25-41f6-abf1-f95cc8f6b6de" />


## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
