### PR TITLE
remove use in use AI search

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -4,7 +4,7 @@
         <label>
             <input type="checkbox"
                    ng-model="searchQuery.useAISearch"/>
-            Use AI search
+            AI search
         </label>
     </span>
     <span class="search-query">


### PR DESCRIPTION
## What does this change?

It looks a bit neater for the tickbox to just say 'AI Search' - it takes up less valuable real estate on the search bar and the word 'Use' is superfluous anyway :) 