### PR TITLE
remove explicit height calculation when cropping 5:3s

### DIFF
--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -93,6 +93,3 @@
   right: 0;
   background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
 }
-.easel.vertical-warning-gutters .easel__canvas {
-  height: calc(100vh - 138px);
-}


### PR DESCRIPTION
## What does this change?

This explicit height calculation doesn't take into account warning banners popping in when switching into 5:3 mode, so prevents scrolling to see the full image.

## How should a reviewer test this change?

Without this change, when cropping and switching into 5:3 with the banner active, then the bottom of the image will not appear in the easel. With this change, we can at least scroll to get at it.

Better would be to have cropperjs resize itself correctly, but that's been pretty painful to attempt. This will cease being a problem in a few days when 5:3 is removed as an option from the Guardian, so I'm happy with this.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
