### PR TITLE
add `telemetryUri` to CSP `connectSources`

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -53,7 +53,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val connectSources: Set[String] = getStringSet("security.connectSources") ++ maybeIngestBucket.map { ingestBucket =>
     if (isDev) "https://localstack.media.local.dev-gutools.co.uk"
     else s"https://$ingestBucket.s3.$awsRegion.amazonaws.com"
-  }
+  } ++ telemetryUri
   val fontSources: Set[String] = getStringSet("security.fontSources")
   val imageSources: Set[String] = getStringSet("security.imageSources")
 


### PR DESCRIPTION
## What does this change?
Since we have the `telemetryUri` (assuming its set) available in `KahunaConfig` already, why not add it to the CSP `connect-src` list, rather than to configure that manually.

## How should a reviewer test this change?
Run grid locally (perhaps with fresh config, but with `links.telemetryUri` specifed), inspect with the network tab and see that the `connect-src` part of content-security-policy header contains the telemetryUri.

✅  TESTED in TEST (removed the telemetry URL from the `security.connectSources` list but it still appears in the CSP when inspecting in the Network panel).

## How can success be measured?
Less manual config 🎉 

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
