### PR TITLE
Use `List[Double]` everywhere for Cohere v4 embeddings

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Bedrock.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Bedrock.scala
@@ -76,14 +76,14 @@ class Bedrock(config: CommonConfig)
     }
   }
 
-  def createTextEmbedding(inputData: String)(implicit ec: ExecutionContext, logMarker: LogMarker): Future[List[Float]] = {
+  def createTextEmbedding(inputData: String)(implicit ec: ExecutionContext, logMarker: LogMarker): Future[List[Double]] = {
     val requestBody = createRequestBody(inputData)
     val bedrockFuture = Future { sendBedrockEmbeddingRequest(requestBody) }
     bedrockFuture.map { response =>
       val responseBody = response.body().asUtf8String()
       val json = Json.parse(responseBody)
       // Extract the embedding array (first element since it's an array of arrays)
-      val embedding = (json \ "embeddings" \ "float")(0).as[List[Float]]
+      val embedding = (json \ "embeddings" \ "float")(0).as[List[Double]]
       logger.info(
         logMarker,
         s"Successfully extracted text embedding. Vector size: ${embedding.size}"

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Embedder.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/aws/Embedder.scala
@@ -18,7 +18,7 @@ object EmbedderMessage {
 
 class Embedder(bedrock: Bedrock, sqs: SimpleSqsMessageConsumer)(implicit ec: ExecutionContext) extends GridLogging {
 
-  def createQueryEmbedding(query: String)(implicit logMarker: LogMarker): Future[List[Float]] = {
+  def createQueryEmbedding(query: String)(implicit logMarker: LogMarker): Future[List[Double]] = {
     logger.info(logMarker, s"Creating text embedding for query: $query")
     for {
       embedding <- bedrock.createTextEmbedding(query)

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -55,7 +55,7 @@ class MediaApi(
   // Process-local cache keyed on normalised query text. Stores the Bedrock Future so that
   // concurrent requests for the same query share a single in-flight Bedrock call, and
   // subsequent requests within the TTL window skip Bedrock entirely.
-  private val embeddingCache: AsyncLoadingCache[String, List[Float]] = Scaffeine()
+  private val embeddingCache: AsyncLoadingCache[String, List[Double]] = Scaffeine()
     .maximumSize(config.aiSearchEmbeddingCacheMaxSize)
     .buildAsyncFuture((normQuery: String) =>
       embedder.createQueryEmbedding(normQuery)(MarkerMap())
@@ -621,7 +621,7 @@ class MediaApi(
           .filter(image => isVisibleToAccessor(request.user, image))
           .flatMap(_.embedding)
           .flatMap(_.cohereEmbedV4)
-          .map(_.image.map(_.toFloat))
+          .map(_.image)
         searchResults <- maybeEmbedding match {
           // If we have an embedding, perform the KNN search. If not, return an empty result set.
           case Some(embedding) =>

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -179,14 +179,14 @@ class ElasticSearch(
       }
   }
 
-  def knnSearch(queryEmbedding: List[Float], k: Int, numCandidates: Int, filterOpt: Option[Query])
+  def knnSearch(queryEmbedding: List[Double], k: Int, numCandidates: Int, filterOpt: Option[Query])
                (implicit ex: ExecutionContext, logMarker: LogMarker): Future[SearchResults] = {
     if (!includeDenseVectorMappings) {
       logger.warn(logMarker, "knnSearch called but includeDenseVectorMappings=false, returning empty results")
       Future.successful(SearchResults(Nil, total = 0, extraCounts = None))
     } else {
       val knn = Knn("embedding.cohereEmbedV4.image", filter = filterOpt)
-        .queryVector(queryEmbedding.map(_.toDouble))
+        .queryVector(queryEmbedding)
         .k(k)
         .numCandidates(numCandidates)
 
@@ -268,7 +268,7 @@ class ElasticSearch(
 
   def hybridSearch(
     query: String,
-    queryEmbedding: List[Float],
+    queryEmbedding: List[Double],
     k: Int,
     numCandidates: Int,
     vecWeight: Double,
@@ -281,11 +281,9 @@ class ElasticSearch(
       logger.warn(logMarker, "hybridSearch called but includeDenseVectorMappings=false, returning empty results")
       Future.successful(SearchResults(Nil, total = 0, extraCounts = None))
     } else {
-      val queryEmbeddingDouble: List[Double] = queryEmbedding.map(_.toDouble)
-
       for {
         maxScore <- fetchMaxBm25Score(query, filterOpt)
-        searchRequest = makeHybridSearchRequest(query, queryEmbeddingDouble, k, numCandidates, vecWeight, maxScore, filterOpt)
+        searchRequest = makeHybridSearchRequest(query, queryEmbedding, k, numCandidates, vecWeight, maxScore, filterOpt)
         result <- executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid search")
       } yield {
         val imageHits = result.result.hits.hits.map(resolveHit).toSeq.flatten.map(i => (i.instance.id, i))


### PR DESCRIPTION
On the query side we've been parsing our vector as `List[Float]`, whereas on the image vector side we parse as `List[Double]` when it comes out of elasticsearch.

In both cases they are Cohere v4 embeddings, embedded via Bedrock, so we should be consistent and save ourselves some pointless conversions.

Of course, once they go into elasticsearch they get heavily quantised so it's unlikely we're gaining any actual precision by passing around `Double` instead of `Float`, but let's go consistent on `Double` rather than `Float` because:

- In JSON all numbers are double-precision floats so when we serialise for Thrall we're sending doubles
- In elastic4s it wants a `Double` for the `queryVector` when we do KNN queries
- in fact in Cohere's OpenAPI spec they describe the embedding type `float` as actually `double`: https://docs.cohere.com/reference/embed.md