### PR TITLE
Additional usages API links to help with automatic testing

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -108,7 +108,8 @@ class MediaApi(
       Link("permissions",     s"${config.rootUri}/permissions"),
       Link("leases",          config.leasesUri),
       Link("syndicate-image", s"${config.rootUri}/images/{id}/{partnerName}/{startPending}/syndicateImage"),
-      Link("undelete",        s"${config.rootUri}/images/{id}/undelete")
+      Link("undelete",        s"${config.rootUri}/images/{id}/undelete"),
+      Link("usage",           config.usageUri),
     ) ++ maybeLoaderLink.toList ++ maybeArchiveLink.toList
     respond(indexData, indexLinks)
   }

--- a/usage/app/controllers/UsageApi.scala
+++ b/usage/app/controllers/UsageApi.scala
@@ -58,8 +58,10 @@ class UsageApi(
     )
 
     val printPostUri = URI.create(s"${config.usageUri}/usages/print")
+    val syndicationPostUri = URI.create(s"${config.usageUri}/usages/syndication")
     val actions = List(
-      ArgoAction("print-usage", printPostUri, "POST")
+      ArgoAction("print-usage", printPostUri, "POST"),
+      ArgoAction("syndication-usage", syndicationPostUri, "POST"),
     )
 
     respond(indexData, indexLinks, actions)


### PR DESCRIPTION
## What does this change?

Additional links on from the media-api links page to the usages service and the syndication usage action.

Helps tests to click through usages actions.


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
