### PR TITLE
update elasticsearch AMI recipe to arm variant

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -110,7 +110,7 @@ deployments:
         ElasticSearchAMI:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-elasticsearch-focal
+          Recipe: grid-elasticsearch-focal-arm
 
   image-counter-lambda:
     type: aws-lambda


### PR DESCRIPTION
We're moving our cluster to run on arm64 machines, so update to the arm variant of our amigo recipe