### PR TITLE
Slightly increase the backfill rate

### DIFF
--- a/cdk/lib/image-embedder-lambda.ts
+++ b/cdk/lib/image-embedder-lambda.ts
@@ -21,9 +21,9 @@ import { Queue } from 'aws-cdk-lib/aws-sqs';
 
 const CONCURRENCY: Record<string, { backfill: number; loader: number; total: number }> = {
 	'PROD': {
-		backfill: 20,
+		backfill: 25,
 		loader: 5,
-		total: 25,
+		total: 30,
 	},
 	'TEST': {
 		backfill: 2,


### PR DESCRIPTION
## What does this change?
Increase the consumption rate of backfill messages, to shorten the total processing time.
<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
