### PR TITLE
adding and passing logMarkers to (almost) all logging in media-api

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/elasticsearch/ElasticSearchExecutions.scala
@@ -21,13 +21,13 @@ trait ElasticSearchExecutions extends GridLogging {
 
     val result = client.execute(request).transform {
       case Success(r) =>
-        r.isSuccess match {
-          case true => Success(r)
-          case false => r.status match {
-            case 404 if notFoundSuccessful => {
-                   logger.warn(s"No image found for $message.")
-                   Success(r)
-            }
+        if (r.isSuccess) {
+          Success(r)
+        } else {
+          r.status match {
+            case 404 if notFoundSuccessful =>
+              logger.warn(logMarkers, s"No image found for $message.")
+              Success(r)
             case 404 => Failure(ElasticNotFoundException)
             case _ => Failure(ElasticSearchException(r.error))
           }

--- a/media-api/app/controllers/AggregationController.scala
+++ b/media-api/app/controllers/AggregationController.scala
@@ -1,6 +1,8 @@
 package controllers
 
 import com.gu.mediaservice.lib.auth.Authentication
+import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
+import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import lib.elasticsearch.{AggregateSearchParams, ElasticSearch}
 import play.api.mvc._
 
@@ -11,7 +13,11 @@ class AggregationController(auth: Authentication, elasticSearch: ElasticSearch,
   extends BaseController with AggregateResponses {
 
   def dateHistogram(field: String, q: Option[String]) = auth.async { request =>
-    implicit val r: Authentication.Request[AnyContent] = request
+    implicit val logMarker: LogMarker = MarkerMap(
+      "requestType" -> "date-histogram",
+      "requestId" -> RequestLoggingFilter.getRequestId(request),
+      "fieldName" -> field,
+    ) ++ RequestLoggingFilter.loggablePrincipal(request.user)
 
     elasticSearch.dateHistogramAggregate(AggregateSearchParams(field, request))
       .map(aggregateResponse)

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -3,7 +3,7 @@ package lib
 import com.gu.mediaservice.lib.argo.model._
 import com.gu.mediaservice.lib.auth.{Internal, Tier}
 import com.gu.mediaservice.lib.collections.CollectionsManager
-import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.{LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage._
@@ -55,12 +55,13 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
   def canBeDeleted(image: Image) = image.canBeDeleted
 
   def create(
-              id: String,
-              imageWrapper: SourceWrapper[Image],
-              withWritePermission: Boolean,
-              withDeleteImagePermission: Boolean,
-              withDeleteCropsOrUsagePermission: Boolean,
-              included: List[String] = List(), tier: Tier): (JsValue, List[Link], List[Action]) = {
+    id: String,
+    imageWrapper: SourceWrapper[Image],
+    withWritePermission: Boolean,
+    withDeleteImagePermission: Boolean,
+    withDeleteCropsOrUsagePermission: Boolean,
+    included: List[String] = List(), tier: Tier
+  )(implicit logMarker: LogMarker): (JsValue, List[Link], List[Action]) = {
 
     val image = imageWrapper.instance
 
@@ -68,7 +69,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3Client, usageQuota: Usag
       Json.toJsObject(image)(imageResponseWrites(image.id, included.contains("fileMetadata"))) ++ imageWrapper.fields
     }.recoverWith {
       case e =>
-        logger.error(s"Failed to read ElasticSearch response $id into Image object: ${e.getMessage}")
+        logger.error(logMarker, s"Failed to read ElasticSearch response $id into Image object: ${e.getMessage}")
         Failure(e)
     }.get
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -100,6 +100,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
   describe("get by id") {
     it("can load a single image by id") {
       val expectedImage = images.head
+      implicit val logMarker: LogMarker = MarkerMap()
+
       whenReady(ES.getImageById(expectedImage.id)) { r =>
         r.get.id shouldEqual expectedImage.id
       }
@@ -147,6 +149,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
 
   describe("usages for supplier") {
     it("can count published agency images within the last number of days") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
       val publishedAgencyImages = images.filter(i => i.usageRights.isInstanceOf[Agency] && i.usages.exists(_.status == PublishedUsageStatus))
       publishedAgencyImages.size shouldBe 2
 
@@ -163,6 +167,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
 
   describe("aggregations") {
     it("can load date aggregations") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
       val aggregateSearchParams = AggregateSearchParams(field = "uploadTime", q = None, structuredQuery = List.empty)
 
       val results = Await.result(ES.dateHistogramAggregate(aggregateSearchParams), fiveSeconds)
@@ -172,6 +178,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
     }
 
     it("can load metadata aggregations") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
       val aggregateSearchParams = AggregateSearchParams(field = "keywords", q = None, structuredQuery = List.empty)
 
       val results = Await.result(ES.metadataSearch(aggregateSearchParams), fiveSeconds)

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/auth/Authentication.scala
@@ -5,6 +5,7 @@ import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.lib.auth.Authentication.{InnerServicePrincipal, MachinePrincipal, OnBehalfOfPrincipal, Principal, UserPrincipal}
 import com.gu.mediaservice.lib.auth.provider._
 import com.gu.mediaservice.lib.config.CommonConfig
+import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import play.api.libs.typedmap.TypedMap
 import play.api.libs.ws.WSRequest
 import play.api.mvc.Security.AuthenticatedRequest
@@ -76,7 +77,9 @@ class Authentication(config: CommonConfig,
     // gracePeriodCountsAsAuthenticated is set to true here, so requests using this block should accept users whose session is in the grace period
     authenticationStatus(request, gracePeriodCountsAsAuthenticated = true) match {
       // we have a principal, so process the block
-      case Right(principal) => block(new AuthenticatedRequest(principal, request))
+      case Right(principal) =>
+        block(new AuthenticatedRequest(principal, request))
+          .map(result => result.addAttr(RequestLoggingFilter.requestPrincipal, principal))
       // no principal so return a result which will either be an error or a form of redirect
       case Left(result) => result
     }


### PR DESCRIPTION
## What does this change?

One of my occasional passes through a service, setting up better log markers and passing them to all the log statements that I can find. This time focusing on media-api.

(Of passing interest here, play does have an internal request-id, but it's a monotonically increasing integer starting from 1 for each instance, which means that those request-ids will be non-unique which isn't helpful for us :( BUT we should follow https://github.com/playframework/playframework/issues/10273 where these may be switched to UUIDv7 in the future!)

## How should a reviewer test this change?

Deploy to TEST and perform some interactions with media-api (searches, retrieving a single image, etc.). Is there a stable request ID, allowing you to find all the log messages associated with this request?



## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
