### PR TITLE
use arn attribute to enforce dependency between bucket and index

### DIFF
--- a/cdk/lib/__snapshots__/image-embedder-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/image-embedder-lambda.test.ts.snap
@@ -70,7 +70,12 @@ exports[`The MediaService stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "VectorBucketName": "image-embeddings-test",
+        "VectorBucketArn": {
+          "Fn::GetAtt": [
+            "GridEmbeddingsVectorBucket",
+            "VectorBucketArn",
+          ],
+        },
       },
       "Type": "AWS::S3Vectors::Index",
     },
@@ -723,15 +728,13 @@ exports[`The MediaService stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:s3vectors:",
                     {
-                      "Ref": "AWS::Region",
+                      "Fn::GetAtt": [
+                        "GridEmbeddingsVectorBucket",
+                        "VectorBucketArn",
+                      ],
                     },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":bucket/image-embeddings-test/index/*",
+                    "/index/*",
                   ],
                 ],
               },

--- a/cdk/lib/image-embedder-lambda.ts
+++ b/cdk/lib/image-embedder-lambda.ts
@@ -27,7 +27,7 @@ export class ImageEmbedder extends GuStack {
     const appName = 'image-embedder';
     const downscaledImageBucketName = `${this.stack}-${props.stage.toLowerCase()}-${appName}-downscaled-images`;
 
-    new CfnVectorBucket(this, 'GridEmbeddingsVectorBucket', {
+    const vectorBucket = new CfnVectorBucket(this, 'GridEmbeddingsVectorBucket', {
       vectorBucketName: `image-embeddings-${this.stage.toLowerCase()}`,
     });
 
@@ -36,7 +36,7 @@ export class ImageEmbedder extends GuStack {
       dimension: 1536,
       distanceMetric: 'cosine',
       indexName: 'cohere-embed-v4',
-      vectorBucketName: `image-embeddings-${this.stage.toLowerCase()}`,
+      vectorBucketArn: vectorBucket.attrVectorBucketArn
     });
 
     // These are exposed as parameters by the cloudformation in editorial-tools-platform
@@ -186,7 +186,7 @@ export class ImageEmbedder extends GuStack {
       new PolicyStatement({
         actions: ['s3vectors:PutVectors'],
         resources: [
-          `arn:aws:s3vectors:${Stack.of(this).region}:${Stack.of(this).account}:bucket/image-embeddings-${props.stage.toLowerCase()}/index/*`,
+          `${vectorBucket.attrVectorBucketArn}/index/*`,
         ],
       }),
     );


### PR DESCRIPTION
## What does this change?

Quick fix to #4694 - use a GetAtt to enforce the dependency between the vector bucket and index, to ensure the index is only created once the bucket exists

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
