### PR TITLE
PR and Third Party mapping

### DIFF
--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -83,8 +83,22 @@ usageRights.applicable = [
   "com.gu.mediaservice.model.StaffIllustrator",
   "com.gu.mediaservice.model.Composite",
   "com.gu.mediaservice.model.PublicDomain",
+]
+
+usageRightsV2.applicable = [
+  "com.gu.mediaservice.model.NoRights",
+  "com.gu.mediaservice.model.Chargeable",
+  "com.gu.mediaservice.model.Bylines",
+  "com.gu.mediaservice.model.StaffPhotographer",
+  "com.gu.mediaservice.model.ContractPhotographer",
+  "com.gu.mediaservice.model.CommissionedPhotographer",
+  "com.gu.mediaservice.model.ContractIllustrator",
+  "com.gu.mediaservice.model.CommissionedIllustrator",
+  "com.gu.mediaservice.model.StaffIllustrator",
   "com.gu.mediaservice.model.PRAndThirdParty"
 ]
+
+usageRights.showVersion2 = true
 
 # ----------------------------------------------------------------------------------------
 # List of usage right categories standard users cannot select whilst uploading or editing

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -82,7 +82,8 @@ usageRights.applicable = [
   "com.gu.mediaservice.model.CommissionedIllustrator",
   "com.gu.mediaservice.model.StaffIllustrator",
   "com.gu.mediaservice.model.Composite",
-  "com.gu.mediaservice.model.PublicDomain"
+  "com.gu.mediaservice.model.PublicDomain",
+  "com.gu.mediaservice.model.PRAndThirdParty"
 ]
 
 # ----------------------------------------------------------------------------------------

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -98,7 +98,7 @@ usageRightsV2.applicable = [
   "com.gu.mediaservice.model.PRAndThirdParty"
 ]
 
-usageRights.showVersion2 = true
+showUsageRightsV2 = true
 
 # ----------------------------------------------------------------------------------------
 # List of usage right categories standard users cannot select whilst uploading or editing

--- a/common-lib/src/main/resources/application.conf
+++ b/common-lib/src/main/resources/application.conf
@@ -85,7 +85,7 @@ usageRights.applicable = [
   "com.gu.mediaservice.model.PublicDomain",
 ]
 
-usageRightsV2.applicable = [
+usageRights.applicableV2 = [
   "com.gu.mediaservice.model.NoRights",
   "com.gu.mediaservice.model.Chargeable",
   "com.gu.mediaservice.model.Bylines",
@@ -98,7 +98,7 @@ usageRightsV2.applicable = [
   "com.gu.mediaservice.model.PRAndThirdParty"
 ]
 
-showUsageRightsV2 = true
+usageRights.showV2 = false
 
 # ----------------------------------------------------------------------------------------
 # List of usage right categories standard users cannot select whilst uploading or editing

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -218,8 +218,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientV1B
    * Depending on the type it will be loaded differently using reflection. Companion objects will be looked up
    * and the singleton instance added to the list.
    */
-  val showUsageRightsV2 = configuration.get[Option[Boolean]]("showUsageRightsV2").getOrElse(false)
-  val applicableUsageRights: Seq[UsageRightsSpec] = if(showUsageRightsV2) configuration.get[Seq[UsageRightsSpec]]("usageRightsV2.applicable")  else configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
+  val showUsageRightsV2 = configuration.get[Option[Boolean]]("usageRights.showV2").getOrElse(false)
+  val applicableUsageRights: Seq[UsageRightsSpec] = if(showUsageRightsV2) configuration.get[Seq[UsageRightsSpec]]("usageRights.applicableV2")  else configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
   val stdUserExcludedUsageRights = getStringSet("usageRights.stdUserExcluded")
 
   val agencyPicksIngredients: Option[Map[String, Seq[String]]] =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -218,8 +218,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientV1B
    * Depending on the type it will be loaded differently using reflection. Companion objects will be looked up
    * and the singleton instance added to the list.
    */
-  val usageRightsV2 = configuration.get[Option[Boolean]]("usageRights.showVersion2").getOrElse(false)
-  val applicableUsageRights: Seq[UsageRightsSpec] = if(usageRightsV2) configuration.get[Seq[UsageRightsSpec]]("usageRightsV2.applicable")  else configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
+  val showUsageRightsV2 = configuration.get[Option[Boolean]]("showUsageRightsV2").getOrElse(false)
+  val applicableUsageRights: Seq[UsageRightsSpec] = if(showUsageRightsV2) configuration.get[Seq[UsageRightsSpec]]("usageRightsV2.applicable")  else configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
   val stdUserExcludedUsageRights = getStringSet("usageRights.stdUserExcluded")
 
   val agencyPicksIngredients: Option[Map[String, Seq[String]]] =

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -218,7 +218,8 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientV1B
    * Depending on the type it will be loaded differently using reflection. Companion objects will be looked up
    * and the singleton instance added to the list.
    */
-  val applicableUsageRights: Seq[UsageRightsSpec] = configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
+  val usageRightsV2 = configuration.get[Option[Boolean]]("usageRights.showVersion2").getOrElse(false)
+  val applicableUsageRights: Seq[UsageRightsSpec] = if(usageRightsV2) configuration.get[Seq[UsageRightsSpec]]("usageRightsV2.applicable")  else configuration.get[Seq[UsageRightsSpec]]("usageRights.applicable")
   val stdUserExcludedUsageRights = getStringSet("usageRights.stdUserExcluded")
 
   val agencyPicksIngredients: Option[Map[String, Seq[String]]] =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -629,11 +629,10 @@ object PRAndThirdParty extends UsageRightsSpec {
 
   override val category: String = "pr-and-third-party"
 
-  override def name(config: CommonConfig): String = "PR & Third Party"
+  override def name(config: CommonConfig): String = "PR & third party"
 
-  override def description(config: CommonConfig): String = "Images received from PRs or as handouts, by default you must explain the restrictions that apply. Also use this category for social media posts, screen grabs, agency commissions and obituraries."
+  override def description(config: CommonConfig): String = "Images received from PRs or as handouts, by default you must explain the restrictions that apply. Also use this category for social media posts, screen grabs, agency commissions and obituaries."
 
-  // TODO - check this
   override val defaultCost: Option[Cost] = Some(Conditional)
 
   implicit val formats: Format[PRAndThirdParty] =

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -634,8 +634,26 @@ object PRAndThirdParty extends UsageRightsSpec {
   override def description(config: CommonConfig): String = "Images received from PRs or as handouts, by default you must explain the restrictions that apply. Also use this category for social media posts, screen grabs, agency commissions and obituraries."
 
   // TODO - check this
-  override val defaultCost: Option[Cost] = None
+  override val defaultCost: Option[Cost] = Some(Conditional)
 
   implicit val formats: Format[PRAndThirdParty] =
     UsageRights.subtypeFormat(PRAndThirdParty.category)(Json.format[PRAndThirdParty])
+
+  val legacyCategories: List[String] = List(
+    Agency.category,
+    CommissionedAgency.category,
+    PrImage.category,
+    Handout.category,
+    Screengrab.category,
+    SocialMedia.category,
+    Obituary.category,
+    Pool.category,
+    CrownCopyright.category,
+    CreativeCommons.category,
+    PublicDomain.category,
+    GuardianWitness.category,
+    Composite.category,
+  )
+
+  val allCategories: NonEmptyList[String] = NonEmptyList.fromSeq(category, legacyCategories)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/model/UsageRights.scala
@@ -105,6 +105,7 @@ object UsageRights {
     case o: ProgrammesAcquisitions => ProgrammesAcquisitions.formats.writes(o)
     case o: ProgrammesIndependents => ProgrammesIndependents.formats.writes(o)
     case o: NoRights.type => NoRights.jsonWrites.writes(o)
+    case o: PRAndThirdParty => PRAndThirdParty.formats.writes(o)
   }
 
   implicit val jsonReads: Reads[UsageRights] = Reads[UsageRights] { json =>
@@ -142,6 +143,7 @@ object UsageRights {
         case ProgrammesOrganisationOwned.category => json.asOpt[ProgrammesOrganisationOwned]
         case ProgrammesAcquisitions.category => json.asOpt[ProgrammesAcquisitions]
         case ProgrammesIndependents.category => json.asOpt[ProgrammesIndependents]
+        case PRAndThirdParty.category => json.asOpt[PRAndThirdParty]
         case _ => None
       })
         .orElse(supplier.flatMap(_ => json.asOpt[Agency]))
@@ -616,4 +618,24 @@ object ProgrammesAcquisitions extends UsageRightsSpec {
 
   implicit val formats: Format[ProgrammesAcquisitions] =
     UsageRights.subtypeFormat(ProgrammesAcquisitions.category)(Json.format[ProgrammesAcquisitions])
+}
+
+final case class PRAndThirdParty(restrictions: Option[String] = None, source: Option[String] = None) extends UsageRights {
+
+  override val defaultCost: Option[Cost] = PRAndThirdParty.defaultCost
+}
+
+object PRAndThirdParty extends UsageRightsSpec {
+
+  override val category: String = "pr-and-third-party"
+
+  override def name(config: CommonConfig): String = "PR & Third Party"
+
+  override def description(config: CommonConfig): String = "Images received from PRs or as handouts, by default you must explain the restrictions that apply. Also use this category for social media posts, screen grabs, agency commissions and obituraries."
+
+  // TODO - check this
+  override val defaultCost: Option[Cost] = None
+
+  implicit val formats: Format[PRAndThirdParty] =
+    UsageRights.subtypeFormat(PRAndThirdParty.category)(Json.format[PRAndThirdParty])
 }

--- a/common-lib/src/test/scala/com/gu/mediaservice/lib/config/CommonConfigFixtures.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/lib/config/CommonConfigFixtures.scala
@@ -34,6 +34,8 @@ trait CommonConfigFixtures {
     "grid.appName"
   )
 
+  val SHOW_USAGE_RIGHTS_V2 = Map("usageRights" -> Map("showV2" -> true, "applicableV2" -> List()))
+
   val commonConfigurations = USED_CONFIGS_IN_TEST ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap
 
   def createGridResourcesConfig(commonConfigurations: Map[String, Any], overrides: Map[String, Any] = Map[String, Any]()) = {

--- a/common-lib/src/test/scala/com/gu/mediaservice/model/UsageRightsTest.scala
+++ b/common-lib/src/test/scala/com/gu/mediaservice/model/UsageRightsTest.scala
@@ -103,7 +103,7 @@ class UsageRightsTest extends AnyFunSpec with Matchers with CommonConfigFixtures
   }
 
   it("Chargeable name should be Pay to use when usageRights.showV2 is true") {
-    val commonConfig = new CommonConfigWithElastic(createGridResourcesConfig(commonConfigurations, Map("usageRights" -> Map("showV2" -> true, "applicableV2" -> List()))))
+    val commonConfig = new CommonConfigWithElastic(createGridResourcesConfig(commonConfigurations, SHOW_USAGE_RIGHTS_V2))
     Chargeable.name(commonConfig) shouldBe "Pay to use"
   }
 

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -24,6 +24,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
   extends EditsResponse with GridLogging {
 
   implicit val usageQuotas: UsageQuota = usageQuota
+  val showUsageRightsV2 = config.usageRightsV2
 
   object Costing extends CostCalculator {
     override val freeSuppliers: List[String] = config.usageRightsConfig.freeSuppliers
@@ -117,7 +118,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
       .flatMap(_.transform(addFromIndex(imageWrapper.fromIndex)))
       .flatMap(_.transform(updateCustomSpecialInstructions(source)))
       .flatMap(_.transform(updateCustomUsageRestrictions(source)))
-      .flatMap(_.transform(updateRightsAndRestrictions(source)))
+      .flatMap(json => if(showUsageRightsV2) json.transform(updateRightsAndRestrictions(source)) else JsSuccess(json))
       .get
 
     val links: List[Link] = tier match {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -294,7 +294,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
     }
   }
 
-  private def updateRightsAndRestrictions(source: JsValue): Reads[JsObject] = {
+  private[lib] def updateRightsAndRestrictions(source: JsValue): Reads[JsObject] = {
     val supplier = (source \ "usageRights" \ "supplier").asOpt[String]
     val suppliers = (source \ "usageRights" \ "suppliers").asOpt[String]
     (source \ "usageRights" \ "category") match {

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -117,6 +117,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
       .flatMap(_.transform(addFromIndex(imageWrapper.fromIndex)))
       .flatMap(_.transform(updateCustomSpecialInstructions(source)))
       .flatMap(_.transform(updateCustomUsageRestrictions(source)))
+      .flatMap(_.transform(updateRightsAndRestrictions(source)))
       .get
 
     val links: List[Link] = tier match {
@@ -289,6 +290,20 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
         } else {
           __.json.update(__.read[JsObject])
         }
+      case _ => __.json.update(__.read[JsObject])
+    }
+  }
+
+  private def updateRightsAndRestrictions(source: JsValue): Reads[JsObject] = {
+    val supplier = (source \ "usageRights" \ "supplier").asOpt[String]
+    val suppliers = (source \ "usageRights" \ "suppliers").asOpt[String]
+    (source \ "usageRights" \ "category") match {
+      case JsDefined(c) if PRAndThirdParty.legacyCategories.contains(c.as[String]) =>
+        (__ \ "usageRights").json.update(__.read[JsObject]
+          .map(_ ++ Json.obj("category" -> PRAndThirdParty.category, "legacyCategory" -> c.as[String])
+            ++ supplier.fold(Json.obj())(s => Json.obj("source" -> s))
+            ++ suppliers.fold(Json.obj())(s => Json.obj("source" -> s))
+          ))
       case _ => __.json.update(__.read[JsObject])
     }
   }

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -24,7 +24,6 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
   extends EditsResponse with GridLogging {
 
   implicit val usageQuotas: UsageQuota = usageQuota
-  val showUsageRightsV2 = config.usageRightsV2
 
   object Costing extends CostCalculator {
     override val freeSuppliers: List[String] = config.usageRightsConfig.freeSuppliers
@@ -118,7 +117,7 @@ class ImageResponse(config: MediaApiConfig, s3Client: S3, usageQuota: UsageQuota
       .flatMap(_.transform(addFromIndex(imageWrapper.fromIndex)))
       .flatMap(_.transform(updateCustomSpecialInstructions(source)))
       .flatMap(_.transform(updateCustomUsageRestrictions(source)))
-      .flatMap(json => if(showUsageRightsV2) json.transform(updateRightsAndRestrictions(source)) else JsSuccess(json))
+      .flatMap(json => if(config.showUsageRightsV2) json.transform(updateRightsAndRestrictions(source)) else JsSuccess(json))
       .get
 
     val links: List[Link] = tier match {

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -53,7 +53,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
 
-      case Words(value) if config.usageRightsV2 && field == "usageRights.category" && value == PRAndThirdParty.category =>
+      case Words(value) if config.showUsageRightsV2 && field == "usageRights.category" && value == PRAndThirdParty.category =>
         filters.terms(resolveFieldPath(field), PRAndThirdParty.allCategories)
       // Force AND operator else it will only require *any* of the words, not *all*
       case Words(value) =>

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -53,7 +53,7 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
 
-      case Words(value) if field == "usageRights.category" && value == PRAndThirdParty.category =>
+      case Words(value) if config.usageRightsV2 && field == "usageRights.category" && value == PRAndThirdParty.category =>
         filters.terms(resolveFieldPath(field), PRAndThirdParty.allCategories)
       // Force AND operator else it will only require *any* of the words, not *all*
       case Words(value) =>

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -4,7 +4,7 @@ import com.gu.mediaservice.lib.ImageFields
 import com.gu.mediaservice.lib.elasticsearch.filters
 import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.lib.logging.GridLogging
-import com.gu.mediaservice.model.Agency
+import com.gu.mediaservice.model.{Agency, PRAndThirdParty}
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.common.Operator
@@ -52,6 +52,9 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
     case AnyField => makeMultiQuery(condition.value, matchFields)
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
+
+      case Words(value) if field == "usageRights.category" && value == PRAndThirdParty.category =>
+        filters.terms(resolveFieldPath(field), PRAndThirdParty.allCategories)
       // Force AND operator else it will only require *any* of the words, not *all*
       case Words(value) =>
         matchQuery(resolveFieldPath(field), value).operator(Operator.AND)

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -139,8 +139,8 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
     extractedFields.isEmpty shouldEqual true
   }
 
-  describe("updateRightsAndRestrictions ->") {
-    describe("should transform the following categories:") {
+  describe("updateRightsAndRestrictions") {
+    describe("should map the following categories to pr-and-third-party and set the legacyCategory with the original category name and maintain old fields") {
       it("handout") {
         val inputJson = Json.obj(
           "usageRights" -> JsObject(
@@ -329,61 +329,6 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
           )
         )
       }
-
-      it("agency") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("agency"),
-              "supplier" -> JsString("Action Images"),
-              "suppliersCollection" -> JsString("collection"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("agency"),
-              "supplier" -> JsString("Action Images"),
-              "suppliersCollection" -> JsString("collection"),
-              "restrictions" -> JsString("restrictions"),
-              "source" -> JsString("Action Images")
-            )
-          )
-        )
-      }
-
-      it("commissioned-agency") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("commissioned-agency"),
-              "supplier" -> JsString("Action Images"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("commissioned-agency"),
-              "supplier" -> JsString("Action Images"),
-              "restrictions" -> JsString("restrictions"),
-              "source" -> JsString("Action Images")
-            )
-          )
-        )
-      }
-
       it("public-domain") {
         val inputJson = Json.obj(
           "usageRights" -> JsObject(
@@ -406,7 +351,107 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
           )
         )
       }
-      // TODO - guardian witness, and composite
+      it("guardian-witness") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("guardian-witness"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("guardian-witness"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+      describe("For legacy categories that have a supplier or suppliers field, these should be mapped to source") {
+        it("composite") {
+          val inputJson = Json.obj(
+            "usageRights" -> JsObject(
+              Map(
+                "category" -> JsString("composite"),
+                "restrictions" -> JsString("restrictions"),
+                "suppliers" -> JsString("supplier1 and supplier2")
+              )
+            )
+          )
+          val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+          val result: JsResult[JsObject] = inputJson.transform(transformer)
+          result shouldBe a[JsSuccess[_]]
+          result.get shouldBe Json.obj(
+            "usageRights" -> JsObject(
+              Map(
+                "category" -> JsString("pr-and-third-party"),
+                "legacyCategory" -> JsString("composite"),
+                "restrictions" -> JsString("restrictions"),
+                "suppliers" -> JsString("supplier1 and supplier2"),
+                "source" -> JsString("supplier1 and supplier2")
+              )
+            )
+          )
+        }
+        it("agency") {
+          val inputJson = Json.obj(
+            "usageRights" -> JsObject(
+              Map(
+                "category" -> JsString("agency"),
+                "supplier" -> JsString("Action Images"),
+                "suppliersCollection" -> JsString("collection"),
+                "restrictions" -> JsString("restrictions")
+              )
+            )
+          )
+          val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+          val result: JsResult[JsObject] = inputJson.transform(transformer)
+          result shouldBe a[JsSuccess[_]]
+          result.get shouldBe Json.obj(
+            "usageRights" -> JsObject(
+              Map(
+                "category" -> JsString("pr-and-third-party"),
+                "legacyCategory" -> JsString("agency"),
+                "supplier" -> JsString("Action Images"),
+                "suppliersCollection" -> JsString("collection"),
+                "restrictions" -> JsString("restrictions"),
+                "source" -> JsString("Action Images")
+              )
+            )
+          )
+        }
+        it("commissioned-agency") {
+          val inputJson = Json.obj(
+            "usageRights" -> JsObject(
+              Map(
+                "category" -> JsString("commissioned-agency"),
+                "supplier" -> JsString("Action Images"),
+                "restrictions" -> JsString("restrictions")
+              )
+            )
+          )
+          val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+          val result: JsResult[JsObject] = inputJson.transform(transformer)
+          result shouldBe a[JsSuccess[_]]
+          result.get shouldBe Json.obj(
+            "usageRights" -> JsObject(
+              Map(
+                "category" -> JsString("pr-and-third-party"),
+                "legacyCategory" -> JsString("commissioned-agency"),
+                "supplier" -> JsString("Action Images"),
+                "restrictions" -> JsString("restrictions"),
+                "source" -> JsString("Action Images")
+              )
+            )
+          )
+        }
+      }
     }
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -1,7 +1,9 @@
 package lib
 
+import com.gu.mediaservice.lib.auth.ReadOnly
 import com.gu.mediaservice.lib.aws.S3
 import com.gu.mediaservice.lib.config.GridConfigResources
+import com.gu.mediaservice.lib.logging.LogMarker
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.{PendingUsageStatus, PrintUsage, Usage}
 import lib.elasticsearch.{Fixtures, SourceWrapper}
@@ -16,38 +18,31 @@ import play.api.libs.json._
 import scala.concurrent.Future
 
 class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
+  private val commonConfigurations = USED_CONFIGS_IN_TEST ++ Map(
+    "field.aliases" -> List(
+      Map(
+        "elasticsearchPath" -> "fileMetadata.xmp.org:ProgrammeMaker",
+        "alias" -> "orgProgrammeMaker",
+        "label" -> "Organization Programme Maker",
+        "displaySearchHint" -> false
+      ),
+      Map(
+        "elasticsearchPath" -> "fileMetadata.xmp.aux:Lens",
+        "alias" -> "auxLens",
+        "label" -> "Aux Lens",
+        "displaySearchHint" -> false
+      ),
+      Map(
+        "elasticsearchPath" -> "fileMetadata.iptc.Caption Writer/Editor",
+        "alias" -> "captionWriter",
+        "label" -> "Caption Writer / Editor",
+        "displaySearchHint" -> true
+      ))) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap
 
-  val mediaApiConfig = new MediaApiConfig(GridConfigResources(
-    Configuration.from(USED_CONFIGS_IN_TEST ++ Map(
-      "field.aliases" -> List(
-        Map(
-          "elasticsearchPath" -> "fileMetadata.xmp.org:ProgrammeMaker",
-          "alias" -> "orgProgrammeMaker",
-          "label" -> "Organization Programme Maker",
-          "displaySearchHint" -> false
-        ),
-        Map(
-          "elasticsearchPath" -> "fileMetadata.xmp.aux:Lens",
-          "alias" -> "auxLens",
-          "label" -> "Aux Lens",
-          "displaySearchHint" -> false
-        ),
-        Map(
-          "elasticsearchPath" -> "fileMetadata.iptc.Caption Writer/Editor",
-          "alias" -> "captionWriter",
-          "label" -> "Caption Writer / Editor",
-          "displaySearchHint" -> true
-        )
-      )
-    ) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap),
-    null,
-    new ApplicationLifecycle {
-      override def addStopHook(hook: () => Future[_]): Unit = {}
-      override def stop(): Future[_] = Future.successful(())
-    }
-  ))
+  val mediaApiConfig = createMediaApiConfig(commonConfigurations)
 
   val imageResponse = new ImageResponse(mediaApiConfig, mock[S3], mock[UsageQuota])
+  implicit val logMarker: LogMarker = mock[LogMarker]
 
   it("should replace \\r linebreaks with \\n") {
     val text = "Here is some text\rthat spans across\rmultiple lines\r"
@@ -123,6 +118,48 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
     extractedFields.contains("orgProgrammeMaker" -> JsString("xmp programme maker")) shouldEqual true
     extractedFields.contains("auxLens" -> JsString("xmp aux lens")) shouldEqual true
     extractedFields.contains("captionWriter" -> JsString("the editor")) shouldEqual true
+  }
+
+  describe("create") {
+    it("should not apply the updateRightsAndRestrictions transformation when showUsageRightsV2 is set to false" ) {
+      val image = createImage(
+        id = "test-image",
+        agency
+      )
+      val json = Json.toJson(image)
+      val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
+
+      val (data, _, _) = imageResponse.create("id",
+        sourceWrapper,
+        withWritePermission = false,
+        withDeleteImagePermission = false,
+        withDeleteCropsOrUsagePermission = false,
+        included = Nil,
+        tier = ReadOnly)
+
+      (data \ "usageRights" \ "category").as[String] shouldBe "agency"
+     }
+    it("should  apply the updateRightsAndRestrictions transformation when showUsageRightsV2 is set to true") {
+      val image = createImage(
+        id = "test-image",
+        agency
+      )
+      val json = Json.toJson(image)
+      val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
+      val mediaApiConfig = createMediaApiConfig(commonConfigurations, Map("showUsageRightsV2" -> true))
+
+      val imageResponse = new ImageResponse(mediaApiConfig, mock[S3], mock[UsageQuota])
+
+      val (data, _, _) = imageResponse.create("id",
+        sourceWrapper,
+        withWritePermission = false,
+        withDeleteImagePermission = false,
+        withDeleteCropsOrUsagePermission = false,
+        included = Nil,
+        tier = ReadOnly)
+
+      (data \ "usageRights" \ "category").as[String] shouldBe "pr-and-third-party"
+    }
   }
 
   describe("updateRightsAndRestrictions") {

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -1,5 +1,6 @@
 package lib
 
+import com.gu.mediaservice.lib.aws.S3
 import com.gu.mediaservice.lib.config.GridConfigResources
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.usage.{PendingUsageStatus, PrintUsage, Usage}
@@ -7,6 +8,7 @@ import lib.elasticsearch.{Fixtures, SourceWrapper}
 import org.joda.time.DateTime.now
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json._
@@ -44,6 +46,8 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
       override def stop(): Future[_] = Future.successful(())
     }
   ))
+
+  val imageResponse = new ImageResponse(mediaApiConfig, mock[S3], mock[UsageQuota])
 
   it("should replace \\r linebreaks with \\n") {
     val text = "Here is some text\rthat spans across\rmultiple lines\r"
@@ -133,5 +137,28 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
     val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
 
     extractedFields.isEmpty shouldEqual true
+  }
+
+  describe("updateRightsAndRestrictions ->") {
+    describe("should transform the following categories:") {
+      it("handout") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map("category" ->  JsString("handout"),
+              "restrictions" -> JsString("restrictions"))
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map("category" ->  JsString("pr-and-third-party"),
+            "legacyCategory" -> JsString("handout"),
+            "restrictions" -> JsString("restrictions"))
+          )
+        )
+      }
+    }
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -155,7 +155,7 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures with Comm
       )
       val json = Json.toJson(image)
       val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
-      val mediaApiConfig = createMediaApiConfig(commonConfigurations, Map("usageRights" -> Map("showV2" -> true, "applicableV2" -> List())))
+      val mediaApiConfig = new MediaApiConfig(createGridResourcesConfig(commonConfigurations, SHOW_USAGE_RIGHTS_V2))
 
       val imageResponse = new ImageResponse(mediaApiConfig, mock[S3], mock[UsageQuota])
 

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -159,6 +159,254 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
           )
         )
       }
+      it("PR Image") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("PR Image"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("PR Image"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("screengrab") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("screengrab"),
+              "source" -> JsString("source"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("screengrab"),
+              "source" -> JsString("source"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("social-media") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("social-media"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("social-media"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("creative-commons") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("creative-commons"),
+              "licence" -> JsString("CC BY-4.0"),
+              "source" -> JsString("source"),
+              "creator" -> JsString("creator"),
+              "contentLink" -> JsString("link to content"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("creative-commons"),
+              "licence" -> JsString("CC BY-4.0"),
+              "source" -> JsString("source"),
+              "creator" -> JsString("creator"),
+              "contentLink" -> JsString("link to content"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("pool") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pool"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("pool"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("crown-copyright") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("crown-copyright"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("crown-copyright"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("obituary") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("obituary"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("obituary"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+
+      it("agency") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("agency"),
+              "supplier" -> JsString("Action Images"),
+              "suppliersCollection" -> JsString("collection"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("agency"),
+              "supplier" -> JsString("Action Images"),
+              "suppliersCollection" -> JsString("collection"),
+              "restrictions" -> JsString("restrictions"),
+              "source" -> JsString("Action Images")
+            )
+          )
+        )
+      }
+
+      it("commissioned-agency") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("commissioned-agency"),
+              "supplier" -> JsString("Action Images"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("commissioned-agency"),
+              "supplier" -> JsString("Action Images"),
+              "restrictions" -> JsString("restrictions"),
+              "source" -> JsString("Action Images")
+            )
+          )
+        )
+      }
+
+      it("public-domain") {
+        val inputJson = Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("public-domain"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
+        val result: JsResult[JsObject] = inputJson.transform(transformer)
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> JsObject(
+            Map(
+              "category" -> JsString("pr-and-third-party"),
+              "legacyCategory" -> JsString("public-domain"),
+              "restrictions" -> JsString("restrictions")
+            )
+          )
+        )
+      }
+      // TODO - guardian witness, and composite
     }
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -125,333 +125,81 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
     extractedFields.contains("captionWriter" -> JsString("the editor")) shouldEqual true
   }
 
-  it("should return empty set of extract configured alias fields from sourcewrapper if fields do not exist in image") {
-    val image = createImage(
-      id = "test-image-with-no-filemetadata",
-      agency,
-      fileMetadata = Some(FileMetadata())
-    )
-    val json = Json.toJson(image)
-    val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
-
-    val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
-
-    extractedFields.isEmpty shouldEqual true
-  }
-
   describe("updateRightsAndRestrictions") {
-    describe("should map the following categories to pr-and-third-party and set the legacyCategory with the original category name and maintain old fields") {
-      it("handout") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map("category" ->  JsString("handout"),
-              "restrictions" -> JsString("restrictions"))
-          )
-        )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map("category" ->  JsString("pr-and-third-party"),
-            "legacyCategory" -> JsString("handout"),
-            "restrictions" -> JsString("restrictions"))
-          )
-        )
-      }
-      it("PR Image") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("PR Image"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("PR Image"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
 
-      it("screengrab") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("screengrab"),
-              "source" -> JsString("source"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("screengrab"),
-              "source" -> JsString("source"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
+    it("maps category to pr-and-third-party and retains original as legacyCategory") {
+      val inputJson = Json.obj(
+        "usageRights" -> Json.obj("category" -> "handout")
+      )
+      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
 
-      it("social-media") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("social-media"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+      result shouldBe a[JsSuccess[_]]
+      result.get shouldBe Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "pr-and-third-party",
+          "legacyCategory" -> "handout"
         )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("social-media"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
+      )
+    }
 
-      it("creative-commons") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("creative-commons"),
-              "licence" -> JsString("CC BY-4.0"),
-              "source" -> JsString("source"),
-              "creator" -> JsString("creator"),
-              "contentLink" -> JsString("link to content"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+    it("preserves additional existing fields intact") {
+      val inputJson = Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "creative-commons",
+          "licence" -> "CC BY-4.0",
+          "creator" -> "creator",
+          "restrictions" -> "restrictions"
         )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("creative-commons"),
-              "licence" -> JsString("CC BY-4.0"),
-              "source" -> JsString("source"),
-              "creator" -> JsString("creator"),
-              "contentLink" -> JsString("link to content"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
+      )
+      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
 
-      it("pool") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pool"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+      result.get shouldBe Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "pr-and-third-party",
+          "legacyCategory" -> "creative-commons",
+          "licence" -> "CC BY-4.0",
+          "creator" -> "creator",
+          "restrictions" -> "restrictions"
         )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("pool"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
+      )
+    }
 
-      it("crown-copyright") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("crown-copyright"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+    it("maps single supplier field to source") {
+      val inputJson = Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "agency",
+          "supplier" -> "Action Images"
         )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("crown-copyright"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
+      )
+      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
 
-      it("obituary") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("obituary"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+      result.get shouldBe Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "pr-and-third-party",
+          "legacyCategory" -> "agency",
+          "supplier" -> "Action Images",
+          "source" -> "Action Images"
         )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("obituary"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+      )
+    }
+
+    it("maps plural suppliers field to source") {
+      val inputJson = Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "composite",
+          "suppliers" -> "supplier1 and supplier2"
         )
-      }
-      it("public-domain") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("public-domain"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
+      )
+      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+
+      result.get shouldBe Json.obj(
+        "usageRights" -> Json.obj(
+          "category" -> "pr-and-third-party",
+          "legacyCategory" -> "composite",
+          "suppliers" -> "supplier1 and supplier2",
+          "source" -> "supplier1 and supplier2"
         )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("public-domain"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
-      it("guardian-witness") {
-        val inputJson = Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("guardian-witness"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-        val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-        val result: JsResult[JsObject] = inputJson.transform(transformer)
-        result shouldBe a[JsSuccess[_]]
-        result.get shouldBe Json.obj(
-          "usageRights" -> JsObject(
-            Map(
-              "category" -> JsString("pr-and-third-party"),
-              "legacyCategory" -> JsString("guardian-witness"),
-              "restrictions" -> JsString("restrictions")
-            )
-          )
-        )
-      }
-      describe("For legacy categories that have a supplier or suppliers field, these should be mapped to source") {
-        it("composite") {
-          val inputJson = Json.obj(
-            "usageRights" -> JsObject(
-              Map(
-                "category" -> JsString("composite"),
-                "restrictions" -> JsString("restrictions"),
-                "suppliers" -> JsString("supplier1 and supplier2")
-              )
-            )
-          )
-          val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-          val result: JsResult[JsObject] = inputJson.transform(transformer)
-          result shouldBe a[JsSuccess[_]]
-          result.get shouldBe Json.obj(
-            "usageRights" -> JsObject(
-              Map(
-                "category" -> JsString("pr-and-third-party"),
-                "legacyCategory" -> JsString("composite"),
-                "restrictions" -> JsString("restrictions"),
-                "suppliers" -> JsString("supplier1 and supplier2"),
-                "source" -> JsString("supplier1 and supplier2")
-              )
-            )
-          )
-        }
-        it("agency") {
-          val inputJson = Json.obj(
-            "usageRights" -> JsObject(
-              Map(
-                "category" -> JsString("agency"),
-                "supplier" -> JsString("Action Images"),
-                "suppliersCollection" -> JsString("collection"),
-                "restrictions" -> JsString("restrictions")
-              )
-            )
-          )
-          val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-          val result: JsResult[JsObject] = inputJson.transform(transformer)
-          result shouldBe a[JsSuccess[_]]
-          result.get shouldBe Json.obj(
-            "usageRights" -> JsObject(
-              Map(
-                "category" -> JsString("pr-and-third-party"),
-                "legacyCategory" -> JsString("agency"),
-                "supplier" -> JsString("Action Images"),
-                "suppliersCollection" -> JsString("collection"),
-                "restrictions" -> JsString("restrictions"),
-                "source" -> JsString("Action Images")
-              )
-            )
-          )
-        }
-        it("commissioned-agency") {
-          val inputJson = Json.obj(
-            "usageRights" -> JsObject(
-              Map(
-                "category" -> JsString("commissioned-agency"),
-                "supplier" -> JsString("Action Images"),
-                "restrictions" -> JsString("restrictions")
-              )
-            )
-          )
-          val transformer = imageResponse.updateRightsAndRestrictions(inputJson)
-          val result: JsResult[JsObject] = inputJson.transform(transformer)
-          result shouldBe a[JsSuccess[_]]
-          result.get shouldBe Json.obj(
-            "usageRights" -> JsObject(
-              Map(
-                "category" -> JsString("pr-and-third-party"),
-                "legacyCategory" -> JsString("commissioned-agency"),
-                "supplier" -> JsString("Action Images"),
-                "restrictions" -> JsString("restrictions"),
-                "source" -> JsString("Action Images")
-              )
-            )
-          )
-        }
-      }
+      )
     }
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -126,80 +126,91 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
   }
 
   describe("updateRightsAndRestrictions") {
-
-    it("maps category to pr-and-third-party and retains original as legacyCategory") {
-      val inputJson = Json.obj(
-        "usageRights" -> Json.obj("category" -> "handout")
-      )
-      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
-
-      result shouldBe a[JsSuccess[_]]
-      result.get shouldBe Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "pr-and-third-party",
-          "legacyCategory" -> "handout"
+    describe("Mapping legacy categories to pr-and-third-party as defined in PRAndThirdParty") {
+      it("maps category to pr-and-third-party and retains original as legacyCategory") {
+        val inputJson = Json.obj(
+          "usageRights" -> Json.obj("category" -> "handout")
         )
-      )
-    }
+        val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
 
-    it("preserves additional existing fields intact") {
-      val inputJson = Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "creative-commons",
-          "licence" -> "CC BY-4.0",
-          "creator" -> "creator",
-          "restrictions" -> "restrictions"
+        result shouldBe a[JsSuccess[_]]
+        result.get shouldBe Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "pr-and-third-party",
+            "legacyCategory" -> "handout"
+          )
         )
-      )
-      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+      }
 
-      result.get shouldBe Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "pr-and-third-party",
-          "legacyCategory" -> "creative-commons",
-          "licence" -> "CC BY-4.0",
-          "creator" -> "creator",
-          "restrictions" -> "restrictions"
+      it("preserves additional existing fields intact") {
+        val inputJson = Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "creative-commons",
+            "licence" -> "CC BY-4.0",
+            "creator" -> "creator",
+            "restrictions" -> "restrictions"
+          )
         )
-      )
-    }
+        val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
 
-    it("maps single supplier field to source") {
-      val inputJson = Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "agency",
-          "supplier" -> "Action Images"
+        result.get shouldBe Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "pr-and-third-party",
+            "legacyCategory" -> "creative-commons",
+            "licence" -> "CC BY-4.0",
+            "creator" -> "creator",
+            "restrictions" -> "restrictions"
+          )
         )
-      )
-      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+      }
 
-      result.get shouldBe Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "pr-and-third-party",
-          "legacyCategory" -> "agency",
-          "supplier" -> "Action Images",
-          "source" -> "Action Images"
+      it("maps single supplier field to source") {
+        val inputJson = Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "agency",
+            "supplier" -> "Action Images"
+          )
         )
-      )
-    }
+        val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
 
-    it("maps plural suppliers field to source") {
-      val inputJson = Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "composite",
-          "suppliers" -> "supplier1 and supplier2"
+        result.get shouldBe Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "pr-and-third-party",
+            "legacyCategory" -> "agency",
+            "supplier" -> "Action Images",
+            "source" -> "Action Images"
+          )
         )
-      )
-      val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+      }
 
-      result.get shouldBe Json.obj(
-        "usageRights" -> Json.obj(
-          "category" -> "pr-and-third-party",
-          "legacyCategory" -> "composite",
-          "suppliers" -> "supplier1 and supplier2",
-          "source" -> "supplier1 and supplier2"
+      it("maps plural suppliers field to source") {
+        val inputJson = Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "composite",
+            "suppliers" -> "supplier1 and supplier2"
+          )
         )
-      )
+        val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+
+        result.get shouldBe Json.obj(
+          "usageRights" -> Json.obj(
+            "category" -> "pr-and-third-party",
+            "legacyCategory" -> "composite",
+            "suppliers" -> "supplier1 and supplier2",
+            "source" -> "supplier1 and supplier2"
+          )
+        )
+      }
+      it("does not map a category that is not in the legacyCategories list") {
+        val inputJson = Json.obj("usageRights" -> Json.obj("category" -> "chargeable"))
+        val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+        result.get shouldBe inputJson
+      }
+      it("leaves usageRights untouched when category field is missing") {
+        val inputJson = Json.obj("usageRights" -> Json.obj("restrictions" -> "restrictions"))
+        val result = inputJson.transform(imageResponse.updateRightsAndRestrictions(inputJson))
+        result.get shouldBe inputJson
+      }
     }
   }
 }

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -146,7 +146,7 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
       )
       val json = Json.toJson(image)
       val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
-      val mediaApiConfig = createMediaApiConfig(commonConfigurations, Map("showUsageRightsV2" -> true))
+      val mediaApiConfig = createMediaApiConfig(commonConfigurations, Map("usageRights" -> Map("showV2" -> true, "applicableV2" -> List())))
 
       val imageResponse = new ImageResponse(mediaApiConfig, mock[S3], mock[UsageQuota])
 

--- a/media-api/test/lib/elasticsearch/ConditionFixtures.scala
+++ b/media-api/test/lib/elasticsearch/ConditionFixtures.scala
@@ -8,7 +8,7 @@ trait ConditionFixtures {
   val fieldPhraseMatchCondition = Match(SingleField("afield"), Phrase("avalue"))
   val wordsMatchCondition = Match(SingleField("awordfield"), Words("foo bar"))
   val anotherFieldPhraseMatchCondition = Match(SingleField("anotherfield"), Phrase("anothervalue"))
-
+  val usageRightsFilter = Match(SingleField("usageRights.category"), Words("pr-and-third-party"))
   val dateRangeStart: DateTime = new DateTime(2016, 1, 1, 0, 0).withZone(DateTimeZone.UTC)
   val dateRangeEnd: DateTime = dateRangeStart.plusHours(1)
   val dateMatchCondition = Match(SingleField("adatefield"), DateRange(dateRangeStart, dateRangeEnd))

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -145,18 +145,5 @@ trait Fixtures {
     )
   }
 
-  def createMediaApiConfig(commonConfigurations: Map[String, Any], overrides: Map[String, Any] = Map[String, Any]()): MediaApiConfig = {
-    val config = Configuration.from(overrides)
-      .withFallback(Configuration.from(commonConfigurations))
-
-    new MediaApiConfig(GridConfigResources(
-      config,
-      null,
-      new ApplicationLifecycle {
-        override def addStopHook(hook: () => Future[_]): Unit = {}
-        override def stop(): Future[_] = Future.successful(())
-      }
-    ))
-  }
 
 }

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -1,18 +1,11 @@
 package lib.elasticsearch
 
-import com.gu.mediaservice.lib.config.GridConfigResources
-
 import java.net.URI
 import java.util.UUID
 import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease, LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.{UsageStatus => Status, _}
 import com.gu.mediaservice.model.{StaffPhotographer, _}
-import lib.MediaApiConfig
 import org.joda.time.DateTime
-import play.api.Configuration
-import play.api.inject.ApplicationLifecycle
-
-import scala.concurrent.Future
 
 trait Fixtures {
 

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -19,7 +19,8 @@ trait Fixtures {
     "es6.replicas" -> 0,
     "field.aliases" -> Seq.empty,
     "usageRights" -> Map(
-      "applicable" -> List()
+      "applicable" -> List(),
+      "showVersion2" -> false
     ),
     "usageRightsConfigProvider" -> "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig"
   )

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -19,9 +19,12 @@ trait Fixtures {
     "es6.replicas" -> 0,
     "field.aliases" -> Seq.empty,
     "usageRights" -> Map(
-      "applicable" -> List(),
-      "showVersion2" -> false
+      "applicable" -> List()
     ),
+    "usageRightsV2" -> Map(
+      "applicable" -> List()
+    ),
+    "showUsageRightsV2" -> false,
     "usageRightsConfigProvider" -> "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig"
   )
   val NOT_USED_IN_TEST = "not used in test"

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -1,12 +1,18 @@
 package lib.elasticsearch
 
+import com.gu.mediaservice.lib.config.GridConfigResources
+
 import java.net.URI
 import java.util.UUID
-
 import com.gu.mediaservice.model.leases.{AllowSyndicationLease, DenySyndicationLease, LeasesByMedia, MediaLease}
 import com.gu.mediaservice.model.usage.{UsageStatus => Status, _}
 import com.gu.mediaservice.model.{StaffPhotographer, _}
+import lib.MediaApiConfig
 import org.joda.time.DateTime
+import play.api.Configuration
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.Future
 
 trait Fixtures {
 
@@ -25,7 +31,8 @@ trait Fixtures {
       "applicable" -> List()
     ),
     "showUsageRightsV2" -> false,
-    "usageRightsConfigProvider" -> "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig"
+    "usageRightsConfigProvider" -> "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig",
+    "domain.root" -> "domain"
   )
   val NOT_USED_IN_TEST = "not used in test"
   val MOCK_CONFIG_KEYS = Seq(
@@ -33,7 +40,6 @@ trait Fixtures {
     "persistence.identifier",
     "thrall.kinesis.stream.name",
     "thrall.kinesis.lowPriorityStream.name",
-    "domain.root",
     "s3.config.bucket",
     "s3.usagemail.bucket",
     "quota.store.key",
@@ -168,6 +174,23 @@ trait Fixtures {
       None,
       lastModified = date
     )
+  }
+
+  def createMediaApiConfig(commonConfigurations: Map[String, Any], overrides: Map[String, Any] = Map[String, Any]()): MediaApiConfig = {
+    val configMap = commonConfigurations.foldLeft(Map[String, Any]())((acc, next) => {
+      val (nextKey, nextValue) = next
+      if(overrides.contains(nextKey)) acc.updated(nextKey, overrides(nextKey))
+      else acc.updated(nextKey, nextValue)
+    })
+
+    new MediaApiConfig(GridConfigResources(
+      Configuration.from(configMap),
+      null,
+      new ApplicationLifecycle {
+        override def addStopHook(hook: () => Future[_]): Unit = {}
+        override def stop(): Future[_] = Future.successful(())
+      }
+    ))
   }
 
 }

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -25,12 +25,9 @@ trait Fixtures {
     "es6.replicas" -> 0,
     "field.aliases" -> Seq.empty,
     "usageRights" -> Map(
-      "applicable" -> List()
+      "applicable" -> List(),
+      "showV2" -> false
     ),
-    "usageRightsV2" -> Map(
-      "applicable" -> List()
-    ),
-    "showUsageRightsV2" -> false,
     "usageRightsConfigProvider" -> "com.gu.mediaservice.lib.config.RuntimeUsageRightsConfig",
     "domain.root" -> "domain"
   )
@@ -177,14 +174,11 @@ trait Fixtures {
   }
 
   def createMediaApiConfig(commonConfigurations: Map[String, Any], overrides: Map[String, Any] = Map[String, Any]()): MediaApiConfig = {
-    val configMap = commonConfigurations.foldLeft(Map[String, Any]())((acc, next) => {
-      val (nextKey, nextValue) = next
-      if(overrides.contains(nextKey)) acc.updated(nextKey, overrides(nextKey))
-      else acc.updated(nextKey, nextValue)
-    })
+    val config = Configuration.from(overrides)
+      .withFallback(Configuration.from(commonConfigurations))
 
     new MediaApiConfig(GridConfigResources(
-      Configuration.from(configMap),
+      config,
       null,
       new ApplicationLifecycle {
         override def addStopHook(hook: () => Future[_]): Unit = {}

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -23,16 +23,26 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
   val matchFields: Seq[String] = Seq("afield", "anothermatchfield")
 
+  private def createMediaApiConfig(overrides: Map[String, Any] = Map[String, Any]()): MediaApiConfig = {
+    val configMap = commonConfigurations.foldLeft(Map[String, Any]())((acc, next) => {
+      val (nextKey, nextValue) = next
+      if(overrides.contains(nextKey)) acc.updated(nextKey, overrides(nextKey))
+      else acc.updated(nextKey, nextValue)
+    })
+
+    new MediaApiConfig(GridConfigResources(
+      Configuration.from(configMap),
+      null,
+      new ApplicationLifecycle {
+        override def addStopHook(hook: () => Future[_]): Unit = {}
+        override def stop(): Future[_] = Future.successful(())
+      }
+    ))
+  }
+
   private val commonConfigurations = USED_CONFIGS_IN_TEST ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap
 
-  private val mediaApiConfig = new MediaApiConfig(GridConfigResources(
-    Configuration.from(commonConfigurations),
-    null,
-    new ApplicationLifecycle {
-      override def addStopHook(hook: () => Future[_]): Unit = {}
-      override def stop(): Future[_] = Future.successful(())
-    }
-  ))
+  private val mediaApiConfig = createMediaApiConfig()
 
   val queryBuilder = new QueryBuilder(matchFields, () => Nil, mediaApiConfig)
 
@@ -274,8 +284,10 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
     }
   }
 
-  describe("usage rights filter") {
-    ignore("should map a usage rights filter to legacy categories") {
+  describe("usage rights v2 filter") {
+    val queryBuilder  = new QueryBuilder(matchFields, () => Nil, createMediaApiConfig(Map("showUsageRightsV2" -> true)))
+
+    it("should map a usage rights filter to legacy categories") {
       val query = queryBuilder.makeQuery(List(usageRightsFilter)).asInstanceOf[BoolQuery]
       query.must.size shouldBe 1
 
@@ -283,10 +295,12 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
       termsQuery shouldBe TermsQuery("usageRights.category",
         List("pr-and-third-party", "agency", "commissioned-agency", "PR Image", "handout", "screengrab",
-          "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness")
+          "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness",
+          "composite"
+        )
       )
     }
-    ignore("should map a usage rights filter to legacy categories negation") {
+    it("should map a usage rights filter to legacy categories negation") {
       val query = queryBuilder.makeQuery(List(Negation(usageRightsFilter))).asInstanceOf[BoolQuery]
       query.not.size shouldBe 1
 
@@ -294,7 +308,9 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
       termsQuery shouldBe TermsQuery("usageRights.category",
         List("pr-and-third-party", "agency", "commissioned-agency", "PR Image", "handout", "screengrab",
-          "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness")
+          "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness",
+          "composite"
+        )
       )
     }
 

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -266,7 +266,8 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
   }
 
   describe("usage rights v2 filter") {
-    val queryBuilder  = new QueryBuilder(matchFields, () => Nil, createMediaApiConfig(commonConfigurations, Map("usageRights" -> Map("showV2" -> true, "applicableV2" -> List()))))
+    val mediaApiConfig = new MediaApiConfig(createGridResourcesConfig(commonConfigurations, SHOW_USAGE_RIGHTS_V2))
+    val queryBuilder  = new QueryBuilder(matchFields, () => Nil, mediaApiConfig)
 
     it("should map a usage rights filter to legacy categories") {
       val query = queryBuilder.makeQuery(List(usageRightsFilter)).asInstanceOf[BoolQuery]

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -23,26 +23,10 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
 
   val matchFields: Seq[String] = Seq("afield", "anothermatchfield")
 
-  private def createMediaApiConfig(overrides: Map[String, Any] = Map[String, Any]()): MediaApiConfig = {
-    val configMap = commonConfigurations.foldLeft(Map[String, Any]())((acc, next) => {
-      val (nextKey, nextValue) = next
-      if(overrides.contains(nextKey)) acc.updated(nextKey, overrides(nextKey))
-      else acc.updated(nextKey, nextValue)
-    })
-
-    new MediaApiConfig(GridConfigResources(
-      Configuration.from(configMap),
-      null,
-      new ApplicationLifecycle {
-        override def addStopHook(hook: () => Future[_]): Unit = {}
-        override def stop(): Future[_] = Future.successful(())
-      }
-    ))
-  }
 
   private val commonConfigurations = USED_CONFIGS_IN_TEST ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap
 
-  private val mediaApiConfig = createMediaApiConfig()
+  private val mediaApiConfig = createMediaApiConfig(commonConfigurations)
 
   val queryBuilder = new QueryBuilder(matchFields, () => Nil, mediaApiConfig)
 

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -274,6 +274,32 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
     }
   }
 
+  describe("usage rights filter") {
+    it("should map a usage rights filter to legacy categories") {
+      val query = queryBuilder.makeQuery(List(usageRightsFilter)).asInstanceOf[BoolQuery]
+      query.must.size shouldBe 1
+
+      val termsQuery = query.must.head
+
+      termsQuery shouldBe TermsQuery("usageRights.category",
+        List("pr-and-third-party", "agency", "commissioned-agency", "PR Image", "handout", "screengrab",
+          "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness")
+      )
+    }
+    it("should map a usage rights filter to legacy categories negation") {
+      val query = queryBuilder.makeQuery(List(Negation(usageRightsFilter))).asInstanceOf[BoolQuery]
+      query.not.size shouldBe 1
+
+      val termsQuery = query.not.head
+
+      termsQuery shouldBe TermsQuery("usageRights.category",
+        List("pr-and-third-party", "agency", "commissioned-agency", "PR Image", "handout", "screengrab",
+          "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness")
+      )
+    }
+
+  }
+
   @nowarn("cat=deprecation") // TODO QueryBuilderFn.bytes is deprecated but no upgrade path given
   def asJsonString(query: Query) = {
     new String(QueryBuilderFn.apply(query).bytes)

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -269,7 +269,7 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
   }
 
   describe("usage rights v2 filter") {
-    val queryBuilder  = new QueryBuilder(matchFields, () => Nil, createMediaApiConfig(Map("showUsageRightsV2" -> true)))
+    val queryBuilder  = new QueryBuilder(matchFields, () => Nil, createMediaApiConfig(commonConfigurations, Map("usageRights" -> Map("showV2" -> true, "applicableV2" -> List()))))
 
     it("should map a usage rights filter to legacy categories") {
       val query = queryBuilder.makeQuery(List(usageRightsFilter)).asInstanceOf[BoolQuery]

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -275,7 +275,7 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
   }
 
   describe("usage rights filter") {
-    it("should map a usage rights filter to legacy categories") {
+    ignore("should map a usage rights filter to legacy categories") {
       val query = queryBuilder.makeQuery(List(usageRightsFilter)).asInstanceOf[BoolQuery]
       query.must.size shouldBe 1
 
@@ -286,7 +286,7 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
           "social-media", "obituary", "pool", "crown-copyright", "creative-commons", "public-domain", "guardian-witness")
       )
     }
-    it("should map a usage rights filter to legacy categories negation") {
+    ignore("should map a usage rights filter to legacy categories negation") {
       val query = queryBuilder.makeQuery(List(Negation(usageRightsFilter))).asInstanceOf[BoolQuery]
       query.not.size shouldBe 1
 

--- a/metadata-editor/app/model/UsageRightsProperty.scala
+++ b/metadata-editor/app/model/UsageRightsProperty.scala
@@ -144,6 +144,9 @@ object UsageRightsProperty {
       requiredStringField("productionCompany", "Production Company", examples = Some("Example production"))
     )
 
+    case PRAndThirdParty => List(
+      requiredStringField("source", "Source", examples = Some("Getty Images, Corbis, Reuters")),
+    )
     case _ => List()
   }
 }


### PR DESCRIPTION
## What does this change?
This introduces the change to map existing categories to PR and Third Party. 

The user experience changes are:

#### Displaying previously selected legacy category

- Any legacy categories will now display as `PR and Third Party`. 

- If `restrictions` or `source` these will be visible in the editable fields. 

- Where a category has a `supplier` or `suppliers` set, this will be mapped to `source`

- Any other fields will not be displayed or edited in the U.I, but can still be accessed at the API level

- Restrictions will now be set to required, and making a modification will enforce a user sets one. 


#### Searching for images in the U.I
- Any legacy categories will display when a user selects `pr-and-third-party` in the drop down search
- The legacy categories will not be available to search in the drop down, but the URL can be changed manually and searching for a specific legacy category will yield the appropriate results

#### Selecting a category
- The legacy categories have been removed from the dropdown and `PR and Third Party` has been added


The main code changes this involved was:

1) changing the logic of the elastic search query to perform a many search across all the legacy category when searching for `pr-and-third-party`

2) Rendering the images from ElasticSearch will perform a transformation to map a legacy category to PR and Third Party



## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
