### PR TITLE
make `freeform` the default crop ratio (should be GNM only)

### DIFF
--- a/kahuna/public/js/util/constants/cropOptions.js
+++ b/kahuna/public/js/util/constants/cropOptions.js
@@ -4,6 +4,6 @@ export const landscapeNew = {key: 'landscape NEW', ratio: 5 / 4, ratioString: '5
 export const portrait = {key: 'portrait', ratio: 4 / 5, ratioString: '4:5'};
 export const video = {key: 'video', ratio: 16 / 9, ratioString: '16:9'};
 export const square = {key: 'square', ratio: 1, ratioString: '1:1'};
-export const freeform = {key: 'freeform', ratio: null};
+export const freeform = {key: 'freeform', ratio: null, isDefault: true};
 
 export const cropOptions = [landscape, landscapeNew, portrait, video, square, freeform];

--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -19,7 +19,7 @@ cropUtil.constant('video', video);
 cropUtil.constant('square', square);
 cropUtil.constant('freeform', freeform);
 cropUtil.constant('cropOptions', cropOptions);
-cropUtil.constant('defaultCrop', cropOptions[0]);
+cropUtil.constant('defaultCrop', cropOptions.find(_ => _.isDefault) || cropOptions[0]);
 
 cropUtil.factory('cropSettings', ['storage', function(storage) {
   function getCropOptions() {


### PR DESCRIPTION
NOTE: Other orgs override all of `cropOptions.js` so this should only affect GNM (FYI @RichardLe @Conalb97 @AndyKilmory )

## What does this change?
This makes the default crop ratio 'Freeform' rather than the first in the list (i.e. Landscape) this will be accompanied by changes in composer to ensure `landscape` remains the default for 'main' media (see https://github.com/guardian/flexible-content/pull/5309) and indeed remains the only choice for 'trail'/'thumbnail' 

Freeform crops better preserve the photographers artistic intent.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
