### PR TITLE
remove notion of `shouldShowCropGuttersIfApplicable` query param and always display gutters when cropping 5:3 (for GNM users)

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -180,7 +180,6 @@ crop.controller('ImageCropCtrl', [
         const maybeCropRatioIfStandard = cropOptions.find(_ => _.key === ctrl.cropType)?.ratioString;
         ctrl.shouldShowVerticalWarningGutters =
           window._clientConfig.staffPhotographerOrganisation === "GNM"
-          && cropSettings.shouldShowCropGuttersIfApplicable()
           && maybeCropRatioIfStandard === "5:3";
 
         if (isCropTypeDisabled) {

--- a/kahuna/public/js/crop/index.js
+++ b/kahuna/public/js/crop/index.js
@@ -18,7 +18,7 @@ crop.config(['$stateProvider',
              function($stateProvider) {
 
     $stateProvider.state('crop', {
-        url: '/images/:imageId/crop?cropType&customRatio&shouldShowCropGuttersIfApplicable&defaultCropType',
+        url: '/images/:imageId/crop?cropType&customRatio&defaultCropType',
         template: cropTemplate,
         controller: 'ImageCropCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -103,11 +103,18 @@
 
 <div class="warning status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
     Although this is a 5:3 crop, it might be used in a 5:4 space, so please ensure
-    there is nothing important in the striped sides as these might be clipped.
+    there is nothing important in the striped sides<sup>
+        <a ng-click="ctrl.shouldHideVerticalWarningGutters = !ctrl.shouldHideVerticalWarningGutters">
+            [{{ctrl.shouldHideVerticalWarningGutters ? "show" : "hide"}}]
+        </a>
+    </sup>
+    as these might be clipped.
 </div>
 
-<div class="easel" role="main" aria-label="Image cropper"
-     ng-class="{'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters}">
+<div class="easel" role="main" aria-label="Image cropper" ng-class="{
+    'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters,
+    'hide-vertical-warning-gutters': ctrl.shouldHideVerticalWarningGutters
+}">
     <div class="easel__canvas">
         <div class="easel__image-container" oncontextmenu="return false;">
             <img class="easel__image easel__image--cropper"

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -101,10 +101,9 @@
     Please try to use a larger crop or an alternative image.
 </div>
 
-<div class="warning warning--multiline status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
+<div class="warning status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
     Although this is a 5:3 crop, it might be used in a 5:4 space, so please ensure
-    there is nothing important in the striped sides as these might be clipped.<br/>
-    You can also suggest alternative crops for the trail image back in Composer.
+    there is nothing important in the striped sides as these might be clipped.
 </div>
 
 <div class="easel" role="main" aria-label="Image cropper"

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -44,6 +44,10 @@
 
 
 /* GUTTERS to show what will be clipped if the 5:3 crop is used in 5:4 space */
+.easel.hide-vertical-warning-gutters .cropper-view-box::before,
+.easel.hide-vertical-warning-gutters .cropper-view-box::after {
+  visibility: hidden;
+}
 .easel.vertical-warning-gutters .cropper-view-box::before,
 .easel.vertical-warning-gutters .cropper-view-box::after {
   display: block;
@@ -66,5 +70,5 @@
   background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
 }
 .easel.vertical-warning-gutters .easel__canvas {
-  height: calc(100vh - 115px);
+  height: calc(100vh - 138px);
 }

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -66,5 +66,5 @@
   background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
 }
 .easel.vertical-warning-gutters .easel__canvas {
-  height: calc(100vh - 138px);
+  height: calc(100vh - 115px);
 }

--- a/kahuna/public/js/image/index.js
+++ b/kahuna/public/js/image/index.js
@@ -23,7 +23,7 @@ image.config(['$stateProvider',
               function($stateProvider) {
 
     $stateProvider.state('image', {
-        url: '/images/:imageId?crop?cropType&customRatio&shouldShowCropGuttersIfApplicable&defaultCropType',
+        url: '/images/:imageId?crop?cropType&customRatio&defaultCropType',
         template: imageTemplate,
         controller: 'ImageCtrl',
         controllerAs: 'ctrl',

--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -73,7 +73,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
     $stateProvider.state('search', {
         // FIXME [1]: This state should be abstract, but then we can't navigate to
         // it, which we need to do to access it's deeper / remembered chile state
-        url: '/?cropType&customRatio&shouldShowCropGuttersIfApplicable&defaultCropType',
+        url: '/?cropType&customRatio&defaultCropType',
         template: searchTemplate,
         deepStateRedirect: {
             // Inject a transient $stateParams for the results state

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -4,7 +4,6 @@ import { landscape, portrait, video, square, freeform, cropOptions } from './con
 
 const CROP_TYPE_STORAGE_KEY = 'cropType';
 const CUSTOM_CROP_STORAGE_KEY = 'customCrop';
-const SHOULD_SHOW_CROP_GUTTERS_IF_APPLICABLE_STORAGE_KEY = 'shouldShowCropGuttersIfApplicable';
 const CROP_DEFAULT_TYPE_STORAGE_KEY = 'defaultCropType';
 
 const customCrop = (label, xRatio, yRatio) => {
@@ -71,15 +70,7 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     }
   };
 
-  const setShouldShowCropGuttersIfApplicable = shouldShowCropGuttersIfApplicableStr => {
-    storage.setJs(
-      SHOULD_SHOW_CROP_GUTTERS_IF_APPLICABLE_STORAGE_KEY,
-      shouldShowCropGuttersIfApplicableStr === "true",
-      true
-    );
-  };
-
-  function set({cropType, customRatio, shouldShowCropGuttersIfApplicable, defaultCropType}) {
+  function set({cropType, customRatio, defaultCropType}) {
     // set customRatio first in case cropType relies on a custom crop
     if (customRatio) {
       setCustomCrop(customRatio);
@@ -91,10 +82,6 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
 
     if (defaultCropType) {
       setDefaultCropType(defaultCropType);
-    }
-
-    if (shouldShowCropGuttersIfApplicable) {
-      setShouldShowCropGuttersIfApplicable(shouldShowCropGuttersIfApplicable);
     }
 
   }
@@ -115,11 +102,7 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     }
   }
 
-  function shouldShowCropGuttersIfApplicable() {
-    return storage.getJs(SHOULD_SHOW_CROP_GUTTERS_IF_APPLICABLE_STORAGE_KEY, true);
-  }
-
-  return { set, getCropType, getCropOptions, shouldShowCropGuttersIfApplicable, getDefaultCropType };
+  return { set, getCropType, getCropOptions, getDefaultCropType };
 }]);
 
 cropUtil.filter('asCropType', function() {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -884,12 +884,6 @@ textarea.ng-invalid {
 .warning--small {
   padding: 5px 10px;
 }
-.warning--multiline {
-  min-height: 48px;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-}
 
 .full-error {
     margin-top: 3rem;
@@ -910,6 +904,14 @@ textarea.ng-invalid {
 
 .status--info {
   background-color: #5E9ED6;
+}
+
+.status--info a {
+  color: #0e1831;
+}
+
+.status--info a:hover {
+  color: #1B2E5F;
 }
 
 .status--valid {


### PR DESCRIPTION
Back in #4343 we added the `shouldShowCropGuttersIfApplicable` query param to allow tools which iframe the grid (such as our CMS composer) to nudge the grid to show the striped gutters (see https://github.com/guardian/grid/pull/4331) on the sides of the crop rectangle when cropping for 5:3 (to show what could be clipped if that were used in a 5:4 slot). 

As the we progress towards 5:4 becoming the dominant crop ratio, it would be helpful for all users to see these gutters to reduce the likelihood that we need to replace crops which don't work in 5:4. So here we remove all notion of `shouldShowCropGuttersIfApplicable` query param and it displays the gutters on 5:3 for all GNM users.

We also add a handy toggle in the explainer to temporarily hide/show the gutters, should they be obscuring something important on a given crop...
![gutters-toggle](https://github.com/user-attachments/assets/718580eb-75f0-4f74-b37d-436ecaa4c0f2)
