### PR TITLE
upgrade kcl-pekko-stream to 0.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val thrall = playProject("thrall", 9002)
       // explicit dependencies on kinesis and dynamodb to upgrade the versions used by kcl
       "software.amazon.awssdk" % "kinesis" % awsSdkV2Version,
       "software.amazon.awssdk" % "dynamodb" % awsSdkV2Version,
-      "com.gu" %% "kcl-pekko-stream" % "0.1.0",
+      "com.gu" %% "kcl-pekko-stream" % "0.1.2",
       "org.testcontainers" % "elasticsearch" % "1.19.2" % Test,
       "com.google.protobuf" % "protobuf-java" % "3.19.6"
     ),


### PR DESCRIPTION
## What does this change?

Upgrades kcl-pekko-stream to 0.1.2, which includes an upgrade to the underlying kinesis-client-library to 3.4.2 which includes a bunch of dependency upgrades, as well as the fix to the issue blocking us from further rollout of v3 https://github.com/awslabs/amazon-kinesis-client/pull/1482

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
