### PR TITLE
Dynamo Part 0: Migrate the delete and removeKey methods

### DIFF
--- a/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala
+++ b/metadata-editor/app/lib/MetadataSqsMessageConsumer.scala
@@ -15,6 +15,6 @@ class MetadataSqsMessageConsumer(config: EditsConfig, metadataEditorMetrics: Met
     }
 
   def processDeletedImage(message: JsValue) = Future {
-      withImageId(message)(id => store.deleteItem(id))
+      withImageId(message)(id => store.deleteItemV2(id))
   }
 }

--- a/metadata-editor/app/lib/Syndication.scala
+++ b/metadata-editor/app/lib/Syndication.scala
@@ -48,8 +48,8 @@ trait Syndication extends Edit with MessageSubjects with GridLogging {
                                 (implicit ec: ExecutionContext): Future[Unit] =
     publishChangedSyndicationRightsForPhotoshoot[Unit](id, unchangedPhotoshoot = false) { () =>
       for {
-        edits <- editsStore.removeKey(id, Edits.Photoshoot)
-        _ <- editsStore.removeKey(id, Edits.PhotoshootTitle)
+        edits <- editsStore.removeKeyV2(id, Edits.Photoshoot)
+        _ <- editsStore.removeKeyV2(id, Edits.PhotoshootTitle)
         _ = publish(id, UpdateImagePhotoshootMetadata)(edits)
       } yield ()
     }


### PR DESCRIPTION
## What does this change?

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

- [x] Removing photoshoot removes the title
- [ ] When an image is deleted the call back to delete metadata runs
This is no longer in use 

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
