### PR TITLE
Rename "No Rights" to "Unknown Rights"

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -158,7 +158,7 @@ case object NoRights
   val category = ""
   val defaultCost = None
   val restrictions = None
-  def name(commonConfig: CommonConfig) = "No Rights"
+  def name(commonConfig: CommonConfig) = "Unknown Rights"
   def description(commonConfig: CommonConfig) =
     "Images which we do not currently have the rights to use."
 

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -28,7 +28,7 @@
 
             <div class="image-info__title" ng-if="!ctrl.showUsageRights">
                 <dd ng-if="!ctrl.usageRightsSummary">
-                    {{ctrl.usageCategory || 'None'}}
+                    {{ctrl.usageCategory || 'Unknown'}}
                 </dd>
                 <dd ng-if="ctrl.usageRightsSummary">
                     <usage-rights-summary

--- a/kahuna/public/js/components/gr-usagerights-summary/gr-usagerights-summary.tsx
+++ b/kahuna/public/js/components/gr-usagerights-summary/gr-usagerights-summary.tsx
@@ -107,7 +107,7 @@ const UsageRightsSummary: React.FC<UsageRightsWrapperProps> = ({ props }) => {
 
   return (<div>
     <div className="usage-rights-container">
-      <div className="usage-rights-element">{ category || 'None'}</div>
+      <div className="usage-rights-element">{ category || 'Unknown'}</div>
       <div className="usage-rights-element">
         <div className={agencyStyle} title={agencyTitle}></div>
       </div>

--- a/kahuna/public/js/edits/image-editor.html
+++ b/kahuna/public/js/edits/image-editor.html
@@ -147,7 +147,7 @@
 
                 <div class="result-editor__usage-rights-container">
                     <div ng-hide="ctrl.showUsageRights" class="result-editor__field-value">
-                        <span>{{ctrl.usageRightsCategory || 'None'}}</span>
+                        <span>{{ctrl.usageRightsCategory || 'Unknown'}}</span>
                         <button
                           data-cy="edit-rights-button"
                           class="image-info__edit"


### PR DESCRIPTION
## What does this change?

* Rename `name` field of `NoRights` to 'Unknown Rights' - this doesn't affect writes, and only the rights and restrictions select dropdown options
* Updated copy in the UI from 'None' to 'Unknown'

## How should a reviewer test this change?

<img width="944" height="344" alt="in the upload flow" src="https://github.com/user-attachments/assets/a6d881f2-1050-4be1-8a13-e0a7e58575a3" />


<img width="1184" height="500" alt="Jul-28-2026 11-36-18" src="https://github.com/user-attachments/assets/0940bc10-f5f5-44fe-bf2c-9fee1af6bd92" />


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216798694730976