### PR TITLE
Add searchkey to telemetry and send telemetry when AI search is toggled on

### DIFF
--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -293,8 +293,8 @@ query.controller('SearchQueryCtrl', [
       manageDefaultNonFree(newFilter);
       manageOrgOwnedSetting(newFilter);
 
-      emitQueryTelemetry()
-      
+      emitQueryTelemetry();
+
       if (ctrl.collectionSearch && !curCollectionSearch) {
         storage.setJs("orderBy", CollectionSortOption.value);
         ctrl.ordering["orderBy"] = CollectionSortOption.value;

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -457,6 +457,8 @@ query.controller('SearchQueryCtrl', [
     $scope.$watch(() => ctrl.ordering.orderBy, onValChange(newVal => {
         $state.go('search.results', {...ctrl.filter, orderBy: newVal});
     }));
+
+    let aiSearchInitialised = false;
     $scope.$watch(() => ctrl.useAISearch, () => {
       // Note: $watch expressions execute at least once during initialization, so this is executed on page refresh.
       // This is the behaviour we want so that the URL is updated based on the AI search toggle.

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -453,6 +453,19 @@ query.controller('SearchQueryCtrl', [
     $scope.$watch(() => ctrl.useAISearch, () => {
       // Note: $watch expressions execute at least once during initialization, so this is executed on page refresh.
       // This is the behaviour we want so that the URL is updated based on the AI search toggle
+      
+      const { nonFree, uploadedByMe } = ctrl.filter;
+      let nonFreeCheck = nonFree;
+      if (ctrl.usePermissionsFilter && nonFreeCheck === undefined) {
+        const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
+        nonFreeCheck = defaultShowPaid;
+      } else if (!ctrl.usePermissionsFilter && (nonFreeCheck === 'false' || nonFreeCheck === false)) {
+        nonFreeCheck = undefined;
+      }
+      ctrl.filter.nonFree = nonFreeCheck;
+
+      sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe, ctrl.useAISearch);
+      
       if (ctrl.useAISearch) {
         $state.go('search.results', {
           ...ctrl.filter,

--- a/kahuna/public/js/search/query.js
+++ b/kahuna/public/js/search/query.js
@@ -244,6 +244,22 @@ query.controller('SearchQueryCtrl', [
       }
     }
 
+    function resolveNonFree() {
+      let nonFreeCheck = ctrl.filter.nonFree;
+      if (ctrl.usePermissionsFilter && nonFreeCheck === undefined) {
+        nonFreeCheck = storage.getJs("defaultIsNonFree", true);
+      } else if (!ctrl.usePermissionsFilter && (nonFreeCheck === 'false' || nonFreeCheck === false)) {
+        nonFreeCheck = undefined;
+      }
+      ctrl.filter.nonFree = nonFreeCheck;
+      return nonFreeCheck;
+    }
+
+    function emitQueryTelemetry() {
+      const nonFreeCheck = resolveNonFree();
+      sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, ctrl.filter.uploadedByMe, ctrl.useAISearch);
+    }
+
     // eslint-disable-next-line complexity
     function watchSearchChange(newFilter, sender) {
       let showPaid = newFilter.nonFree ? newFilter.nonFree : false;
@@ -277,17 +293,8 @@ query.controller('SearchQueryCtrl', [
       manageDefaultNonFree(newFilter);
       manageOrgOwnedSetting(newFilter);
 
-      const { nonFree, uploadedByMe } = ctrl.filter;
-      let nonFreeCheck = nonFree;
-      if (ctrl.usePermissionsFilter && nonFreeCheck === undefined) {
-        const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
-        nonFreeCheck = defaultShowPaid;
-      } else if (!ctrl.usePermissionsFilter && (nonFreeCheck === 'false' || nonFreeCheck === false)) {
-        nonFreeCheck = undefined;
-      }
-      ctrl.filter.nonFree = nonFreeCheck;
-
-      sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe, ctrl.useAISearch);
+      emitQueryTelemetry()
+      
       if (ctrl.collectionSearch && !curCollectionSearch) {
         storage.setJs("orderBy", CollectionSortOption.value);
         ctrl.ordering["orderBy"] = CollectionSortOption.value;
@@ -452,20 +459,16 @@ query.controller('SearchQueryCtrl', [
     }));
     $scope.$watch(() => ctrl.useAISearch, () => {
       // Note: $watch expressions execute at least once during initialization, so this is executed on page refresh.
-      // This is the behaviour we want so that the URL is updated based on the AI search toggle
-      
-      const { nonFree, uploadedByMe } = ctrl.filter;
-      let nonFreeCheck = nonFree;
-      if (ctrl.usePermissionsFilter && nonFreeCheck === undefined) {
-        const defaultShowPaid = storage.getJs("defaultIsNonFree", true);
-        nonFreeCheck = defaultShowPaid;
-      } else if (!ctrl.usePermissionsFilter && (nonFreeCheck === 'false' || nonFreeCheck === false)) {
-        nonFreeCheck = undefined;
+      // This is the behaviour we want so that the URL is updated based on the AI search toggle.
+      // We only emit telemetry on an actual toggle though - the load-time search event is emitted
+      // exactly once via the getSession() -> watchSearchChange path, so emitting here on init would double-count.
+      if (aiSearchInitialised) {
+        emitQueryTelemetry();
+      } else {
+        resolveNonFree();
       }
-      ctrl.filter.nonFree = nonFreeCheck;
+      aiSearchInitialised = true;
 
-      sendTelemetryForQuery(ctrl.filter.query, nonFreeCheck, uploadedByMe, ctrl.useAISearch);
-      
       if (ctrl.useAISearch) {
         $state.go('search.results', {
           ...ctrl.filter,

--- a/kahuna/public/js/services/telemetry.ts
+++ b/kahuna/public/js/services/telemetry.ts
@@ -51,6 +51,7 @@ const sendFilterTelemetryEvent = (key: string, value: string, searchUuid: string
 
 export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string, uploadedByMe?: boolean, useAISearch?: boolean ) => {
     const structuredQuery = structureQuery(query || "");
+
     const searchUuid = v4();
     // nonFree is unfortunately either a boolean, stringified boolean, or undefined
     const freeToUseOnly = (!(nonFree === 'true' || nonFree === true));
@@ -74,11 +75,16 @@ export const sendTelemetryForQuery = (query: string, nonFree?: boolean | string,
             return `GRID_${type.toUpperCase()}`;
         };
 
+        const searchKey = (type: string) => {
+            return type === 'text' ? { searchKey: `${getBrowserId()}::${queryComponent.value}` } : undefined;
+        };
+
         // In case search is empty, as with a search containing only filters
         sendTelemetryEvent(formattedType(type), {
             ...queryComponent,
             searchUuid: searchUuid,
-            useAISearch: useAISearch ?? false
+            useAISearch: useAISearch ?? false,
+            ...searchKey(type)
         }, 1);
     });
 };


### PR DESCRIPTION
## What does this change?

This sorts out some telemetry issues.

We want to be able to group search telemetry by user and by their distinct queries. This PR adds a searchKey to text search telemetry events and tightens up when query telemetry is emitted.

- For text query components, emit a new `searchKey` field of the form `${browserUuid}::${queryValue}`. This lets us filter/aggregate telemetry by user (browser id) and by their distinct search terms. Non-text query components (filters) are unaffected.
- Emit query telemetry when the AI-search toggle is changed, so toggling AI search is now reflected in telemetry.
- Guarded with an `aiSearchInitialised` flag so we only emit on an actual user toggle. The `$watch` fires once on init, and the load-time search event is already emitted exactly once via the `getSession()` -> `watchSearchChange path`, so emitting on init would double-count.

## How should a reviewer test this change?

Run locally and look at the telemetry events!