### PR TITLE
Make overquota cost only apply to images that would otherwise be free

### DIFF
--- a/media-api/app/lib/usagerights/CostCalculator.scala
+++ b/media-api/app/lib/usagerights/CostCalculator.scala
@@ -1,18 +1,27 @@
 package lib.usagerights
 
-import com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig
 import com.gu.mediaservice.model._
 import lib.UsageQuota
 
 trait CostCalculator {
-  val defaultCost = Pay
+  val defaultCost: Cost = Pay
   val freeSuppliers: List[String]
   val suppliersCollectionExcl: Map[String, List[String]]
   val quotas: UsageQuota
 
-  def getCost(supplier: String, collection: Option[String]): Option[Cost] = {
-      val free = isFreeSupplier(supplier) && ! collection.exists(isExcludedColl(supplier, _))
-      if (free) Some(Free) else None
+  private def getAgencyCost(agencyUsageRights: Agency): Option[Cost] = {
+    val supplier = agencyUsageRights.supplier
+    val isFreeFromAgency = isFreeSupplier(supplier) && !agencyUsageRights.suppliersCollection.exists(isExcludedColl(supplier, _))
+
+    if (isFreeFromAgency) {
+      if (isOverQuota(agencyUsageRights)) {
+        Some(Overquota)
+      } else {
+        Some(Free)
+      }
+    } else {
+      None
+    }
   }
 
   def isConditional(usageRights: UsageRights): Boolean =
@@ -21,27 +30,20 @@ trait CostCalculator {
   def isPay(usageRights: UsageRights): Boolean =
     getCost(usageRights) == Pay
 
-  def getOverQuota(usageRights: UsageRights) =
-    if (quotas.isOverQuota(usageRights)) {
-      Some(Overquota)
-    } else {
-      None
-    }
+  def isOverQuota(usageRights: UsageRights): Boolean = quotas.isOverQuota(usageRights)
 
   def getCost(usageRights: UsageRights): Cost = {
-      val restricted  : Option[Cost] = usageRights.restrictions.map(r => Conditional)
-      val categoryCost: Option[Cost] = usageRights.defaultCost
-      val overQuota: Option[Cost] = getOverQuota(usageRights)
-      val supplierCost: Option[Cost] = usageRights match {
-        case u: Agency => getCost(u.supplier, u.suppliersCollection)
-        case _ => None
-      }
+    val restricted: Option[Cost] = usageRights.restrictions.map(r => Conditional)
+    val categoryCost: Option[Cost] = usageRights.defaultCost
+    val supplierCost: Option[Cost] = usageRights match {
+      case u: Agency => getAgencyCost(u)
+      case _ => None
+    }
 
-      restricted
-        .orElse(overQuota)
-        .orElse(categoryCost)
-        .orElse(supplierCost)
-        .getOrElse(defaultCost)
+    restricted
+      .orElse(categoryCost)
+      .orElse(supplierCost)
+      .getOrElse(defaultCost)
   }
 
   private def isFreeSupplier(supplier: String) = freeSuppliers.contains(supplier)

--- a/media-api/test/scala/lib/ImageExtrasTest.scala
+++ b/media-api/test/scala/lib/ImageExtrasTest.scala
@@ -16,7 +16,8 @@ class ImageExtrasTest extends AnyFunSpec with Matchers with MockitoSugar {
 
   object Costing extends CostCalculator {
     val quotas: UsageQuota = Quota
-    override def getOverQuota(usageRights: UsageRights): Option[Nothing] = None
+
+    override def isOverQuota(usageRights: UsageRights): Boolean = false
     override val freeSuppliers: List[String] = GuardianUsageRightsConfig.freeSuppliers
     override val suppliersCollectionExcl: Map[String, List[String]] = GuardianUsageRightsConfig.suppliersCollectionExcl
   }

--- a/media-api/test/usagerights/CostCalculatorTest.scala
+++ b/media-api/test/usagerights/CostCalculatorTest.scala
@@ -15,7 +15,7 @@ class CostCalculatorTest extends AnyFunSpec with Matchers with MockitoSugar {
 
     object Costing extends CostCalculator {
       val quotas = Quota
-      override def getOverQuota(usageRights: UsageRights) = None
+      override def isOverQuota(usageRights: UsageRights) = false
 
       override val freeSuppliers: List[String] = GuardianUsageRightsConfig.freeSuppliers
       override val suppliersCollectionExcl: Map[String, List[String]] = GuardianUsageRightsConfig.suppliersCollectionExcl
@@ -23,7 +23,7 @@ class CostCalculatorTest extends AnyFunSpec with Matchers with MockitoSugar {
 
     object OverQuotaCosting extends CostCalculator {
       val quotas = Quota
-      override def getOverQuota(usageRights: UsageRights) = Some(Overquota)
+      override def isOverQuota(usageRights: UsageRights) = true
 
       override val freeSuppliers: List[String] = GuardianUsageRightsConfig.freeSuppliers
       override val suppliersCollectionExcl: Map[String, List[String]] = GuardianUsageRightsConfig.suppliersCollectionExcl
@@ -62,6 +62,13 @@ class CostCalculatorTest extends AnyFunSpec with Matchers with MockitoSugar {
     it("should not be free-to-use with a free supplier but excluded collection") {
       val usageRights = Agency("Getty Images", Some("Bob Thomas Sports Photography"))
       val cost = Costing.getCost(usageRights)
+
+      cost should be (Pay)
+    }
+
+    it("Pay should trump Overquota with a free supplier whose gone over quota, but excluded collection") {
+      val usageRights = Agency("Getty Images", Some("Bob Thomas Sports Photography"))
+      val cost = OverQuotaCosting.getCost(usageRights)
 
       cost should be (Pay)
     }


### PR DESCRIPTION
ie. excluded supplierCollections still appear as cost=pay, even if the agency is otherwise overquota

## What does this change?

We have a concept of Excluded Collections (based on `source` field) where images are Paid, even if their Supplier is Free. Currently, when such a Supplier runs over quota, users are unable to see those images as Paid, they can only see they are Overquota (Overquota badge instead of a `£` one). Paid is a stronger signal (ie. should be leased less lightly) than Overquota, so they are asking for it to trump it.
This PR makes that change.

## How should a reviewer test this change?

- Configure a Free supplier to run over quota
- Upload two images from this Supplier (or edit existing ones), so that one of them is from the Excluded Collection (currently, only Getty)
- notice how badges and Usage Rights notices in Viewer differ with this PR: a pound badge is clearly displayed for an image from an Excluded Collection

## How can success be measured?
Hopefully, users will not lease Paid images as lightly as Overquota ones

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)