### PR TITLE
upgrade panda to latest; partially switching to s3 sdk v2

### DIFF
--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -34,10 +34,13 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
 
   def cookieMonster = auth { request =>
     providers.userProvider match {
-      case panda: PandaAuthenticationProvider =>{
-        val cookieBatter = panda.readAuthenticatedUser(request).map(user => panda.generateCookie(user.copy(expires = Instant.now())))
+      case panda: PandaAuthenticationProvider =>
+        val cookieBatter = panda.readAuthenticatedUser(request)
+          // Note the cookie monster does not expire the cookie itself, but instead expires the panda token stored
+          // by the cookie. The cookie will remain in the browser storage, but if decoded will declare that it expired
+          // at the epoch in 1970.
+          .map(user => panda.generateCookie(user.copy(expires = Instant.ofEpochMilli(0L))))
         cookieBatter.fold(respond("Me want cookie."))(cookie => respond("Cookies are a sometimes food.").withCookies(cookie))
-      }
       case _ => respond("Me want cookie.")
     }
   }

--- a/auth/app/auth/AuthController.scala
+++ b/auth/app/auth/AuthController.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{BaseController, ControllerComponents, Result}
 
 import java.net.URI
-import java.util.Date
+import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -35,7 +35,7 @@ class AuthController(auth: Authentication, providers: AuthenticationProviders, v
   def cookieMonster = auth { request =>
     providers.userProvider match {
       case panda: PandaAuthenticationProvider =>{
-        val cookieBatter = panda.readAuthenticatedUser(request).map(user => panda.generateCookie(user.copy(expires = new Date().getTime)))
+        val cookieBatter = panda.readAuthenticatedUser(request).map(user => panda.generateCookie(user.copy(expires = Instant.now())))
         cookieBatter.fold(respond("Me want cookie."))(cookie => respond("Cookies are a sometimes food.").withCookies(cookie))
       }
       case _ => respond("Me want cookie.")

--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ val maybeBBCLib: Option[sbt.ProjectReference] = if(bbcBuildProcess) Some(bbcProj
 lazy val commonLib = project("common-lib").settings(
   libraryDependencies ++= Seq(
     "com.gu" %% "editorial-permissions-client" % "4.0.0",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "9.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "19.0.0",
     "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
@@ -100,6 +100,7 @@ lazy val commonLib = project("common-lib").settings(
     "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
+    "software.amazon.awssdk" % "s3" % awsSdkV2Version,
     "nl.gn0s1s" %% "elastic4s-core" % elastic4sVersion,
     "nl.gn0s1s" %% "elastic4s-client-esjava" % elastic4sVersion,
     "nl.gn0s1s" %% "elastic4s-domain" % elastic4sVersion,

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/S3.scala
@@ -1,6 +1,6 @@
 package com.gu.mediaservice.lib.aws
 
-import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.model.{Region => _, _}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, model}
 import com.amazonaws.util.IOUtils
 import com.amazonaws.{AmazonServiceException, ClientConfiguration}
@@ -8,6 +8,8 @@ import com.gu.mediaservice.lib.config.CommonConfig
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, Stopwatch}
 import com.gu.mediaservice.model._
 import org.joda.time.{DateTime, Duration}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
 
 import java.io.File
 import java.net.URI
@@ -185,5 +187,15 @@ object S3Ops {
     }
 
     config.withAWSCredentials(builder, localstackAware, maybeRegionOverride).build()
+  }
+
+  def buildS3ClientV2(config: CommonConfig, localstackAware: Boolean = true, maybeRegionOverride: Option[Region] = None): S3Client = {
+    val builder = config.awsLocalEndpoint match {
+      case Some(_) if config.isDev =>
+        S3Client.builder().forcePathStyle(true)
+      case _ => S3Client.builder()
+    }
+
+    config.withAWSCredentialsV2(builder, localstackAware, maybeRegionOverride).build()
   }
 }

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProvider.scala
@@ -2,7 +2,7 @@ package com.gu.mediaservice.lib.guardian.auth
 
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.argo.model.Link
-import com.gu.mediaservice.lib.auth.Authentication.{UserPrincipal, Principal}
+import com.gu.mediaservice.lib.auth.Authentication.{Principal, UserPrincipal}
 import com.gu.mediaservice.lib.auth.provider.AuthenticationProvider.RedirectUri
 import com.gu.mediaservice.lib.auth.provider._
 import com.gu.mediaservice.lib.aws.S3Ops
@@ -17,7 +17,6 @@ import play.api.libs.typedmap.{TypedEntry, TypedKey, TypedMap}
 import play.api.libs.ws.{DefaultWSCookie, WSClient, WSRequest}
 import play.api.mvc.{ControllerComponents, Cookie, RequestHeader, Result}
 
-import scala.concurrent.duration.{Duration, HOURS}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -33,8 +32,6 @@ class PandaAuthenticationProvider(
   override lazy val panDomainSettings: PanDomainAuthSettingsRefresher = buildPandaSettings()
   override def wsClient: WSClient = resources.wsClient
   override def controllerComponents: ControllerComponents = resources.controllerComponents
-
-  override def apiGracePeriod: Long = Duration(24, HOURS).toMillis
 
   val loginLinks = List(
     Link("login", resources.commonConfig.services.loginUriTemplate)
@@ -150,7 +147,7 @@ class PandaAuthenticationProvider(
       system = providerConfiguration.getOptional[String]("panda.system").getOrElse("media-service"),
       bucketName = providerConfiguration.getOptional[String]("panda.bucketName").getOrElse("pan-domain-auth-settings"),
       settingsFileKey = providerConfiguration.getOptional[String]("panda.settingsFileKey").getOrElse(s"$domain.settings"),
-      s3Client = S3Ops.buildS3Client(resources.commonConfig, localstackAware=resources.commonConfig.useLocalAuth)
+      s3Client = S3Ops.buildS3ClientV2(resources.commonConfig, localstackAware=resources.commonConfig.useLocalAuth)
     )
   }
 

--- a/rest-lib/src/test/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProviderTest.scala
+++ b/rest-lib/src/test/scala/com/gu/mediaservice/lib/guardian/auth/PandaAuthenticationProviderTest.scala
@@ -10,7 +10,7 @@ class PandaAuthenticationProviderTest extends AnyFunSuite with Matchers {
   import com.gu.mediaservice.lib.guardian.auth.PandaAuthenticationProvider.validateUser
 
   val user: AuthenticatedUser = AuthenticatedUser(User("Barry", "Chuckle", "barry.chuckle@guardian.co.uk", None),
-    "media-service", Set("media-service"), Instant.now().plusSeconds(100).toEpochMilli, multiFactor = true)
+    "media-service", Set("media-service"), Instant.now().plusSeconds(100), multiFactor = true)
 
   test("user fails email domain validation") {
     validateUser(user, "chucklevision.biz", None) must be(false)


### PR DESCRIPTION
## What does this change?

Upgrade pan-domain-auth to latest version, which requires partially switching to the v2 s3 sdk.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
