### PR TITLE
Add Auth Error workaround to docs

### DIFF
--- a/docs/02-running/01-running-locally.md
+++ b/docs/02-running/01-running-locally.md
@@ -59,7 +59,7 @@ If you haven't used the `--with-local-auth` flag, you'll begin a Google authenti
 
 If you have used the `--no-auth` flag you'll be signed in automatically as John Doe (with no oauth flow) and will have ALL permissions.
 
-# Auth Failed Errors 
+### Auth Failed Errors 
 Sometimes you will see a red notification relating to a failure to auth.  Visiting:
 
 https://media.test.dev-gutools.co.uk/search

--- a/docs/02-running/01-running-locally.md
+++ b/docs/02-running/01-running-locally.md
@@ -59,6 +59,13 @@ If you haven't used the `--with-local-auth` flag, you'll begin a Google authenti
 
 If you have used the `--no-auth` flag you'll be signed in automatically as John Doe (with no oauth flow) and will have ALL permissions.
 
+# Auth Failed Errors 
+Sometimes you will see a red notification relating to a failure to auth.  Visiting:
+
+https://media.test.dev-gutools.co.uk/search
+
+and refreshing the page will resolve this.
+
 ## Cerebro
 
 To inspect the elasticsearch database, cerebro is included as part of the grids local stack.


### PR DESCRIPTION
Only a documentation change.  Adds a line explaining that you can get around the auth errors when running grid locally / using --TEST by visiting https://media.test.dev-gutools.co.uk/search 