### PR TITLE
correctly generate the full thumbnail url

### DIFF
--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -85,7 +85,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
     def s3SignedThumbUrl = s3Client.signUrl(config.thumbBucket, fileUri, image, imageType = Thumbnail)
 
     val thumbUrl = config.cloudFrontDomainThumbBucket
-      .map(_ + fileUri.getPath.drop(1))
+      .map(domain => s"https://$domain${fileUri.getPath}")
       .getOrElse(s3SignedThumbUrl)
 
     val validityMap = checkUsageRestrictions(source, ImageExtras.validityMap(image, withWritePermission))


### PR DESCRIPTION
## What does this change?

The domain doesn't contain the `https://` protocol prefix, or a trailing slash, so remember to reinsert those when constructing the thumbnail URL.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
