### PR TITLE
update scripts for latest scala 2.13 compilation warnings

### DIFF
--- a/scripts/src/main/scala/com/gu/mediaservice/lib/JsonValueCodecJsValue.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/lib/JsonValueCodecJsValue.scala
@@ -75,6 +75,10 @@ object JsonValueCodecJsValue {
         jsValue match {
           case JsBoolean(b) =>
             out.writeVal(b)
+          case JsFalse =>
+            out.writeVal(false)
+          case JsTrue =>
+            out.writeVal(true)
           case JsString(value) =>
             out.writeVal(value)
           case JsNumber(value) =>

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/BackfillEditLastModified.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/BackfillEditLastModified.scala
@@ -55,7 +55,7 @@ object BackfillEditLastModified extends EsScript {
     val lastEvaluatedKey = if (lastFile.exists()) {
       val source = Source.fromFile(lastFile)
       val lastId = try {
-        source.getLines.toList match {
+        source.getLines().toList match {
           case id :: totalStr :: _ =>
             total = totalStr.toInt
             Some(id)

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/BucketMetadata.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/BucketMetadata.scala
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.model.{HeadObjectRequest, ListObjectsV
 
 import java.io.{BufferedWriter, File, FileOutputStream, FileWriter, OutputStreamWriter}
 import java.time.Instant
-import scala.collection.JavaConverters.{asScalaIteratorConverter, iterableAsScalaIterableConverter, mapAsScalaMapConverter}
+import scala.jdk.CollectionConverters._
 
 case class ObjectMetadata(key: String, lastModified: Instant, metadata: Map[String, String])
 object ObjectMetadata {

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/ConvertConfig.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/ConvertConfig.scala
@@ -25,7 +25,7 @@ object ConvertConfig {
       val input = new File(arg)
       assert(input.exists, s"File provided for conversion doesn't exist: $input")
       val files: List[File] = if (input.isDirectory) {
-        val paths: List[Path] = Files.walk(input.toPath).iterator.asScala.toIterable.toList
+        val paths: List[Path] = Files.walk(input.toPath).iterator.asScala.toList
         val regularFiles = paths.filter(file => Files.isRegularFile(file))
         val propertiesFiles = regularFiles.filter(_.toString.endsWith(".properties"))
         val files = propertiesFiles.map(_.toFile)

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EnactS3Changes.scala
@@ -17,7 +17,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, HeadObjectRequest, ListObjectsRequest, ListObjectsV2Request, MetadataDirective, NoSuchKeyException}
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object EnactS3Changes {

--- a/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
+++ b/scripts/src/main/scala/com/gu/mediaservice/scripts/EsScript.scala
@@ -24,7 +24,7 @@ object Reindex extends EsScript {
 
     object IndexClient extends EsClient(esUrl) {
       val srcIndexVersionCheck = """images_(\d+)""".r
-      val srcIndexVersion = currentIndex match {
+      val srcIndexVersion = this.currentIndex match {
         case srcIndexVersionCheck(version) => version.toInt
         case _ => 1
       }
@@ -447,6 +447,6 @@ abstract class EsScript {
 
   }
 
-  def run(esUrl: String, args: List[String])
+  def run(esUrl: String, args: List[String]): Unit
   def usageError: Nothing
 }


### PR DESCRIPTION
## What does this change?

Missed in #4361 since the scripts project is not included in the main compilation. Resolves all of the new compiler warnings.

## How should a reviewer test this change?

run `sbt scripts/compile`

## How can success be measured?

scala scripts are runnable without disabling warnings again 

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
