### PR TITLE
Fix multiple search calls

### DIFF
--- a/kahuna/public/js/search/index.js
+++ b/kahuna/public/js/search/index.js
@@ -193,9 +193,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
         // Non-URL parameters
         params: {
             // Routing-level property indicating whether the state has
-            // been loaded as part of a deep-state redirect. Note that
-            // this param gets cleared below so it should never reach
-            // controllers
+            // been loaded as part of a deep-state redirect.
             isDeepStateRedirect: {value: false, type: 'bool'}
         },
         data: {
@@ -207,11 +205,7 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
             // Helper state to determine whether this is just
             // reloading a previous search state, or a new search
             isReloadingPreviousSearch: ['$stateParams', function($stateParams) {
-                const isDeepStateRedirect = $stateParams.isDeepStateRedirect;
-                // *Clear* that transient routing-level flag so we
-                // *don't pollute the $stateParams
-                delete $stateParams.isDeepStateRedirect;
-                return isDeepStateRedirect;
+                return $stateParams.isDeepStateRedirect === true;
             }],
             selection: ['orderedSetFactory', function(orderedSetFactory) {
                 return orderedSetFactory();
@@ -321,7 +315,15 @@ search.config(['$stateProvider', '$urlMatcherFactoryProvider',
 // FIXME: This is here if you go to another state directly e.g. `'/images/id'`
 // and then navigate to search. As it has no remembered `deepStateRedirect`,
 // we just land on `/`. See [1].
-search.run(['$rootScope', '$state', function($rootScope, $state) {
+search.run(['$rootScope', '$state', '$stateParams', '$timeout', function($rootScope, $state, $stateParams, $timeout) {
+    $rootScope.$on('$viewContentLoaded', (_, view) => {
+        if (view === 'results@search') {
+            // using a timeout of 0 to schedule the task for execution ASAP, but outside the ongoing transition
+            $timeout(() => {
+                $state.go('search.results', {isDeepStateRedirect: false});
+            });
+        }
+    });
     $rootScope.$on('$stateChangeSuccess', (_, toState) => {
         if (toState.name === 'search') {
             $state.go('search.results', null, {reload: true});

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -322,11 +322,11 @@ results.controller('SearchResultsCtrl', [
         onNextEvent($scope, 'gu-lazy-table:height-changed').
             // Attempt to resume the top position ASAP, so as to limit
             // visible jump
-            then(() => scrollPosition.resume($stateParams)).
+            then(() => scrollPosition.resume($state.href('search.results', $stateParams))).
             // When navigating back, resuming the position immediately
             // doesn't work, so we try again after a little while
             then(() => delay(30)).
-            then(() => scrollPosition.resume($stateParams)).
+            then(() => scrollPosition.resume($state.href('search.results', $stateParams))).
             then(scrollPosition.clear);
 
         const pollingPeriod = 15 * 1000; // ms
@@ -866,7 +866,7 @@ results.controller('SearchResultsCtrl', [
         $scope.$on('$destroy', () => {
             // only save scroll position if we're destroying grid scope (avoids issue regarding ng-if triggering scope refresh)
             if (0 < $scope.ctrl.images.length) {
-              scrollPosition.save($stateParams);
+              scrollPosition.save($state.href('search.results', $stateParams));
             }
             freeUpdatesListener();
             freeImageDeleteListener();

--- a/kahuna/public/js/services/scroll-position.js
+++ b/kahuna/public/js/services/scroll-position.js
@@ -9,32 +9,24 @@ scrollPosService.factory('scrollPosition',
     // The saved scroll top position
     let positionTop;
 
-    // The original context where the position was saved
-    let originalContext;
+    // The original URL where the position was saved
+    let originalUrl;
 
     // Enable reset to top on next save
     let forceReset = false;
 
-    function save(currentContext) {
-        // deal with url ambiguity over nonFree parameter
-        if (!currentContext.nonFree) {
-          currentContext.nonFree = "false";
-        }
-        originalContext = currentContext;
+    function save(currentUrl) {
+        originalUrl = currentUrl;
         // Accommodate Chrome & Firefox
         positionTop = document.body.scrollTop || document.documentElement.scrollTop;
     }
 
-    function resume(currentContext) {
-        // deal with url ambiguity over nonFree parameter
-        if (!currentContext.nonFree) {
-          currentContext.nonFree = "false";
-        }
+    function resume(currentUrl) {
         if (forceReset) {
           forceReset = false;
           positionTop = 0;
         }
-        if (angular.equals(currentContext, originalContext)) {
+        if (currentUrl === originalUrl) {
             $window.scrollTo(0, positionTop);
         }
     }
@@ -45,7 +37,7 @@ scrollPosService.factory('scrollPosition',
 
     function clear() {
         positionTop = undefined;
-        originalContext = undefined;
+        originalUrl = undefined;
     }
 
     function resetToTop() {


### PR DESCRIPTION
## The Issue
We have a bug that causes a simple page load on the search result to trigger exactly the same search HTTP request 4 times in a row.

This was somewhat tolerable in a world where the elastic search query was relatively simple, but as we're introducing more costly searches with a knn search, it's suddenly become critical we address this bug.

## The root cause
With the help of Opus 4.7 we did manage to identify that the issue was the fact we were mutating the `$stateParams` object as angular was trying to resolve the state for the search controller, which was in itself a trigger for the deep state redirect extension to re-initialising the controller.

So I started by removing this mutation `delete $stateParams.isDeepStateRedirect;` in `kahuna/public/js/search/index.js`. This fixed the HTTP request issue, but revealed two new issues.

## Loading new images
One of these secondary bugs affected how the client keeps in memory what is the date of the first item of the latest search result `lastSearchFirstResultTime` in `kahuna/public/js/search/results.js`. This date is kept in order to remember the timeline position of the user. In other words, that bug degraded the user experience if:
- a user scrolls down a search result page
- clicks on an image
- comes back to the search result <-- cannot load new images as they are being ingested

This meant the `isDeepStateRedirect` flag that is set to `true` when going from the image controller to the search controller needs to be reset as soon as the page has been rendered. I did this by listening to the `$viewContentLoaded` event, specifically for the `results@search` view, and reset the flag then.

Unfortunately it's not possible to mutate the state during the resolution (otherwise we're back to square one), but it's possible to schedule the mutation using the $timeout angular object, with a delay of 0 (in other words, ASAP once this call stack is finished).

I don't know if there are better events to listen to, nor if there's something cleaner than this as I've never done any angular prior to this PR, so any advice welcome! However, it feels like we're trading one dirty workaround for one slightly less dirty that prevents multiple HTTP requests to be send unecessarily.

## Scroll position
Finally, because the transient `isDeepStateRedirect` flag is now accessible in the `$stateParams`, and because the scroll position was stored by caching `$stateParams`, having this flag switching states caused issue with remembering the latest scroll position. 

To me, solving this required to only pick the parameters of the state that would be serialised in a URL, and what better way to do this than actually rendering the URL? So instead of passing the whole $stateParams, I render the URL that would be used to point at this specific state, and use that URL to cache the scrolling position.

However this creates yet another problem, as the scroll service is also mutating state, and expecting the cached object to be the stateParams.

## Cleaning up
I'm removing the logic in the scroll-position service `kahuna/public/js/services/scroll-position.js` that mutated the state, as I can't see any use to that logic. It seems no matter how I arrive on the search result page, the `nonFree=false` flag is immediately set.


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
