### PR TITLE
Add memory allocation check to e2e-tests global setup

### DIFF
--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -129,7 +129,24 @@ function buildCaddyfile(coreStackProps: Record<string, string>): string {
   return `${blocks.join('\n\n')}\n`;
 }
 
+const REQUIRED_MEMORY_GB = 30;
+
+/** Fail fast if Docker's host/VM is under-provisioned for the full Grid stack. */
+function assertSufficientMemory(): void {
+  const totalGb = os.totalmem() / 1024 ** 3;
+  if (totalGb < REQUIRED_MEMORY_GB) {
+    console.error(
+      `Only ${totalGb.toFixed(1)}GB of memory available, at least ${REQUIRED_MEMORY_GB}GB required. ` +
+        'Increase the memory allocated to Docker and try again.',
+    );
+    process.exit(1);
+  }
+  console.log(`OK: ${totalGb.toFixed(1)}GB of memory available (>= ${REQUIRED_MEMORY_GB}GB required).`);
+}
+
 async function globalSetup(): Promise<void> {
+  assertSufficientMemory();
+
   const started: StartedTestContainer[] = [];
   const startupTimeoutMs = Number(process.env.GRID_STARTUP_TIMEOUT_MS ?? 300_000);
 

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -129,7 +129,7 @@ function buildCaddyfile(coreStackProps: Record<string, string>): string {
   return `${blocks.join('\n\n')}\n`;
 }
 
-const REQUIRED_MEMORY_GB = 30;
+const REQUIRED_MEMORY_GB = 15;
 
 /** Fail fast if Docker's host/VM is under-provisioned for the full Grid stack. */
 function assertSufficientMemory(): void {


### PR DESCRIPTION
## What

Adds a fast-failing memory check at the start of the Playwright `globalSetup` for the e2e tests.

Before any Testcontainers are started, `assertSufficientMemory()` compares `os.totalmem()` against a required threshold (`REQUIRED_MEMORY_GB = 30`). If the Docker host/VM has less memory than required, it logs a clear message and calls `process.exit(1)`, terminating the run immediately.

## Why

The full local Grid stack (Elasticsearch, LocalStack, and the eight Grid services) needs a substantial amount of memory. When Docker is under-provisioned, the stack fails to start in confusing, hard-to-diagnose ways (timeouts, OOM-killed containers). This check surfaces the real problem up front with an actionable message: increase the memory allocated to Docker.

## How

- Uses Node's built-in `os.totalmem()` — cross-platform, no shell subprocess.
- Runs as the first step in `globalSetup`, so it fails before spinning up any containers.
- On failure prints the available vs required memory to stderr and exits non-zero.

## Testing

- Ran the e2e setup locally on a machine with sufficient memory: check passes and prints the `OK: ...` line.

<img width="600"  alt="Screenshot 2026-09-03 at 12 26 02" src="https://github.com/user-attachments/assets/2194a7e2-13db-49e2-b2f9-e5b70be486d7" />

Observed Error when allocation is not enough

<img width="600" alt="Screenshot 2026-09-03 at 12 26 49" src="https://github.com/user-attachments/assets/ac863e4e-3f87-4a64-a6b1-1d21e9f904a5" />


- Verified TypeScript compiles with no errors.