### PR TITLE
Fix an issue where typing e.g. -sport{Enter} would not-dechip the input to produce the plain query -sport

### DIFF
--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -51,7 +51,7 @@ grStructuredQuery.controller("grStructuredQueryCtrl", [
         .debounce(500);
 
       ctrl.getSuggestions = querySuggestions.getChipSuggestions;
-      ctrl.filterFields = querySuggestions.typeaheadFields.map(_ => _.name);
+      ctrl.filterFields = querySuggestions.typeaheadFields.map(_ => _.fieldName);
 
       function valOrUndefined(str) {
         // Watch out for `false`, but we know it's a string here..

--- a/kahuna/public/js/search/structured-query/structured-query.js
+++ b/kahuna/public/js/search/structured-query/structured-query.js
@@ -51,7 +51,7 @@ grStructuredQuery.controller("grStructuredQueryCtrl", [
         .debounce(500);
 
       ctrl.getSuggestions = querySuggestions.getChipSuggestions;
-      ctrl.filterFields = querySuggestions.filterFields;
+      ctrl.filterFields = querySuggestions.typeaheadFields.map(_ => _.name);
 
       function valOrUndefined(str) {
         // Watch out for `false`, but we know it's a string here..


### PR DESCRIPTION
## What does this change?

Fix an issue where typing e.g. -sport{Enter} would not-dechip the input to produce the plain query -sport. Caused by an import that was inadvertently removed without error.

|Before|After|
|-|-|
|![de-chip-nope](https://github.com/user-attachments/assets/d34c3ed4-3fab-45c1-ade1-72aa5584b40d)|![de-chip](https://github.com/user-attachments/assets/69ee71a1-1bff-4d25-8183-f4285786787a)|

## How should a reviewer test this change?

Running locally or in CODE, type `-sport` into the search bar, and then press Enter. The chip should disappear, leaving `-sport`

## How can success be measured?

Fewer confused users wondering why their negations don't work.

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
