### PR TITLE
Add an endpoint for image usages by supplier

### DIFF
--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -6,8 +6,11 @@ import com.gu.mediaservice.lib.auth.Authentication.Principal
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.lib.play.RequestLoggingFilter
 import com.gu.mediaservice.model.Agencies
+import com.gu.mediaservice.model.usage.Usage
 import lib._
-import lib.elasticsearch.ElasticSearch
+import lib.elasticsearch.{ElasticSearch, InvalidUriParams, SearchParams}
+import lib.elasticsearch.SearchParams.parseIntFromQuery
+import lib.querysyntax.Parser
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
@@ -89,5 +92,30 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
           logger.error(logMarker, "quota access failed", e)
           respondError(InternalServerError, "unknown-error", e.toString)
       }
+  }
+
+  def imageUsagesBySupplier(id: String) = auth.async { implicit request =>
+    implicit val logMarker: LogMarker = MarkerMap(
+      "requestType" -> "images-by-supplier",
+      "requestId" -> RequestLoggingFilter.getRequestId(request),
+      "supplierId" -> id,
+    ) ++ RequestLoggingFilter.loggablePrincipal(request.user)
+
+    val structuredQuery = request.getQueryString("q").map(Parser.run).getOrElse(List.empty)
+    val searchParams = SearchParams(request)
+
+    SearchParams.validate(searchParams) match {
+      case Left(errors) =>
+        Future.successful(respondError(BadRequest, InvalidUriParams.errorKey, errors.map(_.message).mkString(", ")))
+      case Right(_) =>
+        elasticSearch.imageUsagesBySupplier(id, structuredQuery, searchParams.offset, searchParams.length)
+          .map { result =>
+            respondCollection(result.images, Some(searchParams.offset.toLong), Some(result.total))
+          }
+          .recover {
+            case e: IllegalArgumentException => respondError(BadRequest, InvalidUriParams.errorKey, e.getMessage)
+            case e => respondError(InternalServerError, "unknown-error", e.toString)
+          }
+    }
   }
 }

--- a/media-api/app/lib/ImageUsagesBySupplier.scala
+++ b/media-api/app/lib/ImageUsagesBySupplier.scala
@@ -1,0 +1,11 @@
+package lib
+
+import com.gu.mediaservice.model.usage.Usage
+import play.api.libs.json.{Json, OFormat}
+
+case class ImageUsagesBySupplier(id: String, supplier: String, usages: List[Usage])
+object ImageUsagesBySupplier {
+  implicit val jsonFormat: OFormat[ImageUsagesBySupplier] = Json.format[ImageUsagesBySupplier]
+}
+
+case class ImageUsagesBySupplierResult(images: List[ImageUsagesBySupplier], total: Long)

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -2,6 +2,7 @@ package lib.elasticsearch
 
 import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.ImageFields
+import com.gu.mediaservice.lib.formatting.printDateTime
 import com.gu.mediaservice.lib.argo.model.{ExtraCount, ExtraCountConfig, ExtraCounts}
 import com.gu.mediaservice.lib.elasticsearch.filters
 import com.gu.mediaservice.lib.auth.Authentication.Principal
@@ -9,6 +10,7 @@ import com.gu.mediaservice.lib.elasticsearch.{CompletionPreview, ElasticSearchCl
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap, Stopwatch, combineMarkers}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
 import com.gu.mediaservice.model.{Agencies, Agency, AwaitingReviewForSyndication, Image}
+import com.gu.mediaservice.model.usage.{DigitalUsage, PrintUsage, PublishedUsageStatus, RemovedUsageStatus, Usage, UnknownUsageStatus, UsageStatus, UsageType}
 import com.sksamuel.elastic4s.{ElasticDsl, Hit}
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.common.Operator
@@ -24,8 +26,8 @@ import com.sksamuel.elastic4s.requests.searches.knn.Knn
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.BEST_FIELDS
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{FieldWithOptionalBoost, MultiMatchQuery}
 import lib.elasticsearch.ResultSource.{Both, Lexical, Semantic}
-import lib.querysyntax.{HierarchyField, Match, Parser, Phrase}
-import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary}
+import lib.querysyntax.{Condition, DateRange, HierarchyField, Match, Nested, Parser, Phrase, SingleField}
+import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary, ImageUsagesBySupplier, ImageUsagesBySupplierResult}
 import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
 import play.api.mvc.AnyContent
 import play.api.mvc.Security.AuthenticatedRequest
@@ -480,6 +482,66 @@ class ElasticSearch(
       import r.result
       logSearchQueryIfTimedOut(search, result)
       SupplierUsageSummary(supplier, result.hits.total.value)
+    }
+  }
+
+  def imageUsagesBySupplier(
+    id: String,
+    structuredQuery: List[Condition] = List.empty,
+    offset: Int = 0,
+    length: Int = 10
+  )(implicit ex: ExecutionContext, logMarker: LogMarker): Future[ImageUsagesBySupplierResult] = {
+    if (offset + length > 10000)
+      return Future.failed(new IllegalArgumentException(s"offset + length cannot exceed 10000 (Elasticsearch result window limit)"))
+
+    val supplier = Agencies.get(id)
+    val supplierName = supplier.supplier
+
+    val qualifyingStatuses = Set[UsageStatus](PublishedUsageStatus, UnknownUsageStatus, RemovedUsageStatus)
+    val qualifyingPlatforms = Set[UsageType](PrintUsage, DigitalUsage)
+
+    val haveQualifyingStatus = termsQuery("usages.status", qualifyingStatuses.map(_.toString))
+    val haveQualifyingPlatform = termsQuery("usages.platform", qualifyingPlatforms.map(_.toString))
+
+    // e.g. usages@<added:2026-07-31 usages@>added:2026-07-01 - each date bound is inclusive,
+    // and since they all apply within the same nested "usages" entry, multiple bounds combine into a range.
+    val dateAddedRanges = structuredQuery.collect {
+      case Nested(SingleField("usages"), SingleField("dateAdded"), DateRange(start, end)) => (start, end)
+    }
+    val maybeDateAddedRange = dateAddedRanges match {
+      case Nil => None
+      case ranges =>
+        val from = ranges.map(_._1).maxBy(_.getMillis)
+        val to = ranges.map(_._2).minBy(_.getMillis)
+        Some((from, to))
+    }
+
+    val qualifyingUsageClauses = List(haveQualifyingStatus, haveQualifyingPlatform) ++
+      maybeDateAddedRange.map { case (from, to) => rangeQuery("usages.dateAdded").gte(printDateTime(from)).lte(printDateTime(to)) }
+    val haveQualifyingUsage = nestedQuery("usages", boolQuery().must(qualifyingUsageClauses))
+
+    val beSupplier = termQuery("usageRights.supplier", supplierName)
+
+    val query = boolQuery().must(matchAllQuery()).filter(boolQuery().must(beSupplier, haveQualifyingUsage))
+
+    val search = prepareSearch(query).trackTotalHits(true).from(offset).size(length)
+
+    def isQualifyingUsage(usage: Usage): Boolean =
+      qualifyingStatuses.contains(usage.status) &&
+        qualifyingPlatforms.contains(usage.platform) &&
+        maybeDateAddedRange.forall { case (from, to) =>
+          usage.dateAdded.exists(dateAdded => !dateAdded.isBefore(from) && !dateAdded.isAfter(to))
+        }
+
+    executeAndLog(search, s"$id image usages by supplier search").map { r =>
+      import r.result
+      logSearchQueryIfTimedOut(search, result)
+      val images = result.hits.hits.toList
+        .flatMap(resolveHit)
+        .map(sourceWrapperImage => sourceWrapperImage.instance)
+        .map(image => ImageUsagesBySupplier(image.id, supplierName, image.usages.filter(isQualifyingUsage)))
+        .distinctBy(_.id)
+      ImageUsagesBySupplierResult(images, result.totalHits)
     }
   }
 

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -28,7 +28,6 @@ DELETE  /images/:id                                                 controllers.
 DELETE  /images/:id/hard-delete                                     controllers.MediaApi.hardDeleteImage(id: String)
 PUT     /images/:id/undelete                                        controllers.MediaApi.unSoftDeleteImage(id: String)
 GET     /images                                                     controllers.MediaApi.imageSearch()
-
 # completion
 GET     /suggest/metadata/credit                                    controllers.SuggestionController.suggestMetadataCredit(q: Option[String], size: Option[Int])
 GET     /suggest/metadata/photoshoot                                controllers.SuggestionController.suggestPhotoshoot(q: Option[String], size: Option[Int])
@@ -36,9 +35,9 @@ GET     /suggest/metadata/photoshoot                                controllers.
 # usage quotas
 GET     /usage/suppliers                                            controllers.UsageController.bySupplier
 GET     /usage/suppliers/:id                                        controllers.UsageController.forSupplier(id: String)
+GET     /usage/suppliers/:id/images                                 controllers.UsageController.imageUsagesBySupplier(id: String)
 GET     /usage/quotas                                               controllers.UsageController.quotas
 GET     /usage/quotas/:id                                           controllers.UsageController.quotaForImage(id: String)
-
 # configuration
 GET     /configuration/crop-variations                              controllers.ConfigurationController.cropVariations
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -8,7 +8,7 @@ import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchAliases, ElasticSearc
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.DenySyndicationLease
-import com.gu.mediaservice.model.usage.PublishedUsageStatus
+import com.gu.mediaservice.model.usage.{PublishedUsageStatus, RemovedUsageStatus, UnknownUsageStatus}
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
 import lib.querysyntax._
@@ -152,16 +152,98 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       implicit val logMarker: LogMarker = MarkerMap()
 
       val publishedAgencyImages = images.filter(i => i.usageRights.isInstanceOf[Agency] && i.usages.exists(_.status == PublishedUsageStatus))
-      publishedAgencyImages.size shouldBe 2
+      publishedAgencyImages.size shouldBe 7
 
       // Reporting date range is implemented as round down to last full day
       val withinReportedDateRange = publishedAgencyImages.filter(i => i.usages.
         exists(u => u.dateAdded.exists(_.isBefore(DateTime.now.withTimeAtStartOfDay()))))
-      withinReportedDateRange.size shouldBe 1
+      withinReportedDateRange.size shouldBe 6
 
       val results = Await.result(ES.usageForSupplier("ACME", 5), fiveSeconds)
 
       results.count shouldBe 1
+    }
+  }
+
+  describe("images usages by supplier") {
+    it("only returns images with a qualifying usage status/platform for the given supplier, with the full usages list and supplier populated per item") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
+      val expectedIds = Set(
+        "usages-by-supplier-qualified-published-digital",
+        "usages-by-supplier-qualified-unknown-print",
+        "usages-by-supplier-qualified-removed-digital",
+        "usages-by-supplier-multi-usage",
+        "usages-by-supplier-out-of-date-range"
+      )
+
+      val result = Await.result(ES.imageUsagesBySupplier("test-wire", length = 100), fiveSeconds)
+
+      result.total shouldBe expectedIds.size
+      result.images.map(_.id).toSet shouldBe expectedIds
+      result.images.foreach(_.supplier shouldBe "test-wire")
+
+      // wrong supplier, non-qualifying status and non-qualifying platform are all excluded
+      result.images.map(_.id) should not contain "usages-by-supplier-wrong-supplier"
+      result.images.map(_.id) should not contain "usages-by-supplier-non-qualifying-status"
+      result.images.map(_.id) should not contain "usages-by-supplier-non-qualifying-platform"
+
+      // distinctBy(_.id) collapses multiple qualifying usages into one result. Only the qualifying
+      // usages should be returned - the non-qualifying (pending status) usage on this image is excluded.
+      val multiUsageResult = result.images.find(_.id == "usages-by-supplier-multi-usage").get
+      multiUsageResult.usages should have size 2
+      multiUsageResult.usages.map(_.status) should contain theSameElementsAs List(PublishedUsageStatus, RemovedUsageStatus)
+    }
+
+    it("only returns usages within the requested date range on a matching image, excluding out-of-range usages on the same image") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
+      val dateRangeQuery = List(Nested(
+        SingleField("usages"),
+        SingleField("dateAdded"),
+        DateRange(DateTime.parse("2020-06-20"), DateTime.parse("2020-06-30"))
+      ))
+
+      // the multi-usage image has one qualifying usage in range (2020-06-25, removed/print) and
+      // one qualifying usage out of range (2020-06-01, published/digital) - only the in-range one should be returned.
+      val result = Await.result(ES.imageUsagesBySupplier("test-wire", dateRangeQuery, length = 100), fiveSeconds)
+
+      val multiUsageResult = result.images.find(_.id == "usages-by-supplier-multi-usage").get
+      multiUsageResult.usages should have size 1
+      multiUsageResult.usages.head.status shouldBe RemovedUsageStatus
+    }
+
+    it("applies an inclusive date range filter on usages.dateAdded and paginates the results") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
+      val dateRangeQuery = List(Nested(
+        SingleField("usages"),
+        SingleField("dateAdded"),
+        DateRange(DateTime.parse("2020-06-01"), DateTime.parse("2020-06-30"))
+      ))
+
+      val filteredResult = Await.result(ES.imageUsagesBySupplier("test-wire", dateRangeQuery, length = 100), fiveSeconds)
+      filteredResult.images.map(_.id).toSet shouldBe Set(
+        "usages-by-supplier-qualified-published-digital",
+        "usages-by-supplier-qualified-unknown-print",
+        "usages-by-supplier-qualified-removed-digital",
+        "usages-by-supplier-multi-usage"
+      )
+
+      // pagination: paging through with a small length shouldn't drop or duplicate results
+      val pageSize = 2
+      val pages = (0 until 3).map { page =>
+        Await.result(ES.imageUsagesBySupplier("test-wire", offset = page * pageSize, length = pageSize), fiveSeconds)
+      }
+      pages.map(_.images.size) shouldBe Seq(2, 2, 1)
+      pages.foreach(_.total shouldBe 5)
+      pages.flatMap(_.images.map(_.id)).toSet shouldBe Set(
+        "usages-by-supplier-qualified-published-digital",
+        "usages-by-supplier-qualified-unknown-print",
+        "usages-by-supplier-qualified-removed-digital",
+        "usages-by-supplier-multi-usage",
+        "usages-by-supplier-out-of-date-range"
+      )
     }
   }
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -1,6 +1,7 @@
 package lib.elasticsearch
 
 import com.gu.mediaservice.model._
+import com.gu.mediaservice.model.usage._
 import com.gu.mediaservice.testlib.ElasticSearchDockerBase
 import org.joda.time.DateTime
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
@@ -144,6 +145,17 @@ trait ElasticSearchTestBase extends AnyFunSpec with ElasticSearchDockerBase with
       usages = List(createDigitalUsage(date = DateTime.now))
     ),
 
+    // Agency image with an "unknown" status usage just now - unknown usages should still
+    // count towards the supplier usage summary, alongside "published" usages.
+    createImageForSyndication(
+      id = "test-image-agency-unknown-status",
+      rightsAcquired = false,
+      None,
+      None,
+      usageRights = agency,
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, UnknownUsageStatus, date = DateTime.now.minusDays(1)))
+    ),
+
     // Screen grab with rights acquired, not eligible for syndication review
     createImageForSyndication(
       id = "test-image-11",
@@ -187,5 +199,30 @@ trait ElasticSearchTestBase extends AnyFunSpec with ElasticSearchDockerBase with
     //        )
     //      )
     //    )
+
+    // Fixtures for ES.imageUsagesBySupplier: a dedicated supplier ("test-wire" isn't in Agencies.all,
+    // so Agencies.get("test-wire").supplier falls back to == "test-wire").
+    createImage("usages-by-supplier-qualified-published-digital", Agency("test-wire"),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-06-15")))),
+    createImage("usages-by-supplier-qualified-unknown-print", Agency("test-wire"),
+      usages = List(createUsage(ComposerUsageReference, PrintUsage, UnknownUsageStatus, DateTime.parse("2020-06-16")))),
+    createImage("usages-by-supplier-qualified-removed-digital", Agency("test-wire"),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, RemovedUsageStatus, DateTime.parse("2020-06-17")))),
+    createImage("usages-by-supplier-non-qualifying-status", Agency("test-wire"),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PendingUsageStatus, DateTime.parse("2020-06-18")))),
+    createImage("usages-by-supplier-non-qualifying-platform", Agency("test-wire"),
+      usages = List(createUsage(ComposerUsageReference, SyndicationUsage, PublishedUsageStatus, DateTime.parse("2020-06-19")))),
+    createImage("usages-by-supplier-wrong-supplier", Agency("other-wire"),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-06-20")))),
+    // Has two qualifying usages plus one non-qualifying usage (wrong status) - checks distinctBy(_.id)
+    // collapses to a single result, and that only the qualifying usages are returned (not the non-qualifying one).
+    createImage("usages-by-supplier-multi-usage", Agency("test-wire"),
+      usages = List(
+        createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-06-01")),
+        createUsage(ComposerUsageReference, PrintUsage, RemovedUsageStatus, DateTime.parse("2020-06-25")),
+        createUsage(ComposerUsageReference, DigitalUsage, PendingUsageStatus, DateTime.parse("2020-06-10"))
+      )),
+    createImage("usages-by-supplier-out-of-date-range", Agency("test-wire"),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-08-01"))))
   )
 }

--- a/media-api/test/lib/elasticsearch/Fixtures.scala
+++ b/media-api/test/lib/elasticsearch/Fixtures.scala
@@ -153,7 +153,7 @@ trait Fixtures {
     out
   }
 
-  private def createUsage(t: UsageReferenceType, usageType: UsageType, status: Status, date: DateTime): Usage = {
+  def createUsage(t: UsageReferenceType, usageType: UsageType, status: Status, date: DateTime): Usage = {
     Usage(
       UUID.randomUUID().toString,
       List(UsageReference(t)),


### PR DESCRIPTION
## What does this change?

* Adds an endpoint `/usage/suppliers/:id/images`, which returns a paginated list of images along with its relevant usages for each agency.

* We only care about usages that are under `published`, `unknown`, and `removed` statuses for now, on `digital` and `print` platforms.

* I've allowed for usage `added` date range to be passed in via search params to give us more flexibility around investigating various date ranges and compare against Kevin's RCS email, without being limited to the 'last 30 days' logic.

* This endpoint would be extremely useful for providing some transparency around image usages as we investigate usage reporting in the Grid and quota counting from RCS.



## How should a reviewer test this change?

* Run the Grid locally with `./dev/script/start.sh --use-TEST`
* Go to the endpoint with a generous date range so you get more results: https://api.media.local.dev-gutools.co.uk/usage/suppliers/getty/images?q=usages@%3Cadded:2026-07-31%20usages@%3Eadded:2016-07-01&length=100&offset=0
* You can page through the result by updating `offset` and `length` in the search params

```json
{
  "offset": 0,
  "length": 73,
  "total": 73,
  "data": [
    {
      "id": "09f2c303a1b00697a092272156b4b149cb386354",
      "supplier": "Getty Images",
      "usages": [
        {
          "id": "front/34efed86f207c04264e9ee2ee2cb4bf4_d9a2c6f3b5c5d77d95dfdfd74b834ea3",
          "references": [
            {
              "type": "front",
              "name": "olly"
            }
          ],
          "platform": "digital",
          "media": "image",
          "status": "unknown",
          "dateAdded": "2023-04-27T14:29:21.150Z",
          "lastModified": "2023-04-27T14:29:21.150Z",
          "frontUsageMetadata": {
            "addedBy": "georges.lebreton@guardian.co.uk",
            "front": "olly"
          }
        }
      ]
    },
    {
      "id": "0345c73bf81cafeb11ef8bc1ccc26ff2410a67f4",
      "supplier": "Getty Images",
      "usages": [
        {
          "id": "front/2b46ae683500c561863adfb0856324e_a3f8975262b7c4085f9d07aba3876f56",
          "references": [
            {
              "type": "front",
              "name": "uk"
            }
          ],
          "platform": "digital",
          "media": "image",
          "status": "unknown",
          "dateAdded": "2023-05-04T08:24:04.750Z",
          "lastModified": "2023-05-04T08:24:04.750Z",
          "frontUsageMetadata": {
            "addedBy": "anna.beddow@guardian.co.uk",
            "front": "uk"
          }
        }
      ]
    },
   // ...etc etc
  ]
}
```


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217550364887307