### PR TITLE
update image type detector to handle https in protocol in field

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageType.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageType.scala
@@ -75,18 +75,14 @@ object InsertGuardianImageType extends ImageProcessor with GridLogging {
 
 
 object DigitalSourceType {
-  private val dstUri = "http://cv.iptc.org/newscodes/digitalsourcetype/"
   def unapply(name: String): Option[String] = {
-    if (name.startsWith(dstUri)) {
-      Some(name.stripPrefix(dstUri))
-    } else {
-      None
+    name match {
+      case s"http://cv.iptc.org/newscodes/digitalsourcetype/$value" =>
+        Some(value)
+      // I'm pretty sure https is off-spec as a value here, but it's what Google is using so 🤷
+      case s"https://cv.iptc.org/newscodes/digitalsourcetype/$value" =>
+        Some(value)
+      case _ => None
     }
-    /* TODO in scala 2.13:
-      name match {
-        case s"http://cv.iptc.org/newscodes/digitalsourcetype/$value" =>
-          Some(value)
-        case _ => None
-     */
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageTypeTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/InsertGuardianImageTypeTest.scala
@@ -46,4 +46,17 @@ class InsertGuardianImageTypeTest extends AnyFlatSpec with Matchers with OptionV
 
     inserted.metadata.imageType shouldBe None
   }
+
+  it should "handle using https as the protocol in the uri (mistake?)" in {
+    val base = createImageFromMetadata()
+    val fileMeta = FileMetadata(
+      // note https here
+      xmp = Map("Iptc4xmpExt:DigitalSourceType" -> JsString(s"https://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"))
+    )
+    val img = base.copy(fileMetadata = fileMeta)
+
+    val inserted = InsertGuardianImageType(img)
+
+    inserted.metadata.imageType.value shouldBe "Illustration"
+  }
 }


### PR DESCRIPTION
## What does this change?

We've seen at least one pic come in with https as the prefix to the digitalSourceType value. I'm not sure that that's compliant with the spec, but it's also not explicitly forbidden and _is_ being provided, so let's fix it. Also resolves an open TODO now that Grid is running on Scala 2.13.

## How should a reviewer test this change?

Updated unit tests should be sufficient for this.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
