### PR TITLE
Do not display incorrect 'too many results' after AI search results

### DIFF
--- a/kahuna/public/js/search/results.html
+++ b/kahuna/public/js/search/results.html
@@ -216,7 +216,7 @@
             </li>
         </ul>
 
-        <div ng-if="ctrl.totalResults > ctrl.maxResults && !ctrl.previewView"
+        <div ng-if="ctrl.totalResults > ctrl.maxResults && !ctrl.previewView && !ctrl.isAiSearch"
              class="image-results-more">
             <div class="image-results-more__heading">Too many results to display</div>
             <div class="image-results-more__instructions">Please refine your search to limit the number of results</div>


### PR DESCRIPTION
This is caused by the fact that `totalResults` for AI search now represents the total items matching filters (e.g. 7,757,034) instead of the 200 items on the page, meaning it frequently exceeds `maxResults`

# before
<img width="1818" height="824" alt="Screenshot 2026-07-22 at 12 18 44" src="https://github.com/user-attachments/assets/299658e8-5dc3-446d-a256-b1779b263c98" />

# after
<img width="1818" height="824" alt="Screenshot 2026-07-22 at 12 18 41" src="https://github.com/user-attachments/assets/6d6ca267-a61a-4c8a-abb0-637587635cab" />
