### PR TITLE
docs: fix typo succesfully -> successfully

### DIFF
--- a/docs/99-archives/05.01-reingestion-how-to.md
+++ b/docs/99-archives/05.01-reingestion-how-to.md
@@ -55,7 +55,7 @@ Don't forget to turn off the EventBridge source once this process is complete!
 
 ### 4. Check the images are now present in the Grid
 
-At the end of step 2., every image that has been succesfully processed should have been added to the `thrall` queue as a `reingest-image` message. There's no guarantee, however, that these messages have been processed. This step checks that the images marked as submitted have been processed successfully.
+At the end of step 2., every image that has been successfully processed should have been added to the `thrall` queue as a `reingest-image` message. There's no guarantee, however, that these messages have been processed. This step checks that the images marked as submitted have been processed successfully.
 
 As with step 3., to run the image checker lambda, turn the EventBridge source for the lambda on and wait until the lambda has exhausted its source of images. At the time of writing, this lambda is called `admin-tools-image-batch-check-lambda-{STAGE}`.
 


### PR DESCRIPTION
One-word typo fix in `docs/99-archives/05.01-reingestion-how-to.md:58`.
