### PR TITLE
Enable recording download usage for local config creation

### DIFF
--- a/dev/script/generate-config/service-config.js
+++ b/dev/script/generate-config/service-config.js
@@ -38,7 +38,7 @@ function getCommonConfig(config) {
         |thrall.kinesis.lowPriorityStream.name="${config.coreStackProps.ThrallLowPriorityMessageStream}"
         |es.index.aliases.current="Images_Current"
         |es.index.aliases.migration="Images_Migration"
-        |image.record.download=false
+        |image.record.download=true
         |defaultShouldBlurGraphicImages=true
         |filters.shouldDisplayOrgOwnedCountAndFilterCheckbox=true
         |ai.search.enabled=${aiSearchEnabled}


### PR DESCRIPTION
## What does this change?

Currently `image.record.download` is set to `false` in every config. This switches on download usage recording by default locally on config file creation without us having to set it manually.

## How should a reviewer test this change?

* Run `./dev/script/setup.sh`
* Start up the Grid using all local services
* Go to Console, `window._clientConfig.recordDownloadAsUsage` should be `true`
* Go download an image, in a few seconds, refresh the browser, and you should see the download usage coming through
<img width="300" height="111" alt="Screenshot 2026-08-28 at 15 35 40" src="https://github.com/user-attachments/assets/7cf22b6e-547d-462f-a9bf-b3818ad4d42f" />

* If it doesn't show in the UI or Media API due to Thrall issues, you should still be able to verify with the Usage API: https://media-usage.local.dev-gutools.co.uk/usages/media/[imageId], and see a download usage:
```JSON
{
      "uri": "https://media-usage.local.dev-gutools.co.uk/usages/download%2F7119f39e629b4d634770d132e9329dd1_3ad285fec6c57851f56c6d056893d2fb",
      "data": {
        "id": "download/7119f39e629b4d634770d132e9329dd1_3ad285fec6c57851f56c6d056893d2fb",
        "references": [
          {
            "type": "download",
            "name": "junyuan.xue@guardian.co.uk"
          }
        ],
        "platform": "download",
        "media": "image",
        "status": "downloaded",
        "dateAdded": "2026-08-28T14:59:25.389+01:00",
        "lastModified": "2026-08-28T14:59:25.389+01:00",
        "downloadUsageMetadata": {
          "downloadedBy": "junyuan.xue@guardian.co.uk"
        }
      }
    }
```

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217957220259313