### PR TITLE
use the word `Back` rather than `Cancel` on crop view as its less confusing

### DIFF
--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -2,9 +2,9 @@
     <gr-top-bar-nav role="navigation" aria-label="Primary">
         <a class="top-bar-item clickable side-padded"
            ui-sref="image({ imageId: ctrl.image.data.id })"
-           gr-tooltip="cancel [esc]"
+           gr-tooltip="Go back to image [esc]"
            aria-label="Go back to image">
-            <gr-icon-label gr-icon="cancel">Cancel</gr-icon-label></a>
+            <gr-icon-label gr-icon="cancel">Back</gr-icon-label></a>
     </gr-top-bar-nav>
 
     <gr-top-bar-actions role="region" aria-label="User actions and secondary navigation">


### PR DESCRIPTION
Particularly when using the grid in an iframe and when taken directly (by the host tool) to the cropping view for a given image, the word `Back` (`Go back to image` in the tooltip and `aria-label`) is more intuitive for users than the current word `Cancel`. 

This is useful when the current image isn't quite suitable and so the user wants to navigate to the photoshoot etc. via the metadata panel (currently the Cancel word confuses people into going back to the beginning and starting the search fresh).

<img width="189" alt="Screenshot 2025-03-17 at 5 08 52 pm" src="https://github.com/user-attachments/assets/f0678efe-df52-4f07-a8b1-b3c7b8f3fc0f" />
