### PR TITLE
Panda: monitor non-active-key use

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / libraryDependencySchemes +=
   "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
 
 val commonSettings = Seq(
-  scalaVersion := "2.13.15",
+  scalaVersion := "2.13.16",
   description := "grid",
   organization := "com.gu",
   version := "0.1",
@@ -76,7 +76,7 @@ val maybeBBCLib: Option[sbt.ProjectReference] = if(bbcBuildProcess) Some(bbcProj
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "4.0.0",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "9.0.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
See:

* https://github.com/guardian/pan-domain-authentication/pull/182
* https://github.com/guardian/pan-domain-authentication/releases/tag/v9.0.0

With this change, the [logs](https://logs.gutools.co.uk/app/r/s/YWdfP) tell us when a _non-active key_ is used:

> NON_ACTIVE_KEY_USED (used='1xpqc', active='6k065'): active_freq=Map(false -> 22, true -> 3) key_freq=Map('1xpqc' -> 25)

### Testing

This has cleanly [deployed](https://riffraff.gutools.co.uk/deployment/view/9857a77e-6c71-4782-a9c1-c8a203d146be) to https://media.test.dev-gutools.co.uk/, looks good.