### PR TITLE
add custom error handler to suppress 501 alarms

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -17,6 +17,8 @@ play {
   assets.defaultCache="public, max-age=60"
 }
 
+pekko.http.server.parsing.error-handler = "com.gu.mediaservice.lib.play.UnknownMethodParsingErrorHandler$"
+
 es {
   cluster: media-service
   port: 9300

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/UnknownMethodParsingErrorHandler.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/play/UnknownMethodParsingErrorHandler.scala
@@ -1,0 +1,32 @@
+package com.gu.mediaservice.lib.play
+
+import com.gu.mediaservice.lib.logging.GridLogging
+import org.apache.pekko.event.LoggingAdapter
+import org.apache.pekko.http.{DefaultParsingErrorHandler, ParsingErrorHandler}
+import org.apache.pekko.http.scaladsl.model.{ErrorInfo, HttpResponse, StatusCode, StatusCodes}
+import org.apache.pekko.http.scaladsl.settings.ServerSettings
+
+import scala.annotation.unused
+
+/*
+  Coerces responses from Pekko in response to unknown HTTP methods from 501 to 400.
+  Technically HTTP spec requires 501s in this case, but this allows external parties
+  to spam our 5xx alarms with silly requests. We're comfortable treating these as "Bad
+  requests" instead.
+ */
+@unused
+object UnknownMethodParsingErrorHandler extends ParsingErrorHandler with GridLogging {
+  override def handle(
+    status: StatusCode,
+    error: ErrorInfo,
+    log: LoggingAdapter,
+    settings: ServerSettings
+  ): HttpResponse = {
+    if (status == StatusCodes.NotImplemented && error.summary == "Unsupported HTTP method") {
+      logger.warn(s"Client attempted to use unknown HTTP method '${error.detail}'. Returning 400 instead of 501.")
+      HttpResponse(StatusCodes.BadRequest)
+    } else {
+      DefaultParsingErrorHandler.handle(status, error, log, settings)
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds a Pekko error handling custom thingamajig, to catch when Pekko is about to return a 501 in response to a request with an unknown HTTP method, and instead return a 400. We want to do this since someone is sending lots of requests to our services with unknown methods, which means our 5xx alarms keep firing. Any other misbehaviour from users would result in a 4xx response, so I feel fairly comfortable to do the same on HTTP methods, even though it is [technically off-spec](https://www.rfc-editor.org/rfc/rfc9110#section-9.1-10).

This would be nicer as a [Play filter](https://www.playframework.com/documentation/3.0.x/ScalaHttpFilters), but unfortunately this behaviour isn't coming from Play, the response is coming from Pekko before Play even sees it. This isn't particularly documented, besides this [listing in the config](https://pekko.apache.org/docs/pekko-http/current/configuration.html#:~:text=%23%20When%20a%20request,pekko.http.DefaultParsingErrorHandler%24%22) and this [issue from akka](https://github.com/akka/akka-http/pull/3049).

## How should a reviewer test this change?

Note due to how the server runs in Play's dev mode, this won't be testable locally. In TEST, we can send a request with an unusual method like this: `curl -XGOT <url>`. Most services are behind cloudfront which will also reject requests with invalid methods before we even see it, so won't be useful for testing. You'll need to either get the raw load balancer url and make requests to that, or test with one of the services not behind cloudfront (eg. Thrall).

## How can success be measured?

Much less alarm noise.

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
