### PR TITLE
Remove dupe photographer from config

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/guardian/GuardianUsageRightsConfig.scala
@@ -81,7 +81,6 @@ object GuardianUsageRightsConfig extends UsageRightsConfigProvider {
     )),
     PublicationPhotographers(GuardianPublication, List(
       PublicationPhotographer("Alicia Canter"),
-      PublicationPhotographer("Antonio Olmos"),
       PublicationPhotographer("Christopher Thomond"),
       PublicationPhotographer("David Levene"),
       PublicationPhotographer("Eamonn McCabe"),


### PR DESCRIPTION
## What does this change?

'Antonio Olmos' has been set twice - remove dupe

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
