### PR TITLE
Allow collapse / expand usages display

### DIFF
--- a/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.css
+++ b/kahuna/public/js/components/gr-confirm-delete/gr-confirm-delete.css
@@ -8,6 +8,8 @@ gr-confirm-delete.gr-delete-image {
   line-height: inherit;
   width: 100%;
   height: 100%;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .gr-confirm-delete:hover {

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage-list.html
@@ -1,9 +1,13 @@
 <div class="image-info__group">
-    <span class="flex-container gr-image-usage__field_title">
+    <button
+        class="flex-container gr-image-usage__field_title"
+        ng-click="ctrl.toggle()"
+        aria-label="{{ctrl.isCollapsed ? 'Show' : 'Hide'}} {{ctrl.type.toLowerCase()}} usages">
+        <gr-icon>{{ctrl.isCollapsed ? 'chevron_right' : 'expand_more'}}</gr-icon>
         {{ctrl.type}} ({{ctrl.usages.length}})
-    </span>
+    </button>
 
-    <ul>
+    <ul ng-hide="ctrl.isCollapsed">
         <li class="gr-image-usage__record" ng-repeat="usage in ctrl.usages">
             <gr-icon ng-if="usage.platform === 'print'" class="usage-list__icon" ng-class="{'icon-warning': ctrl.isRecent(usage.dateAdded)}">local_library</gr-icon>
             <gr-icon ng-if="usage.platform === 'digital'" class="usage-list__icon" ng-class="{'icon-warning': ctrl.isRecent(usage.dateAdded)}">phonelink</gr-icon>

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.css
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.css
@@ -7,6 +7,14 @@ gr-image-usage-list .gr-image-usage__field_title {
     color: #999;
     vertical-align: top;
     text-align: left;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+gr-image-usage-list .gr-image-usage__field_title > button {
+    display: inline-flex;
+    align-items: center;
 }
 
 gr-image-usage-list .date-added {
@@ -18,8 +26,9 @@ gr-image-usage-list .gr-image-usage__record {
     width: 90%;
 }
 
-gr-image-usage-list .source-list__icon svg {
-    padding: 0 2px;
+gr-image-usage-list .usage-list__icon {
+    padding-right: 4px;
+    font-size:1.4em;
 }
 
 gr-image-usage-list gr-frontend-icon svg {
@@ -46,7 +55,6 @@ gr-image-usage-list .reference-list__icon:hover svg path {
 
 gr-image-usage-list gr-icon {
     position: relative;
-    top: -2px;
     color: #999;
 }
 

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.html
@@ -1,7 +1,7 @@
 <div>
     <image-usage-photo-sales ng-if="ctrl.showSendToPhotoSales" props="{'usages':ctrl.photoSalesUsages}"></image-usage-photo-sales>
     <div ng-repeat="(type, usages) in ctrl.usages" ng-if="!ctrl.showSendToPhotoSales || ['downloaded', 'replaced', 'derivative'].includes(type)">
-        <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages"></gr-image-usage-list>
+        <gr-image-usage-list type="ctrl.usageTypeToName(type)" usages="usages" has-multiple-status-groups="ctrl.hasMultipleStatusGroups"></gr-image-usage-list>
     </div>
 </div>
 

--- a/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
+++ b/kahuna/public/js/components/gr-image-usage/gr-image-usage.js
@@ -32,17 +32,25 @@ module.controller('grImageUsageCtrl', [
 
     const ctrl = this;
 
-    const bindUsages = (image) => {
+    const statusOrder = ['pending', 'published', 'unknown', 'removed', 'downloaded'];
+
+    function bindUsages(image) {
       const usages = imageUsagesService.getUsages(image);
       const usages$ = usages.groupedByState$
         .map((grouped) => grouped
           .map(list => list.sortBy(usage => usage.get('dateAdded')).reverse())
+          .sortBy((_, status) => {
+            const index = statusOrder.indexOf(status);
+            return index === -1 ? statusOrder.length : index;
+          })
           .toJS()
         );
-      inject$($scope, usages$, ctrl, 'usages');
+      inject$($scope, usages$.do(grouped => {
+        ctrl.hasMultipleStatusGroups = Object.keys(grouped).length > 1;
+      }), ctrl, 'usages');
       inject$($scope, usages.count$, ctrl, 'usagesCount');
       inject$($scope, usages.hasSyndicationUsages$, ctrl, 'hasSyndicationUsages');
-    };
+    }
 
     ctrl.$onInit = () => {
       ctrl.showSendToPhotoSales = $window._clientConfig.showSendToPhotoSales;
@@ -116,6 +124,16 @@ module.controller('grImageUsageListCtrl', [
   function (imageUsagesService) {
     const ctrl = this;
 
+    const collapseThreshold = 10;
+
+    ctrl.$onInit = () => {
+      ctrl.isCollapsed = ctrl.usages.length > collapseThreshold && ctrl.hasMultipleStatusGroups;
+    };
+
+    ctrl.toggle = () => {
+      ctrl.isCollapsed = !ctrl.isCollapsed;
+    };
+
     ctrl.formatTimestamp = (timestamp) => {
       return moment(timestamp).fromNow();
     };
@@ -137,7 +155,8 @@ module.directive('grImageUsageList', [function () {
     bindToController: true,
     scope: {
       type: '=',
-      usages: '='
+      usages: '=',
+      hasMultipleStatusGroups: '<'
     }
   };
 }]);


### PR DESCRIPTION
## What does this change?

When downloads are recorded and displayed as usages, we could easily end up with a longer than usual list of download usages. So I've made a few improvements on usages display:

* Add some sort of order to the statuses displayed. Downloads always come last
* Usages under each list will be sorted by most recent
* Add a toggle to collapse / expand usages. If there are more than 10 items under a usage list, and there is more than 1 usage list, then it'll be collapsed by default


## How should a reviewer test this change?
* Go to https://media.test.dev-gutools.co.uk/images/8453f7a7b6fe28e96583f1ece9f834d95a0a69bb, but if the deploy gets overwritten 👇 
* Start up Grid pointing to TEST data `./dev/script/start.sh --use-TEST`
* Go to https://media.local.dev-gutools.co.uk/images/8453f7a7b6fe28e96583f1ece9f834d95a0a69bb, click on 'Usages' tab, you should see 'Downloads' appearing last, collapsed by default as it's got more than 10 usages and has other types of usage lists present:

<img width="1108" height="970" alt="usage list" src="https://github.com/user-attachments/assets/e82d93db-d116-4a6d-b41b-60a096f10a2d" />



## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
