### PR TITLE
add circle guideline to 1:1 cropping box for GNM users (plus optional circular mask)

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -182,6 +182,10 @@ crop.controller('ImageCropCtrl', [
           window._clientConfig.staffPhotographerOrganisation === "GNM"
           && maybeCropRatioIfStandard === "5:3";
 
+        ctrl.shouldShowCircularGuideline =
+          window._clientConfig.staffPhotographerOrganisation === "GNM"
+          && maybeCropRatioIfStandard === "1:1";
+
         if (isCropTypeDisabled) {
           ctrl.cropType = oldCropType;
         } else {

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -184,7 +184,10 @@ crop.controller('ImageCropCtrl', [
 
         ctrl.shouldShowCircularGuideline =
           window._clientConfig.staffPhotographerOrganisation === "GNM"
-          && maybeCropRatioIfStandard === "1:1";
+          // update this array to apply circular guideline to further ratios (e.g. 5:4)
+          && ["1:1"].includes(maybeCropRatioIfStandard);
+
+        ctrl.isSquareCrop = maybeCropRatioIfStandard === "1:1";
 
         if (isCropTypeDisabled) {
           ctrl.cropType = oldCropType;

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -111,10 +111,18 @@
     as these might be clipped.
 </div>
 
+<div class="circular-mask-toggle-container" ng-if="ctrl.shouldShowCircularGuideline && ctrl.isSquareCrop">
+    <label>
+        Apply circular mask
+        <input type="checkbox" ng-model="ctrl.shouldUseCircularMask">
+    </label>
+</div>
+
 <div class="easel" role="main" aria-label="Image cropper" ng-class="{
     'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters,
     'hide-vertical-warning-gutters': ctrl.shouldHideVerticalWarningGutters,
-    'circular-guideline': ctrl.shouldShowCircularGuideline
+    'circular-guideline': ctrl.shouldShowCircularGuideline && !ctrl.shouldUseCircularMask,
+    'circular-mask': ctrl.shouldUseCircularMask
 }">
     <div class="easel__canvas">
         <div class="easel__image-container" oncontextmenu="return false;">

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -122,7 +122,7 @@
     'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters,
     'hide-vertical-warning-gutters': ctrl.shouldHideVerticalWarningGutters,
     'circular-guideline': ctrl.shouldShowCircularGuideline && !ctrl.shouldUseCircularMask,
-    'circular-mask': ctrl.shouldUseCircularMask
+    'circular-mask': ctrl.shouldShowCircularGuideline && ctrl.shouldUseCircularMask
 }">
     <div class="easel__canvas">
         <div class="easel__image-container" oncontextmenu="return false;">

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -113,7 +113,8 @@
 
 <div class="easel" role="main" aria-label="Image cropper" ng-class="{
     'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters,
-    'hide-vertical-warning-gutters': ctrl.shouldHideVerticalWarningGutters
+    'hide-vertical-warning-gutters': ctrl.shouldHideVerticalWarningGutters,
+    'circular-guideline': ctrl.shouldShowCircularGuideline
 }">
     <div class="easel__canvas">
         <div class="easel__image-container" oncontextmenu="return false;">

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -41,7 +41,23 @@
   background-position: 0 0, 10px 0, 10px -10px, 0px 10px;
 }
 
-
+/* add circle guideline to all ratios (centered and with diameter the smaller of height/width) */
+.easel.circular-guideline .cropper-crop-box::after {
+  display: block;
+  content: "";
+  position: relative; /* can't be absolute otherwise aspect-ratio doesn't work */
+  aspect-ratio: 1 / 1;
+  max-width: 100%;
+  max-height: 100%;
+  border: 1px white dashed;
+  mix-blend-mode: difference;
+  border-radius: 50%;
+  box-sizing: border-box;
+  left: 50%;
+  top: -50%; /* because position relative, we need to move it up by half the height of the container */
+  transform: translate(-50%, -50%); /* center the circle, these percentages refer to the circles own x & y */
+  pointer-events: none;
+}
 
 /* GUTTERS to show what will be clipped if the 5:3 crop is used in 5:4 space */
 .easel.hide-vertical-warning-gutters .cropper-view-box::before,

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -41,7 +41,7 @@
   background-position: 0 0, 10px 0, 10px -10px, 0px 10px;
 }
 
-/* add circle guideline to all ratios (centered and with diameter the smaller of height/width) */
+/* circle guideline, works on any ratio (centered and with diameter the smaller of height/width) */
 .easel.circular-guideline .cropper-crop-box::after {
   display: block;
   content: "";
@@ -57,6 +57,14 @@
   top: -50%; /* because position relative, we need to move it up by half the height of the container */
   transform: translate(-50%, -50%); /* center the circle, these percentages refer to the circles own x & y */
   pointer-events: none;
+}
+
+.easel.circular-mask .cropper-crop-box::after {
+  display: none;
+}
+/* circular mask, only works on 1:1 */
+.easel.circular-mask .cropper-view-box {
+  border-radius: 50%;
 }
 
 /* GUTTERS to show what will be clipped if the 5:3 crop is used in 5:4 space */

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2054,6 +2054,14 @@ FIXME: what to do with touch devices
     visibility: hidden;
 }
 
+.circular-mask-toggle-container {
+  position: absolute;
+  right: 0;
+  padding: 10px;
+  user-select: none;
+}
+
+
 .image-details {
     box-sizing: border-box;
     font-size: 1.3rem;


### PR DESCRIPTION
Often 1:1 crops are used in circular containers, so it's useful to always have in mind what would be chopped off
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/35bbbdec-1f55-4757-a63b-5f0164cf4e0f" />
... this could be applied easily to other ratios in future (e.g. 5:4) by updating the array, as per the comment - the CSS will centre the circle with it's diameter the shorter of height or width (to mirror the behaviour of the platform's auto-cropping of rectangular images).

PLUS (as per user request) a checkbox option to toggle a circular mask (on 1:1 only) instead of the circular guideline.
![mask](https://github.com/user-attachments/assets/9c547fe1-ff4c-4ea3-b741-bf1204a1d357)

NOTE: I've made the mask optional via checkbox, rather than always applied to 1:1, because we don't want to imply that the actual crop will be circular.

NOTE ALSO: the mask will only ever work for 1:1 (unlike the guideline, see above) - on any other ratio it will be an oval 🤮 
