### PR TITLE
document stripping of timestamp param also

### DIFF
--- a/dev/imgops/nginx.conf
+++ b/dev/imgops/nginx.conf
@@ -17,8 +17,10 @@ http {
   map $no_q  $no_w { "~*^(.*)(?:(?:^|&)w=[^&]*)(.*)$" $1$2; default $no_q; }
   map $no_w  $no_h { "~*^(.*)(?:(?:^|&)h=[^&]*)(.*)$" $1$2; default $no_w; }
   map $no_h  $no_r { "~*^(.*)(?:(?:^|&)r=[^&]*)(.*)$" $1$2; default $no_h; }
+  # timestamp param is added by cropperjs for crop previews
+  map $no_r  $no_timestamp { "~*^(.*)(?:(?:^|&)r=[^&]*)(.*)$" $1$2; default $no_r; }
   # Then another pass to remove any leading, trailing or doubled '&'s
-  map $no_r $clean_leading { "~^&+(.*)" $1; default $no_r; }
+  map $no_timestamp $clean_leading { "~^&+(.*)" $1; default $no_timestamp; }
   map $clean_leading $clean_trailing { "~(.*)&+$" $1; default $clean_leading; }
   map $clean_trailing $final_clean_args { "~(?<pre>.*)&&+(?<post>.*)" "$pre&$post"; default $clean_trailing; }
 

--- a/dev/imgops/nginx.conf
+++ b/dev/imgops/nginx.conf
@@ -50,7 +50,7 @@ http {
       image_filter rotate $arg_r;
 
       # connect to the localstack docker container
-      proxy_pass http://localstack:4566$uri?final_clean_args;
+      proxy_pass http://localstack:4566$uri?$final_clean_args;
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Followup to #4634 documenting the need to also strip the timestamp param from forwarded requests from imgops.

## How should a reviewer test this change?

Documentation-only PR. This change was applied to our running imgops services in https://github.com/guardian/editorial-tools-platform/pull/1053

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
