### PR TITLE
Reword advanced search tooltip

### DIFF
--- a/kahuna/public/js/search/query.html
+++ b/kahuna/public/js/search/query.html
@@ -25,8 +25,8 @@
     <button class="search__advanced-toggle" ng-class="searchQuery.usePermissionsFilter ? 'search__advanced-toggle-lbl' : ''"
             type="button"
             ng-click="searchInfo = !searchInfo"
-            gr-tooltip="Display advanced search information"
-            aria-label="Display advanced search information">
+            gr-tooltip="Click to display advanced search information"
+            aria-label="Click to display advanced search information">
         <gr-icon>info_outline</gr-icon>
     </button>
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -1195,10 +1195,13 @@ textarea.ng-invalid {
 
 .search__advanced-toggle {
     margin-left: 10px;
+    padding: 0 5px 3px;
 }
 
 .search__advanced-toggle:hover {
     color: white;
+    background-color: #666666;
+    border-radius: 2px;
 }
 
 .search__advanced-toggle:focus {


### PR DESCRIPTION
## What does this change?

It's not very obvious that the info icon next to the search bar in Grid homepage is a clickable button that will display a whole panel of information about searching. This PR changes the tooltip wording to make it clearer that it is clickable and adds a background on hover.

| Before | After|
| ------- | ----- |
|<img width="300" height="auto" alt="Screenshot 2026-07-20 at 14 10 32" src="https://github.com/user-attachments/assets/58138fb6-3d8b-48a4-a4a2-bbfbca5ddb61" /> | <img width="300" height="auto" alt="Screenshot 2026-07-21 at 10 14 58" src="https://github.com/user-attachments/assets/654db1e1-3275-4d23-ae51-36835ad79b3b" />  |

## How should a reviewer test this change?

Hover over the info icon.

## How can success be measured?

More users are aware that this is a clickable button and are using it. Especially helpful for newer users.

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
