### PR TITLE
Improve PA credit parsing

### DIFF
--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -504,6 +504,54 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
   }
 
 
+  describe("PaParser") {
+    it("matchAndClean - simple example") {
+      val image = createImageFromMetadata("credit" -> "Ben Blackall/Netflix/PA")
+
+      val cleaned = PaParser.apply(image)
+
+      cleaned.metadata.credit should be (Some("Ben Blackall/Netflix/PA"))
+      cleaned.usageRights should be (an[Agency])
+      cleaned.usageRights.asInstanceOf[Agency].supplier should be ("PA")
+    }
+    it("matchAndClean - complex credit at end") {
+      val image = createImageFromMetadata("credit" -> "Ben Blackall/Netflix/PA wIRE/PA Photos")
+
+      val cleaned = PaParser.apply(image)
+
+      cleaned.metadata.credit should be (Some("Ben Blackall/Netflix/PA"))
+      cleaned.usageRights should be (an[Agency])
+      cleaned.usageRights.asInstanceOf[Agency].supplier should be ("PA")
+    }
+    it("matchAndClean - simple credit in middle of credit listing") {
+      val image = createImageFromMetadata("credit" -> "Ben Blackall/PA/Netflix")
+
+      val cleaned = PaParser.apply(image)
+
+      cleaned.metadata.credit should be (Some("Ben Blackall/Netflix/PA"))
+      cleaned.usageRights should be (an[Agency])
+      cleaned.usageRights.asInstanceOf[Agency].supplier should be ("PA")
+    }
+    it("matchAndClean - complex credit in middle of credit listing") {
+      val image = createImageFromMetadata("credit" -> "Ben Blackall/PA Archive/PA Images/Netflix")
+
+      val cleaned = PaParser.apply(image)
+
+      cleaned.metadata.credit should be (Some("Ben Blackall/Netflix/PA"))
+      cleaned.usageRights should be (an[Agency])
+      cleaned.usageRights.asInstanceOf[Agency].supplier should be ("PA")
+    }
+    it("matchAndClean - unmatched credit is unchanged") {
+      val image = createImageFromMetadata("credit" -> "Ben Blackall/NPA Archive/PA Images/Netflix")
+
+      val cleaned = PaParser.apply(image)
+
+      cleaned.metadata.credit should be (Some("Ben Blackall/NPA Archive/PA Images/Netflix"))
+      cleaned.usageRights should be (NoRights)
+    }
+  }
+
+
   def applyProcessors(image: Image): Image = {
     val processorResources = ImageProcessorResources(config, actorSystem)
     new SupplierProcessors(processorResources).apply(image)


### PR DESCRIPTION
## What does this change?

Improves parsing of PA credits. Rather than replacing credit with "PA" wholesale, we extract the section which identifies PA, then place "PA" as the final part of the credit.

## How should a reviewer test this change?

Ask @paperboyo very nicely to test this change.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
