### PR TITLE
Stop repeat AI search requests on scroll

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -48,6 +48,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
 
   val showDenySyndicationWarning: Option[Boolean] = booleanOpt("showDenySyndicationWarning")
   val showSendToPhotoSales: Option[Boolean] = booleanOpt("showSendToPhotoSales")
+  val aiSearchResultLimit: Int = intOpt("ai.search.resultLimit").getOrElse(200)
 
   val frameAncestors: Set[String] = getStringSet("security.frameAncestors")
   val connectSources: Set[String] = getStringSet("security.connectSources") ++ maybeBucketForUIUploads.map { bucket =>

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -86,6 +86,7 @@
           featureSwitches: @Html(featureSwitches),
           telemetryUri: '@kahunaConfig.telemetryUri.getOrElse("")',
           usePermissionsFilter: @kahunaConfig.usePermissionsFilter.getOrElse(false),
+          aiSearchResultLimit: @kahunaConfig.aiSearchResultLimit,
           usageRightsSummary: @kahunaConfig.usageRightsSummary.getOrElse(false),
           interimFilterOptions: @Html(interimFilterOptions),
           permissionsDefault: "@kahunaConfig.permissionsDefault",

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -75,7 +75,6 @@ function compact(array) {
 // rabbit-hole that doesn't seem to have any end. Hence this slightly
 // horrid global state.
 let lastSearchFirstResultTime;
-const aiSearchResultLimit = 200;
 
 results.controller('SearchResultsCtrl', [
     '$rootScope',
@@ -288,7 +287,7 @@ results.controller('SearchResultsCtrl', [
           // TODO: avoid this initial search (two API calls to init!)
           ctrl.searched = search(
             $stateParams.useAISearch
-              ? {offset: 0, length: aiSearchResultLimit}
+              ? {offset: 0, length: $window._clientConfig.aiSearchResultLimit}
               : {length: 1, orderBy: 'newest'}
           ).then(function(images) {
             return initialiseResults(images);

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -75,6 +75,7 @@ function compact(array) {
 // rabbit-hole that doesn't seem to have any end. Hence this slightly
 // horrid global state.
 let lastSearchFirstResultTime;
+const aiSearchResultLimit = 200;
 
 results.controller('SearchResultsCtrl', [
     '$rootScope',
@@ -229,11 +230,7 @@ results.controller('SearchResultsCtrl', [
             lastSearchFirstResultTime = undefined;
         }
 
-        // Initial search to find upper `until` boundary of result set
-        // (i.e. the uploadTime of the newest result in the set)
-
-        // TODO: avoid this initial search (two API calls to init!)
-        ctrl.searched = search({length: 1, orderBy: 'newest'}).then(function(images) {
+        function initialiseResults(images) {
             ctrl.totalResults = images.total;
             // FIXME: https://github.com/argo-rest/theseus has forced us to co-opt the actions field for this
             ctrl.tickerCounts = images.$response?.$$state?.value?.actions?.tickerCounts;
@@ -259,6 +256,15 @@ results.controller('SearchResultsCtrl', [
 
             imagesPositions = new Map();
 
+            if ($stateParams.useAISearch) {
+              images.data.forEach((image, index) => {
+                ctrl.imagesAll[index] = image;
+                imagesPositions.set(image.data.id, index);
+                results.set(index, image);
+              });
+              ctrl.images = images.data.slice(0, totalLength);
+            }
+
             checkForNewImages();
 
             // Keep track of time of the latest result for all
@@ -274,6 +280,18 @@ results.controller('SearchResultsCtrl', [
             }
 
             return images;
+          }
+
+          // Initial search to find upper `until` boundary of result set
+          // (i.e. the uploadTime of the newest result in the set)
+
+          // TODO: avoid this initial search (two API calls to init!)
+          ctrl.searched = search(
+            $stateParams.useAISearch
+              ? {offset: 0, length: aiSearchResultLimit}
+              : {length: 1, orderBy: 'newest'}
+          ).then(function(images) {
+            return initialiseResults(images);
         }).catch(error => {
             ctrl.loadingError = error;
             return $q.reject(error);
@@ -282,6 +300,10 @@ results.controller('SearchResultsCtrl', [
         });
 
         ctrl.loadRange = function(start, end) {
+            if ($stateParams.useAISearch) {
+              return;
+            }
+
             const length = end - start + 1;
             search({offset: start, length: length, countAll: false}).then(images => {
             // Update imagesAll with newly loaded images

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -289,9 +289,7 @@ results.controller('SearchResultsCtrl', [
             $stateParams.useAISearch
               ? {offset: 0, length: $window._clientConfig.aiSearchResultLimit}
               : {length: 1, orderBy: 'newest'}
-          ).then(function(images) {
-            return initialiseResults(images);
-        }).catch(error => {
+          ).then(initialiseResults).catch(error => {
             ctrl.loadingError = error;
             return $q.reject(error);
         }).finally(() => {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -229,67 +229,86 @@ results.controller('SearchResultsCtrl', [
             lastSearchFirstResultTime = undefined;
         }
 
-        function initialiseResults(images) {
-            ctrl.totalResults = images.total;
-            // FIXME: https://github.com/argo-rest/theseus has forced us to co-opt the actions field for this
-            ctrl.tickerCounts = images.$response?.$$state?.value?.actions?.tickerCounts;
+        function initialiseSharedResults(images) {
+          ctrl.totalResults = images.total;
+          // FIXME: https://github.com/argo-rest/theseus has forced us to co-opt the actions field for this
+          ctrl.tickerCounts = images.$response?.$$state?.value?.actions?.tickerCounts;
 
-            ctrl.hasQuery = !!$stateParams.query;
-            ctrl.initialSearchUri = images.uri;
-            ctrl.embeddableUrl = window.location.href;
+          ctrl.hasQuery = !!$stateParams.query;
+          ctrl.initialSearchUri = images.uri;
+          ctrl.embeddableUrl = window.location.href;
 
-            // images will be the array of loaded images, used for display
-            ctrl.images = [];
+          // images will be the array of loaded images, used for display
+          ctrl.images = [];
 
-            // imagesAll will be a sparse array of all the results
-            const totalLength = Math.min(images.total, ctrl.maxResults);
-            ctrl.imagesAll = [];
-            ctrl.imagesAll.length = totalLength;
+          imagesPositions = new Map();
 
-            // TODO: ultimately we want to manage the state in the
-            // results stream exclusively
-            results.clear();
-            results.resize(totalLength);
+          notificationMessages(ctrl.extendedSortProps, ctrl.totalResults);
+        }
 
-            notificationMessages(ctrl.extendedSortProps, images.total);
+        function initialiseAiResults(images) {
+          const totalLength = images.data.length;
+          ctrl.imagesAll = new Array(totalLength);
 
-            imagesPositions = new Map();
+          results.clear();
+          results.resize(totalLength);
 
-            if ($stateParams.useAISearch) {
-              images.data.forEach((image, index) => {
-                ctrl.imagesAll[index] = image;
-                imagesPositions.set(image.data.id, index);
-                results.set(index, image);
-              });
-              ctrl.images = images.data.slice(0, totalLength);
-            }
+          images.data.forEach((image, index) => {
+            ctrl.imagesAll[index] = image;
+            imagesPositions.set(image.data.id, index);
+            results.set(index, image);
+          });
 
-            checkForNewImages();
+          ctrl.images = images.data.slice();
+        }
 
-            // Keep track of time of the latest result for all
-            // subsequent searches (so we always query the same set of
-            // results), unless we're reloading a previous search in
-            // which case we reuse the previous time too
+        function initialisePagedResults(images) {
+          const totalLength = Math.min(images.total, ctrl.maxResults);
+          ctrl.imagesAll = [];
+          ctrl.imagesAll.length = totalLength;
 
-            const until = $stateParams.until || null;
-            const latestTime = until || moment().toISOString();
+          // TODO: ultimately we want to manage the state in the
+          // results stream exclusively
+          results.clear();
+          results.resize(totalLength);
+        }
 
-            if (latestTime && ! isReloadingPreviousSearch) {
-                lastSearchFirstResultTime = latestTime;
-            }
+        function updateLastSearchBoundary() {
+          const until = $stateParams.until || null;
+          const latestTime = until || moment().toISOString();
 
-            return images;
+          if (latestTime && ! isReloadingPreviousSearch) {
+            lastSearchFirstResultTime = latestTime;
           }
+        }
+
+        function initialiseResults(images, { isAiSearch }) {
+          initialiseSharedResults(images);
+
+          if (isAiSearch) {
+            initialiseAiResults(images);
+          } else {
+            initialisePagedResults(images);
+            checkForNewImages();
+          }
+
+          updateLastSearchBoundary();
+
+          return images;
+        }
 
           // Initial search to find upper `until` boundary of result set
           // (i.e. the uploadTime of the newest result in the set)
 
           // TODO: avoid this initial search (two API calls to init!)
-          ctrl.searched = search(
-            $stateParams.useAISearch
-              ? {offset: 0, length: $window._clientConfig.aiSearchResultLimit}
-              : {length: 1, orderBy: 'newest'}
-          ).then(initialiseResults).catch(error => {
+          const isAiSearch = !!$stateParams.useAISearch;
+          const initialSearchParams = isAiSearch
+            ? {offset: 0, length: $window._clientConfig.aiSearchResultLimit}
+            : {length: 1, orderBy: 'newest'};
+
+          ctrl.searched = search(initialSearchParams).then(images =>
+            initialiseResults(images, { isAiSearch })
+          ).catch(error => {
             ctrl.loadingError = error;
             return $q.reject(error);
         }).finally(() => {

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -250,6 +250,8 @@ results.controller('SearchResultsCtrl', [
           const totalLength = images.data.length;
           ctrl.imagesAll = new Array(totalLength);
 
+          // AI search returns a single fixed result set rather than a paged/lazy-loaded one,
+          // so we populate the full backing array up front to avoid placeholder rows.
           results.clear();
           results.resize(totalLength);
 

--- a/kahuna/public/js/window.ts
+++ b/kahuna/public/js/window.ts
@@ -8,6 +8,7 @@ declare global {
     _clientConfig: {
       rootUri: string;
       telemetryUri: string;
+      aiSearchResultLimit: number;
       featureSwitches: Array<FeatureSwitchData>;
       interimFilterOptions: Array<PermissionOption>;
       maybeOrgOwnedValue: string | undefined;

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -641,7 +641,7 @@ class MediaApi(
     }
 
     def performAiSearchAndRespond(query: String): Future[Result] = {
-      val k = 200
+      val k = config.aiSearchResultLimit
       val searchResultsFuture = parseAiSearchMode(query) match {
         case SimilarSearch(imageId) => semanticSearchByImage(imageId, k)
         case TextSearch(textQuery) => semanticSearchByText(textQuery, k)

--- a/media-api/app/lib/MediaApiConfig.scala
+++ b/media-api/app/lib/MediaApiConfig.scala
@@ -76,6 +76,7 @@ class MediaApiConfig(resources: GridConfigResources) extends CommonConfigWithEla
 
   val queueUrl: String = stringOpt("sqs.embedder.queue.url").getOrElse("")
 
+  val aiSearchResultLimit: Int = intOpt("ai.search.resultLimit").getOrElse(200)
   val aiSearchEmbeddingCacheMaxSize: Int = intOpt("ai.search.embeddingCache.maxSize").getOrElse(500)
 
   val maybeAgencyPickQuery: Option[Query] = agencyPicksIngredients.map { ingredients =>

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -187,7 +187,7 @@ class ElasticSearch(
 
     executeAndLog(withSearchQueryTimeout(searchRequest), "knn search").map { r =>
       val imageHits = r.result.hits.hits.map(resolveHit).toSeq.flatten.map(i => (i.instance.id, i))
-      SearchResults(hits = imageHits, total = r.result.totalHits, extraCounts = None)
+      SearchResults(hits = imageHits, total = imageHits.length, extraCounts = None)
     }
   }
 


### PR DESCRIPTION
## What does this change?
This PR stops repeated AI search requests from firing as users scroll through AI search results.

Although the 15-second polling path was already disabled for AI search, the search page was still issuing follow-up range requests via the lazy table as users scrolled. Because the AI search backend returns a single fixed result set, those range requests caused the same AI search to be re-run unnecessarily and led to repeated image reloads in the network panel.

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
