### PR TITLE
support 'negated' NestedFilters with 🆕 `NegatedNestedFilter`

### DIFF
--- a/media-api/app/lib/querysyntax/QuerySyntax.scala
+++ b/media-api/app/lib/querysyntax/QuerySyntax.scala
@@ -19,7 +19,9 @@ class QuerySyntax(val input: ParserInput) extends Parser with ImageFields {
 
   def Expression = rule { zeroOrMore(Term) separatedBy Whitespace }
 
-  def Term = rule { NestedFilter | NegatedFilter | Filter }
+  def Term = rule { NegatedNestedFilter | NestedFilter | NegatedFilter | Filter }
+
+  def NegatedNestedFilter = rule { '-' ~ NestedFilter ~> NegationNested }
 
   def NegatedFilter = rule { '-' ~ Filter ~> Negation }
 

--- a/media-api/app/lib/querysyntax/model.scala
+++ b/media-api/app/lib/querysyntax/model.scala
@@ -5,6 +5,7 @@ import org.joda.time.DateTime
 sealed trait Condition
 final case class Negation(m: Match) extends Condition
 final case class Match(field: Field, value: Value) extends Condition
+final case class NegationNested(n: Nested) extends Condition
 final case class Nested(parentField: Field, field: Field, value: Value) extends Condition
 
 sealed trait Field


### PR DESCRIPTION
Co-authored-by: @frederickobrien 

As per https://trello.com/c/6YFv1T5L/955-feature-small-usages-searches-cant-be-used-in-exclusions until now we haven't been able to perform a negated search (a.k.a. NOT - signified by the `-` on the chip, rather than `+`) on `usages@...` (i.e. `NestedFields` because such a 'term' in the query was simply ignored, because there was no logic to deal with it and map/convert it to the ElasticSearch clause... this PR adds that logic 🎉 

This also unblocks #3998 (as there we want to hide `usage@status:replaced` from search by default) which is somewhat urgent (so we don't need to merge #4498).