### PR TITLE
convert api requests asking for "orderBy=oldest" to the corect value

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -120,6 +120,11 @@ object SearchParams {
   def parseBooleanFromQuery(s: String): Option[Boolean] = Try(s.toBoolean).toOption
   def parseSyndicationStatus(s: String): Option[SyndicationStatus] = Some(SyndicationStatus(s))
 
+  private def readOrderBy(orderByRaw: String): String = {
+    if (orderByRaw == "oldest") "uploadTime"
+    else orderByRaw
+  }
+
   def apply(request: Authentication.Request[Any]): SearchParams = {
 
     def commaSep(key: String): List[String] = request.getQueryString(key).toList.flatMap(commasToList)
@@ -143,7 +148,7 @@ object SearchParams {
       request.getQueryString("ids").map(_.split(",").toList),
       request.getQueryString("offset") flatMap parseIntFromQuery getOrElse 0,
       request.getQueryString("length") flatMap parseIntFromQuery getOrElse 10,
-      request.getQueryString("orderBy"),
+      request.getQueryString("orderBy") map readOrderBy,
       request.getQueryString("since") flatMap parseDateFromQuery,
       request.getQueryString("until") flatMap parseDateFromQuery,
       request.getQueryString("modifiedSince") flatMap parseDateFromQuery,


### PR DESCRIPTION
## What does this change?

There's a discrepancy between the search params shown and used by Kahuna, and what's expected in the grid API. One is `orderBy` - the default (so not shown in the kahuna params) is upload date, from newest to oldest, which the API phrases as `-uploadTime`. Next is upload date from oldest to newest; kahuna shows this as `&orderBy=oldest`; but the media API requires `uploadTime`.

We've had a handful of errors from the media-api from someone trying to order on "oldest", instead of "uploadTime". After some digging I've found the culprit (a service which tries to convert kahuna search params into media-api queries), but rather than fix it there, it's a simple fix to do inside grid itself, to be more resilient to slightly-wrong but still understandable queries.

## How should a reviewer test this change?

Make some API queries, ordering on "oldest" - you should get successful requests, instead of 500s. Also/alternatively, paste a grid URL where you've been ordering by "oldest" into pinboard (note _not_ using the "add to pinboard" button, which already does the right thing).

## How can success be measured?

Fewer 5xxs

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
