### PR TITLE
Include images with usageRights.suppliers field when querying for usages

### DIFF
--- a/media-api/app/lib/ImageUsagesBySupplier.scala
+++ b/media-api/app/lib/ImageUsagesBySupplier.scala
@@ -1,10 +1,20 @@
 package lib
 
+import com.gu.mediaservice.model.{Agency, CommissionedAgency, Composite, UsageRights}
 import com.gu.mediaservice.model.usage.Usage
 import play.api.libs.json.{Json, OFormat}
 
 case class ImageUsagesBySupplier(id: String, supplier: String, usages: List[Usage])
 object ImageUsagesBySupplier {
+  def apply(id: String, usageRights: UsageRights, usages: List[Usage]): ImageUsagesBySupplier = {
+    val supplier = usageRights match {
+      case c: Composite          => c.suppliers
+      case a: Agency             => a.supplier
+      case ca: CommissionedAgency => ca.supplier
+      case u                     => ""
+    }
+    ImageUsagesBySupplier(id, supplier, usages)
+  }
   implicit val jsonFormat: OFormat[ImageUsagesBySupplier] = Json.format[ImageUsagesBySupplier]
 }
 

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -512,7 +512,8 @@ class ElasticSearch(
       case Nil => None
       case ranges =>
         val from = ranges.map(_._1).maxBy(_.getMillis)
-        val to = ranges.map(_._2).minBy(_.getMillis)
+        // `<date` is parsed as midnight of that day; extend to end of day to make the bound inclusive
+        val to = ranges.map(_._2).minBy(_.getMillis).withTime(23, 59, 59, 999)
         Some((from, to))
     }
 
@@ -520,7 +521,10 @@ class ElasticSearch(
       maybeDateAddedRange.map { case (from, to) => rangeQuery("usages.dateAdded").gte(printDateTime(from)).lte(printDateTime(to)) }
     val haveQualifyingUsage = nestedQuery("usages", boolQuery().must(qualifyingUsageClauses))
 
-    val beSupplier = termQuery("usageRights.supplier", supplierName)
+    val beSupplier = boolQuery().should(
+      termQuery("usageRights.supplier", supplierName),
+      matchQuery("usageRights.suppliers", supplierName)
+    ).minimumShouldMatch(1)
 
     val query = boolQuery().must(matchAllQuery()).filter(boolQuery().must(beSupplier, haveQualifyingUsage))
 
@@ -539,7 +543,7 @@ class ElasticSearch(
       val images = result.hits.hits.toList
         .flatMap(resolveHit)
         .map(sourceWrapperImage => sourceWrapperImage.instance)
-        .map(image => ImageUsagesBySupplier(image.id, supplierName, image.usages.filter(isQualifyingUsage)))
+        .map(image => ImageUsagesBySupplier(image.id, image.usageRights, image.usages.filter(isQualifyingUsage)))
         .distinctBy(_.id)
       ImageUsagesBySupplierResult(images, result.totalHits)
     }

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -174,14 +174,15 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
         "usages-by-supplier-qualified-unknown-print",
         "usages-by-supplier-qualified-removed-digital",
         "usages-by-supplier-multi-usage",
-        "usages-by-supplier-out-of-date-range"
+        "usages-by-supplier-out-of-date-range",
+        "usages-by-supplier-composite"
       )
 
       val result = Await.result(ES.imageUsagesBySupplier("test-wire", length = 100), fiveSeconds)
 
       result.total shouldBe expectedIds.size
       result.images.map(_.id).toSet shouldBe expectedIds
-      result.images.foreach(_.supplier shouldBe "test-wire")
+      result.images.filterNot(_.id == "usages-by-supplier-composite").foreach(_.supplier shouldBe "test-wire")
 
       // wrong supplier, non-qualifying status and non-qualifying platform are all excluded
       result.images.map(_.id) should not contain "usages-by-supplier-wrong-supplier"
@@ -227,7 +228,8 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
         "usages-by-supplier-qualified-published-digital",
         "usages-by-supplier-qualified-unknown-print",
         "usages-by-supplier-qualified-removed-digital",
-        "usages-by-supplier-multi-usage"
+        "usages-by-supplier-multi-usage",
+        "usages-by-supplier-composite"
       )
 
       // pagination: paging through with a small length shouldn't drop or duplicate results
@@ -235,15 +237,27 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       val pages = (0 until 3).map { page =>
         Await.result(ES.imageUsagesBySupplier("test-wire", offset = page * pageSize, length = pageSize), fiveSeconds)
       }
-      pages.map(_.images.size) shouldBe Seq(2, 2, 1)
-      pages.foreach(_.total shouldBe 5)
+      pages.map(_.images.size) shouldBe Seq(2, 2, 2)
+      pages.foreach(_.total shouldBe 6)
       pages.flatMap(_.images.map(_.id)).toSet shouldBe Set(
         "usages-by-supplier-qualified-published-digital",
         "usages-by-supplier-qualified-unknown-print",
         "usages-by-supplier-qualified-removed-digital",
         "usages-by-supplier-multi-usage",
-        "usages-by-supplier-out-of-date-range"
+        "usages-by-supplier-out-of-date-range",
+        "usages-by-supplier-composite"
       )
+    }
+
+    it("includes composite images whose suppliers field contains the given supplier name") {
+      implicit val logMarker: LogMarker = MarkerMap()
+
+      val result = Await.result(ES.imageUsagesBySupplier("test-wire", length = 100), fiveSeconds)
+
+      val compositeResult = result.images.find(_.id == "usages-by-supplier-composite")
+      compositeResult shouldBe defined
+      // supplier field is populated from usageRights.suppliers for composite images
+      compositeResult.get.supplier shouldBe "test-wire, other-supplier"
     }
   }
 

--- a/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTestBase.scala
@@ -207,7 +207,7 @@ trait ElasticSearchTestBase extends AnyFunSpec with ElasticSearchDockerBase with
     createImage("usages-by-supplier-qualified-unknown-print", Agency("test-wire"),
       usages = List(createUsage(ComposerUsageReference, PrintUsage, UnknownUsageStatus, DateTime.parse("2020-06-16")))),
     createImage("usages-by-supplier-qualified-removed-digital", Agency("test-wire"),
-      usages = List(createUsage(ComposerUsageReference, DigitalUsage, RemovedUsageStatus, DateTime.parse("2020-06-17")))),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, RemovedUsageStatus, DateTime.parse("2020-06-30T23:59:59")))),
     createImage("usages-by-supplier-non-qualifying-status", Agency("test-wire"),
       usages = List(createUsage(ComposerUsageReference, DigitalUsage, PendingUsageStatus, DateTime.parse("2020-06-18")))),
     createImage("usages-by-supplier-non-qualifying-platform", Agency("test-wire"),
@@ -223,6 +223,9 @@ trait ElasticSearchTestBase extends AnyFunSpec with ElasticSearchDockerBase with
         createUsage(ComposerUsageReference, DigitalUsage, PendingUsageStatus, DateTime.parse("2020-06-10"))
       )),
     createImage("usages-by-supplier-out-of-date-range", Agency("test-wire"),
-      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-08-01"))))
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-07-01")))),
+    // Composite image whose `suppliers` field contains "test-wire" alongside another supplier
+    createImage("usages-by-supplier-composite", Composite("test-wire, other-supplier"),
+      usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.parse("2020-06-15"))))
   )
 }


### PR DESCRIPTION
## What does this change?

* In the `imageUsagesBySupplier` endpoint, we've missed images with `composite` usage rights, which use `suppliers` field instead of `supplier`. This PR includes those in the logic when filtering for images with relevant usages.
* I've also made the date range inclusive when it's specified in the search params

## How should a reviewer test this change?

* Run Grid locally with `--use-TEST` flag
* Go to https://api.media.local.dev-gutools.co.uk/usage/suppliers/alamy/images?length=20&offset=0, pick an image
* Go to the image in the Grid, update its usage to 'composite', and update the 'suppliers' field to 'Alamy, Getty Images':
<img width="300" height="380" alt="Screenshot 2026-08-21 at 11 27 06" src="https://github.com/user-attachments/assets/cc4e117e-c7c2-4141-ae33-ba1d6ea422f9" />

* Go to https://api.media.local.dev-gutools.co.uk/usage/suppliers/alamy/images?length=20&offset=0 again, and you should see the image still included in the response:
<img width="671" height="128" alt="Screenshot 2026-08-21 at 11 26 54" src="https://github.com/user-attachments/assets/4a18841e-85ba-49d8-ad9c-8e877df25121" />


## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217683735198951