### PR TITLE
add z-index to .circular-mask-toggle-container

### DIFF
--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2096,6 +2096,7 @@ FIXME: what to do with touch devices
   right: 0;
   padding: 10px;
   user-select: none;
+  z-index: 1;
 }
 
 


### PR DESCRIPTION
## What does this change?

Adds a z-index of 1 to the container for the "circular mask" toggle.

A user reported that they could not toggle the option. The reason seems to be that it is masked by the ".easel__canvas"  element. Adding the z-index puts the toggle "above" so it can still be clicked.

## How should a reviewer test this change?

Run locally, open an image, select "crop image" (top right of UI), then select 1:1 crop.
 on this branch, the toggle should be clickable.

On main, the toggle is not clickable, but still reachable using the keyboard to tab it into focus


## How can success be measured?
restores functionality

## Who should look at this?


## Tested? Documented?

Just tested by changing the css in the browser (don't have grid set up locally ATM)

- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
