### PR TITLE
Target ES6

### DIFF
--- a/kahuna/tsconfig.json
+++ b/kahuna/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "module": "es6",
-    "target": "es5",
+    "target": "es6",
     "lib": ["es6", "dom"],
     "jsx": "react",
     "alwaysStrict": true,


### PR DESCRIPTION
## What does this change?

Targets ES6, to enable Typescript to parse the wacky regex in https://github.com/guardian/grid/blob/6001d42263a04ecfb6b3f116e73885222be1dc95/kahuna/public/js/search/structured-query/syntax.js#L6 in preparation for #4468, which will ultimately make it redundant 👿  (but still, targeting es6 is a [good thing to do!](https://www.learningtypescript.com/articles/why-increase-your-tsconfig-target))

## How should a reviewer test this change?

This should be a no-op. Running locally or deploying to CODE and smoke testing the app should be sufficient.

## How can success be measured?

We're ready for #4468. 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
