### PR TITLE
Tweak top-bar spacing

### DIFF
--- a/kahuna/public/js/components/gr-sort-control/base-sort-control.tsx
+++ b/kahuna/public/js/components/gr-sort-control/base-sort-control.tsx
@@ -13,7 +13,7 @@ const PANEL_IDENTIFIER = "info";
 const SCROLL_IDENTIFIER = "scroll";
 
 const downArrowIcon = () =>
-  <svg width="12" height="12" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <svg width="10" height="10" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path d="M11.178 19.569a.998.998 0 0 0 1.644 0l9-13A.999.999 0 0 0 21 5H3a1.002 1.002 0 0 0-.822 1.569l9 13z"/>
   </svg>;
 

--- a/kahuna/public/js/components/gr-sort-control/gr-sort-control.css
+++ b/kahuna/public/js/components/gr-sort-control/gr-sort-control.css
@@ -149,7 +149,7 @@
   }
 }
 
-@media screen and (max-width: 1380px) {
+@media screen and (max-width: 1400px) {
   .sort-selection-title {
     display: none;
   }

--- a/kahuna/public/js/components/gu-date-range/gu-date-range.css
+++ b/kahuna/public/js/components/gu-date-range/gu-date-range.css
@@ -18,7 +18,7 @@
 
 .gu-date-range__display__icon__toggle {
     display: inline-block;
-    margin-left: 5px;
+    margin-left: 3px;
 }
 
 .gu-date-range__icon {

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -736,7 +736,7 @@ textarea.ng-invalid {
     display: inline-flex;
     flex-direction: row;
     align-items: center;
-    border-left: 2px solid #565656;
+    border-left: 1px solid #565656;
     height: 50px;
 }
 
@@ -745,7 +745,7 @@ textarea.ng-invalid {
 }
 
 .top-bar-item:last-child {
-    border-right: 2px solid #565656;
+    border-right: 1px solid #565656;
 }
 
 .top-bar-item__form {
@@ -953,7 +953,7 @@ textarea.ng-invalid {
     border: 1px solid #999;
     box-sizing: border-box;
 
-    min-width: 300px;
+    min-width: 270px;
     flex-grow: 1;
 }
 
@@ -980,7 +980,7 @@ textarea.ng-invalid {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  margin-left: 25px;
+  margin-left: 10px;
   align-items: center; /* vertical align all filters */
 }
 
@@ -1050,7 +1050,7 @@ textarea.ng-invalid {
     }
 }
 
-@media screen and (max-width: 1380px) {
+@media screen and (max-width: 1400px) {
     .search__modifier-toggle {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
Previously, I have introduced a little visual regression to the top-bar at a very specific breakpoint:
<img width="348" height="50" alt="Screenshot 2026-08-14 at 12 33 43" src="https://github.com/user-attachments/assets/e9793bf7-7920-4ad7-bf78-1937d2e0f022" />

I think the top bar is getting a little cramped with the introduced AI search, and might be good to be able to have another look at reorganising things there a little from a design perspective, but I've tweaked spacing slightly to address that regression and for things look slightly more balanced:


<img width="1810" height="936" alt="top bar" src="https://github.com/user-attachments/assets/0e1c0aa9-1fa9-487e-9a2e-1ae78bd8aa99" />



## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217476404655065