### PR TITLE
Add GNM-owned, agency picks and filtered matches to AI search

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -22,7 +22,8 @@
 
             <div class="results-toolbar-item results-toolbar-item--static
                     image-results-count">
-                {{ctrl.totalResults | toLocaleString}} matches
+                <span ng-if="ctrl.isAiSearch">Best {{ctrl.aiResultsShown | toLocaleString}} of {{ctrl.totalResults | toLocaleString}} matches</span>
+                <span ng-if="! ctrl.isAiSearch">{{ctrl.totalResults | toLocaleString}} matches</span>
                 <button ng-if="ctrl.newImagesCount > 0"
                         ng-click="ctrl.revealNewImages()"
                         class="image-results-count__new"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -248,6 +248,9 @@ results.controller('SearchResultsCtrl', [
         function initialiseAiResults(images) {
           const totalLength = images.data.length;
           ctrl.imagesAll = new Array(totalLength);
+          // Number of results actually shown (the top k), so we can display
+          // "Best k of N matches" where N is ctrl.totalResults.
+          ctrl.aiResultsShown = totalLength;
 
           // AI search returns a single fixed result set rather than a paged/lazy-loaded one,
           // so we populate the full backing array up front to avoid placeholder rows.
@@ -292,6 +295,8 @@ results.controller('SearchResultsCtrl', [
             initialisePagedResults(images);
             checkForNewImages();
           }
+
+          ctrl.isAiSearch = isAiSearch;
 
           updateLastSearchBoundary();
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -611,7 +611,7 @@ class MediaApi(
         data = imageEntities,
         offset = Some(0),
         total = Some(searchResults.total),
-        maybeExtraCounts = None,
+        maybeExtraCounts = searchResults.extraCounts,
         links = Nil
       )
     }

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -341,12 +341,45 @@ class ElasticSearch(
         case _ => fusedLexicalAndSemanticSearch(query, queryEmbedding, k, numCandidates, vecWeight, filterOpt)
       }
 
-      searchResults.andThen { case _ =>
+      // Run in parallel: how many images match the filters in total (so we can
+      // show "Best k of N matches"). The ticker count badges are computed over
+      // the top-k results we actually return, not the whole filtered set.
+      val filterTotal = countMatchingFilter(filterOpt)
+
+      (for {
+        results <- searchResults
+        total <- filterTotal
+        extraCounts <- extraCountsForIds(results.hits.map(_._1))
+      } yield results.copy(total = total, extraCounts = Some(extraCounts))).andThen { case _ =>
         val elapsed = stopwatch.elapsed
         logger.info(
           combineMarkers(logMarker, elapsed),
           s"Hybrid AI search completed in ${elapsed.toMillis} ms"
         )
+      }
+    }
+  }
+
+  // How many images match the active filters in total, so we can show
+  // "Best k of N matches".
+  private def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
+    val searchRequest = prepareSearch(filterOpt.getOrElse(matchAllQuery()))
+      .trackTotalHits(true)
+      .size(0)
+
+    executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid AI search filter count").map(_.result.totalHits)
+  }
+
+  // The ticker count badges restricted to the given (top-k) result ids.
+  private def extraCountsForIds(ids: Seq[String])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[ExtraCounts] = {
+    if (ids.isEmpty) Future.successful(ExtraCounts(tickerCounts = Map.empty))
+    else {
+      val searchRequest = prepareSearch(filters.ids(ids.toList))
+        .size(0)
+        .aggregations(extraCountAggregations)
+
+      executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid AI search ticker counts").map { r =>
+        extraCountsFrom(r.result.aggregations)
       }
     }
   }
@@ -391,10 +424,7 @@ class ElasticSearch(
       .runtimeMappings(runtimeMappings)
       .storedFields("_source") // this needs to be explicit when using script fields
       .scriptfields(graphicImagesScriptFields)
-      .aggregations(aggregationsNameToSearchClauseMap.map {
-        case (name, ExtraCountConfig(searchClause, _, maybeSubAggregation)) =>
-          filterAgg(name, queryBuilder.makeQuery(Parser.run(searchClause))).subAggregations(maybeSubAggregation)
-      })
+      .aggregations(extraCountAggregations)
       .from(params.offset)
       .size(params.length)
       .sortBy(sort)
@@ -408,26 +438,35 @@ class ElasticSearch(
       SearchResults(
         hits = imageHits,
         total = if (trackTotalHits) r.result.totalHits else 0,
-        extraCounts = Some(ExtraCounts(
-          tickerCounts = aggregationsNameToSearchClauseMap.map {
-            case (name, ExtraCountConfig(searchClause, backgroundColour, maybeSubAggregation)) =>
-              val aggResult = r.result.aggregations.filter(name)
-              val maybeSubAggResult = maybeSubAggregation.map(_.name).map(aggResult.result[Terms])
-              name -> ExtraCount(
-                value = aggResult.docCount,
-                searchClause,
-                backgroundColour,
-                subCounts = maybeSubAggResult.map { termsAgg =>
-                  ListMap(termsAgg.buckets.sortBy(_.docCount).reverse.map { bucket =>
-                    (bucket.key, bucket.docCount)
-                  }: _*) + ("other" -> termsAgg.otherDocCount)
-                }.filter(_.exists { case (_, count) => count > 0 })
-              )
-          }
-        ))
+        extraCounts = Some(extraCountsFrom(r.result.aggregations))
       )
     }
   }
+
+  // The aggregations used to compute the ticker count badges ("GNM-owned",
+  // "agency picks" etc) shown above search results.
+  private def extraCountAggregations = aggregationsNameToSearchClauseMap.map {
+    case (name, ExtraCountConfig(searchClause, _, maybeSubAggregation)) =>
+      filterAgg(name, queryBuilder.makeQuery(Parser.run(searchClause))).subAggregations(maybeSubAggregation)
+  }
+
+  private def extraCountsFrom(aggregations: Aggregations): ExtraCounts = ExtraCounts(
+    tickerCounts = aggregationsNameToSearchClauseMap.map {
+      case (name, ExtraCountConfig(searchClause, backgroundColour, maybeSubAggregation)) =>
+        val aggResult = aggregations.filter(name)
+        val maybeSubAggResult = maybeSubAggregation.map(_.name).map(aggResult.result[Terms])
+        name -> ExtraCount(
+          value = aggResult.docCount,
+          searchClause,
+          backgroundColour,
+          subCounts = maybeSubAggResult.map { termsAgg =>
+            ListMap(termsAgg.buckets.sortBy(_.docCount).reverse.map { bucket =>
+              (bucket.key, bucket.docCount)
+            }: _*) + ("other" -> termsAgg.otherDocCount)
+          }.filter(_.exists { case (_, count) => count > 0 })
+        )
+    }
+  )
 
   def usageForSupplier(id: String, numDays: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[SupplierUsageSummary] = {
     val supplier = Agencies.get(id)

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -369,6 +369,9 @@ class ElasticSearch(
   }
 
   // The ticker count badges restricted to the given (top-k) result ids.
+  // In principle, we could compute this here, without an extra request.
+  // But it would require awkward duplication of the search logic
+  // from `maybeOrgOwnedExtraCount` and `maybeAgencyPicksExtraCount`
   private def extraCountsForIds(ids: Seq[String])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[ExtraCounts] = {
     if (ids.isEmpty) Future.successful(ExtraCounts(tickerCounts = Map.empty))
     else {

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -363,18 +363,17 @@ class ElasticSearch(
   // How many images match the active filters in total, so we can show
   // "Best k of N matches".
   private def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
-    val searchRequest = prepareSearch(filterOpt.getOrElse(matchAllQuery()))
-      .trackTotalHits(true)
-      .size(0)
+    val countRequest = ElasticDsl.count(imagesCurrentAlias).query(filterOpt.getOrElse(matchAllQuery()))
 
-    executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid AI search filter count").map(_.result.totalHits)
+    executeAndLog(countRequest, "hybrid AI search filter count").map(_.result.count)
   }
 
   // The ticker count badges restricted to the given (top-k) result ids.
   private def extraCountsForIds(ids: Seq[String])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[ExtraCounts] = {
     if (ids.isEmpty) Future.successful(ExtraCounts(tickerCounts = Map.empty))
     else {
-      val searchRequest = prepareSearch(filters.ids(ids.toList))
+      val searchRequest = ElasticDsl.search(imagesCurrentAlias)
+        .query(filters.ids(ids.toList))
         .size(0)
         .aggregations(extraCountAggregations)
 


### PR DESCRIPTION
<img width="560" height="92" alt="Screenshot 2026-06-29 at 12 12 10" src="https://github.com/user-attachments/assets/e5f9b898-08c1-4af2-ac2b-9df499331a3e" />
<img width="560" height="92" alt="Screenshot 2026-06-29 at 12 12 55" src="https://github.com/user-attachments/assets/1ebbbbb9-4e04-4381-b155-d6604ff898e5" />


Unfortunately we need extra queries to achieve this. We cannot simply add an `aggregations` clause to an existing query, primarily because the final result set isn't actually the result of a query, it's the result of a clientside merge. Even if we could do aggregations on the individual queries, we wouldn't know which results contributed to the count and therefore couldn't preserve the information on de-duplication.

For GNM-owned and agency picks, an alternative approach could be to compute them in a script field like `isPotentiallyGraphic` and do all the aggregation in Scala. This _might_ also mean you could get rid of the duplication of logic clientside, e.g. https://github.com/guardian/grid/blob/main/kahuna/public/js/services/image-logic.js#L47-L58. I feel like this would be significant change though and would only be a win if you could consolidate the logic for these in one place.

Meanwhile for the "x matches" in "best k of x matches", aggregations are always computed over the matched documents, e.g. over the `k` for `knn` or over the BM25 matches for the lexical query. This means it would never give you true background filtered count over which your main query was running.

Extra queries shouldn't add too much latency because
- both of them are size=0, we just want the aggregation counts
- one of them is constrained to just `k` ids
- one of them can be run in parallel with existing queries

and indeed they seem to be well under 100ms in TEST

<img width="1110" height="518" alt="Screenshot 2026-06-29 at 17 31 22" src="https://github.com/user-attachments/assets/c65e6374-dbef-411b-bb1d-6c4ef0047336" />
