### PR TITLE
upgrade commons-compress in scripts module to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,7 @@ lazy val scripts = project("scripts")
       "software.amazon.awssdk" % "dynamodb" % awsSdkV2Version,
       // bump jcommander explicitly as AWS SDK is pulling in a vulnerable version
       "com.beust" % "jcommander" % "1.75",
-      "org.apache.commons" % "commons-compress" % "1.20",
+      "org.apache.commons" % "commons-compress" % "1.27.1",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.6.4"
     )
   )


### PR DESCRIPTION
## What does this change?

Upgrades the commons-compress package, used in our scala scripts module, to the latest version. The previous version had  several security warnings against it, although these were for usages of zip, 7z and tar modules, whereas we only use for bz2.

## How should a reviewer test this change?

Successful compilation should be enough, it is unlikely we will run these scripts in the near future and commons-compress is pretty stable, so likelihood of breakage is very low.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
