### PR TITLE
Cost of `Pay`, because of excluded collection, should trump `Overquota`

### DIFF
--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -33,14 +33,16 @@ trait CostCalculator {
       val categoryCost: Option[Cost] = usageRights.defaultCost
       val overQuota: Option[Cost] = getOverQuota(usageRights)
       val supplierCost: Option[Cost] = usageRights match {
-        case u: Agency => getCost(u.supplier, u.suppliersCollection)
+        case u: Agency =>
+          if (isExcludedColl(u.supplier, u.suppliersCollection.getOrElse(""))) Some(Pay)
+          else getCost(u.supplier, u.suppliersCollection)
         case _ => None
       }
 
       restricted
-        .orElse(overQuota)
-        .orElse(categoryCost)
+        .orElse(overQuota.filter(_ => !supplierCost.contains(Pay)))
         .orElse(supplierCost)
+        .orElse(categoryCost)
         .getOrElse(defaultCost)
   }
 

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -65,5 +65,12 @@ class CostCalculatorTest extends AnyFunSpec with Matchers with MockitoSugar {
 
       cost should be (Pay)
     }
+
+    it("Pay should trump Overquota with a free supplier whose gone over quota, but excluded collection") {
+      val usageRights = Agency("Getty Images", Some("Bob Thomas Sports Photography"))
+      val cost = OverQuotaCosting.getCost(usageRights)
+
+      cost should be (Pay)
+    }
   }
 }


### PR DESCRIPTION
Co-authored by Copilot 🙀🔫🤖.  

## What does this change?
We have a concept of Excluded Collections (based on `source` field) where images are Paid, even if their Supplier is Free. Currently, when such a Supplier runs over quota, users are unable to see those images as Paid, they can only see they are Overquota (Overquota badge instead of a `£` one). Paid is a stronger signal (ie. should be leased less lightly) than Overquota, so they are asking for it to trump it.
This PR makes that change.

## How should a reviewer test this change?
- Configure a Free supplier to run over quota
- Upload two images from this Supplier (or edit existing ones), so that one of them is from the Excluded Collection (currently, only Getty)
- notice how badges and Usage Rights notices in Viewer differ with this PR: a pound badge is clearly displayed for an image from an Excluded Collection

## How can success be measured?
Hopefully, users will not lease Paid images as lightly as Overquota ones

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
