### PR TITLE
Remove S3 signer override

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -177,21 +177,13 @@ object S3Ops {
   val s3Endpoint = "s3.amazonaws.com"
 
   def buildS3Client(config: CommonConfig, forceV2Sigs: Boolean = false, localstackAware: Boolean = true, maybeRegionOverride: Option[String] = None): AmazonS3 = {
-
-    val clientConfig = new ClientConfiguration()
-    // Option to disable v4 signatures (https://github.com/aws/aws-sdk-java/issues/372) which is required by imgops
-    // which proxies direct to S3, passing the AWS security signature as query parameters. This does not work with
-    // AWS v4 signatures, presumably because the signature includes the host
-    if (forceV2Sigs) clientConfig.setSignerOverride("S3SignerType")
-
     val builder = config.awsLocalEndpoint match {
-      case Some(_) if config.isDev => {
+      case Some(_) if config.isDev =>
         // TODO revise closer to the time of deprecation https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
         //  `withPathStyleAccessEnabled` for localstack
         //  see https://github.com/localstack/localstack/issues/1512
         AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true)
-      }
-      case _ => AmazonS3ClientBuilder.standard().withClientConfiguration(clientConfig)
+      case _ => AmazonS3ClientBuilder.standard()
     }
 
     config.withAWSCredentials(builder, localstackAware, maybeRegionOverride).build()

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -66,8 +66,6 @@ class S3(config: CommonConfig) extends GridLogging with ContentDisposition with 
   type UserMetadata = Map[String, String]
 
   lazy val client: AmazonS3 = S3Ops.buildS3Client(config)
-  // also create a legacy client that uses v2 signatures for URL signing
-  private lazy val legacySigningClient: AmazonS3 = S3Ops.buildS3Client(config, forceV2Sigs = true)
 
   def signUrl(bucket: Bucket, url: URI, image: Image, expiration: DateTime = cachableExpiration(), imageType: ImageFileType = Source): String = {
     // get path and remove leading `/`
@@ -78,7 +76,7 @@ class S3(config: CommonConfig) extends GridLogging with ContentDisposition with 
     val headers = new ResponseHeaderOverrides().withContentDisposition(contentDisposition)
 
     val request = new GeneratePresignedUrlRequest(bucket, key).withExpiration(expiration.toDate).withResponseHeaders(headers)
-    legacySigningClient.generatePresignedUrl(request).toExternalForm
+    client.generatePresignedUrl(request).toExternalForm
   }
 
   def getObject(bucket: Bucket, url: URI): model.S3Object = {
@@ -176,7 +174,7 @@ object S3Ops {
   // TODO: Make this region aware - i.e. RegionUtils.getRegion(region).getServiceEndpoint(AmazonS3.ENDPOINT_PREFIX)
   val s3Endpoint = "s3.amazonaws.com"
 
-  def buildS3Client(config: CommonConfig, forceV2Sigs: Boolean = false, localstackAware: Boolean = true, maybeRegionOverride: Option[String] = None): AmazonS3 = {
+  def buildS3Client(config: CommonConfig, localstackAware: Boolean = true, maybeRegionOverride: Option[String] = None): AmazonS3 = {
     val builder = config.awsLocalEndpoint match {
       case Some(_) if config.isDev =>
         // TODO revise closer to the time of deprecation https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/

--- a/dev/imgops/nginx.conf
+++ b/dev/imgops/nginx.conf
@@ -10,6 +10,20 @@ http {
   sendfile           on;
   keepalive_timeout  65;
 
+  # Chain of maps to strip the q,w,h,r params from image proxy requests, as they'll confuse the
+  # signature verification if they're included in the request to AWS.
+  # This chain needs to be built here instead of in the location block due to nginx limitations.
+  map $args  $no_q { "~*^(.*)(?:(?:^|&)q=[^&]*)(.*)$" $1$2; default $args; }
+  map $no_q  $no_w { "~*^(.*)(?:(?:^|&)w=[^&]*)(.*)$" $1$2; default $no_q; }
+  map $no_w  $no_h { "~*^(.*)(?:(?:^|&)h=[^&]*)(.*)$" $1$2; default $no_w; }
+  map $no_h  $no_r { "~*^(.*)(?:(?:^|&)r=[^&]*)(.*)$" $1$2; default $no_h; }
+  # Then another pass to remove any leading, trailing or doubled '&'s
+  map $no_r $clean_leading { "~^&+(.*)" $1; default $no_r; }
+  map $clean_leading $clean_trailing { "~(.*)&+$" $1; default $clean_leading; }
+  map $clean_trailing $final_clean_args { "~(?<pre>.*)&&+(?<post>.*)" "$pre&$post"; default $clean_trailing; }
+
+  # $final_clean_args is now ready to be included in the proxy requests.
+
   server {
     listen 80;
 
@@ -34,7 +48,7 @@ http {
       image_filter rotate $arg_r;
 
       # connect to the localstack docker container
-      proxy_pass http://localstack:4566$request_uri;
+      proxy_pass http://localstack:4566$uri?final_clean_args;
     }
   }
 }


### PR DESCRIPTION
In the grid, we want to upgrade from AWS Java SDK v1 to v2. Working on the s3 module, we discovered one non-standard usage:

https://github.com/guardian/grid/blob/ad24535143bf96b2a288e177fd8d74f350d22f27/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala#L181-L193

Here we override the SDK defaults which use AWS Signature version 4, to instead use version 2. We do this as the presigned urls created for and sent to "imgops" (the nginx service) are failing to authenticate with the version 4.

It's failing for 2 reasons:

1. It's making requests to the "global", ie. un-regionalized, S3 endpoint, but the version 4 signer is signing against the endpoint which declares the region.
2. It makes requests to the S3 backend by using nginx's "proxy_pass" directive. This receives a request, makes a request (currently the _same_ request) to a different remote URL and then transforms the response. The problem here is that we pass 4 parameters to _imgops_ (width `w`, height `h`, quality `q`, rotation `r`) which are not relevant to the _S3_ endpoint, and so are not included in the signature. But as they're not removed from the request, they are included when the S3 service authenticates the signature, which causes a failure due to a lack of equality. 
 
We need to filter those 4 parameters out, so that only the parameters which are signed are included in the final request. This is not at all straight forward in nginx config, which despite looking like a scripting language (with variables and condition flow statements), is in fact a configuration language, where those constructs regularly do *not* work as you'd expect (read this page for more info if you're interested: <https://github.com/nginxinc/nginx-wiki/blob/master/source/start/topics/depth/ifisevil.rst>).

We've done this for our nginx imops backend already, so we should now be free to remove the signer override, which will free us to perform the S3 SDK upgrade!