### PR TITLE
make has and is queries understand quoted values

### DIFF
--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -42,12 +42,12 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
   def HasMatch = rule { HasMatchField ~ ':' ~ HasMatchValue }
   def HasMatchField = rule { capture(HasFieldName) ~> (_ => HasField) }
   def HasFieldName = rule { "has" }
-  def HasMatchValue = rule { String ~> HasValue }
+  def HasMatchValue = rule { QuotedString ~> HasValue | String ~> HasValue }
 
   def IsMatch = rule { IsMatchField ~ ':' ~ IsMatchValue }
   def IsMatchField = rule { capture(IsFieldName) ~> (_ => IsField) }
   def IsFieldName = rule { "is" }
-  def IsMatchValue = rule { String ~> IsValue }
+  def IsMatchValue = rule { QuotedString ~> IsValue | String ~> IsValue }
 
   def NestedMatch = rule { ParentField ~ "@" ~ NestedField ~ ':' ~ ExactMatchValue }
   def NestedDateMatch = rule { ParentField ~ "@" ~ DateConstraintMatch ~> (


### PR DESCRIPTION
## What does this change?

Fix the query syntax to allow quoted phrases as input to `+has:` and `+is:` chips, to allow values with spaces

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
