### PR TITLE
Set .text instead of .html in tooltips

### DIFF
--- a/kahuna/public/js/components/gr-tooltip/gr-tooltip.js
+++ b/kahuna/public/js/components/gr-tooltip/gr-tooltip.js
@@ -23,7 +23,7 @@ tooltip.directive('grTooltip', [
                 // Use .titip-content for HTML tooltips
                 const content = attrs.grTooltip || '';
                 const contentSpan = angular.element('<span class="titip-content"></span>');
-                contentSpan.html(content);
+                contentSpan.text(content);
                 element.append(contentSpan);
               } else {
                 // Use data-title for plain text tooltips
@@ -35,7 +35,7 @@ tooltip.directive('grTooltip', [
                 if (autoUpdates) {
                   $scope.$watch(() => attrs.grTooltip, onValChange(newTooltip => {
                     if (attrs.grTooltipHtml !== undefined) {
-                      element.find('.titip-content').html(newTooltip);
+                      element.find('.titip-content').text(newTooltip);
                     } else {
                       element.attr('data-title', newTooltip);
                     }

--- a/kahuna/public/js/leases/leases.js
+++ b/kahuna/public/js/leases/leases.js
@@ -209,7 +209,7 @@ leases.controller('LeasesCtrl', [
           };
 
           ctrl.toolTip = (lease) => {
-            return Boolean(lease.leasedBy) ? `leased by: ${lease.leasedBy}<br> leased at: ${moment(lease.createdAt).format('D MMM YYYY, HH:mm')}` : ``;
+            return Boolean(lease.leasedBy) ? `leased by: ${lease.leasedBy}\nleased at: ${moment(lease.createdAt).format('D MMM YYYY, HH:mm')}` : ``;
           };
 
           ctrl.inactiveLeases = (leases) => {


### PR DESCRIPTION
## What does this change?

It seems as though if we set tooltip content via `.text` then `\n` will be rendered as a line break, and setting `.text` on an element should be safer than setting `.html`.

<img width="120" height="173" alt="image" src="https://github.com/user-attachments/assets/adf81729-a480-4cb8-ac75-78aaab6d977a" /> <-- line break is still present


<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
