### PR TITLE
Strip useless fullstops token

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/RedundantTokenRemover.scala
@@ -25,6 +25,7 @@ object RedundantTokenRemover extends MetadataCleaner {
     "Supplied",
     "SUPPLIED",
     "-",
+    ".",
     "UNCREDITED",
     "Uncredited",
     "uncredited",


### PR DESCRIPTION
## What does this change?

This information is of zero value to readers.

## How can success be measured?

Less manual cleanup and/or less redundant reader-facing information.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
