### PR TITLE
also add some horizontal gutters when cropping 5:4s, because it is true that they might be used in 5:3 places

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -182,6 +182,10 @@ crop.controller('ImageCropCtrl', [
           window._clientConfig.staffPhotographerOrganisation === "GNM"
           && maybeCropRatioIfStandard === "5:3";
 
+        ctrl.shouldShowHorizontalWarningGutters =
+          window._clientConfig.staffPhotographerOrganisation === "GNM"
+          && maybeCropRatioIfStandard === "5:4";
+
         ctrl.shouldShowCircularGuideline =
           window._clientConfig.staffPhotographerOrganisation === "GNM"
           // update this array to apply circular guideline to further ratios (e.g. 5:4)

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -104,10 +104,20 @@
 <div class="warning status--info" ng-if="ctrl.shouldShowVerticalWarningGutters">
     Although this is a 5:3 crop, it might be used in a 5:4 space, so please ensure
     there is nothing important in the striped sides<sup>
-        <a ng-click="ctrl.shouldHideVerticalWarningGutters = !ctrl.shouldHideVerticalWarningGutters">
-            [{{ctrl.shouldHideVerticalWarningGutters ? "show" : "hide"}}]
+        <a ng-click="ctrl.shouldHideWarningGutters = !ctrl.shouldHideWarningGutters">
+            [{{ctrl.shouldHideWarningGutters ? "show" : "hide"}}]
         </a>
     </sup>
+    as these might be clipped.
+</div>
+
+<div class="warning status--info" ng-if="ctrl.shouldShowHorizontalWarningGutters">
+    Although this is a 5:4 crop, it might be used in a 5:3 space, so please ensure
+    there is nothing important in the striped sides<sup>
+    <a ng-click="ctrl.shouldHideWarningGutters = !ctrl.shouldHideWarningGutters">
+        [{{ctrl.shouldHideWarningGutters ? "show" : "hide"}}]
+    </a>
+</sup>
     as these might be clipped.
 </div>
 
@@ -120,7 +130,8 @@
 
 <div class="easel" role="main" aria-label="Image cropper" ng-class="{
     'vertical-warning-gutters': ctrl.shouldShowVerticalWarningGutters,
-    'hide-vertical-warning-gutters': ctrl.shouldHideVerticalWarningGutters,
+    'horizontal-warning-gutters': ctrl.shouldShowHorizontalWarningGutters,
+    'hide-warning-gutters': ctrl.shouldHideWarningGutters,
     'circular-guideline': ctrl.shouldShowCircularGuideline && !ctrl.shouldUseCircularMask,
     'circular-mask': ctrl.shouldShowCircularGuideline && ctrl.shouldUseCircularMask
 }">

--- a/kahuna/public/js/directives/ui-crop-box/cropper-override.css
+++ b/kahuna/public/js/directives/ui-crop-box/cropper-override.css
@@ -68,28 +68,47 @@
 }
 
 /* GUTTERS to show what will be clipped if the 5:3 crop is used in 5:4 space */
-.easel.hide-vertical-warning-gutters .cropper-view-box::before,
-.easel.hide-vertical-warning-gutters .cropper-view-box::after {
+.easel.hide-warning-gutters .cropper-view-box::before,
+.easel.hide-warning-gutters .cropper-view-box::after {
   visibility: hidden;
 }
 .easel.vertical-warning-gutters .cropper-view-box::before,
-.easel.vertical-warning-gutters .cropper-view-box::after {
+.easel.vertical-warning-gutters .cropper-view-box::after,
+.easel.horizontal-warning-gutters .cropper-view-box::before,
+.easel.horizontal-warning-gutters .cropper-view-box::after {
   display: block;
   content: '';
   position: absolute;
   z-index: 999;
-  width: 12.5%;
-  top: 0;
-  bottom: 0;
   mix-blend-mode: difference;
   opacity: 0.5;
   pointer-events: none;
 }
-.easel.vertical-warning-gutters .cropper-view-box::before { /* left gutter */
+.easel.vertical-warning-gutters .cropper-view-box::before,
+.easel.vertical-warning-gutters .cropper-view-box::after {
+  width: 12.5%;
+  top: 0;
+  bottom: 0;
+}
+.easel.horizontal-warning-gutters .cropper-view-box::before,
+.easel.horizontal-warning-gutters .cropper-view-box::after {
+  height: 12.5%;
+  left: 0;
+  right: 0;
+}
+.easel.vertical-warning-gutters .cropper-view-box::before{ /* left/top gutter */
   left: 0;
   background: repeating-linear-gradient(-45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
 }
-.easel.vertical-warning-gutters .cropper-view-box::after { /* right gutter */
+.easel.vertical-warning-gutters .cropper-view-box::after { /* right/bottom gutter */
   right: 0;
+  background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
+}
+.easel.horizontal-warning-gutters .cropper-view-box::before {
+  top: 0;
+  background: repeating-linear-gradient(-45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
+}
+.easel.horizontal-warning-gutters .cropper-view-box::after {
+  bottom: 0;
   background: repeating-linear-gradient(45deg,  transparent,  white 1px,  transparent 3px,  transparent 6px);
 }


### PR DESCRIPTION
## What does this change?

We've had vertical gutters when cropping 5:3s showing what bits will be cut off when they are forced into 5:4 containers, but now that we're switching over to defaulting to 5:4, for a while there will be the opposite problem: 5:4 crops forced into 5:3 containers. For the duration of the switchover, add a couple more gutters demonstrating what portion of the image may be lost to this.

![image](https://github.com/user-attachments/assets/8ac74e87-dc57-43b2-9371-1667b6a3af09)


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
