### PR TITLE
Match on AP intermediaries, retain them in Credit and write them into Supplier Collection

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -265,7 +265,7 @@ trait CanonicalisingImageProcessor extends ImageProcessor {
 
 object ApParser extends ImageProcessor {
   val InvisionFor = "^invision for (.+)".r
-  val PersonInvisionAp = "(.+)\\s*/invision/ap$".r
+  val IntermediaryAp = "(.+)/ap$".r
 
   def getSuppliersReference(image: Image) = {
     image.fileMetadata.readXmpHeadStringProp("plus:ImageSupplierImageID").orElse(image.metadata.suppliersReference)
@@ -280,10 +280,19 @@ object ApParser extends ImageProcessor {
       metadata    = image.metadata.copy(credit = Some("AP"), suppliersReference = getSuppliersReference(image))
     )
     case Some("invision") | Some("invision/ap") |
-         Some(InvisionFor(_)) | Some(PersonInvisionAp(_)) => image.copy(
+         Some(InvisionFor(_)) => image.copy(
       usageRights = Agency("AP", Some("Invision")),
       metadata = image.metadata.copy(suppliersReference = getSuppliersReference(image))
     )
+    case Some(IntermediaryAp(_)) =>
+      val collection = image.metadata.credit.map(c => c.replaceAll("(?i)/ap$", ""))
+      image.copy(
+        usageRights = Agency("AP", collection),
+        metadata    = image.metadata.copy(
+          credit = image.metadata.credit.map(c => c.replaceAll("(?i)/ap$", "/AP")),
+          suppliersReference = getSuppliersReference(image)
+        )
+      )
     case _ => image
   }
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -300,6 +300,41 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       processedImage.usageRights should be(Agency("AP", Some("Lehtikuva")))
       processedImage.metadata.credit should be(Some("Lehtikuva/AP"))
     }
+
+    it("should match intermediary/ap credit, capitalising AP") {
+      val image = createImageFromMetadata("credit" -> "Lehtikuva/ap")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("AP", Some("Lehtikuva")))
+      processedImage.metadata.credit should be(Some("Lehtikuva/AP"))
+    }
+
+    it("should match ABC/NYT/AP credit") {
+      val image = createImageFromMetadata("credit" -> "ABC/NYT/AP")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("AP", Some("ABC/NYT")))
+      processedImage.metadata.credit should be(Some("ABC/NYT/AP"))
+    }
+
+    it("should not match 'ABC/NYT/AP AP' credit") {
+      val image = createImageFromMetadata("credit" -> "ABC/NYT/AP AP")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(NoRights)
+      processedImage.metadata.credit should be(Some("ABC/NYT/AP AP"))
+    }
+
+    it("should not match 'ABC/Associated Press', because we don't think we get those") {
+      val image = createImageFromMetadata("credit" -> "ABC/Associated Press")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(NoRights)
+      processedImage.metadata.credit should be(Some("ABC/Associated Press"))
+    }
+
+    it("should still cover the case of 'Photographer /Invision/AP', which had its own special case before") {
+      val image = createImageFromMetadata("credit" -> "Photographer /Invision/AP")
+      val processedImage = applyProcessors(image)
+      processedImage.usageRights should be(Agency("AP", Some("Photographer /Invision")))
+      processedImage.metadata.credit should be(Some("Photographer /Invision/AP"))
+    }
   }
 
 

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -294,11 +294,11 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       processedImage.metadata.credit should be(Some("Invision for Quaker"))
     }
 
-    it("should match __/Invision/AP credit") {
-      val image = createImageFromMetadata("credit" -> "Andy Kropa /Invision/AP")
+    it("should match intermediary/AP credit") {
+      val image = createImageFromMetadata("credit" -> "Lehtikuva/AP")
       val processedImage = applyProcessors(image)
-      processedImage.usageRights should be(Agency("AP", Some("Invision")))
-      processedImage.metadata.credit should be(Some("Andy Kropa /Invision/AP"))
+      processedImage.usageRights should be(Agency("AP", Some("Lehtikuva")))
+      processedImage.metadata.credit should be(Some("Lehtikuva/AP"))
     }
   }
 


### PR DESCRIPTION
Co-authored by Claude Opus 4.6. Description written by a human, 48.

## What does this change?

This is a followup to https://github.com/guardian/grid/pull/4741. It:
- matches on `…/AP` credits, writing prefixes into Supplier Collection and retaining original Credit line
- removes redundant Invision-specific matcher
- removes outdated test that can’t happen now we have BylineCreditReorganiser (and other) cleaners

Worth noting that it will retain some credits we will want to clean more. Mostly, [the ones mentioning](https://github.com/guardian/grid/pull/4664/changes#diff-6d6e6afcd0775239dd031cd304fd26386c13a76f384ee798bf32f5d80821b074R344-R346) `Pool` in all sorts of combinations, but also some other [redundant or ugly things](https://github.com/guardian/grid/pull/4664/changes#diff-6d6e6afcd0775239dd031cd304fd26386c13a76f384ee798bf32f5d80821b074R306-R341). Proper fix from [here](https://github.com/guardian/grid/pull/4664) will clean them better (and remove redundant Description blobs too).

## How can success be measured?

AP images from third-party intermediaries are recognised correctly

## Who should look at this?
@guardian/newsroom-resilience 

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
