### PR TITLE
select elasticsearch 8 amigo recipe for upgrades

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -110,7 +110,7 @@ deployments:
         ElasticSearchAMI:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: grid-elasticsearch-jammy-arm
+          Recipe: grid-elasticsearch-8
 
   image-counter-lambda:
     type: aws-lambda


### PR DESCRIPTION
## What does this change?

Switch to our elasticsearch 8 recipe in Grid.

(Yes this could be done by updating the existing recipe and rebaking, but this is a big enough change to justify the new recipe IMO.)

## How should a reviewer test this change?

Grid TEST is already running this recipe. Try out some queries on TEST.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
