### PR TITLE
Revert "Merge pull request #4430 from guardian/an/kcl-3-preview"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,13 +157,14 @@ lazy val thrall = playProject("thrall", 9002)
     pipelineStages := Seq(digest, gzip),
     libraryDependencies ++= Seq(
       "org.codehaus.groovy" % "groovy-json" % "3.0.7",
-      // amazon-kinesis-client brings in a critical vulnerability warning through apache avro, resolved in versions 1.11.4 and 1.12.0.
-      // updating amazon-kinesis-client? check if the override below can be removed
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "3.0.2",
-      "com.gu" %% "kcl-pekko-stream" % "0.1.1",
+      // TODO upgrading kcl to v3? check if you can remove avro override below
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.1",
+      "com.gu" %% "kcl-pekko-stream" % "0.1.0",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
     ),
+    // amazon-kinesis-client 2.6.0 brings in a critically vulnerable version of apache avro,
+    // but we cannot upgrade amazon-kinesis-client further without performing the v2->v3 upgrade https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html
     dependencyOverrides ++= Seq(
       "org.apache.avro" % "avro" % "1.11.4",
       "org.apache.pekko" %% "pekko-stream" % "1.0.3"

--- a/common-lib/src/main/resources/logback.xml
+++ b/common-lib/src/main/resources/logback.xml
@@ -37,7 +37,6 @@
     <logger name="play" level="INFO" />
     <logger name="application" level="INFO" />
     <logger name="request" level="INFO" />
-    <logger name="software.amazon.kinesis" level="WARN" />
 
     <root level="INFO">
       <appender-ref ref="LOGFILE"/>


### PR DESCRIPTION
This reverts commit 89cd535a3007a5aff2cda48ce4368976d0027c6c, reversing changes made to 3af817906dd41a1d36c914912c21af719f7743b1.

Reverts #4430 

## What does this change?

The leader handover process has changed in KCL v3, and takes 2 minutes while the previous leader's lease (note not the shard processing lease!) expires. This seems to happen on every deploy for us, and while we investigate whether this is due to a fault in KCL or a fault in our instance shutdown code, we need to revert to the previous version to receive the previous behaviour.

Requires following the manual rollback steps in https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-rollback.html

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
