### PR TITLE
Post PR4475 fixes for Free to use only check box

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -246,8 +246,11 @@ query.controller('SearchQueryCtrl', [
     // eslint-disable-next-line complexity
     function watchSearchChange(newFilter, sender) {
       let showPaid = newFilter.nonFree ? newFilter.nonFree : false;
-      if (sender && sender == "filterChange" && !newFilter.nonFree) {
-        showPaid = ctrl.user.permissions.showPaid;
+      if (ctrl.usePermissionsFilter) {
+        // Fixes Free to use only check-box is cleared on Back to search
+        if (sender && sender === "filterChange" && !newFilter.nonFree) {
+          showPaid = ctrl.user.permissions.showPaid;
+        }
       }
       storage.setJs("isNonFree", showPaid, true);
 
@@ -318,7 +321,7 @@ query.controller('SearchQueryCtrl', [
     }
 
     ctrl.sortProps = {
-      onSortSelect: updateSortChips,
+      onSelect: updateSortChips,
       query: $stateParams.query,
       orderBy: ctrl.ordering ? ctrl.ordering.orderBy : ""
     };


### PR DESCRIPTION
After rebasing up to this point, we found the behaviour of the Free to use only check box regressed.
<img width="982" height="176" alt="Screenshot 2026-03-03 at 21 36 58" src="https://github.com/user-attachments/assets/af0cecaa-e9f4-42c6-bfaf-0e0d7def434e" />

Disclaimer; we are forked quite away from the main Grid so this may not reflect want happens in the main branch.
Provided FYI.

#### Back to search

With Free to use only checked,
clicking into an image then
click Back to search the Free to use only check box has lost it's state:

https://github.com/user-attachments/assets/fd369e15-bdf6-4736-a84a-f83dfaa9adcf

Free to use only should have kept it's checked state

#### Logo click

With Free to use only checked and none of the other check boxes.
clicking on the Grid logo
Free to use only remains checked
and the next click to any of the check boxes is broken.

https://github.com/user-attachments/assets/a60cef9b-909e-4a88-a260-2122a94d1f47

Free to use only should have reset to empty.
The other checkboxes should have worked as normal on the next click.


## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
