### PR TITLE
Add node version to .tool-versions for mise

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 java corretto-11.0.24.8.1
+nodejs 22.12.0


### PR DESCRIPTION
## What does this change?

Add Node version to `.tool-versions` for those who use `mise` for version management 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
