### PR TITLE
default AI feature switch to true

### DIFF
--- a/kahuna/app/lib/FeatureSwitch.scala
+++ b/kahuna/app/lib/FeatureSwitch.scala
@@ -19,7 +19,7 @@ object UseCqlChips extends FeatureSwitch(
 object EnableAISearch extends FeatureSwitch(
   key = "enable-ai-search",
   title = "Enable the use of AI search",
-  default = false
+  default = true
 )
 
 class FeatureSwitches(featureSwitches: List[FeatureSwitch]){


### PR DESCRIPTION
## What does this change?
This should be merged before morning conference on Wednesday, when we're releasing AI search 🚀

If something goes wrong, we can merge this https://github.com/guardian/grid/pull/4813 to turn the AI search off. 