### PR TITLE
[e2e-tests] Add terminal UI for e2e-test startup, and optimise startup tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ image-embedder-lambda/__tests__/embedder/test-data
 /e2e-tests/blob-report/
 /e2e-tests/playwright/.cache/
 /e2e-tests/playwright/.auth/
-
-# Testcontainers global-setup artifacts
-/e2e-tests/.grid-urls.json

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@aws-sdk/client-cloudformation": "^3.658.0",
+        "@aws-sdk/client-dynamodb": "^3.1127.0",
+        "@aws-sdk/client-kinesis": "^3.1127.0",
         "@aws-sdk/client-s3": "^3.658.0",
         "@playwright/test": "^1.61.1",
         "@testcontainers/localstack": "^10.13.2",
@@ -59,6 +61,48 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1127.0.tgz",
+      "integrity": "sha512-rV9TC7gqtwekWR9jXBdzuvCG65fnv7jphnYdJmFBfLX1b0Q+ma3xijzZaGGeN+US2pKw/XaQiZapJX/nZqtBJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/dynamodb-codec": "^3.973.44",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.30",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis": {
+      "version": "3.1127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.1127.0.tgz",
+      "integrity": "sha512-8uAuIE20oxRFocQfD71v8xBhrIKaFO8xYsnuKcAuw0OP+5DsXUmDg4lOv8bsdYJPi7tJxE9HkSz7cHxEw+Y5jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1089.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1089.0.tgz",
@@ -83,18 +127,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
-      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.4",
-        "@smithy/signature-v4": "^5.6.5",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -103,16 +147,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
-      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -120,18 +164,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
-      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -139,24 +183,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
-      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-login": "^3.972.66",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -164,17 +208,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
-      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -182,22 +226,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
-      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-ini": "^3.973.4",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -205,16 +249,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
-      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -222,18 +266,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
-      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/token-providers": "3.1088.0",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -241,17 +285,64 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
-      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.44.tgz",
+      "integrity": "sha512-eo27HNeBqMAfy9JBQug6ErU6DeG8OmOH6ou8+KmX3/fWdTmWUsHsfisz2tEQOG+GJ57bBC7kC6AjKAjpcxU4QA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.30.tgz",
+      "integrity": "sha512-0hmD7/NG2NoVOVHvUb6rtY5POQYr+/9gdHvrYhIBA1zmCqKOBd5Gz3dL+iZ15FHOJbs/5kLplGoePc8PHTlzYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -277,19 +368,19 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
-      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -297,15 +388,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
-      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.5",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -313,17 +404,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
-      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -331,13 +422,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -345,13 +436,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
-      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -693,13 +784,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
-      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -707,14 +798,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
-      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.5",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -722,14 +813,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
-      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.5",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -737,14 +828,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
-      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.5",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -752,14 +843,14 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
-      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.5",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -767,9 +858,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2083,6 +2174,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2107,6 +2208,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -17,6 +17,7 @@
         "@testcontainers/localstack": "^10.13.2",
         "@types/node": "^26.1.1",
         "json5": "^2.2.3",
+        "listr2": "^10.1.2",
         "playwright-bdd": "^9.2.0",
         "testcontainers": "^10.13.2"
       },
@@ -973,6 +974,22 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1344,6 +1361,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -1403,6 +1436,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -1516,6 +1583,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1760,6 +1834,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1779,6 +1866,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -1872,6 +1966,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-port": {
@@ -2056,6 +2163,58 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/listr2": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.1.2.tgz",
+      "integrity": "sha512-ENXj5KYVtdZigbaWY0+lUCzRZNvKDEbxree+93oaCeSz8GICxgJyOMi6U9mHuiFd3hJ9y0RIDQh8RYttBKOnaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.1.tgz",
+      "integrity": "sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -2076,6 +2235,102 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -2126,6 +2381,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2224,6 +2492,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -2504,6 +2788,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -2513,6 +2814,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2576,6 +2884,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -20,6 +20,8 @@
   "license": "ISC",
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.658.0",
+    "@aws-sdk/client-dynamodb": "^3.1127.0",
+    "@aws-sdk/client-kinesis": "^3.1127.0",
     "@aws-sdk/client-s3": "^3.658.0",
     "@playwright/test": "^1.61.1",
     "@testcontainers/localstack": "^10.13.2",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -27,6 +27,7 @@
     "@testcontainers/localstack": "^10.13.2",
     "@types/node": "^26.1.1",
     "json5": "^2.2.3",
+    "listr2": "^10.1.2",
     "playwright-bdd": "^9.2.0",
     "testcontainers": "^10.13.2"
   }

--- a/e2e-tests/setup/constants.ts
+++ b/e2e-tests/setup/constants.ts
@@ -60,9 +60,6 @@ export const SERVICE_PORTS: Record<string, number> = {
 export const KAHUNA_PORT = SERVICE_PORTS.kahuna;
 export const MEDIA_API_PORT = SERVICE_PORTS['media-api'];
 
-/** File (repo-relative to e2e-tests) where global-setup records the resolved service URLs. */
-export const URLS_FILE = path.join(import.meta.dirname, '..', '.grid-urls.json');
-
 /**
  * Generated per-service config, bind-mounted into the app container.
  */

--- a/e2e-tests/setup/dev.ts
+++ b/e2e-tests/setup/dev.ts
@@ -8,15 +8,13 @@
 import {
   DOMAIN,
   ELASTICSEARCH_PORT,
-  GRID_IMAGE,
   LOCALSTACK_PORT,
   SERVICE_PORTS,
-  URLS_FILE,
 } from './constants.ts';
 import { probeStack, startStack, stopStack } from './stack.ts';
 import type { GridEnvironment } from './state.ts';
 
-function banner(environment: GridEnvironment): string {
+function banner(elapsedMs: number): string {
   const services = Object.keys(SERVICE_PORTS)
     .sort()
     .map((service) => `    ${service.padEnd(16)} http://localhost:${SERVICE_PORTS[service]}`)
@@ -24,10 +22,7 @@ function banner(environment: GridEnvironment): string {
 
   return [
     '',
-    '  Grid is up.',
-    '',
-    `    kahuna (UI)      https://media.${DOMAIN}`,
-    `    media-api        ${environment.mediaApiUrl}`,
+    `  Grid is up in ${Math.round(elapsedMs / 1000)}s at https://media.${DOMAIN}`,
     '',
     '  Services:',
     services,
@@ -35,11 +30,6 @@ function banner(environment: GridEnvironment): string {
     '  Infrastructure:',
     `    localstack       http://localhost:${LOCALSTACK_PORT}`,
     `    elasticsearch    http://localhost:${ELASTICSEARCH_PORT}`,
-    '',
-    `  Image:             ${GRID_IMAGE}`,
-    `  Config:            ${environment.configDir}`,
-    `  URLs:              ${URLS_FILE}`,
-    `  Domains:           https://media.${DOMAIN} (via dev-nginx or GRID_PROXY=true)`,
     '',
     '  Press Ctrl-C to tear everything down.',
     '',
@@ -81,8 +71,9 @@ async function dev(): Promise<void> {
     );
   }
 
+  const startedAt = Date.now();
   environment = await startStack({ proxy: process.env.GRID_PROXY === 'true' });
-  console.log(banner(environment));
+  console.log(banner(Date.now() - startedAt));
 
   // Hold the process open indefinitely.
   setInterval(() => {}, 2_000_000_000);

--- a/e2e-tests/setup/dev.ts
+++ b/e2e-tests/setup/dev.ts
@@ -6,6 +6,7 @@
  * running locally.
  */
 import {
+  CONFIG_DIR,
   DOMAIN,
   ELASTICSEARCH_PORT,
   LOCALSTACK_PORT,
@@ -30,6 +31,8 @@ function banner(elapsedMs: number): string {
     '  Infrastructure:',
     `    localstack       http://localhost:${LOCALSTACK_PORT}`,
     `    elasticsearch    http://localhost:${ELASTICSEARCH_PORT}`,
+    '',
+    `  Config at ${CONFIG_DIR}`,
     '',
     '  Press Ctrl-C to tear everything down.',
     '',

--- a/e2e-tests/setup/progress.ts
+++ b/e2e-tests/setup/progress.ts
@@ -38,3 +38,5 @@ export async function runTasks<Ctx extends object>(
 
   return runner.run();
 }
+
+export const reportTo = (task: { output: string }) => (message: string) => { task.output = message; };

--- a/e2e-tests/setup/progress.ts
+++ b/e2e-tests/setup/progress.ts
@@ -1,0 +1,39 @@
+/**
+ * Renders long-running work as a listr2 task tree, so booting or tearing down the stack
+ * shows which container or gate is currently being waited on instead of a silent terminal.
+ *
+ * Interactive terminals get the animated renderer; CI and piped output fall back to the
+ * line-oriented `simple` renderer, which prints one line per task transition.
+ */
+import { Listr, PRESET_TIMER } from 'listr2';
+import type { ListrTask } from 'listr2';
+
+export type { ListrTask };
+
+export interface RunTasksOptions {
+  /** Keep going after a failed task. Used by teardown, where every step is best-effort. */
+  exitOnError?: boolean;
+}
+
+/** Run `tasks` against `context`, which they mutate as they go, and return it. */
+export async function runTasks<Ctx extends object>(
+  tasks: ListrTask<Ctx>[],
+  context: Ctx,
+  options: RunTasksOptions = {},
+): Promise<Ctx> {
+  const runner = new Listr<Ctx>(tasks, {
+    ctx: context,
+    exitOnError: options.exitOnError ?? true,
+    // The animated renderer redraws in place, which CI logs record as a wall of escape codes.
+    fallbackRendererCondition: () => !!process.env.CI,
+    rendererOptions: {
+      timer: PRESET_TIMER,
+      // Keep finished containers and services on screen: the completed list is the summary.
+      collapseSubtasks: false,
+      collapseErrors: false,
+    },
+    fallbackRendererOptions: { timer: PRESET_TIMER },
+  });
+
+  return runner.run();
+}

--- a/e2e-tests/setup/progress.ts
+++ b/e2e-tests/setup/progress.ts
@@ -32,6 +32,7 @@ export async function runTasks<Ctx extends object>(
       collapseSubtasks: false,
       collapseErrors: false,
     },
+    registerSignalListeners: false,
     fallbackRendererOptions: { timer: PRESET_TIMER },
   });
 

--- a/e2e-tests/setup/provision.ts
+++ b/e2e-tests/setup/provision.ts
@@ -19,9 +19,9 @@ import { API_KEY as API_KEY_PATH, CORE_STACK_NAME, PERMISSIONS_BUCKET, REGION, R
 
 const CREDENTIALS = { accessKeyId: 'test', secretAccessKey: 'test' };
 
-type StackProps = Record<string, string>;
+export type StackProps = Record<string, string>;
 
-function clients(endpoint: string) {
+export function provisioningClients(endpoint: string) {
   const cfn = new CloudFormationClient({ endpoint, region: REGION, credentials: CREDENTIALS });
   const s3 = new S3Client({
     endpoint,
@@ -39,15 +39,16 @@ function clients(endpoint: string) {
  * core stack, waits for completion, reads the created resource names, and seeds the
  * buckets with the config files the services expect (similar to dev/script/setup.sh).
  */
-async function createCoreStack(cfn: CloudFormationClient): Promise<StackProps> {
+export async function createCoreStack(cfn: CloudFormationClient): Promise<StackProps> {
   const templateBody = fs.readFileSync(
     path.join(REPO_ROOT, 'dev', 'cloudformation', 'grid-dev-core.yml'),
     'utf8',
   );
 
   await cfn.send(new CreateStackCommand({ StackName: CORE_STACK_NAME, TemplateBody: templateBody }));
+  // LocalStack applies the stack in seconds; the SDK default would sit out its 30s minimum delay.
   await waitUntilStackCreateComplete(
-    { client: cfn, maxWaitTime: 180 },
+    { client: cfn, maxWaitTime: 180, minDelay: 1, maxDelay: 5 },
     { StackName: CORE_STACK_NAME },
   );
 
@@ -72,23 +73,23 @@ async function putObject(
   await s3.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: body }));
 }
 
-async function seedBuckets(s3: S3Client, props: StackProps): Promise<void> {
+export async function seedBuckets(s3: S3Client, props: StackProps): Promise<void> {
   const devConfig = path.join(REPO_ROOT, 'dev', 'config');
 
-  // API key used by the machine authentication provider.
-  await putObject(s3, props.KeyBucket, API_KEY_PATH, 'DEV Key');
-
-  // Static config consumed by the services.
-  for (const file of ['photographers.json', 'rcs-quota.json', 'usage_rights.json']) {
-    await putObject(s3, props.ConfigBucket, file, fs.readFileSync(path.join(devConfig, file)));
-  }
-
-  await putObject(
-    s3,
-    props.UsageMailBucket,
-    'usages.eml',
-    fs.readFileSync(path.join(devConfig, 'usages.eml')),
-  );
+  await Promise.all([
+    // API key used by the machine authentication provider.
+    putObject(s3, props.KeyBucket, API_KEY_PATH, 'DEV Key'),
+    // Static config consumed by the services.
+    ...['photographers.json', 'rcs-quota.json', 'usage_rights.json'].map((file) =>
+      putObject(s3, props.ConfigBucket, file, fs.readFileSync(path.join(devConfig, file))),
+    ),
+    putObject(
+      s3,
+      props.UsageMailBucket,
+      'usages.eml',
+      fs.readFileSync(path.join(devConfig, 'usages.eml')),
+    ),
+  ]);
 }
 
 /**
@@ -96,7 +97,7 @@ async function seedBuckets(s3: S3Client, props: StackProps): Promise<void> {
  * permissions fixture so the real authorisation provider can read `permissions.json`.
  * Returns the bucket name so it can be added to the stack props map.
  */
-async function provisionPermissionsBucket(s3: S3Client): Promise<string> {
+export async function provisionPermissionsBucket(s3: S3Client): Promise<string> {
   await s3.send(
     new CreateBucketCommand({
       Bucket: PERMISSIONS_BUCKET,
@@ -131,7 +132,7 @@ async function provisionPermissionsBucket(s3: S3Client): Promise<string> {
  * neither the jitter nor the shard sync runs: the lease taker picks up the unowned leases
  * on its first pass instead.
  */
-async function seedKclLeaseTable(
+export async function seedKclLeaseTable(
   dynamo: DynamoDBClient,
   kinesis: KinesisClient,
   streamName: string,
@@ -144,41 +145,28 @@ async function seedKclLeaseTable(
       BillingMode: 'PAY_PER_REQUEST',
     }),
   );
-  await waitUntilTableExists({ client: dynamo, maxWaitTime: 60 }, { TableName: streamName });
+  await waitUntilTableExists({ client: dynamo, maxWaitTime: 60, minDelay: 1 }, { TableName: streamName });
 
   const { Shards = [] } = await kinesis.send(new ListShardsCommand({ StreamName: streamName }));
 
-  for (const shard of Shards) {
-    await dynamo.send(
-      new PutItemCommand({
-        TableName: streamName,
-        Item: {
-          leaseKey: { S: shard.ShardId! },
-          leaseCounter: { N: '0' },
-          checkpoint: { S: 'TRIM_HORIZON' },
-          checkpointSubSequenceNumber: { N: '0' },
-          ownerSwitchesSinceCheckpoint: { N: '0' },
-          // Without the hash range KCL's lease auditor reports the stream as having holes.
-          startingHashKey: { S: shard.HashKeyRange!.StartingHashKey! },
-          endingHashKey: { S: shard.HashKeyRange!.EndingHashKey! },
-        },
-      }),
-    );
-  }
+  await Promise.all(
+    Shards.map((shard) =>
+      dynamo.send(
+        new PutItemCommand({
+          TableName: streamName,
+          Item: {
+            leaseKey: { S: shard.ShardId! },
+            leaseCounter: { N: '0' },
+            checkpoint: { S: 'TRIM_HORIZON' },
+            checkpointSubSequenceNumber: { N: '0' },
+            ownerSwitchesSinceCheckpoint: { N: '0' },
+            // Without the hash range KCL's lease auditor reports the stream as having holes.
+            startingHashKey: { S: shard.HashKeyRange!.StartingHashKey! },
+            endingHashKey: { S: shard.HashKeyRange!.EndingHashKey! },
+          },
+        }),
+      ),
+    ),
+  );
 }
 
-/**
- * Apply the core stack and seed its buckets. Returns the LogicalResourceId ->
- * PhysicalResourceId map used to generate service config.
- */export async function provisionCoreStack(localstackEndpoint: string): Promise<StackProps> {
-  const { cfn, s3, dynamo, kinesis } = clients(localstackEndpoint);
-  const props = await createCoreStack(cfn);
-  await seedBuckets(s3, props);
-  props.PermissionsBucket = await provisionPermissionsBucket(s3);
-
-  for (const stream of [props.ThrallMessageStream, props.ThrallLowPriorityMessageStream]) {
-    await seedKclLeaseTable(dynamo, kinesis, stream);
-  }
-
-  return props;
-}

--- a/e2e-tests/setup/provision.ts
+++ b/e2e-tests/setup/provision.ts
@@ -46,9 +46,10 @@ export async function createCoreStack(cfn: CloudFormationClient): Promise<StackP
   );
 
   await cfn.send(new CreateStackCommand({ StackName: CORE_STACK_NAME, TemplateBody: templateBody }));
+
   // LocalStack applies the stack in seconds; the SDK default would sit out its 30s minimum delay.
   await waitUntilStackCreateComplete(
-    { client: cfn, maxWaitTime: 180, minDelay: 1, maxDelay: 5 },
+    { client: cfn, maxWaitTime: 180, minDelay: 1, maxDelay: 1 },
     { StackName: CORE_STACK_NAME },
   );
 

--- a/e2e-tests/setup/provision.ts
+++ b/e2e-tests/setup/provision.ts
@@ -6,6 +6,14 @@ import {
   DescribeStackResourcesCommand,
   waitUntilStackCreateComplete,
 } from '@aws-sdk/client-cloudformation';
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  PutItemCommand,
+  ScanCommand,
+  waitUntilTableExists,
+} from '@aws-sdk/client-dynamodb';
+import { KinesisClient, ListShardsCommand } from '@aws-sdk/client-kinesis';
 import { CreateBucketCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { API_KEY as API_KEY_PATH, CORE_STACK_NAME, PERMISSIONS_BUCKET, REGION, REPO_ROOT } from './constants.ts';
 
@@ -21,7 +29,9 @@ function clients(endpoint: string) {
     credentials: CREDENTIALS,
     forcePathStyle: true,
   });
-  return { cfn, s3 };
+  const dynamo = new DynamoDBClient({ endpoint, region: REGION, credentials: CREDENTIALS });
+  const kinesis = new KinesisClient({ endpoint, region: REGION, credentials: CREDENTIALS });
+  return { cfn, s3, dynamo, kinesis };
 }
 
 /**
@@ -105,13 +115,70 @@ async function provisionPermissionsBucket(s3: S3Client): Promise<string> {
 }
 
 /**
+ * Pre-create the KCL lease table for a stream, with an unowned lease per shard.
+ *
+ * Thrall consumes each stream with the Kinesis Client Library, which names its DynamoDB
+ * lease table after the KCL application name — and thrall sets that to the stream name.
+ * Left to itself on a cold stack, KCL spends ~70s before it reads a single record:
+ *
+ *   - `Scheduler.initialize()` calls `shouldInitiateLeaseSync()`, which sleeps a random
+ *     1-30s (polling every 3s) for as long as the lease table is empty. It is anti-stampede
+ *     jitter for a real fleet, is not configurable, and is pure cost for a single worker.
+ *   - It then runs the initial shard sync synchronously, and `ShardSyncTask` finishes with
+ *     `Thread.sleep(shardSyncIntervalMillis)` — 60s on KCL's defaults.
+ *
+ * Seeding the leases here makes `isLeaseTableEmpty()` false on the very first check, so
+ * neither the jitter nor the shard sync runs: the lease taker picks up the unowned leases
+ * on its first pass instead.
+ */
+async function seedKclLeaseTable(
+  dynamo: DynamoDBClient,
+  kinesis: KinesisClient,
+  streamName: string,
+): Promise<void> {
+  await dynamo.send(
+    new CreateTableCommand({
+      TableName: streamName,
+      KeySchema: [{ AttributeName: 'leaseKey', KeyType: 'HASH' }],
+      AttributeDefinitions: [{ AttributeName: 'leaseKey', AttributeType: 'S' }],
+      BillingMode: 'PAY_PER_REQUEST',
+    }),
+  );
+  await waitUntilTableExists({ client: dynamo, maxWaitTime: 60 }, { TableName: streamName });
+
+  const { Shards = [] } = await kinesis.send(new ListShardsCommand({ StreamName: streamName }));
+
+  for (const shard of Shards) {
+    await dynamo.send(
+      new PutItemCommand({
+        TableName: streamName,
+        Item: {
+          leaseKey: { S: shard.ShardId! },
+          leaseCounter: { N: '0' },
+          checkpoint: { S: 'TRIM_HORIZON' },
+          checkpointSubSequenceNumber: { N: '0' },
+          ownerSwitchesSinceCheckpoint: { N: '0' },
+          // Without the hash range KCL's lease auditor reports the stream as having holes.
+          startingHashKey: { S: shard.HashKeyRange!.StartingHashKey! },
+          endingHashKey: { S: shard.HashKeyRange!.EndingHashKey! },
+        },
+      }),
+    );
+  }
+}
+
+/**
  * Apply the core stack and seed its buckets. Returns the LogicalResourceId ->
  * PhysicalResourceId map used to generate service config.
- */
-export async function provisionCoreStack(localstackEndpoint: string): Promise<StackProps> {
-  const { cfn, s3 } = clients(localstackEndpoint);
+ */export async function provisionCoreStack(localstackEndpoint: string): Promise<StackProps> {
+  const { cfn, s3, dynamo, kinesis } = clients(localstackEndpoint);
   const props = await createCoreStack(cfn);
   await seedBuckets(s3, props);
   props.PermissionsBucket = await provisionPermissionsBucket(s3);
+
+  for (const stream of [props.ThrallMessageStream, props.ThrallLowPriorityMessageStream]) {
+    await seedKclLeaseTable(dynamo, kinesis, stream);
+  }
+
   return props;
 }

--- a/e2e-tests/setup/seed-elasticsearch.ts
+++ b/e2e-tests/setup/seed-elasticsearch.ts
@@ -75,8 +75,7 @@ export async function seedElasticsearch(
   const hits = fixture.body?.hits?.hits ?? [];
 
   if (hits.length === 0) {
-    report('No image fixtures found to seed into Elasticsearch');
-    return;
+    throw new Error('No image fixtures found to seed into Elasticsearch. This is unexpected - failing early');
   }
 
   report(`Waiting for the '${IMAGES_ALIAS}' alias`);

--- a/e2e-tests/setup/seed-elasticsearch.ts
+++ b/e2e-tests/setup/seed-elasticsearch.ts
@@ -69,7 +69,7 @@ async function waitForAlias(esBaseUrl: string, timeoutMs = 60_000): Promise<void
  */
 export async function seedElasticsearch(
   esBaseUrl: string,
-  report: (message: string) => void = console.log,
+  report: (message: string) => void,
 ): Promise<void> {
   const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as EsSearchFixture;
   const hits = fixture.body?.hits?.hits ?? [];

--- a/e2e-tests/setup/seed-elasticsearch.ts
+++ b/e2e-tests/setup/seed-elasticsearch.ts
@@ -44,7 +44,7 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  * Poll the alias until the Grid app has created the index and assigned it, so the bulk
  * insert below has a valid write target. Throws if it never appears within the timeout.
  */
-async function waitForAlias(esBaseUrl: string, timeoutMs = 60_000): Promise<void> {
+async function waitForAlias(esBaseUrl: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let lastStatus = 'no response';
   while (Date.now() < deadline) {
@@ -69,6 +69,7 @@ async function waitForAlias(esBaseUrl: string, timeoutMs = 60_000): Promise<void
  */
 export async function seedElasticsearch(
   esBaseUrl: string,
+  startupTimeoutMs: number,
   report: (message: string) => void,
 ): Promise<void> {
   const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as EsSearchFixture;
@@ -79,7 +80,7 @@ export async function seedElasticsearch(
   }
 
   report(`Waiting for the '${IMAGES_ALIAS}' alias`);
-  await waitForAlias(esBaseUrl);
+  await waitForAlias(esBaseUrl, startupTimeoutMs);
 
   // NDJSON bulk body: an index action line (targeting the document's `_id`) followed by
   // the source document, repeated for every hit.

--- a/e2e-tests/setup/seed-elasticsearch.ts
+++ b/e2e-tests/setup/seed-elasticsearch.ts
@@ -67,15 +67,19 @@ async function waitForAlias(esBaseUrl: string, timeoutMs = 60_000): Promise<void
 /**
  * Load the image fixtures into Elasticsearch. No-op if the fixture has no documents.
  */
-export async function seedElasticsearch(esBaseUrl: string): Promise<void> {
+export async function seedElasticsearch(
+  esBaseUrl: string,
+  report: (message: string) => void = console.log,
+): Promise<void> {
   const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as EsSearchFixture;
   const hits = fixture.body?.hits?.hits ?? [];
 
   if (hits.length === 0) {
-    console.warn('No image fixtures found to seed into Elasticsearch');
+    report('No image fixtures found to seed into Elasticsearch');
     return;
   }
 
+  report(`Waiting for the '${IMAGES_ALIAS}' alias`);
   await waitForAlias(esBaseUrl);
 
   // NDJSON bulk body: an index action line (targeting the document's `_id`) followed by
@@ -107,5 +111,5 @@ export async function seedElasticsearch(esBaseUrl: string): Promise<void> {
     throw new Error(`Elasticsearch bulk seed reported errors: ${JSON.stringify(firstError)}`);
   }
 
-  console.log(`Seeded ${hits.length} image fixture(s) into Elasticsearch alias '${IMAGES_ALIAS}'`);
+  report(`Seeded ${hits.length} image fixture(s) into Elasticsearch alias '${IMAGES_ALIAS}'`);
 }

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -361,9 +361,9 @@ function localstackTasks(): ListrTask<BootContext>[] {
     {
       title: 'Start container',
       task: async (ctx) => {
-        ctx.localstack = await localstackContainer(ctx.network!).start();
-        ctx.containers.push(ctx.localstack);
-        clients = provisioningClients(ctx.localstack.getConnectionUri());
+        const localstack = await localstackContainer(ctx.network!).start();
+        ctx.containers.push(localstack);
+        clients = provisioningClients(localstack.getConnectionUri());
       },
     },
     {

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -51,7 +51,7 @@ import {
 import type { StackProps } from './provision.ts';
 import { seedElasticsearch } from './seed-elasticsearch.ts';
 import type { GridEnvironment } from './state.ts';
-import { ListrTaskFn } from 'listr2';
+import type { ListrTaskFn } from 'listr2';
 
 const LOCALSTACK_SERVICES = [
   "cloudformation",
@@ -445,7 +445,6 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
                       },
                     },
                   ],
-                  // Subtasks inherit the concurrency of the group above, which these cannot use.
                   { concurrent: false },
                 );
               },

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -640,11 +640,9 @@ export async function stopStack(environment: StoppableStack | undefined): Promis
     // Reverse start order, so nothing is stopped before whatever depends on it.
     ...[...containers].reverse().map((container) => ({
       title: `Stop ${container.getLabels()[ROLE_LABEL] ?? container.getName()}`,
-      task: async () => {
-        await container.stop();
-      },
+      task: container.stop,
     })),
-    ...(network ? [{ title: 'Remove network', task: () => { network.stop() } }] : []),
+    ...(network ? [{ title: 'Remove network', task: network.stop }] : []),
     ...(configDir
       ? [
         {

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -75,12 +75,18 @@ export interface StartStackOptions {
   seed?: boolean;
 }
 
+// Every service is bound to a fixed host port, so its URL is the same whether this process
+// started the stack or attached to one already running.
+const KAHUNA_URL = `http://localhost:${KAHUNA_PORT}`;
+const MEDIA_API_URL = `http://localhost:${MEDIA_API_PORT}`;
+const ELASTICSEARCH_URL = `http://localhost:${ELASTICSEARCH_PORT}`;
+
 /** How much of the stack is already listening on the fixed host ports. */
 type StackProbe = 'none' | 'healthy' | 'partial';
 
 const PROBE_OUTCOMES: Record<StackProbe, string> = {
   none: 'No running Grid stack found',
-  healthy: `Found a Grid stack already running on http://localhost:${KAHUNA_PORT}`,
+  healthy: `Found a Grid stack already running on ${KAHUNA_URL}`,
   partial: 'Found a partially running Grid stack',
 };
 
@@ -98,9 +104,7 @@ interface StoppableStack {
 
 /** What the boot tasks build up. Each task mutates it in place for the ones that follow. */
 interface BootContext extends StoppableStack {
-  elasticsearch?: StartedTestContainer;
   localstack?: StartedLocalStackContainer;
-  grid?: StartedTestContainer;
   coreStackProps?: StackProps;
 }
 
@@ -416,8 +420,7 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
             {
               title: 'Elasticsearch',
               task: async (ctx) => {
-                ctx.elasticsearch = await elasticsearchContainer(ctx.network!).start();
-                ctx.containers.push(ctx.elasticsearch);
+                ctx.containers.push(await elasticsearchContainer(ctx.network!).start());
               },
             },
             {
@@ -476,8 +479,9 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
           {
             title: 'Start container',
             task: async (ctx) => {
-              ctx.grid = await gridContainer(ctx.network!, ctx.configDir!, startupTimeoutMs).start();
-              ctx.containers.push(ctx.grid);
+              ctx.containers.push(
+                await gridContainer(ctx.network!, ctx.configDir!, startupTimeoutMs).start(),
+              );
             },
           },
           {
@@ -496,9 +500,8 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
                   // only needs the container running, not every service healthy.
                   title: 'Seed Elasticsearch',
                   skip: () => !seed && 'seeding not requested',
-                  task: async (ctx, seedTask) => {
-                    const esBaseUrl = `http://${ctx.elasticsearch!.getHost()}:${ctx.elasticsearch!.getMappedPort(ELASTICSEARCH_PORT)}`;
-                    await seedElasticsearch(esBaseUrl, (message) => {
+                  task: async (_, seedTask) => {
+                    await seedElasticsearch(ELASTICSEARCH_URL, (message) => {
                       seedTask.output = message;
                     });
                   },
@@ -523,14 +526,12 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
   try {
     await runTasks(tasks, context);
 
-    const host = context.grid!.getHost();
-
     return {
       network: context.network,
       containers: context.containers,
       configDir: context.configDir,
-      baseUrl: `http://${host}:${context.grid!.getMappedPort(KAHUNA_PORT)}`,
-      mediaApiUrl: `http://${host}:${context.grid!.getMappedPort(MEDIA_API_PORT)}`,
+      baseUrl: KAHUNA_URL,
+      mediaApiUrl: MEDIA_API_URL,
     };
   } catch (error) {
     // Leave nothing running if we failed part-way through the boot.
@@ -627,9 +628,6 @@ export async function ensureStack(options: StartStackOptions = {}): Promise<Grid
  * so `stopStack` leaves everything running.
  */
 async function attachToStack(options: StartStackOptions): Promise<GridEnvironment> {
-  const baseUrl = `http://localhost:${KAHUNA_PORT}`;
-  const mediaApiUrl = `http://localhost:${MEDIA_API_PORT}`;
-
   // Re-seeding is opt-in: whoever started the stack already seeded it, and the fixtures
   // are only reloaded on request because tests may have since changed the data.
   const reseed = options.seed === true || process.env.GRID_RESEED === 'true';
@@ -640,7 +638,7 @@ async function attachToStack(options: StartStackOptions): Promise<GridEnvironmen
         title: 'Seed Elasticsearch',
         skip: () => !reseed && 'reseeding not requested',
         task: async (_, task) => {
-          await seedElasticsearch(`http://localhost:${ELASTICSEARCH_PORT}`, (message) => {
+          await seedElasticsearch(ELASTICSEARCH_URL, (message) => {
             task.output = message;
           });
         },
@@ -649,7 +647,7 @@ async function attachToStack(options: StartStackOptions): Promise<GridEnvironmen
     {},
   );
 
-  return { containers: [], baseUrl, mediaApiUrl };
+  return { containers: [], baseUrl: KAHUNA_URL, mediaApiUrl: MEDIA_API_URL };
 }
 
 /** Stop what this process started and delete what it wrote; anything else is left alone. */

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -580,21 +580,8 @@ export async function ensureStack(options: StartStackOptions = {}): Promise<Grid
   // Nothing pre-exists in CI, and silently attaching there would undermine the run.
   const reuseAllowed = !process.env.CI;
 
-  const probe: { result?: Awaited<ReturnType<typeof probeStack>> } = {};
-  await runTasks(
-    [
-      {
-        title: 'Look for a running Grid stack',
-        task: async (ctx, task) => {
-          ctx.result = await probeStack();
-          task.title = PROBE_OUTCOMES[ctx.result.state];
-        },
-      },
-    ],
-    probe,
-  );
-
-  const { state, healthy, ports } = probe.result!;
+  const { state, healthy, ports } = await probeStack();
+  console.log(PROBE_OUTCOMES[state]);
 
   if (state === 'partial') {
     const missing = ports.filter((port) => !healthy.includes(port));

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -398,7 +398,7 @@ function localstackTasks(): ListrTask<BootContext>[] {
 export async function startStack(options: StartStackOptions = {}): Promise<GridEnvironment> {
   const { proxy = !!process.env.CI, seed = true } = options;
 
-  const startupTimeoutMs = Number(process.env.GRID_STARTUP_TIMEOUT_MS ?? 300_000);
+  const startupTimeoutMs = Number(process.env.GRID_STARTUP_TIMEOUT_MS ?? 120_000);
   const context: BootContext = { containers: [] };
 
   const tasks: ListrTask<BootContext>[] = [
@@ -496,7 +496,7 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
                   title: 'Seed Elasticsearch',
                   skip: () => !seed && 'seeding not requested',
                   task: async (_, seedTask) => {
-                    await seedElasticsearch(ELASTICSEARCH_URL, reportTo(seedTask));
+                    await seedElasticsearch(ELASTICSEARCH_URL, startupTimeoutMs, reportTo(seedTask));
                   },
                 },
               ];
@@ -618,7 +618,7 @@ async function attachToStack(options: StartStackOptions): Promise<GridEnvironmen
         title: 'Seed Elasticsearch',
         skip: () => !reseed && 'reseeding not requested',
         task: async (_, task) => {
-          await seedElasticsearch(ELASTICSEARCH_URL, reportTo(task));
+          await seedElasticsearch(ELASTICSEARCH_URL, 60_000, reportTo(task));
         },
       },
     ],

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -52,6 +52,7 @@ import {
 import type { StackProps } from './provision.ts';
 import { seedElasticsearch } from './seed-elasticsearch.ts';
 import type { GridEnvironment } from './state.ts';
+import { ListrTaskFn } from 'listr2';
 
 const LOCALSTACK_SERVICES = [
   "cloudformation",
@@ -293,7 +294,7 @@ function gridContainer(
     // Waiting on the healthchecks here would collapse every service into one opaque wait;
     // the first line of output is enough to hand over to the per-service checks below.
     .withWaitStrategy(Wait.forLogMessage(/./))
-    .withStartupTimeout(startupTimeoutMs);
+    .withStartupTimeout(10_000);
 
   if (!process.env.GRID_DEBUG) {
     return container;
@@ -331,7 +332,7 @@ async function waitForHealthy(
   const startedAt = Date.now();
   const deadline = startedAt + timeoutMs;
 
-  for (;;) {
+  for (; ;) {
     const { healthy } = await isServiceHealthy(healthPath)(port);
     if (healthy) {
       return;
@@ -483,9 +484,9 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
             title: 'Wait for services',
             task: (_, services) => {
               const readiness: ListrTask<BootContext>[] = [
-                ...Object.entries(SERVICE_PORTS).map(([service, port]) => ({
+                ...Object.entries(SERVICE_PORTS).map(([service, port]): { title: string, task: ListrTaskFn<BootContext, any, any> } => ({
                   title: service,
-                  task: (_: BootContext, serviceTask: { output: string }) =>
+                  task: (_, serviceTask) =>
                     waitForHealthy(port, 'management/healthcheck', startupTimeoutMs, (message) => {
                       serviceTask.output = message;
                     }),
@@ -667,17 +668,17 @@ export async function stopStack(environment: StoppableStack | undefined): Promis
         await container.stop();
       },
     })),
-    ...(network ? [{ title: 'Remove network', task: () => network.stop() }] : []),
+    ...(network ? [{ title: 'Remove network', task: () => { network.stop() } }] : []),
     ...(configDir
       ? [
-          {
-            title: 'Remove generated config',
-            task: () => {
-              fs.rmSync(configDir, { recursive: true, force: true });
-              ownedConfigDir = undefined;
-            },
+        {
+          title: 'Remove generated config',
+          task: () => {
+            fs.rmSync(configDir, { recursive: true, force: true });
+            ownedConfigDir = undefined;
           },
-        ]
+        },
+      ]
       : []),
   ];
 

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -640,9 +640,9 @@ export async function stopStack(environment: StoppableStack | undefined): Promis
     // Reverse start order, so nothing is stopped before whatever depends on it.
     ...[...containers].reverse().map((container) => ({
       title: `Stop ${container.getLabels()[ROLE_LABEL] ?? container.getName()}`,
-      task: container.stop,
+      task: () => container.stop(),
     })),
-    ...(network ? [{ title: 'Remove network', task: network.stop }] : []),
+    ...(network ? [{ title: 'Remove network', task: () => network.stop() }] : []),
     ...(configDir
       ? [
         {

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { LocalstackContainer } from '@testcontainers/localstack';
+import type { StartedLocalStackContainer } from '@testcontainers/localstack';
 import { GenericContainer, Network, Wait } from 'testcontainers';
 import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
 import {
@@ -37,10 +38,18 @@ import {
   REGION,
   REPO_ROOT,
   SERVICE_PORTS,
-  URLS_FILE,
 } from './constants.ts';
 import { generateServiceConfig } from './config.ts';
-import { provisionCoreStack } from './provision.ts';
+import { runTasks } from './progress.ts';
+import type { ListrTask } from './progress.ts';
+import {
+  createCoreStack,
+  provisioningClients,
+  provisionPermissionsBucket,
+  seedBuckets,
+  seedKclLeaseTable,
+} from './provision.ts';
+import type { StackProps } from './provision.ts';
 import { seedElasticsearch } from './seed-elasticsearch.ts';
 import type { GridEnvironment } from './state.ts';
 
@@ -68,14 +77,30 @@ export interface StartStackOptions {
 /** How much of the stack is already listening on the fixed host ports. */
 type StackProbe = 'none' | 'healthy' | 'partial';
 
+const PROBE_OUTCOMES: Record<StackProbe, string> = {
+  none: 'No running Grid stack found',
+  healthy: `Found a Grid stack already running on http://localhost:${KAHUNA_PORT}`,
+  partial: 'Found a partially running Grid stack',
+};
+
 const PROBE_TIMEOUT_MS = 2_000;
+
+/** Names a container by its role in the stack, since Docker otherwise assigns a random one. */
+const ROLE_LABEL = 'uk.co.guardian.grid.role';
 
 /** The subset of a started stack that teardown needs; a partially-booted stack also fits. */
 interface StoppableStack {
   network?: StartedNetwork;
   containers: StartedTestContainer[];
   configDir?: string;
-  urlsFile?: string;
+}
+
+/** What the boot tasks build up. Each task mutates it in place for the ones that follow. */
+interface BootContext extends StoppableStack {
+  elasticsearch?: StartedTestContainer;
+  localstack?: StartedLocalStackContainer;
+  grid?: StartedTestContainer;
+  coreStackProps?: StackProps;
 }
 
 /**
@@ -179,180 +204,337 @@ process.on('exit', () => {
   }
 });
 
+function elasticsearchContainer(network: StartedNetwork): GenericContainer {
+  return new GenericContainer(ELASTICSEARCH_IMAGE)
+    .withNetwork(network)
+    .withNetworkAliases(ELASTICSEARCH_ALIAS)
+    .withLabels({ [ROLE_LABEL]: 'Elasticsearch' })
+    .withEnvironment({
+      'discovery.type': 'single-node',
+      'xpack.security.enabled': 'false',
+      ES_JAVA_OPTS: '-Xms1024m -Xmx1024m',
+    })
+    .withExposedPorts({ container: ELASTICSEARCH_PORT, host: ELASTICSEARCH_PORT })
+    .withWaitStrategy(
+      Wait.forHttp('/_cluster/health', ELASTICSEARCH_PORT).forStatusCodeMatching((code) => code < 300),
+    )
+    .withStartupTimeout(180_000);
+}
+
+function localstackContainer(network: StartedNetwork): LocalstackContainer {
+  return new LocalstackContainer(LOCALSTACK_IMAGE)
+    .withNetwork(network)
+    .withNetworkAliases(LOCALSTACK_ALIAS)
+    .withLabels({ [ROLE_LABEL]: 'LocalStack' })
+    // Pin to the fixed host port dev-nginx expects for the S3 vanity domains
+    // (images.media / public.media / localstack.media -> 4566).
+    .withExposedPorts({ container: LOCALSTACK_PORT, host: LOCALSTACK_PORT })
+    .withEnvironment({
+      SERVICES: LOCALSTACK_SERVICES,
+      DEFAULT_REGION: REGION,
+      KINESIS_ERROR_PROBABILITY: '0.0',
+      // Make resource URLs resolve via the network alias so the
+      // app container can reach them, and keep queue URLs path-style.
+      LOCALSTACK_HOST: `${LOCALSTACK_ALIAS}:${LOCALSTACK_PORT}`,
+      SQS_ENDPOINT_STRATEGY: 'path',
+    })
+    .withStartupTimeout(120_000);
+}
+
+/**
+ * imgops: standalone nginx image resizer, built from dev/imgops. Its nginx.conf proxies to
+ * the `localstack` alias on 4566, so it shares the stack network.
+ */
+function imgopsContainer(image: GenericContainer, network: StartedNetwork): GenericContainer {
+  return image
+    .withNetwork(network)
+    .withNetworkAliases(IMGOPS_ALIAS)
+    .withLabels({ [ROLE_LABEL]: 'imgops' })
+    .withCopyFilesToContainer([{ source: IMGOPS_NGINX_CONF, target: '/etc/nginx/nginx.conf' }])
+    .withExposedPorts({ container: 80, host: IMGOPS_PORT })
+    .withWaitStrategy(Wait.forHttp('/_', 80).forStatusCode(200))
+    .withStartupTimeout(120_000);
+}
+
+/**
+ * All Grid services under test run inside this single container and talk to each
+ * other over its localhost. Each is published on the fixed host port its
+ * dev-nginx mapping expects (dev/nginx-mappings.yml), so the developer's
+ * dev-nginx routes the https://*.media.<domain> domains straight into this
+ * container.
+ */
+function gridContainer(
+  network: StartedNetwork,
+  configDir: string,
+  startupTimeoutMs: number,
+): GenericContainer {
+  const container = new GenericContainer(GRID_IMAGE)
+    .withNetwork(network)
+    .withNetworkAliases(GRID_ALIAS)
+    .withLabels({ [ROLE_LABEL]: 'the Grid services' })
+    .withExposedPorts(
+      ...Object.values(SERVICE_PORTS).map((port) => ({ container: port, host: port })),
+    )
+    .withBindMounts([
+      // DEV stage reads ~/.grid; /etc/grid is honoured for non-DEV stages. Mount both.
+      { source: configDir, target: '/root/.grid', mode: 'ro' },
+      { source: configDir, target: '/etc/grid', mode: 'ro' },
+      // Outside CI the grid-e2e-dev image runs services under sbt; mount the repo
+      // over /build so host edits recompile live.
+      ...(process.env.CI ? [] : [{ source: REPO_ROOT, target: '/build', mode: 'rw' as const }]),
+    ])
+    .withEnvironment({
+      AWS_ACCESS_KEY_ID: 'test',
+      AWS_SECRET_ACCESS_KEY: 'test',
+      AWS_REGION: REGION,
+      AWS_DEFAULT_REGION: REGION,
+      AWS_CBOR_DISABLE: 'true',
+    })
+    // Waiting on the healthchecks here would collapse every service into one opaque wait;
+    // the first line of output is enough to hand over to the per-service checks below.
+    .withWaitStrategy(Wait.forLogMessage(/./))
+    .withStartupTimeout(startupTimeoutMs);
+
+  if (!process.env.GRID_DEBUG) {
+    return container;
+  }
+
+  const logStream = fs.createWriteStream(path.join(os.tmpdir(), 'grid-boot.log'));
+  return container.withLogConsumer((stream) => {
+    stream.on('data', (line) => logStream.write(line));
+    stream.on('err', (line) => logStream.write(line));
+  });
+}
+
+/**
+ * Locally, the browser reaches the https://*.media.<domain> domains via the developer's
+ * dev-nginx. CI has no dev-nginx, so a Caddy proxy replays the same subdomain routing and
+ * terminates TLS with a self-signed cert, published on the https port the domains resolve to.
+ */
+function proxyContainer(network: StartedNetwork, caddyfile: string): GenericContainer {
+  return new GenericContainer(PROXY_IMAGE)
+    .withNetwork(network)
+    .withLabels({ [ROLE_LABEL]: 'the reverse proxy' })
+    .withExposedPorts({ container: 443, host: 443 })
+    .withCopyContentToContainer([{ content: caddyfile, target: '/etc/caddy/Caddyfile' }])
+    .withWaitStrategy(Wait.forListeningPorts())
+    .withStartupTimeout(60_000);
+}
+
+/** Poll a fixed host port until its healthcheck passes, reporting how long it has waited. */
+async function waitForHealthy(
+  port: number,
+  healthPath: string,
+  timeoutMs: number,
+  report: (message: string) => void,
+): Promise<void> {
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+
+  for (;;) {
+    const { healthy } = await isServiceHealthy(healthPath)(port);
+    if (healthy) {
+      return;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`localhost:${port}/${healthPath} did not pass its healthcheck within ${timeoutMs}ms`);
+    }
+
+    report(`waiting on localhost:${port} (${Math.round((Date.now() - startedAt) / 1000)}s)`);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+}
+
+/**
+ * Start LocalStack and provision everything held in it. Sequential: each step needs the
+ * resources the one before it created.
+ */
+function localstackTasks(): ListrTask<BootContext>[] {
+  let clients: ReturnType<typeof provisioningClients>;
+
+  return [
+    {
+      title: 'Start container',
+      task: async (ctx) => {
+        ctx.localstack = await localstackContainer(ctx.network!).start();
+        ctx.containers.push(ctx.localstack);
+        clients = provisioningClients(ctx.localstack.getConnectionUri());
+      },
+    },
+    {
+      title: 'Apply CloudFormation template',
+      task: async (ctx) => {
+        ctx.coreStackProps = await createCoreStack(clients.cfn);
+      },
+    },
+    {
+      title: 'Seed config buckets',
+      task: (ctx) => seedBuckets(clients.s3, ctx.coreStackProps!),
+    },
+    {
+      title: 'Create permissions bucket',
+      task: async (ctx) => {
+        ctx.coreStackProps!.PermissionsBucket = await provisionPermissionsBucket(clients.s3);
+      },
+    },
+    {
+      title: 'Seed KCL lease tables',
+      task: async (ctx) => {
+        await Promise.all(
+          [
+            ctx.coreStackProps!.ThrallMessageStream,
+            ctx.coreStackProps!.ThrallLowPriorityMessageStream,
+          ].map((stream) => seedKclLeaseTable(clients.dynamo, clients.kinesis, stream)),
+        );
+      },
+    },
+  ];
+}
+
 /** Start the whole stack, tearing down anything already started if a later step fails. */
 export async function startStack(options: StartStackOptions = {}): Promise<GridEnvironment> {
   const { proxy = !!process.env.CI, seed = true } = options;
 
-  const started: StartedTestContainer[] = [];
   const startupTimeoutMs = Number(process.env.GRID_STARTUP_TIMEOUT_MS ?? 300_000);
+  const context: BootContext = { containers: [] };
 
-  let network: StartedNetwork | undefined;
-  let configDir: string | undefined;
+  const tasks: ListrTask<BootContext>[] = [
+    {
+      title: 'Create network',
+      task: async (ctx) => {
+        ctx.network = await new Network().start();
+      },
+    },
+    {
+      // These three share only the network, and Elasticsearch is by far the slowest to come
+      // up, so provisioning LocalStack costs nothing beyond it.
+      title: 'Start infrastructure',
+      task: (_, task) =>
+        task.newListr(
+          [
+            {
+              title: 'Elasticsearch',
+              task: async (ctx) => {
+                ctx.elasticsearch = await elasticsearchContainer(ctx.network!).start();
+                ctx.containers.push(ctx.elasticsearch);
+              },
+            },
+            {
+              // nginx resolves the `localstack` alias per request, so this need not wait for it.
+              title: 'imgops',
+              task: (_, imgopsTask) => {
+                let image: GenericContainer;
+
+                return imgopsTask.newListr(
+                  [
+                    {
+                      title: 'Build image',
+                      task: async () => {
+                        image = await GenericContainer.fromDockerfile(IMGOPS_CONTEXT).build(
+                          IMGOPS_IMAGE,
+                          { deleteOnExit: false },
+                        );
+                      },
+                    },
+                    {
+                      title: 'Start container',
+                      task: async (ctx) => {
+                        ctx.containers.push(await imgopsContainer(image, ctx.network!).start());
+                      },
+                    },
+                  ],
+                  // Subtasks inherit the concurrency of the group above, which these cannot use.
+                  { concurrent: false },
+                );
+              },
+            },
+            {
+              title: 'LocalStack',
+              task: (_, task) => task.newListr(localstackTasks(), { concurrent: false }),
+            },
+          ],
+          { concurrent: true },
+        ),
+    },
+    {
+      title: 'Generate service config',
+      task: (ctx) => {
+        // Reaching here means the probe found no live stack, so recreating the shared path is
+        // safe and clears anything a killed run left behind.
+        fs.rmSync(CONFIG_DIR, { recursive: true, force: true });
+        fs.mkdirSync(CONFIG_DIR, { recursive: true });
+        ctx.configDir = CONFIG_DIR;
+        ownedConfigDir = CONFIG_DIR;
+        generateServiceConfig(CONFIG_DIR, ctx.coreStackProps!);
+      },
+    },
+    {
+      title: 'Start Grid services',
+      task: (_, task) =>
+        task.newListr([
+          {
+            title: 'Start container',
+            task: async (ctx) => {
+              ctx.grid = await gridContainer(ctx.network!, ctx.configDir!, startupTimeoutMs).start();
+              ctx.containers.push(ctx.grid);
+            },
+          },
+          {
+            title: 'Wait for services',
+            task: (_, services) => {
+              const readiness: ListrTask<BootContext>[] = [
+                ...Object.entries(SERVICE_PORTS).map(([service, port]) => ({
+                  title: service,
+                  task: (_: BootContext, serviceTask: { output: string }) =>
+                    waitForHealthy(port, 'management/healthcheck', startupTimeoutMs, (message) => {
+                      serviceTask.output = message;
+                    }),
+                })),
+                {
+                  // Waits for the `Images_Current` alias the app assigns on startup, so this
+                  // only needs the container running, not every service healthy.
+                  title: 'Seed Elasticsearch',
+                  skip: () => !seed && 'seeding not requested',
+                  task: async (ctx, seedTask) => {
+                    const esBaseUrl = `http://${ctx.elasticsearch!.getHost()}:${ctx.elasticsearch!.getMappedPort(ELASTICSEARCH_PORT)}`;
+                    await seedElasticsearch(esBaseUrl, (message) => {
+                      seedTask.output = message;
+                    });
+                  },
+                },
+              ];
+
+              return services.newListr(readiness, { concurrent: true });
+            },
+          },
+        ]),
+    },
+    {
+      title: 'Start reverse proxy',
+      skip: () => !proxy && 'using dev-nginx',
+      task: async (ctx) => {
+        const caddy = await proxyContainer(ctx.network!, buildCaddyfile(ctx.coreStackProps!)).start();
+        ctx.containers.push(caddy);
+      },
+    },
+  ];
 
   try {
-    network = await new Network().start();
+    await runTasks(tasks, context);
 
-    // Infrastructure: Elasticsearch + LocalStack
-    const elasticsearch = await new GenericContainer(ELASTICSEARCH_IMAGE)
-      .withNetwork(network)
-      .withNetworkAliases(ELASTICSEARCH_ALIAS)
-      .withEnvironment({
-        'discovery.type': 'single-node',
-        'xpack.security.enabled': 'false',
-        ES_JAVA_OPTS: '-Xms1024m -Xmx1024m',
-      })
-      .withExposedPorts({ container: ELASTICSEARCH_PORT, host: ELASTICSEARCH_PORT })
-      .withWaitStrategy(
-        Wait.forHttp('/_cluster/health', ELASTICSEARCH_PORT).forStatusCodeMatching((code) => code < 300),
-      )
-      .withStartupTimeout(180_000)
-      .start();
-    started.push(elasticsearch);
-
-    const localstack = await new LocalstackContainer(LOCALSTACK_IMAGE)
-      .withNetwork(network)
-      .withNetworkAliases(LOCALSTACK_ALIAS)
-      // Pin to the fixed host port dev-nginx expects for the S3 vanity domains
-      // (images.media / public.media / localstack.media -> 4566).
-      .withExposedPorts({ container: LOCALSTACK_PORT, host: LOCALSTACK_PORT })
-      .withEnvironment({
-        SERVICES: LOCALSTACK_SERVICES,
-        DEFAULT_REGION: REGION,
-        KINESIS_ERROR_PROBABILITY: '0.0',
-        // Make resource URLs resolve via the network alias so the
-        // app container can reach them, and keep queue URLs path-style.
-        LOCALSTACK_HOST: `${LOCALSTACK_ALIAS}:${LOCALSTACK_PORT}`,
-        SQS_ENDPOINT_STRATEGY: 'path',
-      })
-      .withStartupTimeout(120_000)
-      .start();
-    started.push(localstack);
-
-    // imgops: standalone nginx image resizer, built from dev/imgops. Its nginx.conf proxies to
-    // the `localstack` alias on 4566, so it shares this network.
-    const imgopsImage = await GenericContainer.fromDockerfile(IMGOPS_CONTEXT).build(IMGOPS_IMAGE, {
-      deleteOnExit: false,
-    });
-    const imgops = await imgopsImage
-      .withNetwork(network)
-      .withNetworkAliases(IMGOPS_ALIAS)
-      .withCopyFilesToContainer([{ source: IMGOPS_NGINX_CONF, target: '/etc/nginx/nginx.conf' }])
-      .withExposedPorts({ container: 80, host: IMGOPS_PORT })
-      .withWaitStrategy(Wait.forHttp('/_', 80).forStatusCode(200))
-      .withStartupTimeout(120_000)
-      .start();
-    started.push(imgops);
-
-    // Provisioning + config generation
-    const coreStackProps = await provisionCoreStack(localstack.getConnectionUri());
-
-    // Reaching here means the probe found no live stack, so recreating the shared path is
-    // safe and clears anything a killed run left behind.
-    configDir = CONFIG_DIR;
-    fs.rmSync(configDir, { recursive: true, force: true });
-    fs.mkdirSync(configDir, { recursive: true });
-    ownedConfigDir = configDir;
-    generateServiceConfig(configDir, coreStackProps);
-
-    // All Grid services under test run inside this single container and talk to each
-    // other over its localhost. Each is published on the fixed host port its
-    // dev-nginx mapping expects (dev/nginx-mappings.yml), so the developer's
-    // dev-nginx routes the https://*.media.<domain> domains straight into this
-    // container.
-    let gridBuilder = new GenericContainer(GRID_IMAGE)
-      .withNetwork(network)
-      .withNetworkAliases(GRID_ALIAS)
-      .withExposedPorts(
-        ...Object.values(SERVICE_PORTS).map((port) => ({ container: port, host: port })),
-      )
-      .withBindMounts([
-        // DEV stage reads ~/.grid; /etc/grid is honoured for non-DEV stages. Mount both.
-        { source: configDir, target: '/root/.grid', mode: 'ro' },
-        { source: configDir, target: '/etc/grid', mode: 'ro' },
-        // Outside CI the grid-e2e-dev image runs services under sbt; mount the repo
-        // over /build so host edits recompile live.
-        ...(process.env.CI ? [] : [{ source: REPO_ROOT, target: '/build', mode: 'rw' as const }]),
-      ])
-      .withEnvironment({
-        AWS_ACCESS_KEY_ID: 'test',
-        AWS_SECRET_ACCESS_KEY: 'test',
-        AWS_REGION: REGION,
-        AWS_DEFAULT_REGION: REGION,
-        AWS_CBOR_DISABLE: 'true',
-      })
-      .withWaitStrategy(
-        Wait.forAll(Object.values(SERVICE_PORTS).map(port =>
-          Wait.forHttp('/management/healthcheck', port).forStatusCode(200),
-        ))
-      )
-      .withStartupTimeout(startupTimeoutMs);
-
-    if (process.env.GRID_DEBUG) {
-      const logStream = fs.createWriteStream(path.join(os.tmpdir(), 'grid-boot.log'));
-      gridBuilder = gridBuilder.withLogConsumer((stream) => {
-        stream.on('data', (line) => logStream.write(line));
-        stream.on('err', (line) => logStream.write(line));
-      });
-    }
-
-    const grid = await gridBuilder.start();
-    started.push(grid);
-
-    // Seed Elasticsearch with image fixtures
-    //
-    // The app creates the `images` index + `Images_Current` alias on startup; seed once the
-    // stack is healthy so searches during the tests return the fixture documents.
-    if (seed) {
-      const esBaseUrl = `http://${elasticsearch.getHost()}:${elasticsearch.getMappedPort(ELASTICSEARCH_PORT)}`;
-      await seedElasticsearch(esBaseUrl);
-    }
-
-    // CI routing: bundled reverse proxy
-    //
-    // Locally, the browser reaches the https://*.media.<domain> domains via the developer's
-    // dev-nginx. CI has no dev-nginx, so when running under CI (GitHub Actions sets CI=true)
-    // start a Caddy proxy that replays the same subdomain routing and terminates TLS with a
-    // self-signed cert, published on the standard https port the domains resolve to.
-    if (proxy) {
-      const caddy = await new GenericContainer(PROXY_IMAGE)
-        .withNetwork(network)
-        .withExposedPorts({ container: 443, host: 443 })
-        .withCopyContentToContainer([
-          { content: buildCaddyfile(coreStackProps), target: '/etc/caddy/Caddyfile' },
-        ])
-        .withWaitStrategy(Wait.forListeningPorts())
-        .withStartupTimeout(60_000)
-        .start();
-      started.push(caddy);
-    }
-
-    const host = grid.getHost();
-    const baseUrl = `http://${host}:${grid.getMappedPort(KAHUNA_PORT)}`;
-    const mediaApiUrl = `http://${host}:${grid.getMappedPort(MEDIA_API_PORT)}`;
-
-    fs.writeFileSync(URLS_FILE, JSON.stringify({ kahuna: baseUrl, mediaApi: mediaApiUrl }));
+    const host = context.grid!.getHost();
 
     return {
-      network,
-      containers: started,
-      configDir,
-      urlsFile: URLS_FILE,
-      baseUrl,
-      mediaApiUrl,
+      network: context.network,
+      containers: context.containers,
+      configDir: context.configDir,
+      baseUrl: `http://${host}:${context.grid!.getMappedPort(KAHUNA_PORT)}`,
+      mediaApiUrl: `http://${host}:${context.grid!.getMappedPort(MEDIA_API_PORT)}`,
     };
   } catch (error) {
     // Leave nothing running if we failed part-way through the boot.
-    await stopStack({ network, containers: started, configDir });
+    await stopStack(context);
     throw error;
-  }
-}
-
-/** Run a best-effort teardown step, warning (not throwing) so the rest still runs. */
-async function warnOnException(label: string, fn: () => unknown): Promise<void> {
-  try {
-    await fn();
-  } catch (error) {
-    console.warn(`${label}: ${(error as Error).message}`);
   }
 }
 
@@ -402,7 +584,21 @@ export async function ensureStack(options: StartStackOptions = {}): Promise<Grid
   // Nothing pre-exists in CI, and silently attaching there would undermine the run.
   const reuseAllowed = !process.env.CI;
 
-  const { state, healthy, ports } = await probeStack();
+  const probe: { result?: Awaited<ReturnType<typeof probeStack>> } = {};
+  await runTasks(
+    [
+      {
+        title: 'Look for a running Grid stack',
+        task: async (ctx, task) => {
+          ctx.result = await probeStack();
+          task.title = PROBE_OUTCOMES[ctx.result.state];
+        },
+      },
+    ],
+    probe,
+  );
+
+  const { state, healthy, ports } = probe.result!;
 
   if (state === 'partial') {
     const missing = ports.filter((port) => !healthy.includes(port));
@@ -433,22 +629,26 @@ async function attachToStack(options: StartStackOptions): Promise<GridEnvironmen
   const baseUrl = `http://localhost:${KAHUNA_PORT}`;
   const mediaApiUrl = `http://localhost:${MEDIA_API_PORT}`;
 
-  console.log(`Reusing the Grid stack already running on ${baseUrl}`);
-
   // Re-seeding is opt-in: whoever started the stack already seeded it, and the fixtures
   // are only reloaded on request because tests may have since changed the data.
-  if (options.seed === true || process.env.GRID_RESEED === 'true') {
-    await seedElasticsearch(`http://localhost:${ELASTICSEARCH_PORT}`);
-  }
+  const reseed = options.seed === true || process.env.GRID_RESEED === 'true';
 
-  // Only claim the URLs file if it is missing, so teardown never deletes another stack's.
-  let urlsFile: string | undefined;
-  if (!fs.existsSync(URLS_FILE)) {
-    fs.writeFileSync(URLS_FILE, JSON.stringify({ kahuna: baseUrl, mediaApi: mediaApiUrl }));
-    urlsFile = URLS_FILE;
-  }
+  await runTasks(
+    [
+      {
+        title: 'Seed Elasticsearch',
+        skip: () => !reseed && 'reseeding not requested',
+        task: async (_, task) => {
+          await seedElasticsearch(`http://localhost:${ELASTICSEARCH_PORT}`, (message) => {
+            task.output = message;
+          });
+        },
+      },
+    ],
+    {},
+  );
 
-  return { containers: [], urlsFile, baseUrl, mediaApiUrl };
+  return { containers: [], baseUrl, mediaApiUrl };
 }
 
 /** Stop what this process started and delete what it wrote; anything else is left alone. */
@@ -457,22 +657,34 @@ export async function stopStack(environment: StoppableStack | undefined): Promis
     return;
   }
 
-  const { containers, network, configDir, urlsFile } = environment;
+  const { containers, network, configDir } = environment;
 
-  for (const container of [...containers].reverse()) {
-    await warnOnException('Failed to stop container', () => container.stop());
+  const tasks: ListrTask<object>[] = [
+    // Reverse start order, so nothing is stopped before whatever depends on it.
+    ...[...containers].reverse().map((container) => ({
+      title: `Stop ${container.getLabels()[ROLE_LABEL] ?? container.getName()}`,
+      task: async () => {
+        await container.stop();
+      },
+    })),
+    ...(network ? [{ title: 'Remove network', task: () => network.stop() }] : []),
+    ...(configDir
+      ? [
+          {
+            title: 'Remove generated config',
+            task: () => {
+              fs.rmSync(configDir, { recursive: true, force: true });
+              ownedConfigDir = undefined;
+            },
+          },
+        ]
+      : []),
+  ];
+
+  if (tasks.length === 0) {
+    return;
   }
 
-  if (network) {
-    await warnOnException('Failed to stop network', () => network.stop());
-  }
-  if (configDir) {
-    await warnOnException('Failed to remove config dir', () =>
-      fs.rmSync(configDir, { recursive: true, force: true }),
-    );
-    ownedConfigDir = undefined;
-  }
-  if (urlsFile) {
-    await warnOnException('Failed to remove urls file', () => fs.rmSync(urlsFile, { force: true }));
-  }
+  // Every step is best-effort: a failure is reported against its task and the rest still run.
+  await runTasks(tasks, {}, { exitOnError: false });
 }

--- a/e2e-tests/setup/stack.ts
+++ b/e2e-tests/setup/stack.ts
@@ -13,7 +13,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { LocalstackContainer } from '@testcontainers/localstack';
-import type { StartedLocalStackContainer } from '@testcontainers/localstack';
 import { GenericContainer, Network, Wait } from 'testcontainers';
 import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
 import {
@@ -40,7 +39,7 @@ import {
   SERVICE_PORTS,
 } from './constants.ts';
 import { generateServiceConfig } from './config.ts';
-import { runTasks } from './progress.ts';
+import { reportTo, runTasks } from './progress.ts';
 import type { ListrTask } from './progress.ts';
 import {
   createCoreStack,
@@ -104,7 +103,6 @@ interface StoppableStack {
 
 /** What the boot tasks build up. Each task mutates it in place for the ones that follow. */
 interface BootContext extends StoppableStack {
-  localstack?: StartedLocalStackContainer;
   coreStackProps?: StackProps;
 }
 
@@ -491,9 +489,7 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
                 ...Object.entries(SERVICE_PORTS).map(([service, port]): { title: string, task: ListrTaskFn<BootContext, any, any> } => ({
                   title: service,
                   task: (_, serviceTask) =>
-                    waitForHealthy(port, 'management/healthcheck', startupTimeoutMs, (message) => {
-                      serviceTask.output = message;
-                    }),
+                    waitForHealthy(port, 'management/healthcheck', startupTimeoutMs, reportTo(serviceTask)),
                 })),
                 {
                   // Waits for the `Images_Current` alias the app assigns on startup, so this
@@ -501,9 +497,7 @@ export async function startStack(options: StartStackOptions = {}): Promise<GridE
                   title: 'Seed Elasticsearch',
                   skip: () => !seed && 'seeding not requested',
                   task: async (_, seedTask) => {
-                    await seedElasticsearch(ELASTICSEARCH_URL, (message) => {
-                      seedTask.output = message;
-                    });
+                    await seedElasticsearch(ELASTICSEARCH_URL, reportTo(seedTask));
                   },
                 },
               ];
@@ -638,9 +632,7 @@ async function attachToStack(options: StartStackOptions): Promise<GridEnvironmen
         title: 'Seed Elasticsearch',
         skip: () => !reseed && 'reseeding not requested',
         task: async (_, task) => {
-          await seedElasticsearch(ELASTICSEARCH_URL, (message) => {
-            task.output = message;
-          });
+          await seedElasticsearch(ELASTICSEARCH_URL, reportTo(task));
         },
       },
     ],

--- a/e2e-tests/setup/state.ts
+++ b/e2e-tests/setup/state.ts
@@ -18,8 +18,6 @@ export interface GridEnvironment {
   containers: StartedTestContainer[];
   /** Absolute path to the generated config directory mounted into the app container. */
   configDir?: string;
-  /** Set only when this process wrote the URLs file, so teardown does not delete another stack's. */
-  urlsFile?: string;
   /** Base URL of the Kahuna UI, e.g. http://localhost:9005 */
   baseUrl: string;
   /** Base URL of the media-api, e.g. http://localhost:9001 */

--- a/e2e-tests/steps/fixtures.ts
+++ b/e2e-tests/steps/fixtures.ts
@@ -1,21 +1,9 @@
 import { expect } from '@playwright/test';
 import type { APIResponse, Response } from '@playwright/test';
 import { test as base, createBdd } from 'playwright-bdd';
-import * as fs from 'fs';
-import { DOMAIN, URLS_FILE } from '../setup/constants.ts';
-
-interface GridUrls {
-  /** Kahuna base URL on its fixed host port (for API-level `request` tests). */
-  kahuna: string;
-  /** media-api base URL on its fixed host port (for API-level `request` tests). */
-  mediaApi: string;
-}
+import { DOMAIN } from '../setup/constants.ts';
 
 export const KAHUNA_APP_URL = `https://media.${DOMAIN}`;
-
-function readGridUrls(): GridUrls {
-  return JSON.parse(fs.readFileSync(URLS_FILE, 'utf8')) as GridUrls;
-}
 
 /**
  * Mutable per-scenario state shared between steps (e.g. the response captured in a
@@ -27,18 +15,11 @@ interface TestContext {
 }
 
 /**
- * Test fixture that exposes the Grid service URLs resolved by `global-setup.ts` and
- * points `baseURL` at Kahuna's fixed host port for API-level `request` tests. Browser
- * steps should navigate to `KAHUNA_APP_URL` so the page origin is a real Grid domain
- * (required for the services' CORS origins to match).
+ * Browser steps should navigate to `KAHUNA_APP_URL` so the page origin is a real Grid
+ * domain (required for the services' CORS origins to match). API-level `request` tests
+ * use `baseURL` from the Playwright config, which points at Kahuna's fixed host port.
  */
-export const test = base.extend<{ gridUrls: GridUrls; testContext: TestContext }>({
-  gridUrls: async ({}, use) => {
-    await use(readGridUrls());
-  },
-  baseURL: async ({}, use) => {
-    await use(readGridUrls().kahuna);
-  },
+export const test = base.extend<{ testContext: TestContext }>({
   testContext: async ({}, use) => {
     await use({});
   },


### PR DESCRIPTION
_co-authored-by: Claude, but the PR description is mine._

## What does this change?

Adds a terminal UI for e2e-test startup, and optimises startup tasks. As a dev, you can see exactly what's happening, and the startup time is improved from ~1m locally to about 35s, and from ~7m to 6m 45s in CI, largely because of an optimisation that ensures we don't wait for a default length of time when the cloudformation stack is being provisioned.

It looks like:

<img width="918" height="576" alt="task-list" src="https://github.com/user-attachments/assets/90da4510-5cf6-4952-b8d8-6416b9d5159a" />

I chose listr2 b/c the task-based nature of the output needed something more comprehensive than e.g. ora, which I've used elsewhere. It required a reasonable-sized refactor to express each task discretely, but I can't think of another way to do this that doesn't involve encapsulation of this sort without lots of mutable state, so this made sense to me 👍 

## How should a reviewer test this change?

Run the full gamut of options: 
- `npm run dev:e2e` and then `npm test` or `npm test:ui`,
- `npm test`
- `npm test:ui` (the output appears in the UI, correctly formatted 🎉 )

<img width="776" height="324" alt="Screenshot 2026-09-07 at 14 06 31" src="https://github.com/user-attachments/assets/7ad40cf5-a59b-4305-9ff5-5f2d4f95ba32" />

All should work as expected.

## How can success be measured?

Faster test startup, and a clearer sense of task progress.
