### PR TITLE
Remove min-width from top bar action

### DIFF
--- a/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
+++ b/kahuna/public/js/components/gr-top-bar/gr-top-bar.css
@@ -16,9 +16,9 @@ gr-top-bar-nav {
 
 gr-top-bar-actions {
     display: flex;
+    flex-shrink: 0;
     flex-direction: row;
     justify-content: flex-end;
-    min-width: 278px;
 }
 
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -796,9 +796,6 @@ textarea.ng-invalid {
         min-width: inherit;
     }
 
-    gr-top-bar-actions {
-      min-width: 128px;
-    }
 
     .results-toolbar-item .gr-confirm-delete gr-icon-label {
         padding: 0


### PR DESCRIPTION
## What does this change?

Remove min-width from top bar action, so when user doesn't have permission to upload, the other elements in the top bar can stretch across the whole screen.

<img width="1752" height="152" alt="Screenshot 2026-08-12 at 16 59 12" src="https://github.com/user-attachments/assets/f46d2143-02ed-4bfb-b997-0a923993628f" />


The `min-width` was put there to address the issue where elements under top bar action wraps awkwardly on a smaller screen size, but this can be fixed by `flex-shrink:0`.

We still have the issue where on a very small screen size, the top bar actions overlaps the filter buttons. But that's the current behaviour so not a regression, and would require a wider design change around placement of top-bar elements on mobile screens.

<img width="634" height="51" alt="Screenshot 2026-08-13 at 13 16 20" src="https://github.com/user-attachments/assets/9d8f71e3-c40d-44b7-b25a-e285188145b1" />




## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
