### PR TITLE
Usage and Lease creation datetime displayed in tooltips

### DIFF
--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
@@ -11,7 +11,8 @@
             {{usage.title}}
 
             <div class="more-info">
-                <span class="date-added">{{::ctrl.formatTimestamp(usage.dateAdded)}}</span>
+                <span title="{{usage.dateAdded | date:'d MMM yyyy, HH:mm'}}" class="date-added">{{::ctrl.formatTimestamp(usage.dateAdded)}}</span>
+
                 <ul class="reference-list">
                     <li ng-repeat="reference in usage.references">
                         <a ng-if="reference.uri" href="{{reference.uri}}" title="Open in {{reference.type}}" rel="noopener" target="_blank">

--- a/kahuna/public/js/leases/leases.html
+++ b/kahuna/public/js/leases/leases.html
@@ -141,9 +141,8 @@
     </li>
     <li ng-switch-default
         ng-repeat="lease in ctrl.leases.leases"
-        gr-tooltip="{{ctrl.toolTip(lease)}}"
-        class="lease__item"
-        gr-tooltip-position="bottom">
+        title="{{ctrl.toolTip(lease)}}"
+        class="lease__item">
 
         <div class="lease__wrapper" ng-class="ctrl.leaseClass(lease)">
           <div class="lease">

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -209,7 +209,7 @@ leases.controller('LeasesCtrl', [
           };
 
           ctrl.toolTip = (lease) => {
-            return Boolean(lease.leasedBy) ? ` leased by: ${lease.leasedBy}\ncreated at: ${moment(lease.createdAt).format('D MMM YYYY, HH:mm')}` : ``;
+            return Boolean(lease.leasedBy) ? `leased by: ${lease.leasedBy}\n leased at: ${moment(lease.createdAt).format('D MMM YYYY, HH:mm')}` : ``;
           };
 
           ctrl.inactiveLeases = (leases) => {

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -209,7 +209,7 @@ leases.controller('LeasesCtrl', [
           };
 
           ctrl.toolTip = (lease) => {
-            return Boolean(lease.leasedBy) ? `leased by: ${lease.leasedBy}` : ``;
+            return Boolean(lease.leasedBy) ? ` leased by: ${lease.leasedBy}\ncreated at: ${moment(lease.createdAt).format('D MMM YYYY, HH:mm')}` : ``;
           };
 
           ctrl.inactiveLeases = (leases) => {


### PR DESCRIPTION
## What does this change?

Our colleagues from Licensing&Syndication would like to see more data around syndication flow right in the UI. This PR adds:
- creation datetime of a Lease in its tooltip (in addition to existing createdBy)
- non-relative datetime when hovering over usage relative one

It also switches Leases tooltips from fancy top standard, because I couldn’t figure out how to make titip accept a line break… (if you know how: shoot!)

Before:
<img width="298" height="121" alt="image" src="https://github.com/user-attachments/assets/59fbab2e-04a5-4993-b6b4-a7386b41a801" />

After:

<img width="275" height="93" alt="image" src="https://github.com/user-attachments/assets/3726d34d-9afc-4f54-bd14-d2529f54f53e" />

<img width="296" height="129" alt="image" src="https://github.com/user-attachments/assets/faf4bdaf-8c88-42fb-a227-74618c8c8b10" />


I also fantasised about dollar signs in browser to tooltip when image was sent to syndication (for green ones) and when RCS sent syndication payload (for white ones), but this is too hard.

## How should a reviewer test this change?

Find images with Leases and or/Usages and hower over a Lease and over Usage date.
## How can success be measured?

Tooltips should spell out maximum of useful information.

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
