### PR TITLE
Less pngquant effort when cropping

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/imaging/ImageOperations.scala
@@ -132,7 +132,7 @@ class ImageOperations(playPath: String) extends GridLogging {
       val fileName: String = resizedFile.getAbsolutePath
 
       val optimisedImageName: String = fileName.split('.')(0) + "optimised.png"
-      Seq("pngquant","-s8",  "--quality", "1-85", fileName, "--output", optimisedImageName).!
+      Seq("pngquant","-s10",  "--quality", "1-85", fileName, "--output", optimisedImageName).!
 
       new File(optimisedImageName)
     case Jpeg => resizedFile


### PR DESCRIPTION
## What does this change?

Makes pngquant optimisation of static crop assets faster in the hope that this step is making cropping time out.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
