### PR TITLE
Fix collection modal overlay z-index

### DIFF
--- a/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.css
+++ b/kahuna/public/js/components/gr-collection-overlay/gr-collection-overlay.css
@@ -5,7 +5,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 40;
+    z-index: 200;
 }
 
 .collection-overlay__button:hover {


### PR DESCRIPTION
## What does this change?

As in title - bring up collection modal overlay z-index so it shows on top of the tooltip triangle



Before: 
<img width="1212" height="599" alt="Screenshot 2026-09-07 at 13 52 29" src="https://github.com/user-attachments/assets/74ef4780-dcbc-4f15-8bb2-03a4472062a3" />


After:
<img width="1332" height="308" alt="Screenshot 2026-09-07 at 14 37 12" src="https://github.com/user-attachments/assets/85425643-b2d4-4589-9513-2c9a927554ca" />



## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
