### PR TITLE
correct dimensions on sidebar

### DIFF
--- a/kahuna/public/js/image/controller.js
+++ b/kahuna/public/js/image/controller.js
@@ -239,17 +239,8 @@ image.controller('ImageCtrl', [
       });
     };
 
-    // TODO: move this to a more sensible place.
-    function getCropDimensions() {
-      return {
-        width: ctrl.crop.specification.bounds.width,
-        height: ctrl.crop.specification.bounds.height
-      };
-    }
-    // TODO: move this to a more sensible place.
-    function getImageDimensions() {
-      return ctrl.image.data.source.dimensions;
-    }
+    // have a fallback for images that were loaded without orientedDimensions
+    ctrl.dimensions = ctrl.image.data.source.orientedDimensions || ctrl.image.data.source.dimensions;
 
     function getImageIdFromCropResource(cropsResource) {
       const imageHref = cropsResource.links.find(link => link.rel == 'image')?.href;
@@ -304,13 +295,6 @@ image.controller('ImageCtrl', [
       //boolean version for use in template
       ctrl.hasFullCrop = angular.isDefined(ctrl.fullCrop);
       ctrl.hasCrops = ctrl.crops.length > 0;
-    }).finally(() => {
-      ctrl.dimensions = angular.isDefined(ctrl.crop) ?
-        getCropDimensions() : getImageDimensions();
-
-      if (angular.isDefined(ctrl.crop)) {
-        ctrl.originalDimensions = getImageDimensions();
-      }
     });
 
     function cropSelected(crop) {

--- a/kahuna/public/js/image/view.html
+++ b/kahuna/public/js/image/view.html
@@ -50,7 +50,7 @@
                                      ng-src="{{:: ctrl.image.data.thumbnail | assetFile }}" />
                                 <div class="image-crop__aspect-ratio"
                                     ng-class="{'image-crop__aspect-ratio--selected': !ctrl.crop}">
-                                    {{::ctrl.image.data.source.dimensions.width}} &times; {{::ctrl.image.data.source.dimensions.height}}
+                                    {{::ctrl.dimensions.width}} &times; {{::ctrl.dimensions.height}}
                                 </div>
                                 <asset-handle
                                     data-source="grid"


### PR DESCRIPTION
## What does this change?

Corrects the dimensions for the source image which appear on the sidebar in grid, to account for them flipping for re-oriented images.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
