### PR TITLE
Add feature switch for enforcing upload images permissions

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/CommonConfig.scala
@@ -224,6 +224,7 @@ abstract class CommonConfig(resources: GridConfigResources) extends AwsClientV1B
   val agencyPicksIngredients: Option[Map[String, Seq[String]]] =
     configuration.getOptional[Map[String, Seq[String]]]("agencyPicks.ingredients")
   val agencyPicksColour: String = stringDefault("agencyPicks.colour", "#7d0068")
+  val enforceUploadImagesPermissions: Boolean = booleanOpt("enforceUploadImagesPermissions").getOrElse(false)
 
   private def getKinesisConfigForStream(streamName: String) = KinesisSenderConfig(awsRegionV2, awsCredentialsV2, awsLocalEndpointUri, isDev, streamName)
 

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -57,6 +57,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       case DeleteCropsOrUsages => hasPermission(Permissions.DeleteCrops)
       case ShowPaid => hasPermission(Permissions.ShowPaid)
       case Pinboard => hasPermission(Permissions.Pinboard)
+      case UploadImages if config.enforceUploadImagesPermissions => true // @TODO: Check for permissions
       case UploadImages => true
       case ArchiveImages => true
     }


### PR DESCRIPTION
## What does this change?

- Looks for a `enforceUploadImagesPermissions` switch from `common.conf` when determining upload images permissions

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217059235392509