### PR TITLE
AP Photo quickfix

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -275,7 +275,7 @@ object ApParser extends ImageProcessor {
   }
 
   def apply(image: Image): Image = image.metadata.credit.map(_.toLowerCase) match {
-    case Some("ap") | Some("associated press") => image.copy(
+    case Some("ap") | Some("ap photo") | Some("associated press") => image.copy(
       usageRights = Agency("AP"),
       metadata    = image.metadata.copy(credit = Some("AP"), suppliersReference = getSuppliersReference(image))
     )


### PR DESCRIPTION
Our friends changed how they credit images. It’s better now. And we were warned. Slightly late and without examples, but still. This is a quick fix for first party AP images. By my rough calculation this (`search?query=uploader:ap credit:"AP Photo"`) is gonna fix two thirds of images. For the remaining on third (`search?query=uploader:ap -credit:"AP Photo"`), the proper fix is this https://github.com/guardian/grid/pull/4664. Yes, that proper fix can be stripped down, most probably. But I’m not gonna be the one doing that, no Sir, because I don’t think that would be correct. 😛

## Who should look at this?
@guardian/newsroom-resilience 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)