### PR TITLE
Bump @guardian/cql to 1.8.6

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@babel/polyfill": "7.8.7",
-        "@guardian/cql": "1.8.5",
+        "@guardian/cql": "1.8.6",
         "@guardian/user-telemetry-client": "1.1.0",
         "@sentry/browser": "6.11.0",
         "@sentry/integrations": "6.11.0",
@@ -2243,9 +2243,9 @@
       "license": "MIT"
     },
     "node_modules/@guardian/cql": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@guardian/cql/-/cql-1.8.5.tgz",
-      "integrity": "sha512-VU8UPeFeoMUpEc4wMHkXo65nEXGWmxYu5CofKXNrOQvtGSwTE3mYYdwZT9IG22ILpeWhlMF4Wzmo1EnFfwffxA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@guardian/cql/-/cql-1.8.6.tgz",
+      "integrity": "sha512-R8UoHaSiUVCOfgbFOCBxfPUQmUNoasd/Rj0o1KF7ikO0g+amsX3Dro2mabuzeuszMjAT4kMD809kuS+w+igvXg==",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",
         "preact": "^10.25.4",

--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@babel/polyfill": "7.8.7",
-        "@guardian/cql": "1.8.4",
+        "@guardian/cql": "1.8.5",
         "@guardian/user-telemetry-client": "1.1.0",
         "@sentry/browser": "6.11.0",
         "@sentry/integrations": "6.11.0",
@@ -2243,9 +2243,9 @@
       "license": "MIT"
     },
     "node_modules/@guardian/cql": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@guardian/cql/-/cql-1.8.4.tgz",
-      "integrity": "sha512-cDhPd63XcAs6Xj4Rerstjbo9uO0aJL8DEyrZ6FX2tmlpm0WY6vVzQ6aKmXpej9hw9wka8jHE02ZvoHY0yfhbdQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@guardian/cql/-/cql-1.8.5.tgz",
+      "integrity": "sha512-VU8UPeFeoMUpEc4wMHkXo65nEXGWmxYu5CofKXNrOQvtGSwTE3mYYdwZT9IG22ILpeWhlMF4Wzmo1EnFfwffxA==",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",
         "preact": "^10.25.4",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@babel/polyfill": "7.8.7",
-    "@guardian/cql": "1.8.4",
+    "@guardian/cql": "1.8.5",
     "@guardian/user-telemetry-client": "1.1.0",
     "@sentry/browser": "6.11.0",
     "@sentry/integrations": "6.11.0",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@babel/polyfill": "7.8.7",
-    "@guardian/cql": "1.8.5",
+    "@guardian/cql": "1.8.6",
     "@guardian/user-telemetry-client": "1.1.0",
     "@sentry/browser": "6.11.0",
     "@sentry/integrations": "6.11.0",


### PR DESCRIPTION
## What does this change?

Bumps @guardian/cql from 1.8.4 to 1.8.6, to fix a few behaviour issues spotted by @paperboyo. Changelog is [here.](https://github.com/guardian/cql/releases/) 

## How should a reviewer test this change?

Run locally, and deploy to CODE The issues specified as fixed in the changelog should be fixed.