### PR TITLE
Add an endpoint for showing the usages and supplier of image ids

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,8 @@ lazy val mediaApi = playProject("media-api", 9001)
       "org.apache.commons" % "commons-email" % "1.5",
       "org.parboiled" %% "parboiled" % "2.1.7",
       "org.http4s" %% "http4s-core" % "0.23.17",
-      "com.github.blemale" %% "scaffeine" % "5.3.0"
+      "com.github.blemale" %% "scaffeine" % "5.3.0",
+      "io.lemonlabs" %% "scala-uri" % "3.6.0"
     )
   )
 

--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -17,6 +17,7 @@ import com.gu.mediaservice.model._
 import com.gu.mediaservice.syntax.MessageSubjects
 import com.gu.mediaservice.{GridClient, JsonDiff}
 import com.sksamuel.elastic4s.requests.searches.queries.Query
+import lib.Api.{getNextLink, getPrevLink}
 import lib._
 import lib.elasticsearch._
 import lib.querysyntax.Condition
@@ -543,7 +544,6 @@ class MediaApi(
     request.post(Json.toJson(Map("data" -> usagesMetadata))) //fire and forget
   }
 
-
   def imageSearch() = auth.async { implicit request =>
     val shouldFlagGraphicImages = request.cookies.get("SHOULD_BLUR_GRAPHIC_IMAGES")
       .map(_.value).getOrElse(config.defaultShouldBlurGraphicImages.toString) == "true"
@@ -575,12 +575,15 @@ class MediaApi(
         )
       )
       imageEntities = hits map (hitToImageEntity _).tupled
-      prevLink = getPrevLink(searchParams)
-      nextLink = getNextLink(searchParams, totalCount)
+      // Updated here to make the images-usages pagination work
+      // but I would suggest leaving the behaviour in this endpoint the same
+      // as before, so that the changes only affect the new endpoint
+      prevLink = getPrevLink(searchParams, "search")
+      nextLink = getNextLink(searchParams, totalCount, "search")
       links = List(prevLink, nextLink).flatten
     } yield respondCollection(imageEntities, Some(searchParams.offset), Some(totalCount), extraCounts, links)
 
-    val _searchParams = SearchParams(request)
+    val _searchParams = SearchParams(request, defaultPageSize = 10)
     val hasDeletePermission = authorisation.isUploaderOrHasPermission(request.user, "", DeleteImagePermission)
     val canViewDeletedImages = _searchParams.query.contains("is:deleted") && !hasDeletePermission
 
@@ -795,41 +798,6 @@ class MediaApi(
         Some((source.instance, imageData, imageLinks, imageActions))
 
       case _ => None
-    }
-  }
-
-  private def getSearchUrl(searchParams: SearchParams, updatedOffset: Int, length: Int): String = {
-    // Enforce a toDate to exclude new images since the current request
-    val toDate = searchParams.until.getOrElse(DateTime.now)
-
-    val paramMap: Map[String, String] = SearchParams.toStringMap(searchParams) ++ Map(
-      "offset" -> updatedOffset.toString,
-      "length" -> length.toString,
-      "toDate" -> printDateTime(toDate)
-    )
-
-    paramMap.foldLeft(UriTemplate()){ (acc, pair) => acc.expandAny(pair._1, pair._2)}.toString
-  }
-
-  private def getPrevLink(searchParams: SearchParams): Option[Link] = {
-    val prevOffset = List(searchParams.offset - searchParams.length, 0).max
-    if (searchParams.offset > 0) {
-      // adapt length to avoid overlapping with current
-      val prevLength = List(searchParams.length, searchParams.offset - prevOffset).min
-      val prevUrl = getSearchUrl(searchParams, prevOffset, prevLength)
-      Some(Link("prev", prevUrl))
-    } else {
-      None
-    }
-  }
-
-  private def getNextLink(searchParams: SearchParams, totalCount: Long): Option[Link] = {
-    val nextOffset = searchParams.offset + searchParams.length
-    if (nextOffset < totalCount) {
-      val nextUrl = getSearchUrl(searchParams, nextOffset, searchParams.length)
-      Some(Link("next", nextUrl))
-    } else {
-      None
     }
   }
 

--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -7,8 +7,9 @@ import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import com.gu.mediaservice.model.Agencies
 import com.gu.mediaservice.model.usage.Usage
+import lib.Api.{getNextLink, getPrevLink}
 import lib._
-import lib.elasticsearch.{ElasticSearch, SearchParams}
+import lib.elasticsearch.{ElasticSearch, SearchParams, SearchResults}
 import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -94,14 +95,18 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
   }
 
   def imageIdsBySupplier() = auth.async { implicit request =>
-    val _searchParams = SearchParams(request)
+    val searchParams = SearchParams(request, defaultPageSize = 100)
     for {
-      res <- elasticSearch.search(_searchParams)
+      res <- elasticSearch.search(searchParams)
       items = res.hits.map({ case (_, sourceWrapperImage) =>
         val image = sourceWrapperImage.instance
         UsageBySupplier(image.id, image.metadata.source, image.usages)}
       )
-      response = Response(res.total, items)
+      totalCount = res.total
+      prevLink = getPrevLink(searchParams, "images-usages")
+      nextLink = getNextLink(searchParams, totalCount, "images-usages")
+      links = List(prevLink, nextLink).flatten
+      response = Response(totalCount, items, links)
     }
     yield Ok(Json.toJson(response))
   }

--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -6,8 +6,10 @@ import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import com.gu.mediaservice.model.Agencies
+import com.gu.mediaservice.model.usage.Usage
 import lib._
-import lib.elasticsearch.ElasticSearch
+import lib.elasticsearch.{ElasticSearch, SearchParams}
+import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
@@ -89,5 +91,18 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
           logger.error(logMarker, "quota access failed", e)
           respondError(InternalServerError, "unknown-error", e.toString)
       }
+  }
+
+  def imageIdsBySupplier() = auth.async { implicit request =>
+    val _searchParams = SearchParams(request)
+    for {
+      res <- elasticSearch.search(_searchParams)
+      items = res.hits.map({ case (_, sourceWrapperImage) =>
+        val image = sourceWrapperImage.instance
+        UsageBySupplier(image.id, image.metadata.source, image.usages)}
+      )
+      response = Response(res.total, items)
+    }
+    yield Ok(Json.toJson(response))
   }
 }

--- a/media-api/app/lib/Api.scala
+++ b/media-api/app/lib/Api.scala
@@ -1,0 +1,43 @@
+package lib
+
+import com.gu.mediaservice.lib.argo.model.Link
+import com.gu.mediaservice.lib.formatting.printDateTime
+import io.lemonlabs.uri.Url
+import lib.elasticsearch.SearchParams
+import org.http4s.UriTemplate
+import org.joda.time.DateTime
+
+object Api {
+
+  def getPrevLink(searchParams: SearchParams, path: String): Option[Link] = {
+    val prevOffset = List(searchParams.offset - searchParams.length, 0).max
+    if (searchParams.offset > 0) {
+      // adapt length to avoid overlapping with current
+      val prevLength = List(searchParams.length, searchParams.offset - prevOffset).min
+      val prevUrl = getSearchUrl(searchParams, prevOffset, prevLength, path)
+      Some(Link("prev", prevUrl))
+    } else {
+      None
+    }
+  }
+
+  def getNextLink(searchParams: SearchParams, totalCount: Long, path: String): Option[Link] = {
+    val nextOffset = searchParams.offset + searchParams.length
+    if (nextOffset < totalCount) {
+      val nextUrl = getSearchUrl(searchParams, nextOffset, searchParams.length, path)
+      Some(Link("next", nextUrl))
+    } else {
+      None
+    }
+  }
+
+  private def getSearchUrl(searchParams: SearchParams, updatedOffset: Int, length: Int, path: String): String = {
+    // Enforce a toDate to exclude new images since the current request
+    val baseUrl = Url.parse(s"/$path")
+    val paramMap: Map[String, String] = SearchParams.toStringMap(searchParams) ++ Map(
+      "offset" -> updatedOffset.toString,
+      "length" -> length.toString,
+    )
+    baseUrl.addParams(paramMap).toString
+  }
+}

--- a/media-api/app/lib/UsageBySupplier.scala
+++ b/media-api/app/lib/UsageBySupplier.scala
@@ -1,0 +1,16 @@
+package lib
+
+import com.gu.mediaservice.model.usage.Usage
+import play.api.libs.json.{Json, OFormat}
+
+case class UsageBySupplier(id: String, supplier: Option[String], usages: List[Usage])
+object UsageBySupplier {
+  implicit val jsonFormat: OFormat[UsageBySupplier] = Json.format[UsageBySupplier]
+
+}
+
+case class Response(total: Long, images: Seq[UsageBySupplier])
+
+object Response {
+  implicit val jsonFormat: OFormat[Response] = Json.format[Response]
+}

--- a/media-api/app/lib/UsageBySupplier.scala
+++ b/media-api/app/lib/UsageBySupplier.scala
@@ -1,16 +1,17 @@
 package lib
 
+import com.gu.mediaservice.lib.argo.model.Link
 import com.gu.mediaservice.model.usage.Usage
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, OWrites}
 
 case class UsageBySupplier(id: String, supplier: Option[String], usages: List[Usage])
 object UsageBySupplier {
-  implicit val jsonFormat: OFormat[UsageBySupplier] = Json.format[UsageBySupplier]
+  implicit val jsonWrites: OWrites[UsageBySupplier] = Json.writes[UsageBySupplier]
 
 }
-
-case class Response(total: Long, images: Seq[UsageBySupplier])
 
 object Response {
-  implicit val jsonFormat: OFormat[Response] = Json.format[Response]
+  implicit val jsonWrites: OWrites[Response] = Json.writes[Response]
 }
+
+case class Response(total: Long, images: Seq[UsageBySupplier], list: List[Link])

--- a/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearchModel.scala
@@ -200,7 +200,7 @@ object SearchParams {
     else orderByRaw
   }
 
-  def apply(request: Authentication.Request[Any]): SearchParams = {
+  def apply(request: Authentication.Request[Any], defaultPageSize: Int): SearchParams = {
 
     def commaSep(key: String): List[String] = request.getQueryString(key).toList.flatMap(commasToList)
 
@@ -222,7 +222,7 @@ object SearchParams {
       structuredQuery,
       request.getQueryString("ids").map(_.split(",").toList),
       request.getQueryString("offset") flatMap parseIntFromQuery getOrElse 0,
-      request.getQueryString("length") flatMap parseIntFromQuery getOrElse 10,
+      request.getQueryString("length") flatMap parseIntFromQuery getOrElse defaultPageSize,
       request.getQueryString("orderBy") map readOrderBy,
       request.getQueryString("since") flatMap parseDateFromQuery,
       request.getQueryString("until") flatMap parseDateFromQuery,

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -28,7 +28,6 @@ DELETE  /images/:id                                                 controllers.
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch()
-
 # completion
 GET     /suggest/metadata/credit                                    controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
 GET     /suggest/metadata/photoshoot                                controllers.SuggestionController.suggestPhotoshoot(q: Option[String], size: Option[Int])
@@ -38,7 +37,7 @@ GET     /usage/suppliers                                            controllers.
 GET     /usage/suppliers/:id                                        controllers.UsageController.forSupplier(id: String)
 GET     /usage/quotas                                               controllers.UsageController.quotas
 GET     /usage/quotas/:id                                           controllers.UsageController.quotaForImage(id: String)
-
+GET     /images-usages                                              controllers.UsageController.imageIdsBySupplier()
 # configuration
 GET     /configuration/crop-variations                              controllers.ConfigurationController.cropVariations
 


### PR DESCRIPTION
## What does this change?
This adds a bespoke endpoint that uses the same query params as the search API, but returns only an image id, supplier and usages to make it easier to reconcile how many images have been used as part of the quota. 

The params to use the test the output are:

https://api.media.local.dev-gutools.co.uk/images-usages?q=usages@%3Eadded:2026-07-01%20usages@%3Cadded:2026-07-31%20usages@status:published&nonFree=true

A specific supplier can optionally be added:

https://api.media.local.dev-gutools.co.uk/images-usages?q=usages@%3Eadded:2026-07-01%20usages@%3Cadded:2026-07-31%20usages@status:published%20supplier:AAP&nonFree=true


This also changes the way pagination is implemented as the existing logic did not seem to be working from what I could see 🤔 
At the moment this updates the `search` endpoint too, though I think it would be better to scope any changes to just this endpoint before releasing

It might be a bit of annoying user experience to have to paginate manually. A good next step could be to implement a recursive search to get all the ids and then produce a `.csv` file to download. 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
