### PR TITLE
 add 5:4 as `Landscape NEW` and make ratio toggle bar more responsive

### DIFF
--- a/kahuna/public/js/components/gr-radio-list/gr-radio-list.css
+++ b/kahuna/public/js/components/gr-radio-list/gr-radio-list.css
@@ -49,3 +49,15 @@ gr-radio-list label:hover {
   background-color: #666;
   color: white;
 }
+
+gr-radio-list label span.full {
+  @media (max-width: 1294px) {
+    display: none;
+  }
+}
+
+gr-radio-list label span.minimal {
+  @media (min-width: 1295px) {
+    display: none;
+  }
+}

--- a/kahuna/public/js/components/gr-radio-list/gr-radio-list.html
+++ b/kahuna/public/js/components/gr-radio-list/gr-radio-list.html
@@ -6,6 +6,7 @@
          ng-value="option.key"
          ng-model="$parent.selection"/>
   <label for="{{listFor}}-{{option.key}}" gr-tooltip="{{option.tooltip}}">
-    {{option.value || option.key}}
+      <span class="minimal">{{option.minimalValue || option.value || option.key}}</span>
+      <span class="full">{{option.value || option.key}}</span>
   </label>
 </span>

--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -51,14 +51,11 @@ crop.controller('ImageCropCtrl', [
       const storageCropType = cropSettings.getCropType();
       const storageDefaultCropType = cropSettings.getDefaultCropType();
 
-      const cropOptionDisplayValue = cropOption => cropOption.ratioString
-        ? `${cropOption.key} (${cropOption.ratioString})`
-        : cropOption.key;
-
     ctrl.cropOptions = allCropOptions
         .filter(option => !storageCropType || storageCropType === option.key)
         .map(option => Object.assign(option, {
-          value: cropOptionDisplayValue(option),
+          value: option.ratioString ? `${option.key} (${option.ratioString})` : option.key,
+          minimalValue: option.ratioString || option.key,
           tooltip: `${option.key} [${option.key.charAt(0)}]`,
           disabled: storageCropType && storageCropType !== option.key
         }));

--- a/kahuna/public/js/util/constants/cropOptions.js
+++ b/kahuna/public/js/util/constants/cropOptions.js
@@ -1,8 +1,9 @@
 // `ratioString` is sent to the server, being `undefined` for `freeform` is expected 🙈
 export const landscape = {key: 'landscape', ratio: 5 / 3, ratioString: '5:3'};
+export const landscapeNew = {key: 'landscape NEW', ratio: 5 / 4, ratioString: '5:4'};
 export const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
 export const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
 export const square = {key: 'square', ratio: 1, ratioString: '1:1'};
 export const freeform = {key: 'freeform', ratio: null};
 
-export const cropOptions = [landscape, portrait, video, square, freeform];
+export const cropOptions = [landscape, landscapeNew, portrait, video, square, freeform];


### PR DESCRIPTION
5:4 is soon to become the main ratio for Landscape crops, so it should be selectable (leaving 5:3 as the default for now). The toggle button bar for the crop options was already crowded (particularly ugly on smaller viewports) so now we display just the aspect ratio (if defined, note Freeform) below a certain viewport width, plus we already have the nice tooltip...
![responsive-crop-options](https://github.com/user-attachments/assets/ce6f873b-47b5-4669-a6eb-4d8328b32983)

