### PR TITLE
Move Gary Calton from Obs to Guardian photographers…

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -68,7 +68,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
     PublicationPhotographers(ObserverPublication, List(
       "Andy Hall",
       "Antonio Olmos",
-      "Gary Calton",
       "Jane Bown",
       "Jonathan Lovekin",
       "Karen Robinson",
@@ -78,6 +77,7 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Suki Dhanda"
     )),
      PublicationPhotographers(GuardianPublication, List(
+      "Gary Calton", // moved over from Obs 22 Apr 2025
       "Alicia Canter",
       "Antonio Olmos",
       "Christopher Thomond",


### PR DESCRIPTION
… so that his pics are categorised correctly from now on. One day, we should remove `publication` from being an option to minimise likelihood of mistakes. Which is low. Very much.