### PR TITLE
Do not record download usages from InDesign

### DIFF
--- a/media-api/app/controllers/MediaApi.scala
+++ b/media-api/app/controllers/MediaApi.scala
@@ -35,6 +35,14 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
+object MediaApi {
+  val InDesignIdentity = "InDesign (testing)"
+
+  def shouldSkipUsageRecording(uri: String, user: String): Boolean =
+    // We don't want to record usages for InDesign downloads for now
+    uri.contains("download") && user == InDesignIdentity
+}
+
 class MediaApi(
                 auth: Authentication,
                 messageSender: ThrallMessageSender,
@@ -518,29 +526,33 @@ class MediaApi(
     user: String,
     partnerName: Option[String] = None,
     startPending: Option[String] = None,
-  )(implicit logMarker: LogMarker) = {
+  )(implicit logMarker: LogMarker): Future[Unit] = {
+    if (MediaApi.shouldSkipUsageRecording(uri, user)) {
+      logger.info(logMarker, s"Skipping usages request to $uri for $user")
+      Future.successful(())
+    } else {
+      val baseRequest = ws.url(uri)
+        .withHttpHeaders(Authentication.originalServiceHeaderName -> config.appName,
+          HttpHeaders.ORIGIN -> config.rootUri,
+          HttpHeaders.CONTENT_TYPE -> ContentType.APPLICATION_JSON.getMimeType)
 
-    val baseRequest = ws.url(uri)
-      .withHttpHeaders(Authentication.originalServiceHeaderName -> config.appName,
-        HttpHeaders.ORIGIN -> config.rootUri,
-        HttpHeaders.CONTENT_TYPE -> ContentType.APPLICATION_JSON.getMimeType)
+      val request = onBehalfOfPrincipal(baseRequest)
 
-    val request = onBehalfOfPrincipal(baseRequest)
-
-    val usagesMetadata = uri match {
-      case s if s.contains("download") =>  Map("mediaId" -> mediaId,
-        "dateAdded" -> printDateTime(DateTime.now()),
-        "downloadedBy" -> user)
-      case s if s.contains("syndication") => Map("mediaId" -> mediaId,
-        "dateAdded" -> printDateTime(DateTime.now()),
-        "syndicatedBy" -> user,
-        "startPending" -> startPending.getOrElse("false"),
-        "partnerName" -> partnerName.getOrElse(
-          throw new IllegalArgumentException("partnerName required for SyndicationUsageRequest"))
-      )
+      val usagesMetadata = uri match {
+        case s if s.contains("download") =>  Map("mediaId" -> mediaId,
+          "dateAdded" -> printDateTime(DateTime.now()),
+          "downloadedBy" -> user)
+        case s if s.contains("syndication") => Map("mediaId" -> mediaId,
+          "dateAdded" -> printDateTime(DateTime.now()),
+          "syndicatedBy" -> user,
+          "startPending" -> startPending.getOrElse("false"),
+          "partnerName" -> partnerName.getOrElse(
+            throw new IllegalArgumentException("partnerName required for SyndicationUsageRequest"))
+        )
+      }
+      logger.info(logMarker, s"Making usages request to $uri")
+      request.post(Json.toJson(Map("data" -> usagesMetadata))).map(_ => ()) //fire and forget
     }
-    logger.info(logMarker, s"Making usages request to $uri")
-    request.post(Json.toJson(Map("data" -> usagesMetadata))) //fire and forget
   }
 
 

--- a/media-api/test/controllers/MediaApiTest.scala
+++ b/media-api/test/controllers/MediaApiTest.scala
@@ -1,0 +1,37 @@
+package controllers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class MediaApiTest extends AnyFunSpec with Matchers {
+
+  describe("MediaApi.shouldSkipUsageRecording") {
+    it("skips recording when the URI is a download and the user is the InDesign API key") {
+      MediaApi.shouldSkipUsageRecording(
+        uri = "https://usage.example.com/usages/download",
+        user = MediaApi.InDesignIdentity
+      ) shouldBe true
+    }
+
+    it("does not skip recording for a download from a real user") {
+      MediaApi.shouldSkipUsageRecording(
+        uri = "https://usage.example.com/usages/download",
+        user = "some-real-user@guardian.co.uk"
+      ) shouldBe false
+    }
+
+    it("does not skip recording for a syndication request, even from the InDesign API key") {
+      MediaApi.shouldSkipUsageRecording(
+        uri = "https://usage.example.com/usages/syndication",
+        user = MediaApi.InDesignIdentity
+      ) shouldBe false
+    }
+
+    it("does not skip recording for a syndication request from a real user") {
+      MediaApi.shouldSkipUsageRecording(
+        uri = "https://usage.example.com/usages/syndication",
+        user = "some-real-user@guardian.co.uk"
+      ) shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Skip usage recording for downloads from InDesign, as print usages are already recorded and they inevitably involve downloads. We mainly care about download usages from actual users.

## How should a reviewer test this change?

* Deploy this branch to test
* Create an API key for `InDesign (testing)` in `TEST` key bucket
* In your terminal, run `curl -H "X-Gu-Media-Key: [key]" "https://api.media.test.dev-gutools.co.uk/images/6933e821fc56ee90003c7b0b9b3a8e1d382e055f/download"`
* Go to logs and search for `InDesign (testing)`
*  You should be able to see a log entry with `Skipping usages request to /usages/download for InDesign (testing)`
* And you shouldn't see InDesign downloads under usages on this image: https://media.test.dev-gutools.co.uk/images/6933e821fc56ee90003c7b0b9b3a8e1d382e055f


## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [x] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218150756570430