### PR TITLE
usage: start migration to kcl v3 in compatibility mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,7 @@ lazy val usage = playProject("usage", 9009).settings(
     "com.gu" %% "content-api-client-default" % "32.0.0",
     "com.gu" %% "content-api-client-aws" % "0.7.6",
     "io.reactivex" %% "rxscala" % "0.27.0",
-    "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.1",
+    "software.amazon.kinesis" % "amazon-kinesis-client" % "3.0.2",
     "com.google.protobuf" % "protobuf-java" % "3.19.6"
   )
 )

--- a/usage/app/lib/CrierStreamReader.scala
+++ b/usage/app/lib/CrierStreamReader.scala
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 import software.amazon.kinesis.common.{ConfigsBuilder, InitialPositionInStream, InitialPositionInStreamExtended, KinesisClientUtil}
+import software.amazon.kinesis.coordinator.CoordinatorConfig.ClientVersionConfig
 import software.amazon.kinesis.coordinator.Scheduler
 import software.amazon.kinesis.processor.{ShardRecordProcessor, ShardRecordProcessorFactory}
 import software.amazon.kinesis.retrieval.polling.PollingConfig
@@ -82,7 +83,8 @@ class CrierStreamReader(
     val ConfigsBuilderWithStreamName(configsBuilder, streamName) = configsBuilderAndStreamName
     new Scheduler(
       configsBuilder.checkpointConfig(),
-      configsBuilder.coordinatorConfig(),
+      configsBuilder.coordinatorConfig()
+        .clientVersionConfig(ClientVersionConfig.CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2X),
       configsBuilder.leaseManagementConfig(),
       configsBuilder.lifecycleConfig(),
       configsBuilder.metricsConfig(),


### PR DESCRIPTION
## What does this change?

Performs the first step in a migration to Kinesis Client Library (KCL) v3, following the [guide provided in the AWS documentation](https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html). Requires the IAM changes contained in https://github.com/guardian/editorial-tools-platform/pull/841. 

Unlike thrall which uses KCL via https://github.com/guardian/kcl-pekko-stream, usage uses KCL directly. IAM permissions have been prepped along with the ones for Thrall (https://github.com/guardian/editorial-tools-platform/pull/841), and we already meet the rest of the prerequisites. So let's move to KCL v3 in Usage too!









## How should a reviewer test this change?

This PR is already running on TEST - do UI changes flow through thrall and get persisted into the ES cluster?

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
