### PR TITLE
Show circlular mask based on selected crop type, not only recognised 1:1s

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -187,7 +187,7 @@ crop.controller('ImageCropCtrl', [
           // update this array to apply circular guideline to further ratios (e.g. 5:4)
           && ["square"].includes(ctrl.cropType.toLowerCase());
 
-        ctrl.isSquareCrop = maybeCropRatioIfStandard === "1:1";
+        ctrl.isSquareCrop = ctrl.cropType.toLowerCase() === "square";
 
         if (isCropTypeDisabled) {
           ctrl.cropType = oldCropType;


### PR DESCRIPTION
## What does this change?

Followup to #4458 , also fixing the circular mask checkbox to appear with the fixed criteria

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
