### PR TITLE
Embedding lambda sends updateEmbedding message to Thrall on PROD

### DIFF
--- a/image-embedder-lambda/src/embedder/thrallEventPublisher.ts
+++ b/image-embedder-lambda/src/embedder/thrallEventPublisher.ts
@@ -42,19 +42,14 @@ export class ThrallEventPublisher {
     imageIdToMessageId: Map<string, string>,
     batchItemFailures: SQSBatchItemFailure[],
   ) {
-    // Send embeddings to Kinesis for Thrall to write to Elasticsearch
-    if (this.stage === 'PROD') {
-      console.log(`Not writing embeddings to Kinesis yet whilst we test on TEST`);
-    } else {
-      const failedImageIds = await this.putRecordsToKinesis(vectors);
-      for (const imageId of failedImageIds) {
-        const messageId = imageIdToMessageId.get(imageId);
-        if (messageId) {
-          console.log(
-            `Error writing image with ID ${imageId} to Kinesis, adding as batchItemFailure`,
-          );
-          batchItemFailures.push({ itemIdentifier: messageId });
-        }
+    const failedImageIds = await this.putRecordsToKinesis(vectors);
+    for (const imageId of failedImageIds) {
+      const messageId = imageIdToMessageId.get(imageId);
+      if (messageId) {
+        console.log(
+          `Error writing image with ID ${imageId} to Kinesis, adding as batchItemFailure`,
+        );
+        batchItemFailures.push({ itemIdentifier: messageId });
       }
     }
   }


### PR DESCRIPTION
## What does this change?
This is a follow-up to https://github.com/guardian/grid/pull/4631, which introduced writing embeddings to Elasticsearch. Since merging that PR, we've been monitoring TEST and subsequently added memory usage monitoring in https://github.com/guardian/editorial-tools-platform/pull/1045.

<img width="1639" height="660" alt="Screenshot 2026-03-31 at 10 02 49" src="https://github.com/user-attachments/assets/fb53ba3d-947a-4a82-ac3a-0ff822773e5e" />

**What this PR does**
Removes the logic in our lambda that prevented embeddings from being written in prod, so we start writing embeddings to be written to the PROD cluster.

With memory monitoring now in place, we can track the impact on PROD of:

- Writing embeddings to the cluster on memory usage
- Semantic search queries, which should have a greater effect on memory than writing embeddings. This is because Elasticsearch stores dense vector values per segment as an HNSW graph [Elastic](https://www.elastic.co/docs/solutions/search/vector/knn), which must be loaded into memory at query time, and building these approximate kNN structures is compute-intensive. [Elastic](https://www.elastic.co/docs/solutions/search/vector/knn) At search time, the query vector must be compared against potentially large portions of this graph, driving up memory pressure significantly beyond what indexing alone requires.