### PR TITLE
Override the version of netty to use fixed vuln

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,6 @@ lazy val jacksonOverrides = Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVersion
 )
 
-val nettyOverrides = Seq(
-  "io.netty" % "netty-codec-http2" %  "4.1.132.Final"
-)
 val commonSettings = Seq(
   scalaVersion := "2.13.18",
   description := "grid",
@@ -57,7 +54,7 @@ val commonSettings = Seq(
     "org.mockito" % "mockito-core" % "2.18.0" % Test,
     "org.scalamock" %% "scalamock" % "5.1.0" % Test,
   ),
-  dependencyOverrides ++= jacksonOverrides ++ nettyOverrides,
+  dependencyOverrides ++= jacksonOverrides,
 
   Compile / doc / sources := Seq.empty,
   Compile / packageDoc / publishArtifact := false
@@ -104,6 +101,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
+    "io.netty" % "netty-codec-http2" %  "4.1.132.Final",
     "nl.gn0s1s" %% "elastic4s-core" % elastic4sVersion,
     "nl.gn0s1s" %% "elastic4s-client-esjava" % elastic4sVersion,
     "nl.gn0s1s" %% "elastic4s-domain" % elastic4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ Global / concurrentRestrictions := Seq(
 )
 
 val awsSdkVersion = "1.12.470"
-val awsSdkV2Version = "2.32.33"
+val awsSdkV2Version = "2.42.25"
 val elastic4sVersion = "8.18.2"
 val okHttpVersion = "3.12.1"
 
@@ -101,7 +101,6 @@ lazy val commonLib = project("common-lib").settings(
     "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
-    "io.netty" % "netty-codec-http2" %  "4.1.132.Final",
     "nl.gn0s1s" %% "elastic4s-core" % elastic4sVersion,
     "nl.gn0s1s" %% "elastic4s-client-esjava" % elastic4sVersion,
     "nl.gn0s1s" %% "elastic4s-domain" % elastic4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ lazy val jacksonOverrides = Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsVersion
 )
 
+val nettyOverrides = Seq(
+  "io.netty" % "netty-codec-http2" %  "4.1.132.Final"
+)
 val commonSettings = Seq(
   scalaVersion := "2.13.18",
   description := "grid",
@@ -54,7 +57,7 @@ val commonSettings = Seq(
     "org.mockito" % "mockito-core" % "2.18.0" % Test,
     "org.scalamock" %% "scalamock" % "5.1.0" % Test,
   ),
-  dependencyOverrides ++= jacksonOverrides,
+  dependencyOverrides ++= jacksonOverrides ++ nettyOverrides,
 
   Compile / doc / sources := Seq.empty,
   Compile / packageDoc / publishArtifact := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
     versions of `scala-xml`).
  */
 libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+
+addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

This overrides the version of netty to make sure it uses the patched version of that library. According to: https://github.com/guardian/grid/security/dependabot/485

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
