### PR TITLE
Add initial loading state for crop view

### DIFF
--- a/kahuna/public/js/crop/controller.js
+++ b/kahuna/public/js/crop/controller.js
@@ -5,12 +5,14 @@ import {radioList} from '../components/gr-radio-list/gr-radio-list';
 import {cropUtil} from "../util/crop";
 import {cropOptions} from "../util/constants/cropOptions";
 import {storage as storageModule} from "../util/storage";
+import '../imgops/service';
 
 const crop = angular.module('kahuna.crop.controller', [
   'gr.keyboardShortcut',
   radioList.name,
   cropUtil.name,
-  storageModule.name
+  storageModule.name,
+  'kahuna.imgops'
 ]);
 
 crop.controller('ImageCropCtrl', [
@@ -21,7 +23,7 @@ crop.controller('ImageCropCtrl', [
   'mediaApi',
   'mediaCropper',
   'image',
-  'optimisedImageUri',
+  'imgops',
   'keyboardShortcut',
   'defaultCrop',
   'cropSettings',
@@ -37,7 +39,7 @@ crop.controller('ImageCropCtrl', [
     mediaApi,
     mediaCropper,
     image,
-    optimisedImageUri,
+    imgops,
     keyboardShortcut,
     defaultCrop,
     cropSettings,
@@ -84,7 +86,16 @@ crop.controller('ImageCropCtrl', [
       ctrl.cropType = storageCropType || storageDefaultCropType || defaultCrop.key;
 
       ctrl.image = image;
-      ctrl.optimisedImageUri = optimisedImageUri;
+      ctrl.optimisedImageUri = null;
+      ctrl.imageLoading = true;
+
+      imgops.getFullScreenUri(image).then(uri => {
+        ctrl.optimisedImageUri = uri;
+      });
+
+      ctrl.onCropperReady = () => {
+        ctrl.imageLoading = false;
+      };
 
       ctrl.cropping = false;
 

--- a/kahuna/public/js/crop/index.js
+++ b/kahuna/public/js/crop/index.js
@@ -44,9 +44,7 @@ crop.config(['$stateProvider',
                         return $q.reject(error);
                     }
                 });
-            }],
-            optimisedImageUri: ['image', 'imgops',
-                                (image, imgops) => imgops.getFullScreenUri(image)]
+            }]
         }
     });
 

--- a/kahuna/public/js/crop/view.html
+++ b/kahuna/public/js/crop/view.html
@@ -125,6 +125,9 @@
     'circular-mask': ctrl.shouldShowCircularGuideline && ctrl.shouldUseCircularMask
 }">
     <div class="easel__canvas">
+        <div class="easel__loading" ng-if="ctrl.imageLoading">
+            <span>Loading image…</span>
+        </div>
         <div class="easel__image-container" oncontextmenu="return false;">
             <img class="easel__image easel__image--cropper"
                  crossorigin="anonymous"
@@ -135,7 +138,7 @@
                  ui-crop-box-original-width="ctrl.originalWidth"
                  ui-crop-box-original-height="ctrl.originalHeight"
                  ui-crop-box-crop-type="ctrl.cropType"
-
+                 ui-crop-box-on-ready="ctrl.onCropperReady()"
                  grid:track-image="ctrl.image"
                  grid:track-image-location="original-cropping"
                  grid:track-image-loadtime

--- a/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
+++ b/kahuna/public/js/directives/ui-crop-box/ui-crop-box.js
@@ -23,7 +23,8 @@ cropBox.directive('uiCropBox', [
             coords:         '=uiCropBox',
             cropType:       '=uiCropBoxCropType',
             originalWidth:  '=uiCropBoxOriginalWidth',
-            originalHeight: '=uiCropBoxOriginalHeight'
+            originalHeight: '=uiCropBoxOriginalHeight',
+            onReady:        '&uiCropBoxOnReady'
         },
         link: function (scope, element) {
             var cropper;
@@ -87,6 +88,11 @@ cropBox.directive('uiCropBox', [
                 previewImg = cropper.getCanvasData();
                 widthRatio = scope.originalWidth / previewImg.naturalWidth;
                 heightRatio = scope.originalHeight / previewImg.naturalHeight;
+
+                // Cropper.js fires this outside of Angular's digest cycle,
+                // so use safeApply to make sure any bound loading state
+                // updates in the view.
+                safeApply(scope, () => scope.onReady());
             }
 
             function update(c) {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2025,6 +2025,7 @@ FIXME: what to do with touch devices
 }
 
 .easel__canvas {
+    position: relative;
     height: calc(100vh - 50px); /* viewport - top-bar */
     vertical-align: middle;
     overflow: hidden;
@@ -2032,6 +2033,16 @@ FIXME: what to do with touch devices
 .warning + .easel__canvas { /* when an easel__canvas follows a warning banner */
   height: calc(100vh - 134px); /* viewport - (top-bar + warning) */
   margin: 10px;
+}
+
+.easel__loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #999;
+    font-size: 1.6rem;
+    white-space: nowrap;
 }
 
 .easel__image-container {


### PR DESCRIPTION
## What does this change?
Adds a loading state to the crop view so users get immediate feedback instead of a frozen screen during the a few seconds wait for the optimised image to be generated/downloaded.
* Remove `optimisedImageUri` from the blocking resolve — the state transition now only waits on the fast image/imageId resolves, so the crop view renders immediately.
* Inject `imgops` directly into crop controller to fetch the optimised image URI asynchronously after load
* Loading state is then reset when the crop box is ready

## How should a reviewer test this change?
* Go to the crop view of an image. You may want to add some throttling when testing locally
<img width="1418" height="978" alt="loading image" src="https://github.com/user-attachments/assets/eaaee5db-4b86-46fc-89dd-7c8ab54c15f7" />


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216668121615122