### PR TITLE
remove feature switch

### DIFF
--- a/kahuna/app/controllers/KahunaController.scala
+++ b/kahuna/app/controllers/KahunaController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.mediaservice.lib.argo.ArgoHelpers
 import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.auth.{Authentication, Authorisation, BaseControllerWithLoginRedirects}
-import lib.{EnableAISearch, ExampleSwitch, FeatureSwitches, KahunaConfig, UseCqlChips}
+import lib.{ExampleSwitch, FeatureSwitches, KahunaConfig, UseCqlChips}
 import play.api.mvc.ControllerComponents
 import play.api.libs.json._
 
@@ -38,7 +38,7 @@ class KahunaController(
 
     val isIFramed = request.headers.get("Sec-Fetch-Dest").contains("iframe")
     val featureSwitches = new FeatureSwitches(
-      List(ExampleSwitch, UseCqlChips) ++ (if (config.aiSearchEnabled) List(EnableAISearch) else Nil)
+      List(ExampleSwitch, UseCqlChips)
     )
     val featureSwitchesWithClientValues = featureSwitches.getClientSwitchValues(featureSwitches.getFeatureSwitchCookies(request.cookies.get))
     val featureSwitchesJson = Json.stringify(Json.toJson(featureSwitches.getFeatureSwitchesToStringify(featureSwitchesWithClientValues)))

--- a/kahuna/app/lib/FeatureSwitch.scala
+++ b/kahuna/app/lib/FeatureSwitch.scala
@@ -16,12 +16,6 @@ object UseCqlChips extends FeatureSwitch(
   default = true
 )
 
-object EnableAISearch extends FeatureSwitch(
-  key = "enable-ai-search",
-  title = "Enable the use of AI search",
-  default = true
-)
-
 class FeatureSwitches(featureSwitches: List[FeatureSwitch]){
   // Feature switches are defined here, but updated by setting a cookie following the pattern e.g. "feature-switch-my-key"
   // for a switch called "my-key".

--- a/kahuna/public/js/components/gr-more-like-this/gr-more-like-this.js
+++ b/kahuna/public/js/components/gr-more-like-this/gr-more-like-this.js
@@ -1,7 +1,6 @@
 import angular from 'angular';
 import './gr-more-like-this.css';
 import template from './gr-more-like-this.html';
-import {getFeatureSwitchActive} from '../gr-feature-switch-panel/gr-feature-switch-panel';
 
 export const moreLikeThis = angular.module('gr.moreLikeThis', []);
 
@@ -13,7 +12,7 @@ moreLikeThis.controller('MoreLikeThisCtrl', [
     let ctrl = this;
 
     ctrl.$onInit = () => {
-      ctrl.showMoreLikeThis = getFeatureSwitchActive('enable-ai-search');
+      ctrl.showMoreLikeThis = window._clientConfig.aiSearchEnabled;
       ctrl.getMoreLikeThisQuery = function() {
         return `similar:${ctrl.image.data.id}`;
       };

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -26,7 +26,6 @@ import {
   HAS_DATE_TAKEN,
   TAKEN_SORT
 } from "../components/gr-sort-control/gr-sort-control-config";
-import {getFeatureSwitchActive} from "../components/gr-feature-switch-panel/gr-feature-switch-panel";
 
 export var query = angular.module('kahuna.search.query', [
     // Note: temporarily disabled for performance reasons, see above
@@ -79,7 +78,7 @@ query.controller('SearchQueryCtrl', [
     ctrl.filterMyUploads = false;
     ctrl.initialShowPaidEvent = ($stateParams.nonFree === undefined && ctrl.usePermissionsFilter) ? false : true;
 
-    ctrl.shouldDisplayAISearchOption = window._clientConfig.aiSearchEnabled && getFeatureSwitchActive("enable-ai-search");
+    ctrl.shouldDisplayAISearchOption = window._clientConfig.aiSearchEnabled;
     if (!ctrl.shouldDisplayAISearchOption) {
       ctrl.useAISearch = false;
       ctrl.vecWeight = undefined;

--- a/kahuna/public/js/window.ts
+++ b/kahuna/public/js/window.ts
@@ -8,6 +8,7 @@ declare global {
     _clientConfig: {
       rootUri: string;
       telemetryUri: string;
+      aiSearchEnabled: boolean;
       aiSearchResultLimit: number;
       featureSwitches: Array<FeatureSwitchData>;
       interimFilterOptions: Array<PermissionOption>;


### PR DESCRIPTION
## What does this change?
Now that we have the config setting, we can turn AI search on and off by updating the config and re-deploying. 

It's a lot easier for state management to get rid of the feature switch, so let's remove it! 