### PR TITLE
Respect length param in AI search

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -698,7 +698,7 @@ class MediaApi(
           logger.info(logMarker, s"Invalid AI search query: $errorMessage")
           Future.successful(respondError(UnprocessableEntity, "invalid-ai-search", errorMessage))
         case scala.util.Right(_) =>
-          val k = config.aiSearchResultLimit
+          val k = Math.min(params.length, config.aiSearchResultLimit)
           val searchResultsFuture = parseAiSearchMode(params) match {
             case SimilarSearch(imageId) => semanticSearchByImage(imageId, k, params)
             case TextSearch => semanticSearchByText(k, params)


### PR DESCRIPTION
Without this, Pinboard overflows because it expects to be able to request less

<img width="510" height="1412" alt="image" src="https://github.com/user-attachments/assets/f8cfd76d-1037-483f-8f93-2662b3a35405" />
