### PR TITLE
Add quota counting logic and endpoint for supplier

### DIFF
--- a/media-api/app/controllers/UsageController.scala
+++ b/media-api/app/controllers/UsageController.scala
@@ -21,8 +21,6 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
                       override val controllerComponents: ControllerComponents)(implicit val ec: ExecutionContext)
   extends BaseController with ArgoHelpers {
 
-  val numberOfDayInPeriod = 30
-
   def bySupplier = auth.async { implicit request =>
     implicit val logMarker: LogMarker = MarkerMap(
       "requestType" -> "usage-by-supplier",
@@ -30,9 +28,9 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
     ) ++ RequestLoggingFilter.loggablePrincipal(request.user)
 
     Future.sequence(
-      Agencies.all.keys.map(elasticSearch.usageForSupplier(_, numberOfDayInPeriod)))
+      Agencies.all.keys.map(elasticSearch.usageForSupplier(_, UsageStore.countPeriodInDays)))
         .map(_.toList)
-        .map((s: List[SupplierUsageSummary]) => respond(s))
+        .map((s: List[SupplierQuotaCount]) => respond(s))
         .recover {
           case e => respondError(InternalServerError, "unknown-error", e.toString)
         }
@@ -45,15 +43,29 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
       "imageId" -> id,
     ) ++ RequestLoggingFilter.loggablePrincipal(request.user)
 
-    elasticSearch.usageForSupplier(id, numberOfDayInPeriod)
-      .map((s: SupplierUsageSummary) => respond(s))
+    elasticSearch.usageForSupplier(id, UsageStore.countPeriodInDays)
+      .map((s: SupplierQuotaCount) => respond(s))
       .recover {
         case e => respondError(InternalServerError, "unknown-error", e.toString)
       }
 
   }
 
-  def usageStatusForImage(id: String)(implicit logMarker: LogMarker): Future[UsageStatus] = for {
+  def quotaCountForSupplier(id: String) = auth.async { implicit request =>
+    implicit val logMarker: LogMarker = MarkerMap(
+      "requestType" -> "quota-count-for-supplier",
+      "requestId" -> RequestLoggingFilter.getRequestId(request),
+      "supplierId" -> id,
+    ) ++ RequestLoggingFilter.loggablePrincipal(request.user)
+
+    elasticSearch.quotaCountBySupplier(id, UsageStore.countPeriodInDays)
+      .map((s: SupplierQuotaCount) => respond(s))
+      .recover {
+        case e => respondError(InternalServerError, "unknown-error", e.toString)
+      }
+  }
+
+  def usageStatusForImage(id: String)(implicit logMarker: LogMarker): Future[SupplierUsageStatus] = for {
     imageOption <- elasticSearch.getImageById(id)
 
     image <- Future { imageOption.get }
@@ -72,7 +84,7 @@ class UsageController(auth: Authentication, config: MediaApiConfig, elasticSearc
     ) ++ RequestLoggingFilter.loggablePrincipal(request.user)
 
     usageStatusForImage(id)
-      .map((u: UsageStatus) => respond(u))
+      .map((u: SupplierUsageStatus) => respond(u))
       .recover {
         case e: ImageNotFound => respondError(NotFound, "image-not-found", e.toString)
         case e => respondError(InternalServerError, "unknown-error", e.toString)

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -6,6 +6,7 @@ import java.util.Properties
 import com.gu.mediaservice.lib.BaseStore
 import com.gu.mediaservice.lib.logging.GridLogging
 import com.gu.mediaservice.model.{Agencies, Agency, UsageRights}
+import com.gu.mediaservice.model.usage.{DigitalUsage, PrintUsage, PublishedUsageStatus, RemovedUsageStatus, UnknownUsageStatus, Usage, UsageStatus, UsageType}
 import javax.mail.Session
 import javax.mail.internet.{MimeBodyPart, MimeMultipart}
 import org.apache.commons.mail.util.MimeMessageUtils
@@ -30,30 +31,30 @@ object SupplierUsageQuota {
   )(SupplierUsageQuota.apply _)
 }
 
-case class SupplierUsageSummary(agency: Agency, count: Long)
-object SupplierUsageSummary {
-  implicit val customReads: Reads[SupplierUsageSummary] = (
+case class SupplierQuotaCount(agency: Agency, count: Long)
+object SupplierQuotaCount {
+  implicit val customReads: Reads[SupplierQuotaCount] = (
     (__ \ "Supplier").read[String].map(Agency(_)) ~
     (__ \ "Usage").read[Long]
-  )(SupplierUsageSummary.apply _)
+  )(SupplierQuotaCount.apply _)
 
-  implicit val writes: Writes[SupplierUsageSummary] = (
+  implicit val writes: Writes[SupplierQuotaCount] = (
     (__ \ "agency").write[String].contramap((a: Agency) => a.supplier) ~
     (__ \ "count").write[Long]
-  )(unlift(SupplierUsageSummary.unapply))
+  )(unlift(SupplierQuotaCount.unapply))
 }
 
-case class UsageStatus(
+case class SupplierUsageStatus(
   exceeded: Boolean,
   fractionOfQuota: Float,
-  usage: SupplierUsageSummary,
+  usage: SupplierQuotaCount,
   quota: Option[SupplierUsageQuota]
 )
-object UsageStatus {
-  implicit val writes: Writes[UsageStatus] = Json.writes[UsageStatus]
+object SupplierUsageStatus {
+  implicit val writes: Writes[SupplierUsageStatus] = Json.writes[SupplierUsageStatus]
 }
 
-case class StoreAccess(store: Map[String, UsageStatus], lastUpdated: DateTime)
+case class StoreAccess(store: Map[String, SupplierUsageStatus], lastUpdated: DateTime)
 object StoreAccess {
   import play.api.libs.json.JodaWrites._
 
@@ -61,6 +62,10 @@ object StoreAccess {
 }
 
 object UsageStore extends GridLogging {
+  val countQualifyingStatuses: Set[UsageStatus] = Set(PublishedUsageStatus, UnknownUsageStatus, RemovedUsageStatus)
+  val countQualifyingPlatforms: Set[UsageType] = Set(PrintUsage, DigitalUsage)
+  val countPeriodInDays: Int = 30
+
   def extractEmail(stream: InputStream): List[String] = {
     val s = Session.getDefaultInstance(new Properties())
     val message = MimeMessageUtils.createMimeMessage(s, stream)
@@ -88,7 +93,7 @@ object UsageStore extends GridLogging {
     }
   }
 
-  def csvParser(list: List[String]): List[SupplierUsageSummary] = {
+  def csvParser(list: List[String]): List[SupplierQuotaCount] = {
     def stripQuotes(s: String): String = s
       .stripSuffix("\"")
       .stripPrefix("\"")
@@ -108,7 +113,7 @@ object UsageStore extends GridLogging {
       case Some("Cpro Name" :: "Id" :: Nil) =>
         lines.tail.map {
           case supplier :: count :: Nil =>
-            SupplierUsageSummary(Agency(supplier), count.toInt)
+            SupplierQuotaCount(Agency(supplier), count.toInt)
 
           case _ =>
             logger.error("CSV body error. Expected 2 columns")
@@ -132,10 +137,10 @@ class UsageStore(
   bucket: String,
   config: MediaApiConfig,
   quotaStore: QuotaStore
-)(implicit val ec: ExecutionContext) extends BaseStore[String, UsageStatus](bucket, config) with GridLogging {
+)(implicit val ec: ExecutionContext) extends BaseStore[String, SupplierUsageStatus](bucket, config) with GridLogging {
   import UsageStore._
 
-  def getUsageStatusForUsageRights(usageRights: UsageRights): Future[UsageStatus] = {
+  def getUsageStatusForUsageRights(usageRights: UsageRights): Future[SupplierUsageStatus] = {
     usageRights match {
       case agency: Agency => Future.successful(store.get().getOrElse(agency.supplier, { throw NoUsageQuota() }))
       case _ => Future.failed(new Exception("Image is not supplied by Agency"))
@@ -154,7 +159,7 @@ class UsageStore(
     store.set(fetchUsage)
   }
 
-  private def fetchUsage: Map[String, UsageStatus] = {
+  private def fetchUsage: Map[String, SupplierUsageStatus] = {
     logger.info("Updating usage store")
 
     val maybeLines: Option[List[String]] = getLatestS3Stream.map(extractEmail)
@@ -163,9 +168,9 @@ class UsageStore(
       case None => Map.empty
       case Some(lines) =>
         logger.info(s"Last usage file has ${lines.length} lines")
-        val summary: List[SupplierUsageSummary] = csvParser(lines)
+        val summary: List[SupplierQuotaCount] = csvParser(lines)
 
-        def copyAgency(supplier: SupplierUsageSummary, id: String) = Agencies.all.get(id)
+        def copyAgency(supplier: SupplierQuotaCount, id: String) = Agencies.all.get(id)
           .map(a => supplier.copy(agency = a))
           .getOrElse(supplier)
 
@@ -184,12 +189,12 @@ class UsageStore(
           .groupBy(_.agency.supplier)
           .view
           .mapValues(_.head)
-          .mapValues((summary: SupplierUsageSummary) => {
+          .mapValues((summary: SupplierQuotaCount) => {
             val quota = summary.agency.id.flatMap(id => supplierQuota.get(id))
             val exceeded = quota.exists(q => summary.count > q.count)
             val fractionOfQuota: Float = quota.map(q => summary.count.toFloat / q.count).getOrElse(0F)
 
-            UsageStatus(
+            SupplierUsageStatus(
               exceeded,
               fractionOfQuota,
               summary,

--- a/media-api/app/lib/elasticsearch/ElasticSearch.scala
+++ b/media-api/app/lib/elasticsearch/ElasticSearch.scala
@@ -10,7 +10,7 @@ import com.gu.mediaservice.lib.elasticsearch.{CompletionPreview, ElasticSearchCl
 import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap, Stopwatch, combineMarkers}
 import com.gu.mediaservice.lib.metrics.FutureSyntax
 import com.gu.mediaservice.model.{Agencies, Agency, AwaitingReviewForSyndication, Image}
-import com.gu.mediaservice.model.usage.{DigitalUsage, PrintUsage, PublishedUsageStatus, RemovedUsageStatus, Usage, UnknownUsageStatus, UsageStatus, UsageType}
+import com.gu.mediaservice.model.usage.{ComposerUsageReference, DigitalUsage, FrontUsageReference, InDesignUsageReference, PrintUsage, PublishedUsageStatus, RemovedUsageStatus, Usage, UnknownUsageStatus, UsageStatus, UsageType}
 import com.sksamuel.elastic4s.{ElasticDsl, Hit}
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.common.Operator
@@ -27,7 +27,7 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryB
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{FieldWithOptionalBoost, MultiMatchQuery}
 import lib.elasticsearch.ResultSource.{Both, Lexical, Semantic}
 import lib.querysyntax.{Condition, DateRange, HierarchyField, Match, Nested, Parser, Phrase, SingleField}
-import lib.{MediaApiConfig, MediaApiMetrics, SupplierUsageSummary, ImageUsagesBySupplier, ImageUsagesBySupplierResult}
+import lib.{MediaApiConfig, MediaApiMetrics, SupplierQuotaCount, ImageUsagesBySupplier, ImageUsagesBySupplierResult, UsageStore}
 import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
 import play.api.mvc.AnyContent
 import play.api.mvc.Security.AuthenticatedRequest
@@ -460,7 +460,7 @@ class ElasticSearch(
     }
   )
 
-  def usageForSupplier(id: String, numDays: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[SupplierUsageSummary] = {
+  def usageForSupplier(id: String, numDays: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[SupplierQuotaCount] = {
     val supplier = Agencies.get(id)
     val supplierName = supplier.supplier
 
@@ -481,7 +481,86 @@ class ElasticSearch(
     executeAndLog(search, s"$id usage search").map { r =>
       import r.result
       logSearchQueryIfTimedOut(search, result)
-      SupplierUsageSummary(supplier, result.hits.total.value)
+      SupplierQuotaCount(supplier, result.hits.total.value)
+    }
+  }
+
+  def quotaCountBySupplier(id: String, numDays: Int)(implicit ex: ExecutionContext, logMarker: LogMarker): Future[SupplierQuotaCount] = {
+    val supplier = Agencies.get(id)
+    val supplierName = supplier.supplier
+
+    val haveQualifyingStatus   = termsQuery("usages.status", UsageStore.countQualifyingStatuses.map(_.toString))
+    // lt("now+1d/d") instead of lte("now") so the query is day-rounded and fully request-cacheable
+    val beInLastPeriod         = rangeQuery("usages.dateAdded").gt(s"now-${numDays}d/d").lt("now+1d/d")
+    val haveQualifyingPlatform = termsQuery("usages.platform", UsageStore.countQualifyingPlatforms.map(_.toString))
+    val haveQualifyingUsage    = nestedQuery("usages", boolQuery().must(haveQualifyingStatus, haveQualifyingPlatform, beInLastPeriod))
+
+    val beSupplier = boolQuery().should(
+      termQuery("usageRights.supplier", supplierName),
+      matchQuery("usageRights.suppliers", supplierName)
+    ).minimumShouldMatch(1)
+    val query = boolQuery().must(matchAllQuery()).filter(boolQuery().must(beSupplier, haveQualifyingUsage))
+
+
+    // Usage-level filters for counting inside the nested aggregation context
+    val composerUsageFilter = boolQuery().must(
+      haveQualifyingStatus, beInLastPeriod,
+      termQuery("usages.platform", DigitalUsage.toString),
+      termQuery("usages.references.type", ComposerUsageReference.toString)
+    )
+    val frontsUsageFilter = boolQuery().must(
+      haveQualifyingStatus, beInLastPeriod,
+      termQuery("usages.platform", DigitalUsage.toString),
+      termQuery("usages.references.type", FrontUsageReference.toString)
+    )
+    val printUsageFilter = boolQuery().must(
+      haveQualifyingStatus, beInLastPeriod,
+      termQuery("usages.platform", PrintUsage.toString)
+    )
+    // Document-level filters: classify images by which quota bucket they fall into.
+    val hasQualifyingComposer = nestedQuery("usages", composerUsageFilter)
+    val hasQualifyingFronts = nestedQuery("usages", frontsUsageFilter)
+    val hasQualifyingPrint = nestedQuery("usages", printUsageFilter)
+
+    val imagesWithComposer = hasQualifyingComposer
+    val imagesWithFrontsButNoComposer = boolQuery().must(hasQualifyingFronts).withNot(hasQualifyingComposer)
+    val imagesWithPrintButNoComposer  = boolQuery().must(hasQualifyingPrint).withNot(hasQualifyingComposer)
+
+    // Quota counting logic per image:
+    // - Each Composer usage counts as 1; if any exist, Fronts and Print on the same image are not counted additionally.
+    // - Multiple Fronts count as 1 in total.
+    // - Multiple Print usages each count separately.
+    // Three mutually exclusive aggregations:
+    //  1. Images with composer: sum of composer usage counts
+    //  2. Images with fronts, no composer: count of images (each image contributes 1)
+    //  3. Images with print, no composer:  sum of print usage counts
+    val composerQuotaAgg = filterAgg("has_composer", imagesWithComposer)
+      .subAggregations(
+        nestedAggregation("usages_agg", "usages")
+          .subAggregations(
+            filterAgg("qualifying", composerUsageFilter)
+          )
+      )
+    val frontsQuotaAgg = filterAgg("fronts_no_composer", imagesWithFrontsButNoComposer)
+    val printQuotaAgg  = filterAgg("print_no_composer", imagesWithPrintButNoComposer)
+      .subAggregations(
+        nestedAggregation("usages_agg", "usages")
+          .subAggregations(
+            filterAgg("qualifying", printUsageFilter)
+          )
+      )
+
+    val search = prepareSearch(query).size(0).aggs(composerQuotaAgg, frontsQuotaAgg, printQuotaAgg)
+
+    executeAndLog(search, s"$id quota count by supplier search").map { r =>
+      import r.result
+      logSearchQueryIfTimedOut(search, result)
+      val aggs          = result.aggregations
+      val composerQuota = aggs.filter("has_composer").nested("usages_agg").filter("qualifying").docCount.toInt
+      val frontsQuota   = aggs.filter("fronts_no_composer").docCount.toInt
+      val printQuota    = aggs.filter("print_no_composer").nested("usages_agg").filter("qualifying").docCount.toInt
+      logger.info(s"Quota count for supplier $supplierName in last $numDays days: composer=$composerQuota, fronts=$frontsQuota, print=$printQuota")
+      SupplierQuotaCount(supplier, composerQuota + frontsQuota + printQuota)
     }
   }
 
@@ -497,11 +576,8 @@ class ElasticSearch(
     val supplier = Agencies.get(id)
     val supplierName = supplier.supplier
 
-    val qualifyingStatuses = Set[UsageStatus](PublishedUsageStatus, UnknownUsageStatus, RemovedUsageStatus)
-    val qualifyingPlatforms = Set[UsageType](PrintUsage, DigitalUsage)
-
-    val haveQualifyingStatus = termsQuery("usages.status", qualifyingStatuses.map(_.toString))
-    val haveQualifyingPlatform = termsQuery("usages.platform", qualifyingPlatforms.map(_.toString))
+    val haveQualifyingStatus = termsQuery("usages.status", UsageStore.countQualifyingStatuses.map(_.toString))
+    val haveQualifyingPlatform = termsQuery("usages.platform", UsageStore.countQualifyingPlatforms.map(_.toString))
 
     // e.g. usages@<added:2026-07-31 usages@>added:2026-07-01 - each date bound is inclusive,
     // and since they all apply within the same nested "usages" entry, multiple bounds combine into a range.
@@ -531,8 +607,8 @@ class ElasticSearch(
     val search = prepareSearch(query).trackTotalHits(true).from(offset).size(length)
 
     def isQualifyingUsage(usage: Usage): Boolean =
-      qualifyingStatuses.contains(usage.status) &&
-        qualifyingPlatforms.contains(usage.platform) &&
+      UsageStore.countQualifyingStatuses.contains(usage.status) &&
+        UsageStore.countQualifyingPlatforms.contains(usage.platform) &&
         maybeDateAddedRange.forall { case (from, to) =>
           usage.dateAdded.exists(dateAdded => !dateAdded.isBefore(from) && !dateAdded.isAfter(to))
         }

--- a/media-api/conf/routes
+++ b/media-api/conf/routes
@@ -36,6 +36,7 @@ GET     /suggest/metadata/photoshoot                                controllers.
 GET     /usage/suppliers                                            controllers.UsageController.bySupplier
 GET     /usage/suppliers/:id                                        controllers.UsageController.forSupplier(id: String)
 GET     /usage/suppliers/:id/images                                 controllers.UsageController.imageUsagesBySupplier(id: String)
+GET     /usage/suppliers/:id/quotaCount                             controllers.UsageController.quotaCountForSupplier(id: String)
 GET     /usage/quotas                                               controllers.UsageController.quotas
 GET     /usage/quotas/:id                                           controllers.UsageController.quotaForImage(id: String)
 # configuration

--- a/media-api/test/lib/UsageStoreTest.scala
+++ b/media-api/test/lib/UsageStoreTest.scala
@@ -16,7 +16,7 @@ class UsageStoreTest extends AnyFunSpec with Matchers {
 
       val list = UsageStore.csvParser(lines)
 
-      list.head should be (SupplierUsageSummary(Agency("Australian Associated Press Pty Limited (Stacey Shipton)"), 397))
+      list.head should be (SupplierQuotaCount(Agency("Australian Associated Press Pty Limited (Stacey Shipton)"), 397))
     }
 
     it("should parse non-ASCII RCS usage emails") {

--- a/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
+++ b/media-api/test/lib/elasticsearch/ElasticSearchTest.scala
@@ -8,7 +8,7 @@ import com.gu.mediaservice.lib.elasticsearch.{ElasticSearchAliases, ElasticSearc
 import com.gu.mediaservice.lib.logging.{LogMarker, MarkerMap}
 import com.gu.mediaservice.model._
 import com.gu.mediaservice.model.leases.DenySyndicationLease
-import com.gu.mediaservice.model.usage.{PublishedUsageStatus, RemovedUsageStatus, UnknownUsageStatus}
+import com.gu.mediaservice.model.usage.{PendingUsageStatus, PublishedUsageStatus, RemovedUsageStatus, SyndicationUsage, UnknownUsageStatus, ComposerUsageReference, DigitalUsage, FrontUsageReference, InDesignUsageReference, PrintUsage}
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.ElasticDsl._
 import lib.querysyntax._
@@ -162,6 +162,167 @@ class ElasticSearchTest extends ElasticSearchTestBase with Eventually with Elast
       val results = Await.result(ES.usageForSupplier("ACME", 5), fiveSeconds)
 
       results.count shouldBe 1
+    }
+  }
+
+  // Saves images for a single quota test and deletes them by ID afterwards, leaving the
+  // shared image set (loaded in beforeAll) untouched.
+  private def withQuotaImages[A](images: Seq[Image])(test: => A): A = {
+    implicit val logMarker: LogMarker = MarkerMap()
+    Await.ready(saveImages(images), 1.minute)
+    eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(totalImages shouldBe expectedNumberOfImages + images.size)
+    try test finally {
+      val deletes = images.map(i => executeAndLog(deleteById(index, i.id), s"Deleting quota test image ${i.id}"))
+      Await.ready(Future.sequence(deletes), fiveSeconds)
+      eventually(timeout(fiveSeconds), interval(oneHundredMilliseconds))(totalImages shouldBe expectedNumberOfImages)
+    }
+  }
+
+  describe("quotaCountBySupplier") {
+    // "quota-agency" is not in Agencies.all so Agencies.get("quota-agency").supplier falls back to "quota-agency"
+    val supplier = "quota-agency"
+    val inRange  = DateTime.now.minusDays(15)
+    val numDays  = 30
+
+    it("counts a single composer usage as 1") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-composer-1", Agency(supplier),
+        usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange))))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 1
+      }
+    }
+
+    it("counts multiple composer usages on the same image individually") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-composer-2", Agency(supplier),
+        usages = List(
+          createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange),
+          createUsage(ComposerUsageReference, DigitalUsage, UnknownUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 2
+      }
+    }
+
+    it("counts multiple fronts usages on the same image as 1") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-fronts-multi", Agency(supplier),
+        usages = List(
+          createUsage(FrontUsageReference, DigitalUsage, PublishedUsageStatus, inRange),
+          createUsage(FrontUsageReference, DigitalUsage, RemovedUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 1
+      }
+    }
+
+    it("counts each qualifying print usage individually") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-print-multi", Agency(supplier),
+        usages = List(
+          createUsage(InDesignUsageReference, PrintUsage, PublishedUsageStatus, inRange),
+          createUsage(InDesignUsageReference, PrintUsage, RemovedUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 2
+      }
+    }
+
+    it("composer precedence: only counts composer usages when an image has both composer and fronts usages") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-composer-and-fronts", Agency(supplier),
+        usages = List(
+          createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange),
+          createUsage(FrontUsageReference, DigitalUsage, PublishedUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        // fronts usage must not be counted — if it were, result would be 2
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 1
+      }
+    }
+
+    it("composer precedence: only counts composer usages when an image has both composer and print usages") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-composer-and-print", Agency(supplier),
+        usages = List(
+          createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange),
+          createUsage(InDesignUsageReference, PrintUsage, PublishedUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        // print usage must not be counted — if it were, result would be 2
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 1
+      }
+    }
+
+    it("counts both fronts (as 1) and print (per usage) when there are no composer usages") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-fronts-and-print", Agency(supplier),
+        usages = List(
+          createUsage(FrontUsageReference, DigitalUsage, PublishedUsageStatus, inRange),
+          createUsage(InDesignUsageReference, PrintUsage, PublishedUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 2
+      }
+    }
+
+    it("returns 0 when all usages are outside the date range") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-out-of-range", Agency(supplier),
+        usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, DateTime.now.minusDays(31)))))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 0
+      }
+    }
+
+    it("excludes usages with a non-qualifying status") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-pending-status", Agency(supplier),
+        usages = List(createUsage(ComposerUsageReference, DigitalUsage, PendingUsageStatus, inRange))))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 0
+      }
+    }
+
+    it("excludes usages with a non-qualifying platform") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-syndication-platform", Agency(supplier),
+        usages = List(createUsage(ComposerUsageReference, SyndicationUsage, PublishedUsageStatus, inRange))))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 0
+      }
+    }
+
+    it("excludes images belonging to a different supplier") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-wrong-supplier", Agency("completely-different-agency"),
+        usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange))))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 0
+      }
+    }
+
+    it("includes Composite images matched via the usageRights.suppliers field") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-composite", Composite(s"$supplier, other-supplier"),
+        usages = List(createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange))))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 1
+      }
+    }
+
+    it("qualifies all three counting statuses: published, unknown, and removed") {
+      implicit val logMarker: LogMarker = MarkerMap()
+      val images = Seq(createImage("qc-all-statuses", Agency(supplier),
+        usages = List(
+          createUsage(ComposerUsageReference, DigitalUsage, PublishedUsageStatus, inRange),
+          createUsage(ComposerUsageReference, DigitalUsage, UnknownUsageStatus, inRange),
+          createUsage(ComposerUsageReference, DigitalUsage, RemovedUsageStatus, inRange)
+        )))
+      withQuotaImages(images) {
+        Await.result(ES.quotaCountBySupplier(supplier, numDays), fiveSeconds).count shouldBe 3
+      }
     }
   }
 


### PR DESCRIPTION
## What does this change?

* Adds an endpoint that returns the quota count for a given supplier within the last 30-day period
* The quota counting logic is implemented via 3 mutually exclusive ES aggregations
* I have renamed some types within `UsageStore` for more separation between the concepts of 'usage' and 'quota count'
 

## How should a reviewer test this change?

* The unit tests would quite helpful for understanding the quota counting logic 
* Start up the Grid with test data: `./dev/script/start.sh --use-TEST`
* Go to https://api.media.local.dev-gutools.co.uk/usage/suppliers/getty/quotaCount, you should see something like `{"data":{"agency":"Getty Images","count":4}}`
* You can verify the output with: https://api.media.local.dev-gutools.co.uk/usage/suppliers/getty/images?q=usages@>added:2026-07-27%20usages@<added:2026-08-25 (tweak date range accordingly). If you add up the usages there based on the quota counting logic, you should arrive at the same result 



## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
