### PR TITLE
quota parsing survives stringy formatted usage counts

### DIFF
--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -108,7 +108,7 @@ object UsageStore extends GridLogging {
       case Some("Cpro Name" :: "Id" :: Nil) =>
         lines.tail.map {
           case supplier :: count :: Nil =>
-            SupplierUsageSummary(Agency(supplier), count.toInt)
+            SupplierUsageSummary(Agency(supplier), count.replaceAll(",", "").toInt)
 
           case _ =>
             logger.error("CSV body error. Expected 2 columns")


### PR DESCRIPTION
## What does this change?

Sometimes usage counts arrive to us with thousands formatted with commas, like "1,234". This breaks `.toInt` conversions. Strip away the commas before converting so it keeps working, whether the count is formatted or not.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
