### PR TITLE
Eelpie/seperate recent usage signals

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -168,10 +168,12 @@ image.controller('ImageCtrl', [
     const usages = imageUsagesService.getUsages(ctrl.image);
     const usagesCount$ = usages.count$;
 
-    const recentUsages$ = usages.recentUsages$;
+    const recentPrintUsages$ = usages.recentPrintUsages$;
+    const recentDigitalUsages$ = usages.recentDigitalUsages$;
 
     inject$($scope, usagesCount$, ctrl, 'usagesCount');
-    inject$($scope, recentUsages$, ctrl, 'recentUsages');
+    inject$($scope, recentPrintUsages$, ctrl, 'recentPrintUsages');
+    inject$($scope, recentDigitalUsages$, ctrl, 'recentDigitalUsages$');
 
     const freeUsageCountWatch = $scope.$watch('ctrl.usagesCount', value => {
       const usageTab = ctrl.tabs.find(_ => _.key === 'usages');

--- a/kahuna/public/js/preview/image.html
+++ b/kahuna/public/js/preview/image.html
@@ -135,15 +135,15 @@ Credit: {{ctrl.image.data.metadata.credit  || '[none]'}}">
         </span>
 
         <span class="bottom-bar__meta-item preview__has-print-usages"
-              title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
+              title="This image has been used {{ctrl.recentPrintUsages.count() > 0 ? 'RECENTLY': '' }} in Print Content"
               ng-if="ctrl.hasPrintUsages">
-                <gr-icon class="gr-icon--large" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">local_library</gr-icon>
+                <gr-icon class="gr-icon--large" ng-class="{'icon-warning': ctrl.recentPrintUsages.count() > 0}">local_library</gr-icon>
         </span>
 
         <span class="bottom-bar__meta-item preview__has-web-usages"
-              title="This image has been used {{ctrl.recentUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
+              title="This image has been used {{ctrl.recentDigitalUsages.count() > 0 ? 'RECENTLY': '' }} in Digital Content"
               ng-if="ctrl.hasDigitalUsages">
-                <gr-icon class="gr-icon--large" ng-class="{'icon-warning': ctrl.recentUsages.count() > 0}">phonelink</gr-icon>
+                <gr-icon class="gr-icon--large" ng-class="{'icon-warning': ctrl.recentDigitalUsages.count() > 0}">phonelink</gr-icon>
         </span>
 
 

--- a/kahuna/public/js/preview/image.js
+++ b/kahuna/public/js/preview/image.js
@@ -111,13 +111,15 @@ image.controller('uiPreviewImageCtrl', [
       const hasSyndicationUsages$ =
           imageUsagesService.getUsages(ctrl.image).hasSyndicationUsages$;
 
-      const recentUsages$ = imageUsagesService.getUsages(ctrl.image).recentUsages$;
+      const recentPrintUsages$ = imageUsagesService.getUsages(ctrl.image).recentPrintUsages$;
+      const recentDigitalUsages$ = imageUsagesService.getUsages(ctrl.image).recentDigitalUsages$;
 
       $scope.$on('$destroy', function() {
         freeImagesUpdateListener();
       });
 
-      inject$($scope, recentUsages$, ctrl, 'recentUsages');
+      inject$($scope, recentPrintUsages$, ctrl, 'recentPrintUsages');
+      inject$($scope, recentDigitalUsages$, ctrl, 'recentDigitalUsages');
       inject$($scope, hasPrintUsages$, ctrl, 'hasPrintUsages');
       inject$($scope, hasDigitalUsages$, ctrl, 'hasDigitalUsages');
       inject$($scope, hasSyndicationUsages$, ctrl, 'hasSyndicationUsages');

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -70,11 +70,18 @@ imageUsagesService.factory('imageUsagesService', [function() {
       const hasPlatformUsages = (platform) =>
         filterByPlatform(platform).every((group) => !group.isEmpty());
 
-      const recentUsages$ = usages$.map((usagesList) => {
+      const recentPrintUsages$ = usages$.map((usagesList) => {
         return usagesList.filter(item=> {
           const timestamp = item.get('dateAdded');
           const recentIfAfter = moment().subtract(recentDays, 'days');
-          return moment(timestamp).isAfter(recentIfAfter);
+          return item.get('platform') === 'print' && moment(timestamp).isAfter(recentIfAfter);
+        });
+      });
+      const recentDigitalUsages$ = usages$.map((usagesList) => {
+        return usagesList.filter(item=> {
+          const timestamp = item.get('dateAdded');
+          const recentIfAfter = moment().subtract(recentDays, 'days');
+          return item.get('platform') === 'digital' && moment(timestamp).isAfter(recentIfAfter);
         });
       });
 
@@ -94,7 +101,8 @@ imageUsagesService.factory('imageUsagesService', [function() {
         hasDigitalUsages$,
         hasSyndicationUsages$,
         count$,
-        recentUsages$
+        recentPrintUsages$,
+        recentDigitalUsages$
       };
     },
     /*

--- a/kahuna/public/js/services/image/usages.js
+++ b/kahuna/public/js/services/image/usages.js
@@ -70,18 +70,18 @@ imageUsagesService.factory('imageUsagesService', [function() {
       const hasPlatformUsages = (platform) =>
         filterByPlatform(platform).every((group) => !group.isEmpty());
 
-      const recentPrintUsages$ = usages$.map((usagesList) => {
+      const recentPrintUsages$ = filterByPlatform('print').map((usagesList) => {
         return usagesList.filter(item=> {
           const timestamp = item.get('dateAdded');
           const recentIfAfter = moment().subtract(recentDays, 'days');
-          return item.get('platform') === 'print' && moment(timestamp).isAfter(recentIfAfter);
+          return moment(timestamp).isAfter(recentIfAfter);
         });
       });
-      const recentDigitalUsages$ = usages$.map((usagesList) => {
+      const recentDigitalUsages$ = filterByPlatform('digital').map((usagesList) => {
         return usagesList.filter(item=> {
           const timestamp = item.get('dateAdded');
           const recentIfAfter = moment().subtract(recentDays, 'days');
-          return item.get('platform') === 'digital' && moment(timestamp).isAfter(recentIfAfter);
+          return moment(timestamp).isAfter(recentIfAfter);
         });
       });
 


### PR DESCRIPTION
## What does this change?

On the image preview, split `recentUsages` into recent print and recent digital values so that the print and digital usages can be independency highlighted as recent.

Currently it looks like print and digital will both turn red if either of them is qualifies as recent.

![Screenshot 2025-06-30 at 22 05 53](https://github.com/user-attachments/assets/09cae111-2018-4fad-babc-5855f8129cf6)



## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
