### PR TITLE
include the croptype and aspectratio in drag data for pinboard

### DIFF
--- a/kahuna/public/js/util/crop.js
+++ b/kahuna/public/js/util/crop.js
@@ -102,15 +102,17 @@ cropUtil.factory('cropSettings', ['storage', function(storage) {
     }
   }
 
-  return { set, getCropType, getCropOptions, getDefaultCropType };
-}]);
-
-cropUtil.filter('asCropType', function() {
-  return ratioString => {
+  function asCropType(ratioString) {
     const cropSpec = cropOptions.find(_ => _.ratioString === ratioString) || freeform;
     return cropSpec.key;
-  };
-});
+  }
+
+  return { set, getCropType, getCropOptions, getDefaultCropType, asCropType };
+}]);
+
+cropUtil.filter('asCropType', ['cropSettings', function(cropSettings) {
+  return cropSettings.asCropType;
+}]);
 
 cropUtil.factory('pollUntilCropCreated', ['$q', 'apiPoll', function($q, apiPoll) {
   return function pollUntilCropCreated(image, newCropId) {


### PR DESCRIPTION
## What does this change?

Currently the drag data does not include the crop type or aspect ratio, meaning that pinboard cannot pick up this data when an image is dropped, compared to when an image is added with the button. Let's rectify that.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
