### PR TITLE
only set Photographer usage rights if no other processor has set usage rights first

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -22,9 +22,9 @@ class SupplierProcessors(resources: ImageProcessorResources)
     ReutersParser,
     RexParser,
     RonaldGrantParser,
-    new PhotographerParser(resources.commonConfiguration.usageRightsConfig),
     AllstarSportsphotoParser,
     AllStarParser,
+    new PhotographerParser(resources.commonConfiguration.usageRightsConfig),
     UsageRightsToMetadataParser(resources) //This should come after processors that assign usage rights
   )
 
@@ -52,21 +52,24 @@ case class UsageRightsToMetadataParser(resources: ImageProcessorResources) exten
   * Guardian specific logic to correctly identify Guardian and Observer photographers and their contracts
   */
 class PhotographerParser(photographersConfig: UsageRightsConfigProvider) extends ImageProcessor {
-  def apply(image: Image): Image = {
-    image.metadata.byline.flatMap { byline =>
-      photographersConfig.getPhotographer(byline, image.metadata.dateTaken.getOrElse(image.uploadTime)).map{
-        case p: StaffPhotographer => image.copy(
-          usageRights = p,
-          metadata    = image.metadata.copy(credit = Some(p.publication), byline = Some(p.photographer))
-        )
-        case p: ContractPhotographer => image.copy(
-          usageRights = p,
-          metadata    = image.metadata.copy(credit = p.publication, byline = Some(p.photographer))
-        )
-        case _ => image
-      }
-    }
-  }.getOrElse(image)
+  def apply(image: Image): Image = image.usageRights match {
+    // only attempt to set Photographer Usagerights if no other processor has already set usage rights
+    case NoRights =>
+      image.metadata.byline.flatMap { byline =>
+        photographersConfig.getPhotographer(byline, image.metadata.dateTaken.getOrElse(image.uploadTime)).map{
+          case p: StaffPhotographer => image.copy(
+            usageRights = p,
+            metadata    = image.metadata.copy(credit = Some(p.publication), byline = Some(p.photographer))
+          )
+          case p: ContractPhotographer => image.copy(
+            usageRights = p,
+            metadata    = image.metadata.copy(credit = p.publication, byline = Some(p.photographer))
+          )
+          case _ => image
+        }
+      }.getOrElse(image)
+    case _ => image
+  }
 }
 
 object AapParser extends ImageProcessor {

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessorsTest.scala
@@ -68,6 +68,18 @@ class SupplierProcessorsTest extends AnyFunSpec with Matchers with MetadataHelpe
       processedImage.usageRights should be(ContractPhotographer("Murdo MacLeod", Option("The Guardian")))
       processedImage.metadata.byline should be(Some("Murdo MacLeod"))
     }
+
+    it("should only assign Photographer rights if agency rights not already assigned") {
+      val image = createImageFromMetadata(
+        "byline" -> "Murdo MacLeod",
+        "credit" -> "PA Wire/PA Images"
+      )
+      val processedImage = applyProcessors(image)
+      // UsageRights assigned to PA agency rather than ContractPhotographer("Murdo MacLeod") as PA
+      // runs first, and Staff/ContractPhotographer only assign rights if nothing else has first.
+      processedImage.usageRights should be(Agency("PA"))
+      processedImage.metadata.byline should be(Some("Murdo MacLeod"))
+    }
   }
 
   describe("AAP") {


### PR DESCRIPTION

## What does this change?

Sometimes staff or contract photographers will also work or send shots through agencies. The Photographer parser is at the end of the list, so overwrites the changes made by the earlier parsers. We've thought about it, and it makes sense for the Photographer parser to only set usage rights and metadata on the image if it's the final parser, and no other parser has detected anything and set any usage rights.

## How should a reviewer test this change?

Find an image with a byline of a staff photographer, but also has agency metadata (from Getty, or AP, etc.) Before this change, the image would be assigned Staff photographer rights and be credited to The Guardian incorrectly. Afterwards, it should be assigned Agency rights and the correct credit string given.

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215293755029218