### PR TITLE
update elasticsearch docker container for local and tests to v8

### DIFF
--- a/common-lib/src/test/scala/com/gu/mediaservice/testlib/ElasticSearchDockerBase.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/testlib/ElasticSearchDockerBase.scala
@@ -16,7 +16,7 @@ trait ElasticSearchDockerBase extends BeforeAndAfterAll {
 
   val esContainer: Option[ElasticsearchContainer] = if (useEsDocker) {
     {
-      val container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.16.2")
+      val container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.18.3")
         .withExposedPorts(9200)
         .withAccessToHost(true)
         .withEnv(Map(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.3
     environment:
       ES_JAVA_OPTS: "-Xms1024m -Xmx1024m"
     volumes:


### PR DESCRIPTION
## What does this change?

Updates the version of elasticsearch used in local running and in CI to v8, to match our migration to v8 at the Guardian.

In general we've not seen any compatibility issues between these versions, so this should be safe.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
