### PR TITLE
make return value of projectS3Image non-optional

### DIFF
--- a/image-loader/app/ImageLoaderComponents.scala
+++ b/image-loader/app/ImageLoaderComponents.scala
@@ -37,7 +37,7 @@ class ImageLoaderComponents(context: Context) extends GridComponents(context, ne
     }
 
   val uploader = new Uploader(store, config, imageOperations, notifications, maybeEmbedder, imageProcessor, gridClient, auth)
-  val projector = Projector(config, imageOperations, imageProcessor, auth, maybeEmbedder)
+  val projector = Projector(config, imageOperations, imageProcessor, maybeEmbedder)
   val quarantineUploader: Option[QuarantineUploader] = config.maybeQuarantineBucket.map(_ =>
     new QuarantineUploader(new QuarantineStore(config), config)
   )

--- a/image-loader/app/controllers/ImageLoaderController.scala
+++ b/image-loader/app/controllers/ImageLoaderController.scala
@@ -382,16 +382,14 @@ class ImageLoaderController(auth: Authentication,
 
       result.onComplete( _ => Try { deleteTempFile(tempFile) } )
 
-      result.map {
-        case Some(img) =>
-          logger.info(context, "image found")
-          Ok(Json.toJson(img)).as(ArgoMediaType)
-        case None =>
+      result.map { img =>
+        logger.info(context, "image found")
+        Ok(Json.toJson(img)).as(ArgoMediaType)
+      } recover {
+        case _: NoSuchImageExistsInS3 =>
           val s3Path = "s3://" + config.imageBucket + "/" + ImageIngestOperations.fileKeyFromId(imageId)
           logger.info(context, "image not found")
           respondError(NotFound, "image-not-found", s"Could not find image: $imageId in s3 at $s3Path")
-      } recover {
-        case _: NoSuchImageExistsInS3 => NotFound(Json.obj("imageId" -> imageId))
         case e =>
           logger.error(context, s"projectImageBy request for id $imageId ended with a failure", e)
           InternalServerError(Json.obj("imageId" -> imageId, "exception" -> e.getMessage))

--- a/image-loader/app/model/Projector.scala
+++ b/image-loader/app/model/Projector.scala
@@ -30,8 +30,8 @@ object Projector {
 
   import Uploader.toImageUploadOpsCfg
 
-  def apply(config: ImageLoaderConfig, imageOps: ImageOperations, processor: ImageProcessor, auth: Authentication, maybeEmbedder: Option[Embedder])(implicit ec: ExecutionContext): Projector
-  = new Projector(toImageUploadOpsCfg(config), S3Ops.buildS3Client(config), imageOps, processor, auth, maybeEmbedder)
+  def apply(config: ImageLoaderConfig, imageOps: ImageOperations, processor: ImageProcessor, maybeEmbedder: Option[Embedder])(implicit ec: ExecutionContext): Projector
+  = new Projector(toImageUploadOpsCfg(config), S3Ops.buildS3Client(config), imageOps, processor, maybeEmbedder)
 }
 
 case class S3FileExtractedMetadata(
@@ -84,13 +84,12 @@ class Projector(config: ImageUploadOpsCfg,
                 s3: AmazonS3,
                 imageOps: ImageOperations,
                 processor: ImageProcessor,
-                auth: Authentication,
                 maybeEmbedder: Option[Embedder]) extends GridLogging {
 
   private val imageUploadProjectionOps = new ImageUploadProjectionOps(config, imageOps, processor, s3, maybeEmbedder)
 
   def projectS3ImageById(imageId: String, tempFile: File, gridClient: GridClient, onBehalfOfFn: WSRequest => WSRequest)
-                        (implicit ec: ExecutionContext, logMarker: LogMarker): Future[Option[Image]] = {
+                        (implicit ec: ExecutionContext, logMarker: LogMarker): Future[Image] = {
     Future {
       import ImageIngestOperations.fileKeyFromId
       val s3Key = fileKeyFromId(imageId)
@@ -106,14 +105,11 @@ class Projector(config: ImageUploadOpsCfg,
         val digestedFile = getSrcFileDigestForProjection(s3Source, imageId, tempFile)
         val extractedS3Meta = S3FileExtractedMetadata(s3Source.getObjectMetadata)
 
-        val finalImageFuture = projectImage(digestedFile, extractedS3Meta, gridClient, onBehalfOfFn)
-        val finalImage = Await.result(finalImageFuture, Duration.Inf)
-
-        Some(finalImage)
+        projectImage(digestedFile, extractedS3Meta, gridClient, onBehalfOfFn)
       } finally {
         s3Source.close()
       }
-    }
+    }.flatten
   }
 
   private def getSrcFileDigestForProjection(s3Src: AwsS3Object, imageId: String, tempFile: File) = {

--- a/image-loader/test/scala/model/ProjectorTest.scala
+++ b/image-loader/test/scala/model/ProjectorTest.scala
@@ -45,8 +45,7 @@ class ProjectorTest extends AnyFreeSpec with Matchers with ScalaFutures with Moc
   private val maybeEmbedder = None
 
   private val s3 = mock[AmazonS3]
-  private val auth = mock[Authentication]
-  private val projector = new Projector(config, s3, imageOperations, ImageProcessor.identity, auth, maybeEmbedder)
+  private val projector = new Projector(config, s3, imageOperations, ImageProcessor.identity, maybeEmbedder)
 
   // FIXME temporary ignored as test is not executable in CI/CD machine
   // because graphic lib files like srgb.icc, cmyk.icc are in root directory instead of resources


### PR DESCRIPTION
## What does this change?

I noticed that the return type of `projectS3ImageById` is `Future[Option[Image]]`, but it always returns a `Future[Some[Image]]` (the branch where an image isn't found instead throws a `NoSuchImageExistsInS3`). Simplifying that return type to `Future[Image]` reveals that the controller only gives helpful logging when it receives a `None` (which as we saw above, it simply can't), so move the logging to the exception handler instead.

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
