### PR TITLE
Add endpoint to get aggregate count for metadata fields

### DIFF
--- a/media-api/app/controllers/AggregationController.scala
+++ b/media-api/app/controllers/AggregationController.scala
@@ -17,4 +17,13 @@ class AggregationController(auth: Authentication, elasticSearch: ElasticSearch,
       .map(aggregateResponse)
   }
 
+  def metadataFieldValues(field: String, q: Option[String], size: Option[Int]) = auth.async { request =>
+    implicit val r: Authentication.Request[AnyContent] = request
+
+    val baseParams = AggregateSearchParams(field, request)
+    val params = baseParams.copy(size = size.getOrElse(10))
+    elasticSearch.metadataSearch(params)
+      .map(aggregateResponse)
+  }
+
 }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -317,7 +317,8 @@ class ElasticSearch(
   }
 
   def metadataSearch(params: AggregateSearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[AggregateSearchResults] = {
-    aggregateSearch("metadata", params, termsAgg(name = "metadata", field = metadataField(params.field)), fromTermAggregation)
+    val aggregation = termsAgg(name = "metadata", field = metadataField(params.field)).size(params.size)
+    aggregateSearch("metadata", params, aggregation, fromTermAggregation)
   }
 
   def editsSearch(params: AggregateSearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal]): Future[AggregateSearchResults] = {

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -8,6 +8,8 @@ import lib.querysyntax.{Condition, Parser}
 import org.joda.time.DateTime
 import play.api.libs.json.{Json, OWrites}
 import play.api.mvc.{AnyContent, Request}
+
+import scala.util.Try
 import scalaz.syntax.applicative._
 import scalaz.syntax.std.list._
 import scalaz.syntax.validation._
@@ -39,18 +41,21 @@ object BucketResult {
 
 case class AggregateSearchParams(field: String,
                                  q: Option[String],
-                                 structuredQuery: List[Condition])
+                                 structuredQuery: List[Condition],
+                                 size: Int = 10)
 
 object AggregateSearchParams {
   def parseIntFromQuery(s: String): Option[Int] = Try(s.toInt).toOption
 
   def apply(field: String, request: Request[AnyContent]): AggregateSearchParams = {
     val query = request.getQueryString("q")
+    val size = request.getQueryString("size").flatMap(parseIntFromQuery).getOrElse(10)
     val structuredQuery = query.map(Parser.run) getOrElse List[Condition]()
     new AggregateSearchParams(
       field,
       query,
-      structuredQuery
+      structuredQuery,
+      size
     )
   }
 }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -11,6 +11,7 @@ GET     /images/edits/:field                                        controllers.
 
 GET     /images/:id/softDeletedMetadata                             controllers.MediaApi.getSoftDeletedMetadata(id: String)
 GET     /images/aggregations/date/:field                            controllers.AggregationController.dateHistogram(field: String, q: Option[String])
+GET     /images/aggregations/metadata/:field                        controllers.AggregationController.metadataFieldValues(field: String, q: Option[String], size: Option[Int])
 
 # Images
 GET     /images/:id                                                 controllers.MediaApi.getImage(id: String)

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -180,6 +180,15 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       results.results.find(b => b.key == "es").get.count shouldBe images.size
       results.results.find(b => b.key == "test").get.count shouldBe images.size
     }
+
+    it("can load metadata aggregations with custom size") {
+      val aggregateSearchParams = AggregateSearchParams(field = "keywords", q = None, structuredQuery = List.empty, size = 1)
+
+      val results = Await.result(ES.metadataSearch(aggregateSearchParams), fiveSeconds)
+
+      results.total shouldBe 1
+      results.results.size shouldBe 1
+    }
   }
 
   describe("Tiered API access") {


### PR DESCRIPTION
# Metadata Aggregation Endpoint

## Overview

This new endpoint provides the top N values with counts for metadata fields, enabling Kibana-style filtering functionality. It's the first step towards replacing the chips-based search with explicit UI filters.

## Endpoint

```
GET /images/aggregations/metadata/{field}?size={size}&q={query}
```

### Parameters

- `field` (required): The metadata field to aggregate on (e.g., "country", "city", "credit", etc.)
- `size` (optional, default: 10): Maximum number of top values to return
- `q` (optional): Additional query to filter the data before aggregation

### Example Usage

Get top 5 countries from all images:
```bash
curl "http://localhost:9001/images/aggregations/metadata/country?size=5"
```

Get top countries from images with "london" in any field:
```bash
curl "http://localhost:9001/images/aggregations/metadata/country?q=london&size=5"
```

### Example Response

```json
{
  "data": [
    {
      "key": "UK",
      "count": 1250
    },
    {
      "key": "USA", 
      "count": 890
    },
    {
      "key": "France",
      "count": 456
    },
    {
      "key": "Germany",
      "count": 234
    },
    {
      "key": "Spain",
      "count": 123
    }
  ],
  "offset": 0,
  "total": 5
}
```

## Supported Fields

All metadata fields are supported, including:
- `country`, `city`, `state`, `subLocation`
- `credit`, `source`, `supplier`
- `byline`, `photographer`
- `keywords`, `subjects`
- `title`, `description`
- `imageType`
- And more...

## Technical Implementation

- Uses Elasticsearch terms aggregation for efficient counting
- Leverages existing `metadataSearch` functionality in `ElasticSearch` class
- Supports structured query filtering via the `q` parameter
- Returns results in the standard Grid API format

## Next Steps

This endpoint will be used to build explicit filter UI components that show:
1. Available filter values with counts
2. Dynamic filtering based on current search context
3. Multi-select filtering capabilities
4. Clear visual indication of applied filters

This will replace the current chips-based system where users need to know specific syntax like `country:UK`.
