### PR TITLE
Display filteredPool when AI search query is absent

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/CollectionResponse.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/CollectionResponse.scala
@@ -19,8 +19,17 @@ case class ExtraCount(
   subCounts: Option[Map[String, Long]] = None
 )
 
+// Describes an AI search that only had filters applied (no text/similar-image query
+// to rank by), so the client can explain how the filters have narrowed the pool of
+// images (from totalPool to filteredPool) and prompt the user to add a query.
+case class FilterPoolCounts(
+  totalPool: Long,
+  filteredPool: Long
+)
+
 case class ExtraCounts(
-  tickerCounts: Map[String, ExtraCount]
+  tickerCounts: Map[String, ExtraCount],
+  filterPoolCounts: Option[FilterPoolCounts] = None
 )
 
 case class CollectionResponse[T](
@@ -37,6 +46,7 @@ case class CollectionResponse[T](
 object CollectionResponse extends WriteHelpers {
 
   implicit val extraCountWrites: Writes[ExtraCount] = Json.writes[ExtraCount]
+  implicit val filterPoolCountsWrites: Writes[FilterPoolCounts] = Json.writes[FilterPoolCounts]
   implicit val extraCountsWrites: Writes[ExtraCounts] = Json.writes[ExtraCounts]
 
   implicit def collectionResponseWrites[T: Writes]: Writes[CollectionResponse[T]] = (

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/CollectionResponse.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/argo/model/CollectionResponse.scala
@@ -19,11 +19,10 @@ case class ExtraCount(
   subCounts: Option[Map[String, Long]] = None
 )
 
-// Describes an AI search that only had filters applied (no text/similar-image query
-// to rank by), so the client can explain how the filters have narrowed the pool of
-// images (from totalPool to filteredPool) and prompt the user to add a query.
+// Describes an AI search that had no text/similar-image query to rank by, so the
+// client can tell the user how many images are in the pool a query would rank over
+// (filteredPool) and prompt them to add a query.
 case class FilterPoolCounts(
-  totalPool: Long,
   filteredPool: Long
 )
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -222,14 +222,13 @@
         <div ng-if="ctrl.filtersOnlyAiSearch"
              class="image-no-results">
             <span>
-                {{ctrl.filterPoolCounts.filteredPool | toLocaleString}} images match your filters. Add a query to see the best 200.
+                {{ctrl.filterPoolCounts.filteredPool | toLocaleString}} images match your filters. Enter a query to rank them and surface the best 200 matches.
             </span>
         </div>
 
         <div ng-if="! ctrl.filtersOnlyAiSearch && ctrl.totalResults == 0"
              class="image-no-results">
-            <span ng-if="!ctrl.needsQuery">No matches, sorry! Try altering your search.</span>
-            <span ng-if="ctrl.needsQuery">Please enter a query. You can include filters, but must include either some text or a similar:image-id term.</span>
+            <span>No matches, sorry! Try altering your search.</span>
         </div>
     </div>
 </div>

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -22,8 +22,10 @@
 
             <div class="results-toolbar-item results-toolbar-item--static
                     image-results-count">
-                <span ng-if="ctrl.isAiSearch && !ctrl.filtersOnlyAiSearch">Best {{ctrl.aiResultsShown | toLocaleString}} of {{ctrl.totalResults | toLocaleString}} matches</span>
-                <span ng-if="ctrl.isAiSearch && ctrl.filtersOnlyAiSearch">{{ctrl.filterPoolCounts.filteredPool | toLocaleString}} matches</span>
+                <span ng-if="ctrl.isAiSearch">
+                    <span ng-if="!ctrl.filtersOnlyAiSearch">Best {{ctrl.aiResultsShown | toLocaleString}} of {{ctrl.totalResults | toLocaleString}} matches</span>
+                    <span ng-if="ctrl.filtersOnlyAiSearch">{{ctrl.filterPoolCounts.filteredPool | toLocaleString}} matches</span>
+                </span>
                 <button ng-if="ctrl.newImagesCount > 0"
                         ng-click="ctrl.revealNewImages()"
                         class="image-results-count__new"

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -222,9 +222,7 @@
         <div ng-if="ctrl.filtersOnlyAiSearch"
              class="image-no-results">
             <span>
-                Your filters have narrowed your pool of images down from {{ctrl.filterPoolCounts.totalPool | toLocaleString}}
-                to {{ctrl.filterPoolCounts.filteredPool | toLocaleString}}.
-                Please add a search query to search over these.
+                {{ctrl.filterPoolCounts.filteredPool | toLocaleString}} images match your filters. Add a query to see the best 200.
             </span>
         </div>
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -22,7 +22,7 @@
 
             <div class="results-toolbar-item results-toolbar-item--static
                     image-results-count">
-                <span ng-if="ctrl.isAiSearch">Best {{ctrl.aiResultsShown | toLocaleString}} of {{ctrl.totalResults | toLocaleString}} matches</span>
+                <span ng-if="ctrl.isAiSearch && !ctrl.filtersOnlyAiSearch">Best {{ctrl.aiResultsShown | toLocaleString}} of {{ctrl.totalResults | toLocaleString}} matches</span>
                 <span ng-if="! ctrl.isAiSearch">{{ctrl.totalResults | toLocaleString}} matches</span>
                 <button ng-if="ctrl.newImagesCount > 0"
                         ng-click="ctrl.revealNewImages()"
@@ -219,7 +219,16 @@
             <div class="image-results-more__instructions">Please refine your search to limit the number of results</div>
         </div>
 
-        <div ng-if="ctrl.totalResults == 0"
+        <div ng-if="ctrl.filtersOnlyAiSearch"
+             class="image-no-results">
+            <span>
+                Your filters have narrowed your pool of images down from {{ctrl.filterPoolCounts.totalPool | toLocaleString}}
+                to {{ctrl.filterPoolCounts.filteredPool | toLocaleString}}.
+                Please add a search query to search over these.
+            </span>
+        </div>
+
+        <div ng-if="! ctrl.filtersOnlyAiSearch && ctrl.totalResults == 0"
              class="image-no-results">
             <span ng-if="!ctrl.needsQuery">No matches, sorry! Try altering your search.</span>
             <span ng-if="ctrl.needsQuery">Please enter a query. You can include filters, but must include either some text or a similar:image-id term.</span>

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -222,7 +222,7 @@
         <div ng-if="ctrl.filtersOnlyAiSearch"
              class="image-no-results">
             <span>
-                {{ctrl.filterPoolCounts.filteredPool | toLocaleString}} images match your filters. Enter a query to rank them and surface the best 200 matches.
+                {{ctrl.filterPoolCounts.filteredPool | toLocaleString}} images match your filters. Add a query to see the best 200.
             </span>
         </div>
 

--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -23,7 +23,7 @@
             <div class="results-toolbar-item results-toolbar-item--static
                     image-results-count">
                 <span ng-if="ctrl.isAiSearch && !ctrl.filtersOnlyAiSearch">Best {{ctrl.aiResultsShown | toLocaleString}} of {{ctrl.totalResults | toLocaleString}} matches</span>
-                <span ng-if="! ctrl.isAiSearch">{{ctrl.totalResults | toLocaleString}} matches</span>
+                <span ng-if="ctrl.isAiSearch && ctrl.filtersOnlyAiSearch">{{ctrl.filterPoolCounts.filteredPool | toLocaleString}} matches</span>
                 <button ng-if="ctrl.newImagesCount > 0"
                         ng-click="ctrl.revealNewImages()"
                         class="image-results-count__new"

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -233,6 +233,12 @@ results.controller('SearchResultsCtrl', [
           // FIXME: https://github.com/argo-rest/theseus has forced us to co-opt the actions field for this
           ctrl.tickerCounts = images.$response?.$$state?.value?.actions?.tickerCounts;
 
+          // Present only when an AI search had filters but no text/similar-image query to
+          // rank by. When set, we show a prompt explaining how the filters have narrowed
+          // the pool of images and inviting the user to add a query.
+          ctrl.filterPoolCounts = images.$response?.$$state?.value?.actions?.filterPoolCounts;
+          ctrl.filtersOnlyAiSearch = !!ctrl.filterPoolCounts;
+
           ctrl.hasQuery = !!$stateParams.query;
           ctrl.initialSearchUri = images.uri;
           ctrl.embeddableUrl = window.location.href;

--- a/kahuna/public/js/search/results.js
+++ b/kahuna/public/js/search/results.js
@@ -233,9 +233,9 @@ results.controller('SearchResultsCtrl', [
           // FIXME: https://github.com/argo-rest/theseus has forced us to co-opt the actions field for this
           ctrl.tickerCounts = images.$response?.$$state?.value?.actions?.tickerCounts;
 
-          // Present only when an AI search had filters but no text/similar-image query to
-          // rank by. When set, we show a prompt explaining how the filters have narrowed
-          // the pool of images and inviting the user to add a query.
+          // Present only when an AI search has no text/similar-image query to
+          // rank by. When set, we show how the filters have narrowed
+          // the pool of images and invite the user to add a query.
           ctrl.filterPoolCounts = images.$response?.$$state?.value?.actions?.filterPoolCounts;
           ctrl.filtersOnlyAiSearch = !!ctrl.filterPoolCounts;
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -624,8 +624,8 @@ class MediaApi(
       val filteredPoolFilter = buildAiFilter(params)
 
       for {
-        totalPool <- elasticSearch.countMatchingFilter(basePoolFilter)
-        filteredPool <- elasticSearch.countMatchingFilter(filteredPoolFilter)
+        totalPool <- elasticSearch.countMatchingFilterWithExtraCounts(basePoolFilter).map(_._1)
+        filteredPool <- elasticSearch.countMatchingFilterWithExtraCounts(filteredPoolFilter).map(_._1)
       } yield respondCollection(
         data = List.empty[EmbeddedEntity[JsValue]],
         offset = Some(0),

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -602,29 +602,17 @@ class MediaApi(
       elasticSearch.searchFilters.filterAndFilter(chipFilterOpt, requestFilterOpt)
     }
 
-    // The pool of images before the user's chip filters are applied (i.e. only the
-    // filters implied by the request itself, e.g. syndication/permissions). Used to
-    // explain how the chip filters have narrowed things down.
-    def buildBasePoolFilter(params: SearchParams): Option[Query] =
-      elasticSearch.queryBuilder.buildFilterOpt(
-        params,
-        elasticSearch.searchFilters,
-        elasticSearch.syndicationFilter
-      )
-
     def emptyAiSearchResponse =
       Future.successful(respondCollection(List.empty[EmbeddedEntity[JsValue]], Some(0), Some(0), None, List()))
 
     // Response for an AI search that only has filters (no text/similar-image query to
     // rank by). Rather than erroring, we return an empty result set annotated with how
-    // the filters have narrowed the pool of images, so the client can prompt the user
-    // to add a query.
+    // many images are in the pool a query would rank over, so the client can prompt the
+    // user to add a query.
     def filtersOnlyAiSearchResponse(params: SearchParams): Future[Result] = {
-      val basePoolFilter = buildBasePoolFilter(params)
       val filteredPoolFilter = buildAiFilter(params)
 
       for {
-        totalPool <- elasticSearch.countMatchingFilterWithExtraCounts(basePoolFilter).map(_._1)
         filteredPool <- elasticSearch.countMatchingFilterWithExtraCounts(filteredPoolFilter).map(_._1)
       } yield respondCollection(
         data = List.empty[EmbeddedEntity[JsValue]],
@@ -632,7 +620,7 @@ class MediaApi(
         total = Some(0),
         maybeExtraCounts = Some(ExtraCounts(
           tickerCounts = Map.empty,
-          filterPoolCounts = Some(FilterPoolCounts(totalPool = totalPool, filteredPool = filteredPool))
+          filterPoolCounts = Some(FilterPoolCounts(filteredPool = filteredPool))
         )),
         links = Nil
       )

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -19,6 +19,7 @@ import com.gu.mediaservice.{GridClient, JsonDiff}
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import lib._
 import lib.elasticsearch._
+import lib.querysyntax.Condition
 import org.apache.http.entity.ContentType
 import org.apache.pekko.stream.scaladsl.StreamConverters
 import org.http4s.UriTemplate
@@ -583,12 +584,10 @@ class MediaApi(
     case object TextSearch extends AiSearchMode
     case class SimilarSearch(imageId: String) extends AiSearchMode
 
-    def parseAiSearchMode(params: SearchParams): AiSearchMode =
-      params.aiQueryParts.similarImageId.map(SimilarSearch).getOrElse(TextSearch)
+    def parseAiSearchMode(parts: AiQueryParts): AiSearchMode =
+      parts.similarImageId.map(SimilarSearch).getOrElse(TextSearch)
 
-    def buildAiFilter(params: SearchParams): Option[Query] = {
-      val filterConditions = params.aiQueryParts.filterConditions
-
+    def buildAiFilter(filterConditions: List[Condition], params: SearchParams): Option[Query] = {
       val chipFilterOpt =
         if (filterConditions.nonEmpty) Some(elasticSearch.queryBuilder.makeQuery(filterConditions))
         else None
@@ -609,8 +608,8 @@ class MediaApi(
     // rank by). Rather than erroring, we return an empty result set annotated with how
     // many images are in the pool a query would rank over, so the client can prompt the
     // user to add a query.
-    def filtersOnlyAiSearchResponse(params: SearchParams): Future[Result] = {
-      val filteredPoolFilter = buildAiFilter(params)
+    def filtersOnlyAiSearchResponse(filterConditions: List[Condition], params: SearchParams): Future[Result] = {
+      val filteredPoolFilter = buildAiFilter(filterConditions, params)
 
       for {
         filteredPool <- elasticSearch.countMatchingFilterWithExtraCounts(filteredPoolFilter).map(_._1)
@@ -637,7 +636,7 @@ class MediaApi(
       )
     }
 
-    def semanticSearchByImage(imageId: String, k: Int, params: SearchParams): Future[SearchResults] = {
+    def semanticSearchByImage(imageId: String, k: Int, parts: AiQueryParts, params: SearchParams): Future[SearchResults] = {
       val outerMarker = logMarker
 
       {
@@ -646,7 +645,7 @@ class MediaApi(
           "aiSearchType" -> "image"
         )
 
-        val filterOpt = buildAiFilter(params)
+        val filterOpt = buildAiFilter(parts.filterConditions, params)
 
         for {
           maybeImage <- elasticSearch.getImageById(imageId)
@@ -666,10 +665,10 @@ class MediaApi(
       }
     }
 
-    def semanticSearchByText(k: Int, params: SearchParams): Future[SearchResults] = {
+    def semanticSearchByText(k: Int, parts: AiQueryParts, params: SearchParams): Future[SearchResults] = {
       // Separate the chips from the main query text
       // So that we can embed just the query text
-      params.aiQueryParts.semanticQuery match {
+      parts.semanticQuery match {
         case None =>
           logger.info(logMarker, s"No semantic query found in structured query; returning no AI results")
           Future.successful(SearchResults(Nil, total = 0, extraCounts = None))
@@ -696,7 +695,7 @@ class MediaApi(
             // load fires and both callers receive the same Future.
             val embeddingFuture = embeddingCache.get(cacheKey)
 
-            val filterOpt = buildAiFilter(params)
+            val filterOpt = buildAiFilter(parts.filterConditions, params)
 
             for {
               embedding <- embeddingFuture
@@ -714,39 +713,39 @@ class MediaApi(
     }
 
     def performAiSearchAndRespond(params: SearchParams): Future[Result] = {
-      params.aiQueryParts.validationError match {
-        case Left(_) =>
-          if (params.aiQueryParts.hasFilterConditions) {
-            logger.info(logMarker, s"AI search with only filters and no query to rank by; returning filter pool counts: ${params.aiQueryParts.filterConditions}")
-            filtersOnlyAiSearchResponse(params)
-          } else {
-            logger.info(logMarker, s"AI search with no query to rank by and no filters; returning filter pool counts over the whole pool")
-            filtersOnlyAiSearchResponse(params)
-          }
-        case scala.util.Right(_) =>
+      params.aiQueryParts match {
+        case scala.util.Right(parts) =>
           val k = Math.min(params.length, config.aiSearchResultLimit)
-          val searchResultsFuture = parseAiSearchMode(params) match {
-            case SimilarSearch(imageId) => semanticSearchByImage(imageId, k, params)
-            case TextSearch => semanticSearchByText(k, params)
+          val searchResultsFuture = parseAiSearchMode(parts) match {
+            case SimilarSearch(imageId) => semanticSearchByImage(imageId, k, parts, params)
+            case TextSearch => semanticSearchByText(k, parts, params)
           }
 
           searchResultsFuture.map(aiSearchResponseFromResults)
+
+        // No query to rank by, so we can't return ranked results. Instead return the
+        // size of the pool we'd be searching over, so the client can prompt the user to
+        // add a query.
+        case Left(AiQueryError.NoRankingSignal(filterConditions)) =>
+          logger.info(logMarker, s"AI search with no query to rank by; returning filter pool counts: $filterConditions")
+          filtersOnlyAiSearchResponse(filterConditions, params)
+
+        case Left(AiQueryError.ConflictingRankingSignals) =>
+          logger.info(logMarker, "AI search combining a similar image with a text query; rankings can't be merged")
+          Future.successful(respondError(
+            UnprocessableEntity,
+            InvalidUriParams.errorKey,
+            AiQueryError.ConflictingRankingSignals.message
+          ))
       }
     }
 
     if (_searchParams.useAISearch.contains(true)) {
-      _searchParams.query match {
-        // Short-circuit polling requests (length=0) and empty queries to avoid unnecessary Bedrock/KNN calls
-        case _ if _searchParams.length == 0 =>
-          emptyAiSearchResponse
-        case Some(q) if !q.isBlank =>
-          performAiSearchAndRespond(_searchParams)
-        // No query text to rank by, so we can't return ranked results. Instead
-        // return the size of the pool we'd be searching over, so the client can
-        // prompt the user to add a query.
-        case _ =>
-          filtersOnlyAiSearchResponse(_searchParams)
-      }
+      // Short-circuit polling requests (length=0) to avoid unnecessary Bedrock/KNN calls.
+      // Everything else is handled by performAiSearchAndRespond, which falls back to
+      // filter-pool counts when there's no query to rank by.
+      if (_searchParams.length == 0) emptyAiSearchResponse
+      else performAiSearchAndRespond(_searchParams)
     } else {
       val searchParams = if (canViewDeletedImages) {
         _searchParams.copy(uploadedBy = Some(Authentication.getIdentity(request.user)))

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -727,13 +727,13 @@ class MediaApi(
 
     def performAiSearchAndRespond(params: SearchParams): Future[Result] = {
       params.aiQueryParts.validationError match {
-        case Left(errorMessage) =>
+        case Left(_) =>
           if (params.aiQueryParts.hasFilterConditions) {
             logger.info(logMarker, s"AI search with only filters and no query to rank by; returning filter pool counts: ${params.aiQueryParts.filterConditions}")
             filtersOnlyAiSearchResponse(params)
           } else {
-            logger.info(logMarker, s"Invalid AI search query: $errorMessage")
-            Future.successful(respondError(UnprocessableEntity, "invalid-ai-search", errorMessage))
+            logger.info(logMarker, s"AI search with no query to rank by and no filters; returning filter pool counts over the whole pool")
+            filtersOnlyAiSearchResponse(params)
           }
         case scala.util.Right(_) =>
           val k = Math.min(params.length, config.aiSearchResultLimit)
@@ -753,11 +753,11 @@ class MediaApi(
           emptyAiSearchResponse
         case Some(q) if !q.isBlank =>
           performAiSearchAndRespond(_searchParams)
-        // Empty queries do not make sense for AI search as we can
-        // only rank results once we have a meaningful vector to compare with.
-        // So return 0 results if the query was empty.
+        // No query text to rank by, so we can't return ranked results. Instead
+        // return the size of the pool we'd be searching over, so the client can
+        // prompt the user to add a query.
         case _ =>
-          emptyAiSearchResponse
+          filtersOnlyAiSearchResponse(_searchParams)
       }
     } else {
       val searchParams = if (canViewDeletedImages) {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -602,8 +602,41 @@ class MediaApi(
       elasticSearch.searchFilters.filterAndFilter(chipFilterOpt, requestFilterOpt)
     }
 
+    // The pool of images before the user's chip filters are applied (i.e. only the
+    // filters implied by the request itself, e.g. syndication/permissions). Used to
+    // explain how the chip filters have narrowed things down.
+    def buildBasePoolFilter(params: SearchParams): Option[Query] =
+      elasticSearch.queryBuilder.buildFilterOpt(
+        params,
+        elasticSearch.searchFilters,
+        elasticSearch.syndicationFilter
+      )
+
     def emptyAiSearchResponse =
       Future.successful(respondCollection(List.empty[EmbeddedEntity[JsValue]], Some(0), Some(0), None, List()))
+
+    // Response for an AI search that only has filters (no text/similar-image query to
+    // rank by). Rather than erroring, we return an empty result set annotated with how
+    // the filters have narrowed the pool of images, so the client can prompt the user
+    // to add a query.
+    def filtersOnlyAiSearchResponse(params: SearchParams): Future[Result] = {
+      val basePoolFilter = buildBasePoolFilter(params)
+      val filteredPoolFilter = buildAiFilter(params)
+
+      for {
+        totalPool <- elasticSearch.countMatchingFilter(basePoolFilter)
+        filteredPool <- elasticSearch.countMatchingFilter(filteredPoolFilter)
+      } yield respondCollection(
+        data = List.empty[EmbeddedEntity[JsValue]],
+        offset = Some(0),
+        total = Some(0),
+        maybeExtraCounts = Some(ExtraCounts(
+          tickerCounts = Map.empty,
+          filterPoolCounts = Some(FilterPoolCounts(totalPool = totalPool, filteredPool = filteredPool))
+        )),
+        links = Nil
+      )
+    }
 
     def aiSearchResponseFromResults(searchResults: SearchResults): Result = {
       val imageEntities = searchResults.hits map (hitToImageEntity _).tupled
@@ -695,8 +728,13 @@ class MediaApi(
     def performAiSearchAndRespond(params: SearchParams): Future[Result] = {
       params.aiQueryParts.validationError match {
         case Left(errorMessage) =>
-          logger.info(logMarker, s"Invalid AI search query: $errorMessage")
-          Future.successful(respondError(UnprocessableEntity, "invalid-ai-search", errorMessage))
+          if (params.aiQueryParts.hasFilterConditions) {
+            logger.info(logMarker, s"AI search with only filters and no query to rank by; returning filter pool counts: ${params.aiQueryParts.filterConditions}")
+            filtersOnlyAiSearchResponse(params)
+          } else {
+            logger.info(logMarker, s"Invalid AI search query: $errorMessage")
+            Future.successful(respondError(UnprocessableEntity, "invalid-ai-search", errorMessage))
+          }
         case scala.util.Right(_) =>
           val k = config.aiSearchResultLimit
           val searchResultsFuture = parseAiSearchMode(params) match {

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -612,13 +612,12 @@ class MediaApi(
       val filteredPoolFilter = buildAiFilter(filterConditions, params)
 
       for {
-        filteredPool <- elasticSearch.countMatchingFilterWithExtraCounts(filteredPoolFilter).map(_._1)
+        (filteredPool, extraCounts) <- elasticSearch.countMatchingFilterWithExtraCounts(filteredPoolFilter)
       } yield respondCollection(
         data = List.empty[EmbeddedEntity[JsValue]],
         offset = Some(0),
         total = Some(0),
-        maybeExtraCounts = Some(ExtraCounts(
-          tickerCounts = Map.empty,
+        maybeExtraCounts = Some(extraCounts.copy(
           filterPoolCounts = Some(FilterPoolCounts(filteredPool = filteredPool))
         )),
         links = Nil
@@ -647,6 +646,11 @@ class MediaApi(
 
         val filterOpt = buildAiFilter(parts.filterConditions, params)
 
+        // Compute the filtered pool total and ticker count badges in parallel with the
+        // KNN search, so similar-image results show the same "Best k of N matches" total
+        // and tickers as text/hybrid AI search.
+        val filterTotalAndCounts = elasticSearch.countMatchingFilterWithExtraCounts(filterOpt)
+
         for {
           maybeImage <- elasticSearch.getImageById(imageId)
           maybeEmbedding = maybeImage
@@ -661,7 +665,8 @@ class MediaApi(
             case None =>
               Future.successful(SearchResults(Nil, total = 0, extraCounts = None))
           }
-        } yield searchResults
+          (total, extraCounts) <- filterTotalAndCounts
+        } yield searchResults.copy(total = total, extraCounts = Some(extraCounts))
       }
     }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -362,7 +362,7 @@ class ElasticSearch(
 
   // How many images match the active filters in total, so we can show
   // "Best k of N matches".
-  private def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
+  def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
     val countRequest = ElasticDsl.count(imagesCurrentAlias).query(filterOpt.getOrElse(matchAllQuery()))
 
     executeAndLog(countRequest, "hybrid AI search filter count").map(_.result.count)

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -374,6 +374,17 @@ class ElasticSearch(
     }
   }
 
+  // How many images match the given filter (or the whole index if no filter),
+  // used to tell the user the size of the pool an AI search would rank over.
+  def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
+    val searchRequest = ElasticDsl.search(imagesCurrentAlias)
+      .query(filterOpt.getOrElse(matchAllQuery()))
+      .trackTotalHits(true)
+      .size(0)
+
+    executeAndLog(withSearchQueryTimeout(searchRequest), "AI search filter pool count").map(_.result.totalHits)
+  }
+
   def search(params: SearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal], logMarker: LogMarker = MarkerMap()): Future[SearchResults] = {
     val query: Query = queryBuilder.makeQuery(params.structuredQuery)
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -362,7 +362,7 @@ class ElasticSearch(
   // How many images match the active filters in total (so we can show
   // "Best k of N matches") along with the ticker count badges, both computed
   // over the whole filtered set in a single request.
-  private def countMatchingFilterWithExtraCounts(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[(Long, ExtraCounts)] = {
+  def countMatchingFilterWithExtraCounts(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[(Long, ExtraCounts)] = {
     val searchRequest = ElasticDsl.search(imagesCurrentAlias)
       .query(filterOpt.getOrElse(matchAllQuery()))
       .trackTotalHits(true)
@@ -372,17 +372,6 @@ class ElasticSearch(
     executeAndLog(withSearchQueryTimeout(searchRequest), "hybrid AI search filter count and ticker counts").map { r =>
       (r.result.totalHits, extraCountsFrom(r.result.aggregations))
     }
-  }
-
-  // How many images match the given filter (or the whole index if no filter),
-  // used to tell the user the size of the pool an AI search would rank over.
-  def countMatchingFilter(filterOpt: Option[Query])(implicit ex: ExecutionContext, logMarker: LogMarker): Future[Long] = {
-    val searchRequest = ElasticDsl.search(imagesCurrentAlias)
-      .query(filterOpt.getOrElse(matchAllQuery()))
-      .trackTotalHits(true)
-      .size(0)
-
-    executeAndLog(withSearchQueryTimeout(searchRequest), "AI search filter pool count").map(_.result.totalHits)
   }
 
   def search(params: SearchParams)(implicit ex: ExecutionContext, request: AuthenticatedRequest[AnyContent, Principal], logMarker: LogMarker = MarkerMap()): Future[SearchResults] = {

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -28,6 +28,8 @@ case class AiQueryParts(
   // a text query (text KNN) or a similar image (image KNN) to be valid.
   def hasKnn: Boolean = similarImageId.nonEmpty || semanticQuery.nonEmpty
 
+  def hasFilterConditions: Boolean = filterConditions.nonEmpty
+
   // Returns Left(error message) if the AI query cannot be satisfied, otherwise Right(()).
   def validationError: Either[String, Unit] = {
     if (hasSimilarAndSemanticText)
@@ -35,12 +37,12 @@ case class AiQueryParts(
         "AI search can't combine a similar image search with a text query because the two rankings can't be merged. " +
           "Please use either a text query or a similar image, not both."
       )
-    else if (!hasKnn)
-      Left(
-        "AI search needs something to rank by. " +
-          "Add a text query or a similar image alongside your filters."
-      )
-    else
+    else if (!hasKnn) {
+        Left(
+          "AI search needs something to rank by. " +
+            "Add a text query or a similar image alongside your filters."
+        )
+    } else
       Right(())
   }
 }

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -17,45 +17,43 @@ case class SearchResults(hits: Seq[(String, SourceWrapper[Image])], total: Long,
 
 case class AggregateSearchResults(results: Seq[BucketResult], total: Long)
 
+// The reasons an AI search can't be run as a ranked query. These are distinct from
+// each other so the caller can decide how to respond: an expected "no ranking signal"
+// case is handled by reporting filter-pool counts, whereas a genuine error is surfaced
+// to the user.
+sealed trait AiQueryError
+object AiQueryError {
+  // The query has no KNN ranking signal (no text and no similar image), so there's
+  // nothing to rank by. We still carry the parsed filter conditions so the caller can
+  // report how big the filtered pool is and prompt the user to add a query.
+  final case class NoRankingSignal(filterConditions: List[Condition]) extends AiQueryError
+
+  // The query combines a similar image with a text query. The two rankings can't be
+  // merged, so this is a genuine error.
+  case object ConflictingRankingSignals extends AiQueryError {
+    val message: String =
+      "AI search can't combine a similar image search with a text query because the two rankings can't be merged. " +
+        "Please use either a text query or a similar image, not both."
+  }
+}
+
 case class AiQueryParts(
   semanticQuery: Option[String],
   filterConditions: List[Condition],
   similarImageId: Option[String]
-) {
-  def hasSimilarAndSemanticText: Boolean = similarImageId.nonEmpty && semanticQuery.nonEmpty
-
-  // A KNN bit is the only thing AI search can rank by, so a query must contain either
-  // a text query (text KNN) or a similar image (image KNN) to be valid.
-  def hasKnn: Boolean = similarImageId.nonEmpty || semanticQuery.nonEmpty
-
-  def hasFilterConditions: Boolean = filterConditions.nonEmpty
-
-  // Returns Left(error message) if the AI query cannot be satisfied, otherwise Right(()).
-  def validationError: Either[String, Unit] = {
-    if (hasSimilarAndSemanticText)
-      Left(
-        "AI search can't combine a similar image search with a text query because the two rankings can't be merged. " +
-          "Please use either a text query or a similar image, not both."
-      )
-    else if (!hasKnn) {
-        Left(
-          "AI search needs something to rank by. " +
-            "Add a text query or a similar image alongside your filters."
-        )
-    } else
-      Right(())
-  }
-}
+)
 
 object AiQueryParts {
-  def from(conditions: List[Condition]): AiQueryParts = {
+  // Parse the structured query into AI search parts. Returns Right with parts ready to
+  // rank by, or Left explaining why the search can't be run as a ranked query.
+  def from(conditions: List[Condition]): Either[AiQueryError, AiQueryParts] = {
     val initial = AiQueryParts(
       semanticQuery = None,
       filterConditions = List.empty,
       similarImageId = None,
     )
 
-    conditions.foldLeft(initial) {
+    val parts = conditions.foldLeft(initial) {
       case (parts, Match(AnyField, Words(value))) =>
         appendSemanticText(parts, value)
       case (parts, Match(AnyField, Phrase(value))) =>
@@ -67,6 +65,15 @@ object AiQueryParts {
       case (parts, condition) =>
         parts.copy(filterConditions = parts.filterConditions :+ condition)
     }
+
+    val hasText = parts.semanticQuery.nonEmpty
+    val hasSimilarImage = parts.similarImageId.nonEmpty
+
+    // A KNN bit is the only thing AI search can rank by, so a query must contain exactly
+    // one of a text query (text KNN) or a similar image (image KNN) to be valid.
+    if (hasText && hasSimilarImage) Left(AiQueryError.ConflictingRankingSignals)
+    else if (!hasText && !hasSimilarImage) Left(AiQueryError.NoRankingSignal(parts.filterConditions))
+    else Right(parts)
   }
 
   private def appendSemanticText(parts: AiQueryParts, value: String): AiQueryParts = {
@@ -151,7 +158,7 @@ case class SearchParams(
   useAISearch: Option[Boolean] = None,
   vecWeight: Option[Double] = None
 ) {
-  lazy val aiQueryParts: AiQueryParts = AiQueryParts.from(structuredQuery)
+  lazy val aiQueryParts: Either[AiQueryError, AiQueryParts] = AiQueryParts.from(structuredQuery)
 }
 
 case class InvalidUriParams(message: String) extends Throwable

--- a/media-api/test/lib/elasticsearch/AiQueryPartsTest.scala
+++ b/media-api/test/lib/elasticsearch/AiQueryPartsTest.scala
@@ -19,111 +19,89 @@ class AiQueryPartsTest extends AnyFunSpec with Matchers with ImageFields {
 
   // Build the AiQueryParts the same way the controller does: parse the raw query
   // string with the production parser, then derive the AI search parts from it.
-  private def aiPartsFor(query: String): AiQueryParts =
+  private def aiPartsFor(query: String): Either[AiQueryError, AiQueryParts] =
     AiQueryParts.from(Parser.run(query))
+
+  // Convenience for the valid cases, which are expected to parse into rankable parts.
+  private def validPartsFor(query: String): AiQueryParts =
+    aiPartsFor(query) match {
+      case Right(parts) => parts
+      case Left(error) => fail(s"expected a rankable AI query but got: $error")
+    }
 
   describe("AiQueryParts validation") {
 
     describe("valid queries (each contains a KNN ranking signal)") {
 
       it("allows a similar-image-only query (image KNN)") {
-        val parts = aiPartsFor("similar:abc123")
+        val parts = validPartsFor("similar:abc123")
 
         parts.similarImageId should be(Some("abc123"))
         parts.semanticQuery should be(None)
-        parts.hasKnn should be(true)
-        parts.validationError should be(Right(()))
       }
 
       it("allows a text-only query (text KNN)") {
-        val parts = aiPartsFor("keir starmer")
+        val parts = validPartsFor("keir starmer")
 
         parts.semanticQuery should be(Some("keir starmer"))
         parts.similarImageId should be(None)
-        parts.hasKnn should be(true)
-        parts.validationError should be(Right(()))
       }
 
       it("allows chips/filters combined with a text query (pre-filter then text KNN)") {
-        val parts = aiPartsFor("fileType:jpeg keir starmer")
+        val parts = validPartsFor("fileType:jpeg keir starmer")
 
         parts.semanticQuery should be(Some("keir starmer"))
         parts.filterConditions should be(jpegFilter :: standardNegations)
-        parts.hasKnn should be(true)
-        parts.validationError should be(Right(()))
       }
 
       it("allows chips/filters combined with a similar image (pre-filter then image KNN)") {
-        val parts = aiPartsFor("similar:abc123 fileType:jpeg")
+        val parts = validPartsFor("similar:abc123 fileType:jpeg")
 
         parts.similarImageId should be(Some("abc123"))
         parts.filterConditions should be(jpegFilter :: standardNegations)
-        parts.hasKnn should be(true)
-        parts.validationError should be(Right(()))
       }
 
       it("allows a negative term combined with a text query (negative is a lexical pre-filter, then text KNN)") {
-        val parts = aiPartsFor("keir starmer -angela")
+        val parts = validPartsFor("keir starmer -angela")
 
         parts.semanticQuery should be(Some("keir starmer"))
         // The negation is treated as a filter condition, not a KNN ranking signal.
         parts.filterConditions should be(negatedAngela :: standardNegations)
-        parts.hasKnn should be(true)
-        parts.validationError should be(Right(()))
       }
 
       it("allows a negative term combined with a similar image (negative pre-filter, then image KNN)") {
-        val parts = aiPartsFor("similar:abc123 -angela")
+        val parts = validPartsFor("similar:abc123 -angela")
 
         parts.similarImageId should be(Some("abc123"))
         parts.filterConditions should be(negatedAngela :: standardNegations)
-        parts.hasKnn should be(true)
-        parts.validationError should be(Right(()))
       }
     }
 
     describe("invalid queries that combine two rankings") {
 
       it("rejects a similar image combined with a text query (rankings can't be merged)") {
-        val parts = aiPartsFor("similar:abc123 keir starmer")
-
-        parts.similarImageId should be(Some("abc123"))
-        parts.semanticQuery should be(Some("keir starmer"))
-        parts.hasSimilarAndSemanticText should be(true)
-        parts.validationError.isLeft should be(true)
+        aiPartsFor("similar:abc123 keir starmer") should be(Left(AiQueryError.ConflictingRankingSignals))
       }
     }
 
     describe("invalid queries that contain no KNN ranking signal") {
 
       it("rejects a chips/filters-only query") {
-        val parts = aiPartsFor("fileType:jpeg")
-
-        parts.semanticQuery should be(None)
-        parts.similarImageId should be(None)
-        parts.filterConditions should be(jpegFilter :: standardNegations)
-        parts.hasKnn should be(false)
-        parts.validationError.isLeft should be(true)
+        aiPartsFor("fileType:jpeg") should be(
+          Left(AiQueryError.NoRankingSignal(jpegFilter :: standardNegations))
+        )
       }
 
       it("rejects a negative-only query") {
-        val parts = aiPartsFor("-angela")
-
-        parts.semanticQuery should be(None)
-        parts.similarImageId should be(None)
-        parts.filterConditions should be(negatedAngela :: standardNegations)
-        parts.hasKnn should be(false)
-        parts.validationError.isLeft should be(true)
+        aiPartsFor("-angela") should be(
+          Left(AiQueryError.NoRankingSignal(negatedAngela :: standardNegations))
+        )
       }
 
       it("rejects a negative term combined with chips/filters") {
-        val parts = aiPartsFor("-angela fileType:jpeg")
-
-        parts.semanticQuery should be(None)
-        parts.similarImageId should be(None)
-        parts.filterConditions should be(negatedAngela :: jpegFilter :: standardNegations)
-        parts.hasKnn should be(false)
-        parts.validationError.isLeft should be(true)
+        aiPartsFor("-angela fileType:jpeg") should be(
+          Left(AiQueryError.NoRankingSignal(negatedAngela :: jpegFilter :: standardNegations))
+        )
       }
     }
   }


### PR DESCRIPTION
## What does this change?

When AI search mode has no ranking query, the UI previously showed two different empty states — one for "no query at all" and one for "filters but no query". This unifies them into a single state that tells the user how many images are in the pool a query would rank over.

- **Backend**: The no-query AI case (with or without filters) now returns filterPoolCounts.filteredPool (the size of the pool a query would rank over) instead of erroring or returning an empty response. Consolidated onto the existing countMatchingFilterWithExtraCounts,
- **Frontend**: Combined the two empty states into one message: "N images match your filters. Add a query to see the best 200." The results count below the search bar now also shows the pool size (N matches) in this state.