### PR TITLE
Revert "Move Gary Calton from Obs to Guardian photographers…"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -68,6 +68,7 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
     PublicationPhotographers(ObserverPublication, List(
       "Andy Hall",
       "Antonio Olmos",
+      "Gary Calton",
       "Jane Bown",
       "Jonathan Lovekin",
       "Karen Robinson",
@@ -77,7 +78,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       "Suki Dhanda"
     )),
      PublicationPhotographers(GuardianPublication, List(
-      "Gary Calton", // moved over from Obs 22 Apr 2025
       "Alicia Canter",
       "Antonio Olmos",
       "Christopher Thomond",


### PR DESCRIPTION
Reverts guardian/grid#4454

I didn’t know it will mean that the whole back catalogue will have rewritten metadata during migration. This is projection after merging:

<img width="501" alt="image" src="https://github.com/user-attachments/assets/63c164bf-2855-4058-b5b2-f7f3d944bcb2" />

We will need another solution for the photographers to be categorised as `The Guardian` but only for new images.