### PR TITLE
Initial Dynamo backed Store tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ val commonSettings = Seq(
     "org.scalatestplus" %% "mockito-3-4" % "3.1.4.0" % Test,
     "org.mockito" % "mockito-core" % "2.18.0" % Test,
     "org.scalamock" %% "scalamock" % "5.1.0" % Test,
+    "org.testcontainers" % "localstack" % "1.21.4" % Test
   ),
   dependencyOverrides ++= jacksonOverrides,
 

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -11,7 +11,7 @@ class CollectionsComponents(context: Context) extends GridComponents(context, ne
   final override val buildInfo = utils.buildinfo.BuildInfo
 
   private val collectionsStore = new CollectionsStore(config.collectionsTable, config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build())
-  val imageCollectionsStore = new ImageCollectionsStore(config)
+  val imageCollectionsStore = new ImageCollectionsStore(config.imageCollectionsTable, config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build())
   val metrics = new CollectionsMetrics(config, actorSystem, applicationLifecycle)
   val notifications = new Notifications(config)
 

--- a/collections/app/CollectionsComponents.scala
+++ b/collections/app/CollectionsComponents.scala
@@ -4,12 +4,13 @@ import controllers.{CollectionsController, ImageCollectionsController}
 import lib.{CollectionsConfig, CollectionsMetrics, Notifications}
 import play.api.ApplicationLoader.Context
 import router.Routes
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import store.{CollectionsStore, ImageCollectionsStore}
 
 class CollectionsComponents(context: Context) extends GridComponents(context, new CollectionsConfig(_)) {
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val collectionsStore = new CollectionsStore(config)
+  private val collectionsStore = new CollectionsStore(config.collectionsTable, config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build())
   val imageCollectionsStore = new ImageCollectionsStore(config)
   val metrics = new CollectionsMetrics(config, actorSystem, applicationLifecycle)
   val notifications = new Notifications(config)

--- a/collections/app/store/CollectionsStore.scala
+++ b/collections/app/store/CollectionsStore.scala
@@ -2,7 +2,6 @@ package store
 
 import com.gu.mediaservice.lib.collections.CollectionsManager
 import com.gu.mediaservice.model.{ActionData, Collection}
-import lib.CollectionsConfig
 import org.joda.time.DateTime
 import org.scanamo.generic.auto.genericDerivedFormat
 import org.scanamo.{DynamoFormat, ScanamoAsync, Table}
@@ -16,9 +15,7 @@ import org.scanamo.generic.semiauto.FieldName
 
 case class Record(id: String, collection: Collection)
 
-class CollectionsStore(config: CollectionsConfig) extends DynamoHelpers {
-  override val tableName: FieldName = config.collectionsTable
-  lazy val client: DynamoDbAsyncClient = config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build()
+class CollectionsStore(val tableName: String, client: DynamoDbAsyncClient) extends DynamoHelpers {
   import org.scanamo.generic.semiauto._
   implicit val dateTimeFormat: Typeclass[DateTime] =
     DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](DateTime.parse, _.toString)

--- a/collections/app/store/ImageCollectionsStore.scala
+++ b/collections/app/store/ImageCollectionsStore.scala
@@ -16,10 +16,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class ImageRecord(id: String, collections: List[Collection])
 
-class ImageCollectionsStore(config: CollectionsConfig) extends DynamoHelpers {
-
-  override val tableName = config.imageCollectionsTable
-  lazy val client: DynamoDbAsyncClient = config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build()
+class ImageCollectionsStore(val tableName: String, val client: DynamoDbAsyncClient) extends DynamoHelpers {
 
   import org.scanamo.generic.semiauto._
   implicit val dateTimeFormat: Typeclass[DateTime] =

--- a/collections/test/store/CollectionsStoreTest.scala
+++ b/collections/test/store/CollectionsStoreTest.scala
@@ -1,0 +1,113 @@
+package store
+
+import com.gu.mediaservice.model.{ActionData, Collection}
+import org.joda.time.DateTime
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service.DYNAMODB
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
+
+class CollectionsStoreTest extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(100, Millis))
+
+  private val dynamoContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.4.0")).withServices(DYNAMODB)
+  dynamoContainer.start()
+
+  private val dynamoClient = DynamoDbAsyncClient.builder().
+    endpointOverride(dynamoContainer.getEndpointOverride(DYNAMODB)).
+    region(Region.of(dynamoContainer.getRegion)).
+    credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(dynamoContainer.getAccessKey, dynamoContainer.getSecretKey))).build()
+
+  private val collectionsTable = "test-collections-table-" + UUID.randomUUID().toString
+  private val collectionsTableForAllTest = "test-collections-table-" + UUID.randomUUID().toString
+  private val store = new CollectionsStore(collectionsTable, dynamoClient)
+  private val storeForAllTest = new CollectionsStore(collectionsTableForAllTest, dynamoClient)
+
+  override def beforeAll(): Unit = {
+    def createTableRequestFor(tableName: String): CreateTableRequest = {
+      val attributeDefinitions = List(
+        AttributeDefinition.builder.attributeName("id").attributeType(ScalarAttributeType.S).build()
+      )
+      val keySchema = List(
+        KeySchemaElement.builder.attributeName("id").keyType(KeyType.HASH).build()
+      )
+      val provisionedThroughput = ProvisionedThroughput.builder.readCapacityUnits(1L).writeCapacityUnits(1L).build()
+      val request = CreateTableRequest.builder
+        .tableName(tableName)
+        .attributeDefinitions(attributeDefinitions.asJava)
+        .keySchema(keySchema.asJava)
+        .provisionedThroughput(provisionedThroughput)
+        .build()
+      request
+    }
+
+    dynamoClient.createTable(createTableRequestFor(collectionsTable)).get()
+    dynamoClient.createTable(createTableRequestFor(collectionsTableForAllTest)).get()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    dynamoContainer.stop()
+  }
+
+  describe("CollectionsStore") {
+    val collection = Collection(List("a", "b"), ActionData("author", DateTime.now()), "description")
+
+    it("should be able to add a collection") {
+      val eventualResult = store.add(collection)
+      whenReady(eventualResult) { c =>
+        c.pathId should be("a/b")
+        c.description should be("description")
+      }
+    }
+
+    it("should be able to get a collection") {
+      val eventualResult = store.get(List("a", "b"))
+      whenReady(eventualResult) { c =>
+        c.get.pathId should be("a/b")
+        c.get.description should be("description")
+      }
+    }
+
+    it("should be able to get all collections") {
+      val collection1 = Collection(List("e", "f"), ActionData("author1", DateTime.now()), "description1")
+      val collection2 = Collection(List("g", "h"), ActionData("author2", DateTime.now()), "description2")
+
+      val eventualAdded = Future.sequence(Seq(storeForAllTest.add(collection1), storeForAllTest.add(collection2)))
+
+      val eventualResult = eventualAdded.flatMap(_ => storeForAllTest.getAll)
+
+      whenReady(eventualResult) { collections =>
+        collections.size should be(2)
+        collections.map(_.pathId) should contain allOf("e/f", "g/h")
+      }
+    }
+
+    it("should be able to remove a collection") {
+      val eventualResult = store.remove(List("a", "b")).flatMap(_ => store.get(List("a", "b")))
+      whenReady(eventualResult) { c =>
+        c should be(None)
+      }
+
+      val eventualReadback = store.get(List("a", "b"))
+      whenReady(eventualReadback) { r =>
+        r should be(None)
+      }
+    }
+  }
+}

--- a/collections/test/store/ImageCollectionsStoreTest.scala
+++ b/collections/test/store/ImageCollectionsStoreTest.scala
@@ -1,0 +1,103 @@
+package store
+
+import com.gu.mediaservice.model.{ActionData, Collection}
+import org.joda.time.DateTime
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service.DYNAMODB
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.util.UUID
+import scala.jdk.CollectionConverters._
+
+class ImageCollectionsStoreTest extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  private val dynamoContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.4.0")).withServices(DYNAMODB)
+  dynamoContainer.start()
+
+  private val dynamoClient = DynamoDbAsyncClient.builder().
+    endpointOverride(dynamoContainer.getEndpointOverride(DYNAMODB)).
+    region(Region.of(dynamoContainer.getRegion)).
+    credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(dynamoContainer.getAccessKey, dynamoContainer.getSecretKey))).build()
+
+  private val imageCollectionsTable = "test-image-collections-table-" + UUID.randomUUID().toString
+  private val store = new ImageCollectionsStore(imageCollectionsTable, dynamoClient)
+
+  override def beforeAll(): Unit = {
+    val attributeDefinitions = List(
+      AttributeDefinition.builder.attributeName("id").attributeType(ScalarAttributeType.S).build()
+    )
+    val keySchema = List(
+      KeySchemaElement.builder.attributeName("id").keyType(KeyType.HASH).build()
+    )
+    val provisionedThroughput = ProvisionedThroughput.builder.readCapacityUnits(1L).writeCapacityUnits(1L).build()
+    val request = CreateTableRequest.builder
+      .tableName(imageCollectionsTable)
+      .attributeDefinitions(attributeDefinitions.asJava)
+      .keySchema(keySchema.asJava)
+      .provisionedThroughput(provisionedThroughput)
+      .build()
+    dynamoClient.createTable(request).get()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    dynamoContainer.stop()
+  }
+
+  describe("ImageCollectionsStore") {
+    val imageId = "test-image-id"
+    val collection1 = Collection(List("a", "b"), ActionData("author", DateTime.now()), "description 1")
+    val collection2 = Collection(List("c", "d"), ActionData("author", DateTime.now()), "description 2")
+
+    it("should be able to add image to a collection") {
+      val eventualAddedResponse = store.add(imageId, collection1)
+      whenReady(eventualAddedResponse) { response =>
+        response.size should be(1)
+        response.head.pathId should be("a/b")
+      }
+
+      // Read back
+      val eventuallyReloaded = store.get(imageId)
+      whenReady(eventuallyReloaded) { collections =>
+        collections.size should be(1)
+        collections.head.pathId should be("a/b")
+      }
+
+      // Add another collection
+      whenReady(store.add(imageId, collection2)) { collections =>
+        collections.size should be(2)
+        collections.map(_.pathId) should contain allOf("a/b", "c/d")
+      }
+
+      whenReady(store.get(imageId)) { collections =>
+        collections.size should be(2)
+        collections.head.pathId should be("a/b")
+        collections.last.pathId should be("c/d")
+      }
+
+      // Update to replace all for this image
+      val newCollection = Collection(List("e", "f"), ActionData("new-author", DateTime.now()), "new description")
+      val eventuallyUpdated = store.update(imageId, List(newCollection))
+      whenReady(eventuallyUpdated) { collections =>
+        collections.size should be(1)
+        collections.head.pathId should be("e/f")
+      }
+
+      whenReady(store.get(imageId)) { collections =>
+        collections.size should be(1)
+        collections.head.pathId should be("e/f")
+      }
+    }
+  }
+}

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/DynamoDB.scala
@@ -1,23 +1,21 @@
 package com.gu.mediaservice.lib.aws
 
-import java.util
 import com.amazonaws.AmazonServiceException
-import com.amazonaws.services.dynamodbv2.document.spec.{DeleteItemSpec, GetItemSpec, PutItemSpec, QuerySpec, UpdateItemSpec}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import com.amazonaws.services.dynamodbv2.document.spec._
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap
 import com.amazonaws.services.dynamodbv2.document.{DynamoDB => AwsDynamoDB, _}
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, DeleteItemRequest, KeysAndAttributes, ReturnValue}
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, KeysAndAttributes, ReturnValue}
 import com.gu.mediaservice.lib.aws.DynamoDB.{deleteExpr, setExpr}
-import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.GridLogging
 import org.joda.time.DateTime
 import play.api.libs.json._
 import software.amazon.awssdk.enhanced.dynamodb._
 import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument
-import software.amazon.awssdk.enhanced.dynamodb.model
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{UpdateItemRequest, AttributeValue => AttributeValueV2, ReturnValue => ReturnValueV2}
 
+import java.util
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
@@ -26,13 +24,13 @@ object NoItemFound extends Throwable("item not found")
 
 /**
   * A lightweight wrapper around AWS dynamo SDK for undertaking various operations
-  * @param config Common grid config including AWS credentials
+  * @param client AmazonDynamoDBAsync client
+  * @param client2 DynamoDbClient client
   * @param tableName the table name for this instance of the dynamoDB wrapper
   * @param lastModifiedKey if set to a string the wrapper will maintain a last modified with that name on any update
   * @tparam T The type of this table
   */
-class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Option[String] = None) extends GridLogging {
-  lazy val client2: DynamoDbClient = config.withAWSCredentialsV2(DynamoDbClient.builder()).build()
+class DynamoDB[T](client: AmazonDynamoDBAsync, client2: DynamoDbClient, tableName: String, lastModifiedKey: Option[String] = None) extends GridLogging {
   lazy val dynamo2: DynamoDbEnhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client2).build()
   lazy val tableSchema = TableSchema.documentSchemaBuilder()
     .addIndexPartitionKey(TableMetadata.primaryIndexName(), IdKey, AttributeValueType.S)
@@ -40,7 +38,6 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
     .build()
   lazy val table2 = dynamo2.table(tableName, tableSchema)
 
-  lazy val client: AmazonDynamoDBAsync = config.withAWSCredentials(AmazonDynamoDBAsyncClientBuilder.standard()).build()
   lazy val dynamo = new AwsDynamoDB(client)
   lazy val table: Table = dynamo.getTable(tableName)
 
@@ -59,7 +56,7 @@ class DynamoDB[T](config: CommonConfig, tableName: String, lastModifiedKey: Opti
     case None => Future.failed(NoItemFound)
   }
 
-  private def get(id: String, attribute: String)(implicit ex: ExecutionContext): Future[Item] = Future {
+  def get(id: String, attribute: String)(implicit ex: ExecutionContext): Future[Item] = Future {
     table.getItem(
       new GetItemSpec()
         .withPrimaryKey(IdKey, id)

--- a/leases/app/LeasesComponents.scala
+++ b/leases/app/LeasesComponents.scala
@@ -4,11 +4,12 @@ import controllers.MediaLeaseController
 import lib.{LeaseNotifier, LeaseStore, LeasesConfig}
 import play.api.ApplicationLoader.Context
 import router.Routes
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
 class LeasesComponents(context: Context) extends GridComponents(context, new LeasesConfig(_)) {
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val store = new LeaseStore(config)
+  val store = new LeaseStore(config.leasesTable,config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build())
   val notifications = new LeaseNotifier(config, store)
 
   val controller = new MediaLeaseController(auth, store, config, notifications, controllerComponents)

--- a/leases/app/lib/LeaseStore.scala
+++ b/leases/app/lib/LeaseStore.scala
@@ -10,15 +10,13 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class LeaseStore(config: LeasesConfig) {
-  val client = config.withAWSCredentialsV2(DynamoDbAsyncClient.builder()).build()
-
+class LeaseStore(tableName: String, client: DynamoDbAsyncClient) {
   implicit val dateTimeFormat: Typeclass[DateTime] =
     DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](DateTime.parse, _.toString)
   implicit val enumFormat: Typeclass[MediaLeaseType] =
     DynamoFormat.coercedXmap[MediaLeaseType, String, IllegalArgumentException](MediaLeaseType(_), _.toString)
 
-  private val leasesTable = Table[MediaLease](config.leasesTable)
+  private val leasesTable = Table[MediaLease](tableName)
 
   def get(id: String)(implicit ec: ExecutionContext): Future[Option[MediaLease]] = {
     ScanamoAsync(client).exec(leasesTable.get("id" === id)).map(_.flatMap(_.toOption))

--- a/leases/test/lib/LeaseStoreSpec.scala
+++ b/leases/test/lib/LeaseStoreSpec.scala
@@ -1,0 +1,138 @@
+package lib
+
+import com.gu.mediaservice.model.leases.{AllowUseLease, MediaLease}
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatestplus.mockito.MockitoSugar
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service.DYNAMODB
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
+
+class LeaseStoreSpec extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll with MockitoSugar {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(100, Millis))
+
+  private val dynamoContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.4.0")).withServices(DYNAMODB)
+  dynamoContainer.start()
+
+  private val dynamoClient = DynamoDbAsyncClient.builder().
+    endpointOverride(dynamoContainer.getEndpointOverride(DYNAMODB)).
+    region(Region.of(dynamoContainer.getRegion)).
+    credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(dynamoContainer.getAccessKey, dynamoContainer.getSecretKey))).build()
+
+  private val leasesTable = "test-leases-table-" + UUID.randomUUID().toString
+
+  private val store = new LeaseStore(leasesTable, dynamoClient)
+
+  override def beforeAll(): Unit = {
+    def createTableRequestFor(tableName: String): CreateTableRequest = {
+      val attributeDefinitions = List(
+        AttributeDefinition.builder.attributeName("id").attributeType(ScalarAttributeType.S).build(),
+        AttributeDefinition.builder.attributeName("mediaId").attributeType(ScalarAttributeType.S).build()
+      )
+      val keySchema = List(
+        KeySchemaElement.builder.attributeName("id").keyType(KeyType.HASH).build()
+      )
+      val globalSecondaryIndexes = List(
+        GlobalSecondaryIndex.builder()
+          .indexName("mediaId")
+          .keySchema(KeySchemaElement.builder().attributeName("mediaId").keyType(KeyType.HASH).build())
+          .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+          .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(1L).writeCapacityUnits(1L).build())
+          .build()
+      )
+      CreateTableRequest.builder
+        .tableName(tableName)
+        .attributeDefinitions(attributeDefinitions.asJava)
+        .keySchema(keySchema.asJava)
+        .globalSecondaryIndexes(globalSecondaryIndexes.asJava)
+        .provisionedThroughput(ProvisionedThroughput.builder.readCapacityUnits(1L).writeCapacityUnits(1L).build())
+        .build()
+    }
+
+    dynamoClient.createTable(createTableRequestFor(leasesTable)).get()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    dynamoContainer.stop()
+  }
+
+  describe("LeaseStore") {
+    val now = DateTime.now.withZone(DateTimeZone.UTC)
+    val lease = MediaLease(
+      id = Some(UUID.randomUUID().toString),
+      mediaId = "media-id-1",
+      leasedBy = Some("test"),
+      notes = Some("test notes"),
+      access = AllowUseLease,
+      createdAt = now
+    )
+
+    it("should be able to add a lease") {
+      val eventualResult = store.put(lease)
+      whenReady(eventualResult) { _ =>
+        val readBack = store.get(lease.id.get)
+        whenReady(readBack) { result =>
+          result should equal(Some(lease))
+        }
+      }
+    }
+
+    it("should be able to get a lease for a media id") {
+      val lease2 = lease.copy(id = Some(UUID.randomUUID().toString), mediaId = "media-id-2")
+      val eventualResult = store.put(lease2)
+      whenReady(eventualResult) { _ =>
+        val readBack = store.getForMedia("media-id-2")
+        whenReady(readBack) { result =>
+          result should be(List(lease2))
+        }
+      }
+    }
+
+    it("should be able to get all leases") {
+      val lease3 = lease.copy(id = Some(UUID.randomUUID().toString))
+      val lease4 = lease.copy(id = Some(UUID.randomUUID().toString))
+      val eventualResult = store.putAll(List(lease3, lease4))
+
+      whenReady(eventualResult) { _ =>
+        val readBack = store.forEach(identity)
+        whenReady(readBack) { result =>
+          result should contain allOf(lease3, lease4)
+        }
+      }
+    }
+
+    it("should be able to delete a lease") {
+      val lease5 = lease.copy(id = Some(UUID.randomUUID().toString))
+      val eventualResult = store.put(lease5)
+
+      whenReady(eventualResult) { _ =>
+        val readBack = store.get(lease5.id.get)
+        whenReady(readBack) { result =>
+          result should be(Some(lease5))
+        }
+
+        val deleteResult = store.delete(lease5.id.get)
+        whenReady(deleteResult) { _ =>
+          val readBackAfterDelete = store.get(lease5.id.get)
+          whenReady(readBackAfterDelete) { result =>
+            result should be(None)
+          }
+        }
+      }
+    }
+  }
+}

--- a/metadata-editor/app/MetadataEditorComponents.scala
+++ b/metadata-editor/app/MetadataEditorComponents.scala
@@ -1,15 +1,22 @@
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.{EditsApi, EditsController, SyndicationController}
 import lib._
 import play.api.ApplicationLoader.Context
 import router.Routes
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class MetadataEditorComponents(context: Context) extends GridComponents(context, new EditsConfig(_)) {
   final override val buildInfo = utils.buildinfo.BuildInfo
 
-  val editsStore = new EditsStore(config)
-  val syndicationStore = new SyndicationStore(config)
+  val editsStore = new EditsStore(config.withAWSCredentials(AmazonDynamoDBAsyncClientBuilder.standard()).build(),
+    config.withAWSCredentialsV2(DynamoDbClient.builder()).build(), config.editsTable)
+  val syndicationStore = new SyndicationStore(
+    config.withAWSCredentials(AmazonDynamoDBAsyncClientBuilder.standard()).build(),
+    config.withAWSCredentialsV2(DynamoDbClient.builder()).build(),
+    config.syndicationTable
+  )
   val notifications = new Notifications(config)
 
   val metrics = new MetadataEditorMetrics(config, actorSystem, applicationLifecycle)

--- a/metadata-editor/app/lib/EditsStore.scala
+++ b/metadata-editor/app/lib/EditsStore.scala
@@ -1,6 +1,8 @@
 package lib
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.model.Edits
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
-class EditsStore(config: EditsConfig) extends DynamoDB[Edits](config, config.editsTable, Some(Edits.LastModified))
+class EditsStore(client: AmazonDynamoDBAsync, client2: DynamoDbClient, tableName: String) extends DynamoDB[Edits](client, client2, tableName, Some(Edits.LastModified))

--- a/metadata-editor/app/lib/SyndicationStore.scala
+++ b/metadata-editor/app/lib/SyndicationStore.scala
@@ -1,6 +1,9 @@
 package lib
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.model.SyndicationRights
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
-class SyndicationStore(config: EditsConfig) extends DynamoDB[SyndicationRights](config, config.syndicationTable)
+class SyndicationStore(client: AmazonDynamoDBAsync, client2: DynamoDbClient, tableName: String)
+  extends DynamoDB[SyndicationRights](client, client2, tableName)

--- a/metadata-editor/test/lib/EditsStoreTest.scala
+++ b/metadata-editor/test/lib/EditsStoreTest.scala
@@ -1,0 +1,330 @@
+package lib
+
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
+import com.gu.mediaservice.model.{Edits, ImageMetadata}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service.DYNAMODB
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
+
+class EditsStoreTest extends AnyFunSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
+
+  private val dynamoContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.4.0")).withServices(DYNAMODB)
+  dynamoContainer.start()
+
+  val testTableName: String = "test-edits-table-" + UUID.randomUUID().toString
+
+  private val dynamoClient = AmazonDynamoDBAsyncClientBuilder.standard().
+    withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(dynamoContainer.getEndpoint.toURL.toExternalForm, dynamoContainer.getRegion)).
+    withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(dynamoContainer.getAccessKey, dynamoContainer.getSecretKey))).
+    build()
+
+  private val dynamoClient2: DynamoDbClient = DynamoDbClient.builder().
+    endpointOverride(dynamoContainer.getEndpointOverride(DYNAMODB)).
+    region(Region.of(dynamoContainer.getRegion)).
+    credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(dynamoContainer.getAccessKey, dynamoContainer.getSecretKey))).build()
+
+  private val store = new EditsStore(dynamoClient, dynamoClient2, testTableName) {
+  }
+
+  override def beforeAll(): Unit = {
+    def createTableRequestFor(tableName: String): CreateTableRequest = {
+      val attributeDefinitions = List(
+        AttributeDefinition.builder.attributeName("id").attributeType(ScalarAttributeType.S).build()
+      )
+      val keySchema = List(
+        KeySchemaElement.builder.attributeName("id").keyType(KeyType.HASH).build()
+      )
+      val provisionedThroughput = ProvisionedThroughput.builder.readCapacityUnits(1L).writeCapacityUnits(1L).build()
+      val request = CreateTableRequest.builder
+        .tableName(tableName)
+        .attributeDefinitions(attributeDefinitions.asJava)
+        .keySchema(keySchema.asJava)
+        .provisionedThroughput(provisionedThroughput)
+        .build()
+      request
+    }
+
+    dynamoClient2.createTable(createTableRequestFor(testTableName))
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    dynamoContainer.stop()
+  }
+
+  describe("EditsStore") {
+
+    it("should fail with NoItemFound for a non-existent item in getV2") {
+      val imageId = "non-existent-image"
+
+      val eventualResult = store.getV2(imageId)
+
+      whenReady(eventualResult.failed) { exception =>
+        exception shouldBe com.gu.mediaservice.lib.aws.NoItemFound
+      }
+    }
+
+    it("should persist a boolean property using V2") {
+      val imageId = "test-image-for-boolean-get-v2"
+
+      val eventualResult = store.booleanSetV2(imageId, Edits.Archived, value = true).flatMap { _ =>
+        store.booleanGetV2(imageId, Edits.Archived)
+      }
+
+      whenReady(eventualResult) { result =>
+        result should be(true)
+      }
+    }
+
+    it("should fail with NoItemFound for a non-existent attribute in booleanGetV2") {
+      val imageId = "test-image-for-boolean-get-v2-non-existent-attribute"
+
+      // First, create the item so it exists
+      store.booleanSetV2(imageId, Edits.Archived, value = true).futureValue
+
+      val eventualResult = store.booleanGetV2(imageId, "another-existent-attribute")
+
+      whenReady(eventualResult.failed) { exception =>
+        exception shouldBe com.gu.mediaservice.lib.aws.NoItemFound
+      }
+    }
+
+    it("should get a previously persisted property using V2") {
+      val imageId = "test-image-for-set-get-v2"
+      val labels = List("label1", "label2")
+      val eventualResult = store.setAddV2(imageId, Edits.Labels, labels).flatMap { _ =>
+        store.setGetV2(imageId, Edits.Labels)
+      }
+
+      whenReady(eventualResult) { result =>
+        result should be(labels.toSet)
+      }
+    }
+
+    describe("setAddV2") {
+      it("should add a value to a non-existent set, creating it") {
+        val imageId = "test-image-for-set-add-non-existent"
+        val label = "label1"
+
+        val eventualResult = store.setAddV2(imageId, Edits.Labels, List(label)).flatMap { _ =>
+          store.setGetV2(imageId, Edits.Labels)
+        }
+
+        whenReady(eventualResult) { result =>
+          result should be(Set(label))
+        }
+      }
+
+      it("should append a value to an existing set") {
+        val imageId = "test-image-for-set-add-existing"
+        val labels = List("label1", "label2")
+        val newLabel = "label3"
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, labels)
+          _ <- store.setAddV2(imageId, Edits.Labels, List(newLabel))
+          result <- store.setGetV2(imageId, Edits.Labels)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          result should be(Set("label1", "label2", "label3"))
+        }
+      }
+
+      it("should not add a duplicate value to a set") {
+        val imageId = "test-image-for-set-add-duplicate"
+        val label = "label1"
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, List(label))
+          _ <- store.setAddV2(imageId, Edits.Labels, List(label))
+          result <- store.setGetV2(imageId, Edits.Labels)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          result should be(Set(label))
+        }
+      }
+    }
+
+    describe("booleanSetOrRemoveV2") {
+      it("should set a boolean property to true using V2") {
+        val imageId = "test-image-for-boolean-set-or-remove-v2-set"
+        val key = "testBoolean"
+
+        val eventualResult = for {
+          _ <- store.booleanSetOrRemoveV2(imageId, key, value = true)
+          result <- store.booleanGetV2(imageId, key)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          result should be(true)
+        }
+      }
+
+      it("should remove a boolean property when setting to false using V2") {
+        val imageId = "test-image-for-boolean-set-or-remove-v2-remove"
+        val key = "testBoolean"
+
+        val setup = for {
+          _ <- store.booleanSetOrRemoveV2(imageId, key, value = true)
+          _ <- store.booleanSetOrRemoveV2(imageId, key, value = false)
+          result <- store.booleanGetV2(imageId, key).failed
+        } yield result
+
+        whenReady(setup) { exception =>
+          exception shouldBe com.gu.mediaservice.lib.aws.NoItemFound
+        }
+      }
+    }
+
+    describe("removeKey") {
+      it("should remove a key from an existing item") {
+        val imageId = "test-image-for-remove-key"
+        val labels = List("label1", "label2")
+        val archived = true
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, labels)
+          _ <- store.booleanSetV2(imageId, Edits.Archived, archived)
+          _ <- store.removeKeyV2(imageId, Edits.Labels)
+          result <- store.getV2(imageId)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          val edits = result.as[Edits]
+          edits.archived should be(archived)
+          edits.labels should be(empty)
+        }
+      }
+
+      it("should not fail when removing a non-existent key from an existing item") {
+        val imageId = "test-image-for-remove-non-existent-key"
+        val labels = List("label1", "label2")
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, labels)
+          _ <- store.removeKeyV2(imageId, Edits.Archived)
+          result <- store.getV2(imageId)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          val edits = result.as[Edits]
+          edits.labels.toSet should be(labels.toSet)
+        }
+      }
+
+      it("will create an item when removing a key from a non-existent item") {
+        // TODO should this really be happening?
+        val imageId = "non-existent-image-for-remove-key"
+
+        val eventualResult = for {
+          _ <- store.removeKeyV2(imageId, Edits.Labels)
+          result <- store.getV2(imageId)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          val edits = result.as[Edits]
+          edits.labels should be(empty)
+          edits.metadata should be(ImageMetadata.empty)
+        }
+      }
+    }
+
+    describe("setDelete") {
+      it("should delete an item from a set") {
+        val imageId = "test-image-for-set-delete"
+        val labels = List("label1", "label2", "label3")
+        val labelToDelete = "label2"
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, labels)
+          _ <- store.setDeleteV2(imageId, Edits.Labels, labelToDelete)
+          result <- store.setGetV2(imageId, Edits.Labels)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          result should be(Set("label1", "label3"))
+        }
+      }
+
+      it("should leave an empty set when deleting the last item from a set") {
+        val imageId = "test-image-for-set-delete-last-item"
+        val label = "label1"
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, List(label))
+          _ <- store.setDeleteV2(imageId, Edits.Labels, label)
+          result <- store.getV2(imageId)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          // After deleting the last item, the key (labels) should be removed.
+          // leaving an empty set rather than a missing key
+          val edits = result.as[Edits]
+          edits.labels should be(empty)
+        }
+      }
+
+      it("should not fail when deleting a non-existent item from a set") {
+        val imageId = "test-image-for-set-delete-non-existent-item"
+        val labels = List("label1", "label2")
+        val labelToDelete = "label3"
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, labels)
+          _ <- store.setDeleteV2(imageId, Edits.Labels, labelToDelete)
+          result <- store.setGetV2(imageId, Edits.Labels)
+        } yield result
+
+        whenReady(eventualResult) { result =>
+          result should be(Set("label1", "label2"))
+        }
+      }
+    }
+
+    describe("deleteItemV2") {
+      it("should delete an existing item") {
+        val imageId = "test-image-for-delete-item-v2"
+        val labels = List("label1", "label2")
+
+        val eventualResult = for {
+          _ <- store.setAddV2(imageId, Edits.Labels, labels)
+          _ <- store.deleteItemV2(imageId)
+          result <- store.getV2(imageId).failed
+        } yield result
+
+        whenReady(eventualResult) { exception =>
+          exception shouldBe com.gu.mediaservice.lib.aws.NoItemFound
+        }
+      }
+
+      it("should not fail when deleting a non-existent item") {
+        val imageId = "non-existent-image-for-delete-item-v2"
+
+        val eventualResult = store.deleteItemV2(imageId)
+
+        whenReady(eventualResult) { result =>
+          result should be(())
+        }
+      }
+    }
+  }
+}

--- a/usage/app/UsageComponents.scala
+++ b/usage/app/UsageComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.contentapi.client.ScheduledExecutor
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder
 import com.gu.mediaservice.lib.management.InnerServiceStatusCheckController
 import com.gu.mediaservice.lib.play.GridComponents
 import controllers.UsageApi
@@ -6,6 +7,7 @@ import lib._
 import model._
 import play.api.ApplicationLoader.Context
 import router.Routes
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import scala.concurrent.Future
 
@@ -17,7 +19,11 @@ class UsageComponents(context: Context) extends GridComponents(context, new Usag
   val mediaWrapper = new MediaWrapperOps(usageMetadataBuilder)
   val liveContentApi = new LiveContentApi(config)(ScheduledExecutor())
   val usageGroupOps = new UsageGroupOps(config, mediaWrapper)
-  val usageTable = new UsageTable(config)
+  val usageTable = new UsageTable(
+    config.withAWSCredentials(AmazonDynamoDBAsyncClientBuilder.standard()).build(),
+    config.withAWSCredentialsV2(DynamoDbClient.builder()).build(),
+    config.usageRecordTable
+  )
   val usageMetrics = new UsageMetrics(config, actorSystem, applicationLifecycle)
   val usageNotifier = new UsageNotifier(config, usageTable)
   val usageRecorder = new UsageRecorder(usageMetrics, usageTable, usageNotifier, usageNotifier)

--- a/usage/app/model/UsageTable.scala
+++ b/usage/app/model/UsageTable.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.document.spec.{DeleteItemSpec, QuerySpec, UpdateItemSpec}
 import com.amazonaws.services.dynamodbv2.document.{DeleteItemOutcome, KeyAttribute, RangeKeyCondition}
 import com.amazonaws.services.dynamodbv2.model.ReturnValue
@@ -7,15 +8,20 @@ import com.gu.mediaservice.lib.aws.DynamoDB
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker}
 import com.gu.mediaservice.lib.usage.ItemToMediaUsage
 import com.gu.mediaservice.model.usage.{MediaUsage, PendingUsageStatus, PublishedUsageStatus, UsageTableFullKey}
-import lib.{BadInputException, UsageConfig, WithLogMarker}
+import lib.{BadInputException, WithLogMarker}
 import play.api.libs.json._
 import rx.lang.scala.Observable
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 
-class UsageTable(config: UsageConfig) extends DynamoDB(config, config.usageRecordTable) with GridLogging {
+class UsageTable(
+                                  client: AmazonDynamoDBAsync,
+                                  client2: DynamoDbClient,
+                                  tableName: String
+                                ) extends DynamoDB[MediaUsage](client, client2, tableName) with GridLogging {
 
   val hashKeyName = "grouping"
   val rangeKeyName = "usage_id"

--- a/usage/test/model/UsageTableTest.scala
+++ b/usage/test/model/UsageTableTest.scala
@@ -1,0 +1,334 @@
+package model
+
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder}
+import com.gu.mediaservice.lib.logging.{GridLogging, MarkerMap}
+import com.gu.mediaservice.model.usage._
+import lib.WithLogMarker
+import org.joda.time.DateTime
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service.DYNAMODB
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.net.URI
+import java.util.UUID
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+  private val tenSeconds = 10.seconds
+
+  private val dynamoContainer = new LocalStackContainer(
+    DockerImageName.parse("localstack/localstack:1.4.0")
+  ).withServices(DYNAMODB)
+  dynamoContainer.start()
+
+  private val dynamoClientV1: AmazonDynamoDBAsync = AmazonDynamoDBAsyncClientBuilder.standard()
+    .withEndpointConfiguration(new EndpointConfiguration(
+      dynamoContainer.getEndpointOverride(DYNAMODB).toString,
+      dynamoContainer.getRegion
+    ))
+    .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+      dynamoContainer.getAccessKey,
+      dynamoContainer.getSecretKey
+    )))
+    .build()
+
+  private val dynamoClientV2: DynamoDbClient = DynamoDbClient.builder()
+    .endpointOverride(dynamoContainer.getEndpointOverride(DYNAMODB))
+    .region(Region.of(dynamoContainer.getRegion))
+    .credentialsProvider(StaticCredentialsProvider.create(
+      AwsBasicCredentials.create(dynamoContainer.getAccessKey, dynamoContainer.getSecretKey)
+    )).build()
+
+  private val usageTable = "test-usage-table-" + UUID.randomUUID().toString
+  private val store = new UsageTable(dynamoClientV1, dynamoClientV2, usageTable)
+
+  override def beforeAll(): Unit = {
+    val attributeDefinitions = List(
+      AttributeDefinition.builder.attributeName("grouping").attributeType(ScalarAttributeType.S).build(),
+      AttributeDefinition.builder.attributeName("usage_id").attributeType(ScalarAttributeType.S).build(),
+      AttributeDefinition.builder.attributeName("media_id").attributeType(ScalarAttributeType.S).build()
+    )
+    val keySchema = List(
+      KeySchemaElement.builder.attributeName("grouping").keyType(KeyType.HASH).build(),
+      KeySchemaElement.builder.attributeName("usage_id").keyType(KeyType.RANGE).build()
+    )
+    val provisionedThroughput = ProvisionedThroughput.builder.readCapacityUnits(1L).writeCapacityUnits(1L).build()
+
+    val imageIndex = GlobalSecondaryIndex.builder()
+      .indexName("media_id")
+      .keySchema(KeySchemaElement.builder()
+        .attributeName("media_id")
+        .keyType(KeyType.HASH).build())
+      .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+      .provisionedThroughput(provisionedThroughput)
+      .build()
+
+    val request = CreateTableRequest.builder
+      .tableName(usageTable)
+      .attributeDefinitions(attributeDefinitions.asJava)
+      .keySchema(keySchema.asJava)
+      .globalSecondaryIndexes(imageIndex)
+      .provisionedThroughput(provisionedThroughput)
+      .build()
+    dynamoClientV2.createTable(request)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    dynamoContainer.stop()
+  }
+
+  describe("UsageTable") {
+    it("should be able to query by image id") {
+      val imageId1 = "test-image-id-1"
+      val imageId2 = "test-image-id-2"
+
+      val usageId1 = UsageId(UUID.randomUUID().toString)
+      val usageId2 = UsageId(UUID.randomUUID().toString)
+
+      val usage1 = MediaUsage(
+        usageId1,
+        s"grouping-${usageId1.toString}",
+        imageId1,
+        DigitalUsage,
+        "image",
+        PendingUsageStatus,
+        None,
+        None,
+        None,
+        None,
+        None,
+        DateTime.now()
+      )
+      val usage2 = MediaUsage(
+        usageId2,
+        s"grouping-${usageId2.toString}",
+        imageId2,
+        DigitalUsage,
+        "image",
+        PublishedUsageStatus,
+        None,
+        None,
+        None,
+        None,
+        None,
+        DateTime.now()
+      )
+
+      val eventualUsage1Created = store.create(usage1)(MarkerMap()).toList.toBlocking.toFuture
+      val eventualUsage2Created = store.create(usage2)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsage1Created, tenSeconds)
+      Await.result(eventualUsage2Created, tenSeconds)
+
+      val eventualResult = store.queryByImageId(imageId1)(MarkerMap())
+
+      whenReady(eventualResult) { result =>
+        result.size should be(1)
+        result.head.mediaId should be(imageId1)
+      }
+    }
+
+    it("should be able to query by usage id") {
+      val imageId = "test-image-id-for-by-usage-id-test"
+      val usageId = UsageId(UUID.randomUUID().toString)
+      val grouping = "some-grouping"
+
+      val usage = MediaUsage(
+        usageId,
+        grouping,
+        imageId,
+        DigitalUsage,
+        "image",
+        PendingUsageStatus,
+        Some(PrintUsageMetadata(
+          sectionCode = "a-section",
+          sectionName = "A section",
+          pageNumber = 7,
+          issueDate = DateTime.now,
+          storyName = "a-story",
+          publicationCode = "tst",
+          publicationName = "Test publication",
+          edition = Some(1)
+        )
+        ),
+        Some(DigitalUsageMetadata(
+          webUrl = new URI("http://localhost/test"),
+          webTitle = "A page",
+          sectionId = "a-section"
+        )),
+        Some(SyndicationUsageMetadata(
+          partnerName = "Test Partner",
+          syndicatedBy = Some("test-syndicator")
+        )),
+        Some(FrontUsageMetadata(
+          addedBy = "test-user",
+          front = "uk/culture"
+        )),
+        Some(DownloadUsageMetadata(
+          downloadedBy = "test-downloader"
+        )),
+        DateTime.now()
+      )
+
+      val eventualUsage1Created = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsage1Created, tenSeconds)
+
+      val eventualResult = store.queryByUsageId(s"${grouping}_${usageId.id}")
+
+      whenReady(eventualResult) { result =>
+        result.get.usageId should be(usageId)
+        result.get should be(usage)
+      }
+    }
+
+    it("should be able to delete a record") {
+      val imageId = "test-image-id-for-delete-test"
+      val usageId = UsageId(UUID.randomUUID().toString)
+      val grouping = "some-grouping-for-delete"
+
+      val usage = MediaUsage(
+        usageId,
+        grouping,
+        imageId,
+        DigitalUsage,
+        "image",
+        PendingUsageStatus,
+        None,
+        None,
+        None,
+        None,
+        None,
+        DateTime.now()
+      )
+      val eventualUsageCreated = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsageCreated, tenSeconds)
+      val eventualReadbackResult = store.queryByUsageId(s"${grouping}_${usageId.id}")
+      whenReady(eventualReadbackResult) { result =>
+        result should be(Some(usage))
+      }
+
+      store.deleteRecord(usage)(MarkerMap())
+
+      val eventualReadbackAfterDelete = store.queryByUsageId(s"${grouping}_${usageId.id}")
+      whenReady(eventualReadbackAfterDelete) { result =>
+        result should be(None)
+      }
+    }
+
+    it("should be able to update a record") {
+      val imageId = "test-image-id-for-update-test"
+      val usageId = UsageId(UUID.randomUUID().toString)
+      val grouping = "some-grouping-for-update"
+
+      val usage = MediaUsage(
+        usageId,
+        grouping,
+        imageId,
+        DigitalUsage,
+        "image",
+        PendingUsageStatus,
+        None,
+        None,
+        None,
+        None,
+        None,
+        DateTime.now()
+      )
+      val eventualUsageCreated = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsageCreated, tenSeconds)
+      val updatedUsage = usage.copy(status = PublishedUsageStatus)
+
+      val eventualUsageUpdated = store.update(updatedUsage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsageUpdated, tenSeconds)
+
+      val eventualReadbackResult = store.queryByUsageId(s"${grouping}_${usageId.id}")
+      whenReady(eventualReadbackResult) { result =>
+        result.get.status should be(PublishedUsageStatus)
+      }
+    }
+
+    it("should be able to mark a record as removed") {
+      val imageId = "test-image-id-for-mark-as-removed-test"
+      val usageId = UsageId(UUID.randomUUID().toString)
+      val grouping = "some-grouping-for-mark-as-removed"
+
+      val usage = MediaUsage(
+        usageId,
+        grouping,
+        imageId,
+        DigitalUsage,
+        "image",
+        PendingUsageStatus,
+        None,
+        None,
+        None,
+        None,
+        None,
+        DateTime.now()
+      )
+      val eventualUsageCreated = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsageCreated, tenSeconds)
+
+      val eventualUsageMarkedAsRemoved = store.markAsRemoved(usage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsageMarkedAsRemoved, tenSeconds)
+
+      val eventualReadbackResult = store.queryByUsageId(s"${grouping}_${usageId.id}")
+      whenReady(eventualReadbackResult) { result =>
+        result.get.isRemoved should be(true)
+      }
+    }
+
+    it("should be able to match a usage group") {
+      // TODO unclear what this means
+      val imageId = "test-image-id-for-match-usage-group-test"
+      val usageId = UsageId(UUID.randomUUID().toString)
+      val grouping = "some-grouping-for-match-usage-group"
+
+      val usage = MediaUsage(
+        usageId,
+        grouping,
+        imageId,
+        DigitalUsage,
+        "image",
+        PendingUsageStatus,
+        None,
+        None,
+        None,
+        None,
+        None,
+        DateTime.now()
+      )
+
+      val eventualUsageCreated = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
+      Await.result(eventualUsageCreated, tenSeconds)
+
+      val usageGroup = UsageGroup(
+        usages = Set(usage),
+        grouping = grouping,
+        lastModified = DateTime.now
+      )
+
+      implicit val logMarker: MarkerMap = MarkerMap()
+      val eventualResult = store.matchUsageGroup(WithLogMarker(usageGroup)).toList.toBlocking.toFuture
+
+      whenReady(eventualResult) { result =>
+        result.head.value should be(Set(usage))
+      }
+    }
+  }
+}

--- a/usage/test/model/UsageTableTest.scala
+++ b/usage/test/model/UsageTableTest.scala
@@ -141,7 +141,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
 
       whenReady(eventualResult) { result =>
         result.size should be(1)
-        result.head.mediaId should be(imageId1)
+        result.head should be(usage1)
       }
     }
 

--- a/usage/test/model/UsageTableTest.scala
+++ b/usage/test/model/UsageTableTest.scala
@@ -128,7 +128,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         None,
         None,
         None,
-        None,
+        Some(ChildUsageMetadata(addedBy = "someone", childMediaId = "123abc")),
         DateTime.now()
       )
 

--- a/usage/test/model/UsageTableTest.scala
+++ b/usage/test/model/UsageTableTest.scala
@@ -113,6 +113,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         None,
         None,
         None,
+        None,
         DateTime.now()
       )
       val usage2 = MediaUsage(
@@ -122,6 +123,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         DigitalUsage,
         "image",
         PublishedUsageStatus,
+        None,
         None,
         None,
         None,
@@ -182,6 +184,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         Some(DownloadUsageMetadata(
           downloadedBy = "test-downloader"
         )),
+        None,
         DateTime.now()
       )
 
@@ -208,6 +211,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         DigitalUsage,
         "image",
         PendingUsageStatus,
+        None,
         None,
         None,
         None,
@@ -247,6 +251,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         None,
         None,
         None,
+        None,
         DateTime.now()
       )
       val eventualUsageCreated = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
@@ -279,6 +284,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         None,
         None,
         None,
+        None,
         DateTime.now()
       )
       val eventualUsageCreated = store.create(usage)(MarkerMap()).toList.toBlocking.toFuture
@@ -306,6 +312,7 @@ class UsageTableTest extends AnyFunSpec with Matchers with GridLogging with Scal
         DigitalUsage,
         "image",
         PendingUsageStatus,
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
## What does this change?

Provides some basic tests of the Dynamo backed Stores.
Follows the test container pattern used in the Elastic tests.

For ease of testing, refactor the constructors of the Stores to accept the specific required dependencies  rather than `CommonConfig`.

This sets up for the rewrite of `UsageTable` into sdk v2 format.


## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
