### PR TITLE
Calculate aggregations against the full filtered set, not top k

### DIFF
--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -342,14 +342,13 @@ class ElasticSearch(
       }
 
       // Run in parallel: how many images match the filters in total (so we can
-      // show "Best k of N matches"). The ticker count badges are computed over
-      // the top-k results we actually return, not the whole filtered set.
-      val filterTotal = countMatchingFilter(filterOpt)
+      // show "Best k of N matches") along with the ticker count badges, both
+      // computed over the whole filtered set.
+      val filterTotalAndCounts = countMatchingFilterWithExtraCounts(filterOpt)
 
       (for {
         results <- searchResults
-        total <- filterTotal
-        extraCounts <- extraCountsForIds(results.hits.map(_._1))
+        (total, extraCounts) <- filterTotalAndCounts
       } yield results.copy(total = total, extraCounts = Some(extraCounts))).andThen { case _ =>
         val elapsed = stopwatch.elapsed
         logger.info(
@@ -360,29 +359,18 @@ class ElasticSearch(
     }
   }
 
-  // How many images match the active filters in total, so we can show
-  // "Best k of N matches".
-  private def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
-    val countRequest = ElasticDsl.count(imagesCurrentAlias).query(filterOpt.getOrElse(matchAllQuery()))
+  // How many images match the active filters in total (so we can show
+  // "Best k of N matches") along with the ticker count badges, both computed
+  // over the whole filtered set in a single request.
+  private def countMatchingFilterWithExtraCounts(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[(Long, ExtraCounts)] = {
+    val searchRequest = ElasticDsl.search(imagesCurrentAlias)
+      .query(filterOpt.getOrElse(matchAllQuery()))
+      .trackTotalHits(true)
+      .size(0)
+      .aggregations(extraCountAggregations)
 
-    executeAndLog(countRequest, "hybrid AI search filter count").map(_.result.count)
-  }
-
-  // The ticker count badges restricted to the given (top-k) result ids.
-  // In principle, we could compute this here, without an extra request.
-  // But it would require awkward duplication of the search logic
-  // from `maybeOrgOwnedExtraCount` and `maybeAgencyPicksExtraCount`
-  private def extraCountsForIds(ids: Seq[String])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[ExtraCounts] = {
-    if (ids.isEmpty) Future.successful(ExtraCounts(tickerCounts = Map.empty))
-    else {
-      val searchRequest = ElasticDsl.search(imagesCurrentAlias)
-        .query(filters.ids(ids.toList))
-        .size(0)
-        .aggregations(extraCountAggregations)
-
-      executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid AI search ticker counts").map { r =>
-        extraCountsFrom(r.result.aggregations)
-      }
+    executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid AI search filter count and ticker counts").map { r =>
+      (r.result.totalHits, extraCountsFrom(r.result.aggregations))
     }
   }
 


### PR DESCRIPTION
# before
GNM-owned and agency picks were out of the top k, to reflect how many you'd actually see if you scrolled through your 200 results on screen.

<img width="582" height="385" alt="Screenshot 2026-07-01 at 12 42 49" src="https://github.com/user-attachments/assets/9bf567d9-72bf-448e-9136-e032c765256a" />

However, this meant that if you clicked on the badge to filter, you would see something very surprising: a pre-filter by GNM-owned, suddenly giving you 200 GNM-owned results when you thought you only had 2!

<img width="582" height="385" alt="Screenshot 2026-07-01 at 12 42 57" src="https://github.com/user-attachments/assets/0a4d073a-ea50-4d64-b8d0-a0d7c93da4b8" />

# after
@andrew-nowak suggested we just make the aggregations over the filtered set, not top k. This is great because it lets us delete a whole query.

It also means the journey when clicking is coherent: your "4,696 GNM-"owned becomes the "4,696 matches" on the next page

<img width="582" height="385" alt="Screenshot 2026-07-01 at 12 41 39" src="https://github.com/user-attachments/assets/01322f8a-9ea5-4bdd-afb0-a43f037208d8" />

<img width="582" height="385" alt="Screenshot 2026-07-01 at 12 41 49" src="https://github.com/user-attachments/assets/42f1cefe-f01e-4cd2-9d9b-bb7fa1055d8c" />
