### PR TITLE
[e2e-tests] e2e-test/devcontainer improvements

### DIFF
--- a/.devcontainer/devenv.yaml
+++ b/.devcontainer/devenv.yaml
@@ -27,6 +27,7 @@ forwardPorts:
   - 9010
   - 9011
   - 9012
+  - 4566
   - 6080
 
 # Optional: Mount directories from host to container

--- a/.devcontainer/shared/devcontainer.json
+++ b/.devcontainer/shared/devcontainer.json
@@ -29,6 +29,7 @@
     9010,
     9011,
     9012,
+    4566,
     6080
   ],
   "image" : "mcr.microsoft.com/devcontainers/base:ubuntu26.04",

--- a/.devcontainer/user/devcontainer.json
+++ b/.devcontainer/user/devcontainer.json
@@ -29,6 +29,7 @@
     9010,
     9011,
     9012,
+    4566,
     6080
   ],
   "image" : "mcr.microsoft.com/devcontainers/base:ubuntu26.04",

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -30,6 +30,7 @@ import {
   MEDIA_API_PORT,
   PROXY_IMAGE,
   REGION,
+  REPO_ROOT,
   SERVICE_PORTS,
   URLS_FILE,
 } from './testcontainers/constants';
@@ -192,6 +193,9 @@ async function globalSetup(): Promise<void> {
       // DEV stage reads ~/.grid; /etc/grid is honoured for non-DEV stages. Mount both.
       { source: configDir, target: '/root/.grid', mode: 'ro' },
       { source: configDir, target: '/etc/grid', mode: 'ro' },
+      // Outside CI the grid-e2e-dev image runs services under sbt; mount the repo
+      // over /build so host edits recompile live.
+      ...(process.env.CI ? [] : [{ source: REPO_ROOT, target: '/build', mode: 'rw' as const }]),
     ])
     .withEnvironment({
       AWS_ACCESS_KEY_ID: 'test',


### PR DESCRIPTION
## What does this change?

Two small changes to the devcontainer/e2e setup —
 - exposes :4566, necessary for the browser to talk to localstack
 - mounts the project when running the dev image, so changes to the devcontainer fs are reflected in the running app
... both of which I forgot to do in #4882 😅 

## How should a reviewer test this change?

Running locally:
- `loader.media.local.dev-gutools.co.uk` should give a `200` response when running `npm run test:ui` in ./e2e-tests/, once the environment is ready.
- once running, local file changes should result in a recompiled app.