### PR TITLE
Revert "Revert "chore(deps): bump immutable from 3.8.3 to 4.3.9 in /kahuna""

### DIFF
--- a/kahuna/package-lock.json
+++ b/kahuna/package-lock.json
@@ -23,7 +23,7 @@
         "any-promise-angular": "0.1.1",
         "cropperjs": "1.5.12",
         "filehash": "1.0.0",
-        "immutable": "3.8.3",
+        "immutable": "4.3.9",
         "javascript-detect-element-resize": "0.5.3",
         "jszip": "3.8.0",
         "moment": "2.29.4",
@@ -8718,13 +8718,10 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "node_modules/immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",

--- a/kahuna/package.json
+++ b/kahuna/package.json
@@ -18,7 +18,7 @@
     "any-promise-angular": "0.1.1",
     "cropperjs": "1.5.12",
     "filehash": "1.0.0",
-    "immutable": "3.8.3",
+    "immutable": "4.3.9",
     "javascript-detect-element-resize": "0.5.3",
     "jszip": "3.8.0",
     "moment": "2.29.4",

--- a/kahuna/public/js/services/image-list.js
+++ b/kahuna/public/js/services/image-list.js
@@ -18,8 +18,14 @@ imageList.factory("imageList", [
         }, new Map());
     }
 
-    function occurrencesToTuple(countsMap) {
-        return countsMap.map((count, data) => ({data, count})).toArray();
+    function occurrencesToArray(countsMap) {
+      // Map is a Keyed collection, so toArray() on it returns [key, value]
+      // entry pairs rather than just the mapped values. Use valueSeq() first
+      // to get a flat array of the mapped {data, count} objects.
+      return countsMap
+        .map((count, data) => ({ data, count }))
+        .valueSeq()
+        .toArray();
     }
 
     // TODO: a lot of these are boilerplate around imageAccessor, can
@@ -54,7 +60,7 @@ imageList.factory("imageList", [
 
     function getOccurrences(items) {
         const valueCounts = countOccurrences(items);
-        return occurrencesToTuple(valueCounts);
+        return occurrencesToArray(valueCounts);
     }
 
     function getSetOfProperties(objects) {


### PR DESCRIPTION
Reverts guardian/grid#4828

Re-installing the version bump for immutable, with a fix for the breaking change around `toArray`

Previously this broke label and keywords rendering, as well as the selected image counts - these should all be working now:

<img width="1299" height="932" alt="Screenshot 2026-07-29 at 11 50 28" src="https://github.com/user-attachments/assets/eb610ff4-afab-4a44-b101-caeae4811bc6" />


