### PR TITLE
Check for upload images permissions based on feature switch

### DIFF
--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/Permissions.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/Permissions.scala
@@ -6,6 +6,7 @@ object Permissions {
   val app = "grid"
 
   val GridAccess: PermissionDefinition = PermissionDefinition("grid_access", app)
+  val UploadImages: PermissionDefinition = PermissionDefinition("upload_images", app)
   val EditMetadata: PermissionDefinition = PermissionDefinition("edit_metadata", app)
   val DeleteImage: PermissionDefinition = PermissionDefinition("delete_image", app)
   //FIXME I think this needs to be renamed ot `delete_crops_or_usages` - see https://github.com/guardian/grid/pull/3416 and https://github.com/guardian/permissions/pull/138

--- a/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
+++ b/rest-lib/src/main/scala/com/gu/mediaservice/lib/guardian/auth/PermissionsAuthorisationProvider.scala
@@ -57,7 +57,7 @@ class PermissionsAuthorisationProvider(configuration: Configuration, resources: 
       case DeleteCropsOrUsages => hasPermission(Permissions.DeleteCrops)
       case ShowPaid => hasPermission(Permissions.ShowPaid)
       case Pinboard => hasPermission(Permissions.Pinboard)
-      case UploadImages if config.enforceUploadImagesPermissions => true // @TODO: Check for permissions
+      case UploadImages if config.enforceUploadImagesPermissions => hasPermission(Permissions.UploadImages)
       case UploadImages => true
       case ArchiveImages => true
     }


### PR DESCRIPTION
## What does this change?

* Now that we've added `upload_images` in Permissions tool (https://github.com/guardian/permissions/pull/416), we can use that to replace the hardcoded `true` under `UploadImages` in `PermissionsAuthorisationProvider`
* Whether this permissions rule will be applied will be driven by the `enforceUploadImagesPermissions` flag (in `common.conf`) 

## How should a reviewer test this change?

* Grant yourself `upload_images` permission in https://permissions.code.dev-gutools.co.uk/
* In your local `~/.grid/common.conf` file, add `enforceUploadImagesPermissions = true`
* Start up the Grid locally, and you shouldn't be able to upload images in the UI:
(I'll tweak the CSS in a separate PR)
<img width="1752" height="88" alt="Screenshot 2026-08-12 at 16 25 23" src="https://github.com/user-attachments/assets/e02cba34-579b-4920-936d-13df0b5251e9" />

(The wording and email address will also change for this page, will be handled in a separate PR)
<img width="1748" height="253" alt="Screenshot 2026-08-12 at 16 27 05" src="https://github.com/user-attachments/assets/8a8dc57f-4662-4efc-9ae5-5fdc5d34ca1c" />

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
