### PR TITLE
Bump libthrift to at least 0.23.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,10 @@ lazy val commonLib = project("common-lib").settings(
     ws,
     "org.testcontainers" % "elasticsearch" % "1.21.4" % Test,
   ),
-  dependencyOverrides += "ch.qos.logback" % "logback-classic" % "1.2.13" % Test
+  dependencyOverrides ++= Seq(
+    "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,
+    "org.apache.thrift" % "libthrift" % "0.23.0"
+  )
 )
 
 lazy val restLib = project("rest-lib").settings(


### PR DESCRIPTION
## What does this change?

Updates the thrift library to address the vulnerability reported here:

https://github.com/advisories/GHSA-7pwc-h2j2-rjgj

<!-- Remember that the reviewer may be unfamiliar with the functionality – please be descriptive! -->
<!-- If it affects the UI, screenshots or gifs of the change may be useful. --> 

## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
