### PR TITLE
Upgrade KCL on Usage to latest v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,7 +158,7 @@ lazy val thrall = playProject("thrall", 9002)
     libraryDependencies ++= Seq(
       "org.codehaus.groovy" % "groovy-json" % "3.0.7",
       // TODO upgrading kcl to v3? check if you can remove avro override below
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.0",
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.1",
       "com.gu" %% "kcl-pekko-stream" % "0.1.0",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
@@ -176,7 +176,7 @@ lazy val usage = playProject("usage", 9009).settings(
     "com.gu" %% "content-api-client-default" % "32.0.0",
     "com.gu" %% "content-api-client-aws" % "0.7.6",
     "io.reactivex" %% "rxscala" % "0.27.0",
-    "com.amazonaws" % "amazon-kinesis-client" % "1.8.10",
+    "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.1",
     "com.google.protobuf" % "protobuf-java" % "3.19.6"
   )
 )

--- a/usage/app/lib/CrierEventProcessor.scala
+++ b/usage/app/lib/CrierEventProcessor.scala
@@ -1,8 +1,5 @@
 package lib
 
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
-import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput}
 import com.gu.contentapi.client.ScheduledExecutor
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.Content
@@ -15,10 +12,14 @@ import model.{UsageGroup, UsageGroupOps}
 import org.joda.time.DateTime
 import rx.lang.scala.Subject
 import rx.lang.scala.subjects.PublishSubject
+import software.amazon.kinesis.exceptions.ShutdownException
+import software.amazon.kinesis.leases.exceptions.InvalidStateException
+import software.amazon.kinesis.lifecycle.events._
+import software.amazon.kinesis.processor.ShardRecordProcessor
 
 import java.util.UUID
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 trait ContentContainer extends GridLogging {
@@ -65,21 +66,20 @@ object CrierUsageStream {
 case class LiveContentItem(content: Content, lastModified: DateTime, isReindex: Boolean = false) extends ContentContainer
 case class PreviewContentItem(content: Content, lastModified: DateTime, isReindex: Boolean = false) extends ContentContainer
 
-abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGroupOps) extends IRecordProcessor with GridLogging {
+abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGroupOps) extends ShardRecordProcessor with GridLogging {
 
   implicit val codec: ThriftStructCodec[Event] = Event
 
   val contentApiClient: UsageContentApiClient
 
   override def initialize(initializationInput: InitializationInput): Unit = {
-    val shardId = initializationInput.getShardId
-    logger.debug(s"Initialized an event processor for shard $shardId")
+    logger.debug(s"Initialized an event processor for shard ${initializationInput.shardId}")
   }
 
   override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
-    val records = processRecordsInput.getRecords
+    val records = processRecordsInput.records
     records.asScala.foreach { record =>
-      val buffer: Array[Byte] = record.getData.array()
+      val buffer: Array[Byte] = record.data.array()
       val deserialization: Try[Event] = ThriftDeserializer.deserialize(buffer)
       deserialization.foreach(processEvent)
       deserialization.failed.foreach { e: Throwable =>
@@ -87,19 +87,40 @@ abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGrou
       }
     }
 
-    processRecordsInput.getCheckpointer.checkpoint(records.asScala.last)
+    val lastRecord = records.asScala.last
+
+    processRecordsInput.checkpointer.checkpoint(lastRecord.sequenceNumber(), lastRecord.subSequenceNumber())
   }
 
-  override def shutdown(shutdownInput: ShutdownInput): Unit = {
-    if (shutdownInput.getShutdownReason == ShutdownReason.TERMINATE) {
-      shutdownInput.getCheckpointer.checkpoint()
+  override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
+    // nothing to do?
+    logger.debug("Lost lease, so stopping processing Crier")
+  }
+
+  override def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
+    try {
+      shardEndedInput.checkpointer.checkpoint()
+      logger.debug("Shard ended, so stopping processing Crier")
+    } catch {
+      case _: ShutdownException | _: InvalidStateException =>
+        ()
+    }
+  }
+
+  override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
+    try {
+      shutdownRequestedInput.checkpointer.checkpoint()
+      logger.debug("Shutdown requested, so stopping processing Crier")
+    } catch {
+      case _: ShutdownException | _: InvalidStateException =>
+        ()
     }
   }
 
   def getContentItem(content: Content, time: DateTime): ContentContainer
 
 
-  def processEvent(event: Event): Unit = {
+  private def processEvent(event: Event): Unit = {
     implicit val logMarker: LogMarker = MarkerMap(
       "payloadId" -> event.payloadId,
       "requestId" -> UUID.randomUUID().toString

--- a/usage/app/lib/CrierEventProcessor.scala
+++ b/usage/app/lib/CrierEventProcessor.scala
@@ -79,8 +79,7 @@ abstract class CrierEventProcessor(config: UsageConfig, usageGroupOps: UsageGrou
   override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
     val records = processRecordsInput.records
     records.asScala.foreach { record =>
-      val buffer: Array[Byte] = record.data.array()
-      val deserialization: Try[Event] = ThriftDeserializer.deserialize(buffer)
+      val deserialization: Try[Event] = ThriftDeserializer.deserialize(record.data)
       deserialization.foreach(processEvent)
       deserialization.failed.foreach { e: Throwable =>
         logger.error("Failed to deserialize crier event", e)

--- a/usage/app/lib/CrierStreamReader.scala
+++ b/usage/app/lib/CrierStreamReader.scala
@@ -1,76 +1,116 @@
 package lib
 
-import java.net.InetAddress
-import java.util.UUID
-import com.amazonaws.auth._
-import com.amazonaws.auth.InstanceProfileCredentialsProvider
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, Worker}
 import com.gu.mediaservice.lib.logging.GridLogging
 import model.UsageGroupOps
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+import software.amazon.kinesis.common.{ConfigsBuilder, InitialPositionInStream, InitialPositionInStreamExtended, KinesisClientUtil}
+import software.amazon.kinesis.coordinator.Scheduler
+import software.amazon.kinesis.processor.{ShardRecordProcessor, ShardRecordProcessorFactory}
 
+import java.net.InetAddress
+import java.util.UUID
+import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
 
-class CrierStreamReader(config: UsageConfig, usageGroupOps: UsageGroupOps, executionContext: ExecutionContext) extends GridLogging {
+class CrierStreamReader(
+  config: UsageConfig,
+  usageGroupOps: UsageGroupOps,
+  executionContext: ExecutionContext
+) extends GridLogging {
 
-  lazy val workerId: String = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
+  private val region = Region.of(config.awsRegionName)
 
-  val credentialsProvider = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("media-service"),
-    InstanceProfileCredentialsProvider.getInstance()
-  )
+  private lazy val workerId: String = InetAddress.getLocalHost.getCanonicalHostName + ":" + UUID.randomUUID()
 
-  private lazy val dynamoCredentialsProvider = credentialsProvider
+  private lazy val awsCredentialsProvider = DefaultCredentialsProvider.builder().profileName("media-service").build()
+  private lazy val stsClient = StsClient.builder().region(region).credentialsProvider(awsCredentialsProvider).build()
 
-  lazy val sessionId: String = "session" + Math.random()
-  val initialPosition = InitialPositionInStream.TRIM_HORIZON
+  private lazy val sessionId: String = "session-" + Math.random()
+  private val initialPosition = InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.TRIM_HORIZON)
 
-  private def kinesisCredentialsProvider(arn: String)  = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("capi"),
-    new STSAssumeRoleSessionCredentialsProvider.Builder(arn, sessionId).build()
-  )
+  private def kinesisCredentialsProvider(arn: String): AwsCredentialsProviderChain = {
+    val assumeRoleRequest = AssumeRoleRequest.builder().roleArn(arn).roleSessionName(sessionId).build()
 
-  private def kinesisClientLibConfig(kinesisReaderConfig: KinesisReaderConfig) =
-    new KinesisClientLibConfiguration(
-      kinesisReaderConfig.appName,
+    AwsCredentialsProviderChain.of(
+      ProfileCredentialsProvider.create("capi"),
+      StsAssumeRoleCredentialsProvider.builder().refreshRequest(assumeRoleRequest).stsClient(stsClient).build()
+    )
+  }
+
+  private def kinesisClientLibConfig(processorFactory: ShardRecordProcessorFactory)
+    (kinesisReaderConfig: KinesisReaderConfig): ConfigsBuilder = {
+
+    val kinesisClient = KinesisClientUtil.createKinesisAsyncClient(KinesisAsyncClient.builder()
+      .region(region)
+      .credentialsProvider(kinesisCredentialsProvider(kinesisReaderConfig.arn)))
+    val dynamoClient = DynamoDbAsyncClient.builder()
+      .region(region)
+      .credentialsProvider(awsCredentialsProvider)
+      .build()
+    val cloudwatchClient = CloudWatchAsyncClient.builder()
+      .region(region)
+      .credentialsProvider(awsCredentialsProvider)
+      .build()
+
+    new ConfigsBuilder(
       kinesisReaderConfig.streamName,
-      kinesisCredentialsProvider(kinesisReaderConfig.arn),
-      dynamoCredentialsProvider,
-      credentialsProvider,
-      workerId
-    ).withInitialPositionInStream(initialPosition)
-     .withRegionName(config.awsRegionName)
+      kinesisReaderConfig.appName,
+      kinesisClient,
+      dynamoClient,
+      cloudwatchClient,
+      workerId,
+      processorFactory
+    )
+  }
 
-  private lazy val liveConfig =
-    config.liveKinesisReaderConfig.map(kinesisClientLibConfig)
+  @nowarn("cat=deprecation") // initialPositionInStreamExtended is deprecated, but the upgrade path is unclear
+  private def kinesisClientLibScheduler(configsBuilder: ConfigsBuilder): Scheduler = {
+    new Scheduler(
+      configsBuilder.checkpointConfig(),
+      configsBuilder.coordinatorConfig(),
+      configsBuilder.leaseManagementConfig(),
+      configsBuilder.lifecycleConfig(),
+      configsBuilder.metricsConfig(),
+      configsBuilder.processorConfig(),
+      configsBuilder.retrievalConfig().initialPositionInStreamExtended(initialPosition),
+    )
+  }
 
-  private lazy val previewConfig =
-    config.previewKinesisReaderConfig.map(kinesisClientLibConfig)
-
-  protected val LiveEventProcessorFactory = new IRecordProcessorFactory {
-    override def createProcessor(): IRecordProcessor =
+  private val LiveEventProcessorFactory = new ShardRecordProcessorFactory {
+    override def shardRecordProcessor(): ShardRecordProcessor =
       new CrierLiveEventProcessor(config, usageGroupOps)
   }
 
-  protected val PreviewEventProcessorFactory = new IRecordProcessorFactory {
-    override def createProcessor(): IRecordProcessor =
+  private val PreviewEventProcessorFactory = new ShardRecordProcessorFactory {
+    override def shardRecordProcessor(): ShardRecordProcessor =
       new CrierPreviewEventProcessor(config, usageGroupOps)
   }
 
-  lazy val liveWorker = liveConfig.map(new Worker.Builder().recordProcessorFactory(LiveEventProcessorFactory).config(_).build())
-  lazy val previewWorker = previewConfig.map(new Worker.Builder().recordProcessorFactory(PreviewEventProcessorFactory).config(_).build())
+  private lazy val liveConfig = config.liveKinesisReaderConfig
+    .map(kinesisClientLibConfig(LiveEventProcessorFactory))
+  private lazy val previewConfig = config.previewKinesisReaderConfig
+    .map(kinesisClientLibConfig(PreviewEventProcessorFactory))
 
-  def start() = {
+  private lazy val liveScheduler = liveConfig.map(kinesisClientLibScheduler)
+  private lazy val previewScheduler = previewConfig.map(kinesisClientLibScheduler)
+
+  def start(): Unit = {
     logger.info("Trying to start Crier Stream Readers")
 
-    liveWorker
+    liveScheduler
       .map(executionContext.execute)
       .fold(
         e => logger.error("No 'Crier Live Stream reader' thread to start", e),
         _ => logger.info("Starting Crier Live Stream reader")
       )
-    previewWorker
+    previewScheduler
       .map(executionContext.execute)
       .fold(
         e => logger.error("No 'Crier Preview Stream reader' thread to start", e),

--- a/usage/app/lib/CrierStreamReader.scala
+++ b/usage/app/lib/CrierStreamReader.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.amazonaws.auth._
 import com.amazonaws.auth.InstanceProfileCredentialsProvider
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor, IRecordProcessorFactory}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, Worker}
 import com.gu.mediaservice.lib.logging.GridLogging
 import model.UsageGroupOps


### PR DESCRIPTION


## What does this change?

In prep for a v3 upgrade, along with Thrall, when all deployments have made the [necessary preparations](https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html), perform the upgrade to latest v2.

First, migrate the to the updated interfaces in v1 - <https://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-implementation-app-java.html#kcl-java-v2-migration>

Then migrate to v2 - <https://docs.aws.amazon.com/streams/latest/dev/kcl-migration.html>

## How should a reviewer test this change?

Deploy to TEST - streamed usages (ie. those added after changes made or published from Composer) should continue as previously.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
