### PR TITLE
Apply circular mask for 1:1 crop by default

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -50,6 +50,7 @@ crop.controller('ImageCropCtrl', [
       const imageId = $stateParams.imageId;
 
       const circularMaskKey = 'crop.shouldUseCircularMask';
+      ctrl.shouldUseCircularMask = true;
       try {
         const stored = storage.getJs(circularMaskKey);
         if (typeof stored === 'boolean') {


### PR DESCRIPTION
## What does this change?

As in title 

## How should a reviewer test this change?

* Clear your local storage for the Grid
* Go to an image, go to crop, and select 1:1
* 'Apply circular mask' should be checked by default

<img width="318" height="93" alt="Screenshot 2026-07-20 at 12 49 21" src="https://github.com/user-attachments/assets/f42ce8f6-35ef-486c-be7d-9428d443810b" />



## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216668199565283