### PR TITLE
Move UsageStore logic to using Grid quota counting instead of RCS emails

### DIFF
--- a/media-api/app/MediaApiComponents.scala
+++ b/media-api/app/MediaApiComponents.scala
@@ -18,12 +18,14 @@ class MediaApiComponents(context: Context) extends GridComponents(context, new M
 
   val s3Client = new S3(config)
 
-  val usageQuota = new UsageQuota(config, actorSystem.scheduler)
+  lazy val usageQuota: UsageQuota = new UsageQuota(config, actorSystem.scheduler,
+    (id, numDays) => { implicit val lm = com.gu.mediaservice.lib.logging.MarkerMap(); elasticSearch.quotaCountBySupplier(id, numDays) }
+  )
   usageQuota.quotaStore.update()
   usageQuota.scheduleUpdates()
   applicationLifecycle.addStopHook(() => Future{usageQuota.stopUpdates()})
 
-  val elasticSearch = new ElasticSearch(config, mediaApiMetrics, config.esConfig, () => usageQuota.usageStore.overQuotaAgencies, actorSystem.scheduler)
+  lazy val elasticSearch = new ElasticSearch(config, mediaApiMetrics, config.esConfig, () => usageQuota.usageStore.overQuotaAgencies, actorSystem.scheduler)
   elasticSearch.ensureIndexExistsAndAliasAssigned()
 
   val imageResponse = new ImageResponse(config, s3Client, usageQuota)

--- a/media-api/app/lib/UsageQuota.scala
+++ b/media-api/app/lib/UsageQuota.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.actor.Scheduler
 import com.gu.mediaservice.lib.FeatureToggle
 import com.gu.mediaservice.model.UsageRights
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.Try
@@ -12,7 +12,7 @@ import scala.util.Try
 case class ImageNotFound() extends Exception("Image not found")
 case class NoUsageQuota() extends Exception("No usage found for this image")
 
-class UsageQuota(config: MediaApiConfig, scheduler: Scheduler) {
+class UsageQuota(config: MediaApiConfig, scheduler: Scheduler, getSupplierQuotaCount: (String, Int) => Future[SupplierQuotaCount]) {
   val quotaStore = new QuotaStore(
     config.quotaStoreConfig.storeKey,
     config.quotaStoreConfig.storeBucket,
@@ -20,8 +20,7 @@ class UsageQuota(config: MediaApiConfig, scheduler: Scheduler) {
   )
 
   val usageStore = new UsageStore(
-    config.usageMailBucket,
-    config,
+    getSupplierQuotaCount,
     quotaStore
   )
 

--- a/media-api/app/lib/UsageStore.scala
+++ b/media-api/app/lib/UsageStore.scala
@@ -1,22 +1,20 @@
 package lib
 
-import java.io.InputStream
-import java.util.Properties
+import java.util.concurrent.atomic.AtomicReference
 
+import org.apache.pekko.actor.{Cancellable, Scheduler}
 import com.gu.mediaservice.lib.BaseStore
-import com.gu.mediaservice.lib.logging.GridLogging
+import com.gu.mediaservice.lib.logging.{GridLogging, LogMarker, MarkerMap}
 import com.gu.mediaservice.model.{Agencies, Agency, UsageRights}
 import com.gu.mediaservice.model.usage.{DigitalUsage, PrintUsage, PublishedUsageStatus, RemovedUsageStatus, UnknownUsageStatus, Usage, UsageStatus, UsageType}
-import javax.mail.Session
-import javax.mail.internet.{MimeBodyPart, MimeMultipart}
-import org.apache.commons.mail.util.MimeMessageUtils
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, Duration}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-import scala.collection.compat._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.io.Source
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 case class SupplierUsageQuota(agency: Agency, count: Int)
 object SupplierUsageQuota {
@@ -65,143 +63,75 @@ object UsageStore extends GridLogging {
   val countQualifyingStatuses: Set[UsageStatus] = Set(PublishedUsageStatus, UnknownUsageStatus, RemovedUsageStatus)
   val countQualifyingPlatforms: Set[UsageType] = Set(PrintUsage, DigitalUsage)
   val countPeriodInDays: Int = 30
+  val refreshInterval: FiniteDuration = 10.minutes
 
-  def extractEmail(stream: InputStream): List[String] = {
-    val s = Session.getDefaultInstance(new Properties())
-    val message = MimeMessageUtils.createMimeMessage(s, stream)
-
-    message.getContent match {
-      case content: MimeMultipart =>
-        val parts = for(n <- 0 until content.getCount) yield content.getBodyPart(n)
-
-        val part = parts
-          .collectFirst { case part: MimeBodyPart if part.getEncoding == "base64" => part }
-          .map(_.getContent)
-
-        part match {
-          case Some(c: InputStream) =>
-            Source.fromInputStream(c).getLines().toList
-
-          case _ =>
-            logger.error("Usage email is missing base64 encoded attachment")
-            List.empty
-        }
-
-      case other =>
-        logger.error(s"Unexpected message content type ${other.getClass}")
-        List.empty
-    }
-  }
-
-  def csvParser(list: List[String]): List[SupplierQuotaCount] = {
-    def stripQuotes(s: String): String = s
-      .stripSuffix("\"")
-      .stripPrefix("\"")
-      .replaceAll("\\P{ASCII}", "") // strip all non-ascii chars from the CSV
-
-    val lines = list
-      .map(_.split(","))
-      .map(_.map(stripQuotes))
-      .map(_.toList)
-
-    if(lines.exists(_.length != 2)) {
-      logger.error("CSV header error. Expected 2 columns")
-      throw new IllegalArgumentException("CSV header error. Expected 2 columns")
-    }
-
-    lines.headOption match {
-      case Some("Cpro Name" :: "Id" :: Nil) =>
-        lines.tail.map {
-          case supplier :: count :: Nil =>
-            SupplierQuotaCount(Agency(supplier), count.toInt)
-
-          case _ =>
-            logger.error("CSV body error. Expected 2 columns")
-            throw new IllegalArgumentException("CSV body error. Expected 2 columns")
-        }
-
-      case Some(other) =>
-        val message = s"Unexpected CSV headers [${other.mkString(",")}]. Expected [Cpro Name, Id]"
-        logger.error(message)
-        throw new IllegalArgumentException(message)
-
-      case None =>
-        val message = "CSV has no lines"
-        logger.error(message)
-        throw new IllegalArgumentException(message)
-    }
+  def getSupplierUsageStatus(quotaCount: SupplierQuotaCount, quota: Option[SupplierUsageQuota]): SupplierUsageStatus = {
+    val exceeded = quota.exists(q => quotaCount.count >= q.count) // Hitting quota counts as exceeding quota
+    val fractionOfQuota = quota.map(q => quotaCount.count.toFloat / q.count).getOrElse(0F)
+    SupplierUsageStatus(exceeded, fractionOfQuota, quotaCount, quota)
   }
 }
 
 class UsageStore(
-  bucket: String,
-  config: MediaApiConfig,
+  getSupplierQuotaCount: (String, Int) => Future[SupplierQuotaCount],
   quotaStore: QuotaStore
-)(implicit val ec: ExecutionContext) extends BaseStore[String, SupplierUsageStatus](bucket, config) with GridLogging {
-  import UsageStore._
+)(implicit val ec: ExecutionContext) extends GridLogging {
 
-  def getUsageStatusForUsageRights(usageRights: UsageRights): Future[SupplierUsageStatus] = {
+  private val store: AtomicReference[Map[String, SupplierUsageStatus]] = new AtomicReference(Map.empty)
+  private val lastUpdated: AtomicReference[DateTime] = new AtomicReference(DateTime.now())
+  private var cancellable: Option[Cancellable] = None
+
+  def getUsageStatusForUsageRights(usageRights: UsageRights): Future[SupplierUsageStatus] =
     usageRights match {
-      case agency: Agency => Future.successful(store.get().getOrElse(agency.supplier, { throw NoUsageQuota() }))
-      case _ => Future.failed(new Exception("Image is not supplied by Agency"))
+      case agency: Agency =>
+        store.get().get(agency.supplier) match {
+          case Some(status) => Future.successful(status)
+          case None         => Future.failed(NoUsageQuota())
+        }
+      case _ =>
+        Future.failed(new Exception("Image is not supplied by Agency"))
     }
-  }
 
-  def getUsageStatus(): Future[StoreAccess] = {
+  def getUsageStatus(): Future[StoreAccess] =
     Future.successful(StoreAccess(store.get(), lastUpdated.get()))
-  }
 
-  def overQuotaAgencies: List[Agency] = store.get.collect {
+  def overQuotaAgencies: List[Agency] = store.get().collect {
     case (_, status) if status.exceeded => status.usage.agency
   }.toList
 
   def update(): Unit = {
-    store.set(fetchUsage)
+    implicit val logMarker: LogMarker = MarkerMap()
+    logger.info("Updating UsageStore from ElasticSearch")
+    fetchQuotaCount.onComplete {
+      case Success(newStore) =>
+        store.set(newStore)
+        lastUpdated.set(DateTime.now())
+        logger.info(s"UsageStore updated: ${newStore.size} suppliers")
+      case Failure(e) =>
+        val staleForMinutes = new Duration(lastUpdated.get(), DateTime.now()).getStandardMinutes
+        logger.error(s"Failed to update UsageStore. Data is now $staleForMinutes minute(s) stale; last updated at: ${lastUpdated.get()}", e)
+    }
   }
 
-  private def fetchUsage: Map[String, SupplierUsageStatus] = {
-    logger.info("Updating usage store")
+  def scheduleUpdates(scheduler: Scheduler): Unit = {
+    cancellable = Some(scheduler.scheduleAtFixedRate(0.seconds, UsageStore.refreshInterval)(() =>
+      try update()
+      catch { case NonFatal(e) => logger.error("UsageStore update failed", e) }
+    ))
+  }
 
-    val maybeLines: Option[List[String]] = getLatestS3Stream.map(extractEmail)
+  def stopUpdates(): Unit = cancellable.foreach(_.cancel())
 
-    maybeLines match {
-      case None => Map.empty
-      case Some(lines) =>
-        logger.info(s"Last usage file has ${lines.length} lines")
-        val summary: List[SupplierQuotaCount] = csvParser(lines)
-
-        def copyAgency(supplier: SupplierQuotaCount, id: String) = Agencies.all.get(id)
-          .map(a => supplier.copy(agency = a))
-          .getOrElse(supplier)
-
-        val cleanedSummary = summary
-          .map {
-            case s if s.agency.supplier.contains("Rex Features") => copyAgency(s, "rex")
-            case s if s.agency.supplier.contains("Getty Images") => copyAgency(s, "getty")
-            case s if s.agency.supplier.contains("Australian Associated Press") => copyAgency(s, "aap")
-            case s if s.agency.supplier.contains("Alamy") => copyAgency(s, "alamy")
-            case s => s
-          }
-
-        val supplierQuota = quotaStore.getQuota
-
-        cleanedSummary
-          .groupBy(_.agency.supplier)
-          .view
-          .mapValues(_.head)
-          .mapValues((summary: SupplierQuotaCount) => {
-            val quota = summary.agency.id.flatMap(id => supplierQuota.get(id))
-            val exceeded = quota.exists(q => summary.count > q.count)
-            val fractionOfQuota: Float = quota.map(q => summary.count.toFloat / q.count).getOrElse(0F)
-
-            SupplierUsageStatus(
-              exceeded,
-              fractionOfQuota,
-              summary,
-              quota
-            )
-          }).toMap
-    }
+  private def fetchQuotaCount(implicit logMarker: LogMarker): Future[Map[String, SupplierUsageStatus]] = {
+    val supplierQuota = quotaStore.getQuota
+    Future.sequence(
+      Agencies.all.map { case (id, agency) =>
+        getSupplierQuotaCount(id, UsageStore.countPeriodInDays).map { quotaCount =>
+          val quota = supplierQuota.get(id)
+          agency.supplier -> UsageStore.getSupplierUsageStatus(quotaCount, quota)
+        }
+      }.toList
+    ).map(_.toMap)
   }
 }
 

--- a/media-api/test/lib/UsageStoreTest.scala
+++ b/media-api/test/lib/UsageStoreTest.scala
@@ -1,30 +1,221 @@
 package lib
 
-import com.gu.mediaservice.model.Agency
+import com.gu.mediaservice.model.{Agencies, Agency}
+import com.gu.mediaservice.model.usage.{DigitalUsage, PrintUsage, PublishedUsageStatus}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito.when
 
-class UsageStoreTest extends AnyFunSpec with Matchers {
-  describe("Usage Store") {
-    it("should parse RCS usage emails") {
-      val stream = getClass.getResourceAsStream("/example.mail")
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-      val lines = UsageStore.extractEmail(stream)
+class UsageStoreTest extends AnyFunSpec with Matchers with ScalaFutures with MockitoSugar {
 
-      lines.head should be ("\"Cpro Name\",\"Id\"")
-      lines.tail.head should be ("\"Australian Associated Press Pty Limited (Stacey Shipton)\",\"397\"")
+  implicit val patience: PatienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(50, Millis))
 
-      val list = UsageStore.csvParser(lines)
+  // Use real known agencies from Agencies.all so we can test the full flow.
+  // "getty" → Agency("Getty Images"), "rex" → Agency("Rex Features") in Agencies.all.
+  val gettyId = "getty"
+  val gettyAgency: Agency = Agencies.all(gettyId)
+  val rexId = "rex"
+  val rexAgency: Agency = Agencies.all(rexId)
 
-      list.head should be (SupplierQuotaCount(Agency("Australian Associated Press Pty Limited (Stacey Shipton)"), 397))
+  private def makeStore(
+    quotaCounts: Map[String, Long],          // agencyId → ES count
+    quotaLimits: Map[String, Int] = Map.empty // agencyId → configured quota
+  ): UsageStore = {
+    val mockQuotaStore = mock[QuotaStore]
+    val quotaMap: Map[String, SupplierUsageQuota] = quotaLimits.map { case (id, limit) =>
+      id -> SupplierUsageQuota(Agencies.all(id), limit)
+    }
+    when(mockQuotaStore.getQuota).thenReturn(quotaMap)
+
+    val getSupplierQuotaCount: (String, Int) => Future[SupplierQuotaCount] = (id, _) =>
+      Future.successful(SupplierQuotaCount(Agencies.get(id), quotaCounts.getOrElse(id, 0L)))
+
+    new UsageStore(getSupplierQuotaCount, mockQuotaStore)
+  }
+
+  private def makeFailingStore(): UsageStore = {
+    val mockQuotaStore = mock[QuotaStore]
+    when(mockQuotaStore.getQuota).thenReturn(Map.empty[String, SupplierUsageQuota])
+
+    val getSupplierQuotaCount: (String, Int) => Future[SupplierQuotaCount] = (_, _) =>
+      Future.failed(new Exception("ElasticSearch is unavailable"))
+
+    new UsageStore(getSupplierQuotaCount, mockQuotaStore)
+  }
+
+  private def updateAndGet(store: UsageStore) = {
+    store.update()
+    // update() is fire-and-forget; give the future a moment to complete
+    Thread.sleep(200)
+    store.getUsageStatus().futureValue
+  }
+
+  describe("UsageStore") {
+    describe("getSupplierUsageStatus") {
+      it("carries through the usage count and quota unchanged") {
+        val quotaCount = SupplierQuotaCount(gettyAgency, 42L)
+        val quota = SupplierUsageQuota(gettyAgency, 100)
+
+        val status = UsageStore.getSupplierUsageStatus(quotaCount, Some(quota))
+
+        status.usage shouldBe quotaCount
+        status.quota shouldBe Some(quota)
+      }
+
+      it("sets exceeded=false when usage is below the quota limit") {
+        val quotaCount = SupplierQuotaCount(gettyAgency, 99L)
+        val quota = SupplierUsageQuota(gettyAgency, 100)
+
+        val status = UsageStore.getSupplierUsageStatus(quotaCount, Some(quota))
+
+        status.exceeded shouldBe false
+      }
+
+      it("sets exceeded=true when usage is above the quota limit") {
+        val quotaCount = SupplierQuotaCount(gettyAgency, 101L)
+        val quota = SupplierUsageQuota(gettyAgency, 100)
+
+        val status = UsageStore.getSupplierUsageStatus(quotaCount, Some(quota))
+
+        status.exceeded shouldBe true
+      }
+
+      it("sets exceeded=true when usage exactly equals the quota limit") {
+        // Hitting the quota limit exactly counts as exceeding it
+        val quotaCount = SupplierQuotaCount(gettyAgency, 100L)
+        val quota = SupplierUsageQuota(gettyAgency, 100)
+
+        val status = UsageStore.getSupplierUsageStatus(quotaCount, Some(quota))
+
+        status.exceeded shouldBe true
+      }
+
+      it("calculates fractionOfQuota correctly") {
+        val quotaCount = SupplierQuotaCount(gettyAgency, 75L)
+        val quota = SupplierUsageQuota(gettyAgency, 100)
+
+        val status = UsageStore.getSupplierUsageStatus(quotaCount, Some(quota))
+
+        status.fractionOfQuota shouldBe 0.75f +- 0.001f
+      }
+
+      it("sets fractionOfQuota=0 when no quota limit is configured") {
+        val quotaCount = SupplierQuotaCount(gettyAgency, 50L)
+
+        val status = UsageStore.getSupplierUsageStatus(quotaCount, quota = None)
+
+        status.fractionOfQuota shouldBe 0f
+      }
     }
 
-    it("should parse non-ASCII RCS usage emails") {
-      val stream = getClass.getResourceAsStream("/nonascii.mail")
+    describe("update / getUsageStatus") {
+      it("populates the store with quota counts for all known agencies") {
+        val store = makeStore(quotaCounts = Map(gettyId -> 42L, rexId -> 17L))
+        val status = updateAndGet(store)
 
-      val lines = UsageStore.extractEmail(stream)
+        status.store should contain key gettyAgency.supplier
+        status.store(gettyAgency.supplier).usage.count shouldBe 42L
+        status.store(gettyAgency.supplier).usage.agency shouldBe gettyAgency
 
-      noException should be thrownBy {  UsageStore.csvParser(lines) }
+        status.store should contain key rexAgency.supplier
+        status.store(rexAgency.supplier).usage.count shouldBe 17L
+        status.store(rexAgency.supplier).usage.agency shouldBe rexAgency
+      }
+
+      it("keeps the previous store contents when a later update fails") {
+        var shouldFail = false
+        val mockQuotaStore = mock[QuotaStore]
+        when(mockQuotaStore.getQuota).thenReturn(Map.empty[String, SupplierUsageQuota])
+
+        val getSupplierQuotaCount: (String, Int) => Future[SupplierQuotaCount] = (id, _) =>
+          if (shouldFail) Future.failed(new Exception("ElasticSearch is unavailable"))
+          else Future.successful(SupplierQuotaCount(Agencies.get(id), 42L))
+
+        val store = new UsageStore(getSupplierQuotaCount, mockQuotaStore)
+        updateAndGet(store) // first update succeeds, populating the store
+
+        shouldFail = true
+        store.update() // second update fails
+        Thread.sleep(200)
+
+        val status = store.getUsageStatus().futureValue
+        status.store(gettyAgency.supplier).usage.count shouldBe 42L
+      }
+
+      it("does not advance lastUpdated when an update fails") {
+        val store = makeFailingStore()
+        val before = store.getUsageStatus().futureValue.lastUpdated
+
+        store.update()
+        Thread.sleep(200)
+
+        val after = store.getUsageStatus().futureValue.lastUpdated
+        after shouldBe before
+      }
+    }
+
+    describe("overQuotaAgencies") {
+      it("returns agencies whose usage exceeds their quota") {
+        val store = makeStore(
+          quotaCounts = Map(gettyId -> 150L, rexId -> 50L),
+          quotaLimits = Map(gettyId -> 100, rexId -> 100)
+        )
+        store.update()
+        Thread.sleep(200)
+
+        store.overQuotaAgencies should contain(gettyAgency)
+        store.overQuotaAgencies should not contain rexAgency
+      }
+
+      it("returns an empty list when no agency is over quota") {
+        val store = makeStore(
+          quotaCounts = Map(gettyId -> 50L),
+          quotaLimits = Map(gettyId -> 100)
+        )
+        store.update()
+        Thread.sleep(200)
+
+        store.overQuotaAgencies shouldBe empty
+      }
+    }
+
+    describe("getUsageStatusForUsageRights") {
+      it("returns the status for an Agency image after update") {
+        val store = makeStore(
+          quotaCounts = Map(gettyId -> 42L),
+          quotaLimits = Map(gettyId -> 100)
+        )
+        store.update()
+        Thread.sleep(200)
+
+        val status = store.getUsageStatusForUsageRights(gettyAgency).futureValue
+        status.usage.count shouldBe 42L
+        status.exceeded shouldBe false
+      }
+
+      it("fails with NoUsageQuota for an agency not in the store") {
+        val store = makeStore(quotaCounts = Map.empty)
+        store.update()
+        Thread.sleep(200)
+
+        // Store has no entry for a made-up agency
+        val unknownAgency = Agency("Unknown Agency")
+        val result = store.getUsageStatusForUsageRights(unknownAgency).failed.futureValue
+        result shouldBe a[NoUsageQuota]
+      }
+
+      it("fails for non-Agency usage rights") {
+        val store = makeStore(quotaCounts = Map.empty)
+        val nonAgency = com.gu.mediaservice.model.Handout()
+        val result = store.getUsageStatusForUsageRights(nonAgency).failed.futureValue
+        result.getMessage should include("Agency")
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this change?
This PR moves the logic behind supplier usage status / summary within `UsageStore` over to using the new quota counting logic, instead of relying on parsing emails from RCS.

* As `UsageStore` no longer requires fetching from S3, I've made it no longer inheriting from `BaseStore`. However as it still maintains an in-memory store of over-quota agencies (to be used for the `is:under-quota` search filter), it still needs a scheduler that refreshes the store on an interval.
* I've changed the `exceeded` logic from `>` to `>=`, as we should start surfacing warning when the quota is full, not just exceeded. This is confirmed by the behaviours below. The wording 'exceeded' is a bit misleading, but as it's used quite extensively, I've refrained from not changing it everywhere.


## How should a reviewer test this change?

* I have set the Getty quota in TEST to a very low number in S3, so Getty quota would be full in TEST
* Run the Grid locally with `--use-TEST` flag
* On launching the Grid you should see some images with the red square with arrow icon indicating they're from a supplier that's hit their quota:
<img width="1247" height="738" alt="Screenshot 2026-08-26 at 15 47 13" src="https://github.com/user-attachments/assets/d2b220e2-b7e0-4faa-84f2-d7429009a17e" />

* Click into one of those images, you should see another warning:
<img width="387" height="193" alt="Screenshot 2026-08-26 at 15 47 28" src="https://github.com/user-attachments/assets/7ef0713f-de2a-499e-bce0-9259b170f536" />

* If you search with the `is:under-quota` filter, the images with the arrow icon should disappear:
<img width="1604" height="700" alt="Screenshot 2026-08-26 at 16 32 08" src="https://github.com/user-attachments/assets/ec034761-02b8-49fc-b347-243feeb04d94" />

* The /quotas page will look like this. Again 4/4 is not exactly 'exceeded', but the alternative is 'quota not full' and I don't think having a 3rd 'quota full' indicator is necessary or particularly useful
<img width="290" height="344" alt="Screenshot 2026-08-26 at 15 48 51" src="https://github.com/user-attachments/assets/73a69a1d-f296-4cf8-ad1c-adffb444bd18" />





## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217597818404838