### PR TITLE
add ability to optionally sample a percentage of images to a lower environment's queue bucket

### DIFF
--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -16,6 +16,9 @@ class ImageLoaderConfig(resources: GridConfigResources) extends CommonConfig(res
 
   val thumbnailBucket: String = string("s3.thumb.bucket")
 
+  val lowerEnvironmentSamplingPercentageAsDecimal = intOpt("s3.sampling.percentage").getOrElse(1) / 100.0
+  val maybeLowerEnvironmentQueueBucketToSampleInto = sys.env.get("LOWER_ENVIRONMENT_QUEUE_BUCKET_TO_SAMPLE_INTO")
+
   val tempDir: File = new File(stringDefault("upload.tmp.dir", "/tmp"))
 
   val thumbWidth: Int = 256

--- a/image-loader/app/lib/ImageLoaderConfig.scala
+++ b/image-loader/app/lib/ImageLoaderConfig.scala
@@ -17,7 +17,7 @@ class ImageLoaderConfig(resources: GridConfigResources) extends CommonConfig(res
   val thumbnailBucket: String = string("s3.thumb.bucket")
 
   val lowerEnvironmentSamplingPercentageAsDecimal = intOpt("s3.sampling.percentage").getOrElse(1) / 100.0
-  val maybeLowerEnvironmentQueueBucketToSampleInto = sys.env.get("LOWER_ENVIRONMENT_QUEUE_BUCKET_TO_SAMPLE_INTO")
+  val maybeLowerEnvironmentQueueBucketToSampleInto = stringOpt("s3.sampling.targetBucket")
 
   val tempDir: File = new File(stringDefault("upload.tmp.dir", "/tmp"))
 

--- a/image-loader/app/model/Uploader.scala
+++ b/image-loader/app/model/Uploader.scala
@@ -2,6 +2,7 @@ package model
 
 import com.gu.mediaservice.{GridClient, ImageDataMerger}
 import com.gu.mediaservice.lib.Files.createTempFile
+import com.gu.mediaservice.lib.ImageIngestOperations.fileKeyFromId
 
 import java.io.File
 import java.nio.file.{Files, Path}
@@ -463,8 +464,26 @@ class Uploader(
         s3KeyForEmbedder,
       ))
       // TODO: centralise where all these URLs are constructed
-    } yield
+    } yield {
+      config.maybeLowerEnvironmentQueueBucketToSampleInto.foreach { lowerEnvironmentQueueBucket =>
+        if (math.random() < config.lowerEnvironmentSamplingPercentageAsDecimal) {
+          val mediaId = imageUpload.image.id
+          logger.info(logMarker, s"Copying $mediaId to lower environment queue bucket $lowerEnvironmentQueueBucket")
+          try {
+            store.client.copyObject(
+              config.imageBucket, fileKeyFromId(mediaId),
+              lowerEnvironmentQueueBucket, s"${uploadRequest.uploadedBy}/${uploadRequest.uploadInfo.filename.getOrElse(mediaId)}"
+            )
+          } catch {
+            case e: Throwable =>
+              logger.error(logMarker, s"Failed to copy $mediaId to lower environment queue bucket $lowerEnvironmentQueueBucket", e)
+          }
+        }
+      }
+
       UploadStatusUri(s"${config.rootUri}/uploadStatus/${uploadRequest.imageId}")
+    }
+
   }
 
   def restoreFile(uploadRequest: UploadRequest,


### PR DESCRIPTION
… after they've successfully uploaded, then using S3 copy operation (quick/cheap) from the image bucket to the lower environment's queue bucket- triggered by presence of new `LOWER_ENVIRONMENT_QUEUE_BUCKET_TO_SAMPLE_INTO ` environment variable (populated by https://github.com/guardian/editorial-tools-platform/pull/988) . 

Sampling is 1% by default, but can be configured via `s3.sampling.percentage`

Means we can effectively revert https://github.com/guardian/editorial-ftp/pull/94 (see https://github.com/guardian/editorial-ftp/pull/175)

## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
