### PR TITLE
Better understand grace periods, and allow UI page loads to demand refresh of cookies in grace period

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -42,8 +42,8 @@ class Authentication(config: CommonConfig,
     Future.successful(respondError(new Status(419), errorKey = "authentication-expired", errorMessage = "User authentication token has expired", loginLinks))
   }
 
-  // authenticatedInGracePeriod - if true, then users with valid but recently-expired cookies are considered authenticated, and not required to immediately reauth
-  def authenticationStatus(requestHeader: RequestHeader, authenticatedInGracePeriod: Boolean): Either[Future[Result], Principal] = {
+  // gracePeriodCountsAsAuthenticated - if true, then users with valid but recently-expired cookies are considered authenticated, and not required to refresh session for this request
+  def authenticationStatus(requestHeader: RequestHeader, gracePeriodCountsAsAuthenticated: Boolean): Either[Future[Result], Principal] = {
     def flushToken(resultWhenAbsent: Result): Result = {
       providers.userProvider.flushToken.fold(resultWhenAbsent)(_(requestHeader, resultWhenAbsent))
     }
@@ -62,7 +62,7 @@ class Authentication(config: CommonConfig,
             providers.userProvider.authenticateRequest(requestHeader) match {
               case NotAuthenticated => Left(unauthorised("Not authenticated"))
               case Expired(principal) => Left(expired(principal))
-              case GracePeriod(principal) if authenticatedInGracePeriod => Right(principal)
+              case GracePeriod(principal) if gracePeriodCountsAsAuthenticated => Right(principal)
               case GracePeriod(principal) => Left(expired(principal))
               case Authenticated(authedUser) => Right(authedUser)
               case Invalid(message, throwable) => Left(unauthorised(message, throwable).map(flushToken))
@@ -73,7 +73,8 @@ class Authentication(config: CommonConfig,
   }
 
   override def invokeBlock[A](request: Request[A], block: Authentication.Request[A] => Future[Result]): Future[Result] = {
-    authenticationStatus(request, authenticatedInGracePeriod = true) match {
+    // gracePeriodCountsAsAuthenticated is set to true here, so requests using this block should accept users whose session is in the grace period
+    authenticationStatus(request, gracePeriodCountsAsAuthenticated = true) match {
       // we have a principal, so process the block
       case Right(principal) => block(new AuthenticatedRequest(principal, request))
       // no principal so return a result which will either be an error or a form of redirect

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
@@ -12,7 +12,9 @@ trait BaseControllerWithLoginRedirects extends BaseController {
   def services: Services
 
   private def withLoginRedirectAsync(isLoginOptional: Boolean)(handler: Request[AnyContent] => Future[Result]): Action[AnyContent] = Action.async { request =>
-    auth.authenticationStatus(request) match {
+    // authenticatedInGracePeriod==false here means that a user must be reauthenticated if they turn up here to count as authenticated.
+    // If login is optional then they may still be allowed access
+    auth.authenticationStatus(request, authenticatedInGracePeriod = false) match {
       case Right(principal) =>
         handler(new AuthenticatedRequest(principal, request))
       case Left(resultFuture) => auth.loginLinks.headOption match {

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/BaseControllerWithLoginRedirects.scala
@@ -12,9 +12,9 @@ trait BaseControllerWithLoginRedirects extends BaseController {
   def services: Services
 
   private def withLoginRedirectAsync(isLoginOptional: Boolean)(handler: Request[AnyContent] => Future[Result]): Action[AnyContent] = Action.async { request =>
-    // authenticatedInGracePeriod==false here means that a user must be reauthenticated if they turn up here to count as authenticated.
+    // gracePeriodCountsAsAuthenticated=false here means that a user must have a fresh session (ie. not yet in grace period) if they turn up here to count as authenticated.
     // If login is optional then they may still be allowed access
-    auth.authenticationStatus(request, authenticatedInGracePeriod = false) match {
+    auth.authenticationStatus(request, gracePeriodCountsAsAuthenticated = false) match {
       case Right(principal) =>
         handler(new AuthenticatedRequest(principal, request))
       case Left(resultFuture) => auth.loginLinks.headOption match {

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationStatus.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/provider/AuthenticationStatus.scala
@@ -8,6 +8,7 @@ sealed trait AuthenticationStatus
 
 /** User authentication is valid but expired */
 case class Expired(authedUser: UserPrincipal) extends AuthenticationStatus
+case class GracePeriod(authedUser: UserPrincipal) extends AuthenticationStatus
 
 // statuses that extend this can be used by both users and machines
 /** Status of an API client's authentication */

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
@@ -54,7 +54,7 @@ class PandaAuthenticationProvider(
       case PandaNotAuthenticated => NotAuthenticated
       case PandaInvalidCookie(e) => Invalid(s"error checking user's auth, clear cookie and re-auth (${e.getClass.getSimpleName})")
       case PandaExpired(authedUser) => Expired(gridUserFrom(authedUser.user, request))
-      case PandaGracePeriod(authedUser) => Authenticated(gridUserFrom(authedUser.user, request))
+      case PandaGracePeriod(authedUser) => GracePeriod(gridUserFrom(authedUser.user, request))
       case PandaNotAuthorised(authedUser) => NotAuthorised(s"${authedUser.user.email} not authorised to use application")
       case PandaAuthenticated(authedUser) => Authenticated(gridUserFrom(authedUser.user, request))
     }


### PR DESCRIPTION
## What does this change?

Since #4405 we've been running Grid with apiGracePeriod turned on. In most tools which directly use the Panda Actions implementations, this is handled by marking routes as requiring "API" auth, or "regular" (ie. unspecified) auth - API routes will continue to allow access during the grace period and then return 419, while the other sort will only allow access during the regular validity period, and afterwards send users to Google for session refresh, even if a grace period is set. 

However Grid uses a more complicated and customised panda verification logic, and as grace period had previously been turned off it had not been properly implemented. This meant that Grid would not send users to reauth during their grace period, and simply allow them to continue accessing until that also ran out. This meant that connection to other tools with different grace periods would fail until either a) the grace period ran out, or b) they visited another tool, which correctly sent them for a session refresh.

Update the logic in Grid's panda implementation to correctly spot and handle grace periods; so that controllers providing API responses can continue accepting tokens during the grace period, and controllers providing UI responses (ie. users will generally visit as part of a _page navigation_) will send users to reauth earlier.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [x] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
