### PR TITLE
Implement ai search tracking

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -286,7 +286,7 @@ query.controller('SearchQueryCtrl', [
       }
       ctrl.filter.nonFree = nonFreeCheck;
 
-      sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe);
+      sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe, ctrl.useAISearch);
       if (ctrl.collectionSearch && !curCollectionSearch) {
         storage.setJs("orderBy", CollectionSortOption.value);
         ctrl.ordering["orderBy"] = CollectionSortOption.value;
@@ -526,7 +526,7 @@ query.controller('SearchQueryCtrl', [
 
 
     const { nonFree, uploadedByMe } = ctrl.filter;
-    sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe);
+    sendTelemetryForQuery(ctrl.filter.query, nonFree, uploadedByMe, ctrl.useAISearch);
 }]);
 
 query.directive('searchQuery', [function() {

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -49,7 +49,7 @@ const sendFilterTelemetryEvent = (key: string, value: string, searchUuid: string
     }, 1);
 };
 
-export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string, uploadedByMe?: boolean ) => {
+export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string, uploadedByMe?: boolean, useAISearch?: boolean ) => {
     const structuredQuery = structureQuery(query || "");
     const searchUuid = v4();
     // nonFree is unfortunately either a boolean, stringified boolean, or undefined
@@ -63,7 +63,6 @@ export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string,
     if (uploadedByMeOnly) {
         sendFilterTelemetryEvent('uploadedByMeOnly', 'true', searchUuid);
     }
-
     structuredQuery.forEach(queryComponent => {
         // e.g. filter or search:
         // search > {type: 'text', value: 'my search'}
@@ -78,7 +77,8 @@ export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string,
         // In case search is empty, as with a search containing only filters
         sendTelemetryEvent(formattedType(type), {
             ...queryComponent,
-            searchUuid: searchUuid
+            searchUuid: searchUuid,
+            useAISearch: useAISearch ?? false
         }, 1);
     });
 };


### PR DESCRIPTION
## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

I'm adding a tag to the search telemetry event such that in our grafana dashboard we can specifically search for events relating to AI search.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
