### PR TITLE
Add Blake Sharp-Wiggins as Staff Photographer

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -26,6 +26,7 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
       PublicationPhotographer("Michael Slezak"),
       PublicationPhotographer("Sean Smith"),
       PublicationPhotographer("Carly Earl"),
+      PublicationPhotographer("Blake Sharp-Wiggins"),
       // Past
       PublicationPhotographer("Dan Chung"),
       PublicationPhotographer("Denis Thorpe"),


### PR DESCRIPTION
## What does this change?

Allows Blake to appear in Photographer Staff dropdown and for images with his Creator/Byline metadata field to be automatically categorised on ingestion.
## How should a reviewer test this change?
Try to find Blake in Usage Rights Staff Photographer dropdown. Upload image with `Blake Sharp-Wiggins` in dc:creator XMP field and check if it’s been automatically categorised.

Or just decide it will work. Spare 15 seconds thinking if hyphen won’t cause armageddon, coz computers.

## How can success be measured?
We nice.

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
