### PR TITLE
move elasticsearch cluster to jammy

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -110,7 +110,7 @@ deployments:
         ElasticSearchAMI:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-elasticsearch-focal-arm
+          Recipe: grid-elasticsearch-jammy-arm
 
   image-counter-lambda:
     type: aws-lambda


### PR DESCRIPTION
guardian only: switch the underlying ubuntu image for our elaticsearch cluster to version 22.04