### PR TITLE
Show circle guideline based on selected crop type, not only recognised 1:1s

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -185,7 +185,7 @@ crop.controller('ImageCropCtrl', [
         ctrl.shouldShowCircularGuideline =
           window._clientConfig.staffPhotographerOrganisation === "GNM"
           // update this array to apply circular guideline to further ratios (e.g. 5:4)
-          && ["1:1"].includes(maybeCropRatioIfStandard);
+          && ["square"].includes(ctrl.cropType.toLowerCase());
 
         ctrl.isSquareCrop = maybeCropRatioIfStandard === "1:1";
 


### PR DESCRIPTION
Currently pinboard opens grid modals for suggesting alternate crop ratios by using the customRatio param - so technically the crop is opened to a non-standard ratio. Updating pinboard to use the standard ratios looks like it may require a bit of thinking, so for now let's just look for cropType param being set to "square" (after normalising to lowercase).