### PR TITLE
Add upload permission support email to config

### DIFF
--- a/kahuna/app/lib/KahunaConfig.scala
+++ b/kahuna/app/lib/KahunaConfig.scala
@@ -32,6 +32,7 @@ class KahunaConfig(resources: GridConfigResources) extends CommonConfig(resource
   val usageRightsHelpLink: Option[String]= stringOpt("links.usageRightsHelp").filterNot(_.isEmpty)
   val invalidSessionHelpLink: Option[String]= stringOpt("links.invalidSessionHelp").filterNot(_.isEmpty)
   val supportEmail: Option[String]= stringOpt("links.supportEmail").filterNot(_.isEmpty)
+  val uploadImagesPermissionSupportEmail: Option[String] = stringOpt("links.uploadImagesPermissionSupportEmail").filterNot(_.isEmpty)
   val telemetryUri: Option[String] = stringOpt("links.telemetryUri").filterNot(_.isEmpty)
 
   val homeLinkHtml: Option[String] = stringOpt("branding.homeLinkHtml").filterNot(_.isEmpty)

--- a/kahuna/app/views/main.scala.html
+++ b/kahuna/app/views/main.scala.html
@@ -59,6 +59,7 @@
           usageRightsHelpLink: "@Html(kahunaConfig.usageRightsHelpLink.getOrElse(""))",
           invalidSessionHelpLink: "@Html(kahunaConfig.invalidSessionHelpLink.getOrElse(""))",
           supportEmail: "@Html(kahunaConfig.supportEmail.getOrElse(""))",
+          uploadImagesPermissionSupportEmail: "@Html(kahunaConfig.uploadImagesPermissionSupportEmail.getOrElse(""))",
           staffPhotographerOrganisation: "@Html(kahunaConfig.staffPhotographerOrganisation)",
           fieldAliases: @Html(fieldAliases),
           homeLinkHtml: '@Html(kahunaConfig.homeLinkHtml.getOrElse(""))',

--- a/kahuna/public/js/upload/controller.css
+++ b/kahuna/public/js/upload/controller.css
@@ -1,5 +1,5 @@
 .unauthorised-message {
     text-align: center;
     font-size: 3rem;
-    margin-top: 50px;
+    margin: 50px 20px 0 20px;
 }

--- a/kahuna/public/js/upload/controller.js
+++ b/kahuna/public/js/upload/controller.js
@@ -34,6 +34,7 @@ upload.controller('UploadCtrl', ['uploadManager', 'mediaApi', 'scrollPosition', 
     };
 
     ctrl.supportEmailLink = window._clientConfig.supportEmail;
+    ctrl.uploadImagesPermissionSupportEmailLink = window._clientConfig.uploadImagesPermissionSupportEmail;
     ctrl.systemName = window._clientConfig.systemName;
 
     mediaApi.canUserUpload().then(canUpload => {

--- a/kahuna/public/js/upload/view.html
+++ b/kahuna/public/js/upload/view.html
@@ -26,6 +26,6 @@
         <recent-uploads></recent-uploads>
     </section>
 </div>
-<div ng-if="ctrl.canUpload === false" class="unauthorised-message" role="main">You are not authorised to upload images. <a href="{{ctrl.supportEmailLink}}" class="coloured-link">Send an email to {{ctrl.systemName}} team</a> if you think this is incorrect.</div>
+<div ng-if="ctrl.canUpload === false" class="unauthorised-message" role="main">You are not authorised to upload images. <a href="{{ctrl.uploadImagesPermissionSupportEmailLink || ctrl.supportEmailLink}}" class="coloured-link">Send an email to support</a> if you think this is incorrect.</div>
 
 <dnd-uploader ng-if="ctrl.canUpload"></dnd-uploader>


### PR DESCRIPTION
## What does this change?

Currently, in the scenario when upload images permission rule is enforced in Grid and a user doesn't have image upload permission, they'll see a 'Send an email Grid team' message with the email address pointed to `thegrid.dev@theguardian.com` which is set as `supportEmail` in config.

For upload images permission, as this will be managed by Central Production pending training, we want to point users to Central Production email instead. This is managed via a new Kahuna config `uploadImagesPermissionSupportEmail`.

## How should a reviewer test this change?
* In your local `~/.grid/common.conf`, add `enforceUploadImagesPermission = true`
* In your local `~/.grid/kahuna.conf`, add `links.uploadImagesPermissionSupportEmail="mailto:central.production@theguardian.com"`
* Start up Grid locally
* You should be able to see the email change:
<img width="1372" height="868" alt="upload permission support email" src="https://github.com/user-attachments/assets/adc3084b-1d72-46e5-bca2-f2f17521de83" />




## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217419702817660