### PR TITLE
Support matching via existence in ES for field aliases

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/config/FieldAlias.scala
@@ -10,7 +10,15 @@ case class FieldAlias(elasticsearchPath: String,
                       displayInAdditionalMetadata: Boolean,
                       displaySearchHint: Boolean,
                       alias: String,
-                      searchHintOptions: List[String])
+                      searchHintOptions: List[String],
+                      // Some fields are only ever indexed when "true" (e.g. a field that is present
+                      // only to support `has:`/`-has:` queries, such as fileMetadata.c2pa.isAvailable).
+                      // For these fields a literal `alias:false` term query can never match, since "false"
+                      // is never actually indexed - it is only ever implied by the field's absence.
+                      // Setting this flag translates `alias:true`/`alias:false` search queries into
+                      // exists/not-exists queries instead of literal term matches, so both values behave
+                      // intuitively for users (e.g. via a searchHintOptions dropdown of "true"/"false").
+                      matchViaExistence: Boolean = false)
 
 object FieldAlias {
   implicit val FieldAliasWrites: Writes[FieldAlias] =
@@ -26,6 +34,8 @@ object FieldAlias {
             config.getBoolean("displaySearchHint") else false
           val searchHintOptions = if (config.hasPath("searchHintOptions"))
             config.getStringList("searchHintOptions").asScala.toList.filter(_.nonEmpty) else List.empty
+          val matchViaExistence = if (config.hasPath("matchViaExistence"))
+            config.getBoolean("matchViaExistence") else false
 
           FieldAlias(
             config.getString("elasticsearchPath"),
@@ -33,7 +43,8 @@ object FieldAlias {
             displayInAdditionalMetadata,
             displaySearchHint,
             config.getString("alias"),
-            searchHintOptions
+            searchHintOptions,
+            matchViaExistence
           )
         }
       ).toSeq

--- a/kahuna/public/js/search/query-filter.spec.js
+++ b/kahuna/public/js/search/query-filter.spec.js
@@ -1,0 +1,46 @@
+// query-filter.js registers itself as an Angular module as a side effect of import
+// (`angular.module(...)`), which needs a real DOM/angular runtime to succeed. Since
+// fieldFilter/maybeQuoted are plain functions with no Angular dependency, stub out
+// angular.module here so the module can be imported in isolation under Jest.
+jest.mock('angular', () => {
+  const chainableModule = {
+    factory: () => chainableModule,
+    filter: () => chainableModule
+  };
+  return { __esModule: true, default: { module: () => chainableModule } };
+});
+
+import { fieldFilter, maybeQuoted } from './query-filter';
+
+describe('maybeQuoted', () => {
+  it("leaves a value without reserved characters untouched", () => {
+    expect(maybeQuoted('true')).toBe('true');
+  });
+
+  it("wraps a value containing whitespace in quotes", () => {
+    expect(maybeQuoted('some value')).toBe('"some value"');
+  });
+
+  it("wraps a value containing a colon in quotes", () => {
+    expect(maybeQuoted('a:b')).toBe('"a:b"');
+  });
+});
+
+describe('fieldFilter', () => {
+  it("builds a simple field:value filter for a plain string value", () => {
+    expect(fieldFilter('credit', 'Getty Images')).toBe('credit:"Getty Images"');
+  });
+
+  it("quotes the field name too, if it contains reserved characters", () => {
+    expect(fieldFilter('some field', 'value')).toBe('"some field":value');
+  });
+
+  it("strips double quotes already present in the value before re-quoting", () => {
+    expect(fieldFilter('credit', '"Getty Images"')).toBe('credit:"Getty Images"');
+  });
+
+  it("builds a correct field:value filter when the value is a boolean, not a string", () => {
+    expect(fieldFilter('c2paMetadataAvailable', true)).toBe('c2paMetadataAvailable:true');
+    expect(fieldFilter('c2paMetadataAvailable', false)).toBe('c2paMetadataAvailable:false');
+  });
+});

--- a/media-api/app/lib/ImageResponse.scala
+++ b/media-api/app/lib/ImageResponse.scala
@@ -428,8 +428,10 @@ object ImageResponse {
     config.fieldAliasConfigs.flatMap { config =>
       val parts = config.elasticsearchPath.split('.').toList.filter(_.nonEmpty)
       val lookupResult = nestedLookup(JsDefined(source.source), parts)
-      lookupResult.toOption.map {
-        config.alias -> _
+      lookupResult.toOption match {
+        case Some(value) => Some(config.alias -> value)
+        case None if config.matchViaExistence => Some(config.alias -> JsBoolean(false))
+        case None => None
       }
     }
   }

--- a/media-api/app/lib/elasticsearch/QueryBuilder.scala
+++ b/media-api/app/lib/elasticsearch/QueryBuilder.scala
@@ -17,11 +17,25 @@ import scalaz.syntax.std.list._
 
 class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agency], config: MediaApiConfig) extends ImageFields with GridLogging {
 
-  def resolveFieldPath(field: String): String = {
-    config.fieldAliasConfigs.find(_.alias == field) match {
-      case Some(x) => x.elasticsearchPath
-      case None => getFieldPath(field)
-    }
+  // Users can search by either the friendly alias (e.g. "c2paMetadataAvailable") or the underlying
+  // Elasticsearch path it resolves to (e.g. "fileMetadata.c2pa.isAvailable"), so field alias configs
+  // are looked up by whichever of the two was typed.
+  private def findFieldAliasConfig(field: String) =
+    config.fieldAliasConfigs.find(fieldAlias => fieldAlias.alias == field || fieldAlias.elasticsearchPath == field)
+
+  def resolveFieldPath(field: String): String =
+    findFieldAliasConfig(field).map(_.elasticsearchPath).getOrElse(getFieldPath(field))
+
+  private def isMatchViaExistence(field: String): Boolean =
+    findFieldAliasConfig(field).exists(_.matchViaExistence)
+
+  private def isBooleanPhrase(value: String): Boolean =
+    value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")
+
+  private def booleanValueOf(value: Value): String = value match {
+    case Words(v) => v
+    case Phrase(v) => v
+    case _ => ""
   }
 
   // For some sad reason, there was no helpful alias for this in the ES library
@@ -52,6 +66,12 @@ class QueryBuilder(matchFields: Seq[String], overQuotaAgencies: () => List[Agenc
     case AnyField => makeMultiQuery(condition.value, matchFields)
     case MultipleField(fields) => makeMultiQuery(condition.value, fields)
     case SingleField(field) => condition.value match {
+      // Some fields are only ever indexed when true (see FieldAlias.matchViaExistence) - for these,
+      // translate a literal true/false value query into an exists/not-exists query so both values
+      // behave intuitively, rather than a literal term match (which could never match "false").
+      case v @ (Words(_) | Phrase(_)) if isMatchViaExistence(field) && isBooleanPhrase(booleanValueOf(v)) =>
+        val existsQ = boolQuery().filter(existsQuery(resolveFieldPath(field)))
+        if (booleanValueOf(v).equalsIgnoreCase("true")) existsQ else boolQuery().not(existsQ)
       // Force AND operator else it will only require *any* of the words, not *all*
       case Words(value) =>
         matchQuery(resolveFieldPath(field), value).operator(Operator.AND)

--- a/media-api/test/lib/ImageResponseTest.scala
+++ b/media-api/test/lib/ImageResponseTest.scala
@@ -35,6 +35,13 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
           "alias" -> "captionWriter",
           "label" -> "Caption Writer / Editor",
           "displaySearchHint" -> true
+        ),
+        Map(
+          "elasticsearchPath" -> "fileMetadata.c2pa.isAvailable",
+          "alias" -> "c2paMetadataAvailable",
+          "label" -> "C2PA Metadata Available",
+          "displaySearchHint" -> true,
+          "matchViaExistence" -> true
         )
       )
     ) ++ MOCK_CONFIG_KEYS.map(_ -> NOT_USED_IN_TEST).toMap),
@@ -114,14 +121,17 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
     val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
 
     extractedFields.nonEmpty shouldEqual true
-    extractedFields should have length 3
+    // 3 regular fields plus c2paMetadataAvailable, which is always present for matchViaExistence
+    // fields (as an explicit `false` here, since this image has no c2pa data - see below)
+    extractedFields should have length 4
 
     extractedFields.contains("orgProgrammeMaker" -> JsString("xmp programme maker")) shouldEqual true
     extractedFields.contains("auxLens" -> JsString("xmp aux lens")) shouldEqual true
     extractedFields.contains("captionWriter" -> JsString("the editor")) shouldEqual true
+    extractedFields.contains("c2paMetadataAvailable" -> JsBoolean(false)) shouldEqual true
   }
 
-  it("should return empty set of extract configured alias fields from sourcewrapper if fields do not exist in image") {
+  it("should return only the matchViaExistence alias fields (as false) if no other configured alias fields exist in image") {
     val image = createImage(
       id = "test-image-with-no-filemetadata",
       agency,
@@ -132,6 +142,34 @@ class ImageResponseTest extends AnyFunSpec with Matchers with Fixtures {
 
     val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
 
-    extractedFields.isEmpty shouldEqual true
+    extractedFields shouldEqual Seq("c2paMetadataAvailable" -> JsBoolean(false))
+  }
+
+  it("should extract a matchViaExistence alias field as true when the underlying field is present") {
+    val image = createImage(
+      id = "test-image-with-c2pa",
+      agency,
+      fileMetadata = Some(FileMetadata(c2pa = FileMetadata.C2paAvailable))
+    )
+    val json = Json.toJson(image)
+    val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
+
+    val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
+
+    extractedFields.contains("c2paMetadataAvailable" -> JsBoolean(true)) shouldEqual true
+  }
+
+  it("should extract a matchViaExistence alias field as false, rather than omitting it, when the underlying field is absent") {
+    val image = createImage(
+      id = "test-image-without-c2pa",
+      agency,
+      fileMetadata = Some(FileMetadata(c2pa = FileMetadata.NoC2PA))
+    )
+    val json = Json.toJson(image)
+    val sourceWrapper = SourceWrapper[Image](json, image, fromIndex="test_index")
+
+    val extractedFields = ImageResponse.extractAliasFieldValues(mediaApiConfig, sourceWrapper)
+
+    extractedFields.contains("c2paMetadataAvailable" -> JsBoolean(false)) shouldEqual true
   }
 }

--- a/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
+++ b/media-api/test/lib/elasticsearch/QueryBuilderTest.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.Operator
 import com.sksamuel.elastic4s.requests.searches.queries._
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{MatchPhraseQuery, MatchQuery, MultiMatchQuery, MultiMatchQueryBuilderType}
-import lib.querysyntax.Negation
+import lib.querysyntax.{Match, Negation, Phrase, SingleField}
 import com.gu.mediaservice.lib.config.GridConfigResources
 import com.sksamuel.elastic4s.handlers.searches.queries.QueryBuilderFn
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
@@ -180,6 +180,93 @@ class QueryBuilderTest extends AnyFunSpec with Matchers with ConditionFixtures w
       val query = queryBuilder.makeQuery(List(nestedCondition, anotherNestedCondition)).asInstanceOf[BoolQuery]
 
       query.must.size shouldBe 2
+    }
+  }
+
+  describe("field alias matchViaExistence queries") {
+    // e.g. `fileMetadata.c2pa.isAvailable` is only ever indexed as `true`, so `:true`/`:false` are
+    // translated into exists/not-exists queries rather than literal term matches (see FieldAlias.matchViaExistence).
+    val c2paFieldAliasConfig = Map(
+      "elasticsearchPath" -> "fileMetadata.c2pa.isAvailable",
+      "alias" -> "c2paMetadataAvailable",
+      "label" -> "C2PA Metadata Available",
+      "matchViaExistence" -> true
+    )
+    val configWithC2paAlias = new MediaApiConfig(GridConfigResources(
+      Configuration.from(commonConfigurations ++ Map("field.aliases" -> Seq(c2paFieldAliasConfig))),
+      null,
+      new ApplicationLifecycle {
+        override def addStopHook(hook: () => Future[_]): Unit = {}
+        override def stop(): Future[_] = Future.successful(())
+      }
+    ))
+    val queryBuilderWithC2paAlias = new QueryBuilder(matchFields, () => Nil, configWithC2paAlias)
+
+    def existsClauseOf(query: Query): ExistsQuery =
+      query.asInstanceOf[BoolQuery].filters.head.asInstanceOf[ExistsQuery]
+
+    it("alias:true is expressed as an exists query on the underlying elasticsearch path") {
+      val condition = Match(SingleField("c2paMetadataAvailable"), Phrase("true"))
+      val query = queryBuilderWithC2paAlias.makeQuery(List(condition)).asInstanceOf[BoolQuery]
+
+      val existsClause = existsClauseOf(query.must.head)
+      existsClause.field shouldBe "fileMetadata.c2pa.isAvailable"
+    }
+
+    it("alias:false is expressed as a not-exists query on the underlying elasticsearch path") {
+      val condition = Match(SingleField("c2paMetadataAvailable"), Phrase("false"))
+      val query = queryBuilderWithC2paAlias.makeQuery(List(condition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+      val notClause = query.must.head.asInstanceOf[BoolQuery]
+      val existsClause = existsClauseOf(notClause.not.head)
+      existsClause.field shouldBe "fileMetadata.c2pa.isAvailable"
+    }
+
+    it("the underlying elasticsearch path:true also resolves to the same exists query as the alias") {
+      val condition = Match(SingleField("fileMetadata.c2pa.isAvailable"), Phrase("true"))
+      val query = queryBuilderWithC2paAlias.makeQuery(List(condition)).asInstanceOf[BoolQuery]
+
+      val existsClause = existsClauseOf(query.must.head)
+      existsClause.field shouldBe "fileMetadata.c2pa.isAvailable"
+    }
+
+    it("the underlying elasticsearch path:false also resolves to the same not-exists query as the alias") {
+      val condition = Match(SingleField("fileMetadata.c2pa.isAvailable"), Phrase("false"))
+      val query = queryBuilderWithC2paAlias.makeQuery(List(condition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+      val notClause = query.must.head.asInstanceOf[BoolQuery]
+      val existsClause = existsClauseOf(notClause.not.head)
+      existsClause.field shouldBe "fileMetadata.c2pa.isAvailable"
+    }
+
+    it("boolean values are matched case-insensitively, e.g. alias:TRUE and alias:False") {
+      val trueQuery = queryBuilderWithC2paAlias.makeQuery(
+        List(Match(SingleField("c2paMetadataAvailable"), Phrase("TRUE")))
+      ).asInstanceOf[BoolQuery]
+      existsClauseOf(trueQuery.must.head).field shouldBe "fileMetadata.c2pa.isAvailable"
+
+      val falseQuery = queryBuilderWithC2paAlias.makeQuery(
+        List(Match(SingleField("c2paMetadataAvailable"), Phrase("False")))
+      ).asInstanceOf[BoolQuery]
+      falseQuery.must.size shouldBe 1
+      val notClause = falseQuery.must.head.asInstanceOf[BoolQuery]
+      existsClauseOf(notClause.not.head).field shouldBe "fileMetadata.c2pa.isAvailable"
+    }
+
+    it("a non-boolean value on a matchViaExistence field falls back to a literal phrase match, not an exists query") {
+      val condition = Match(SingleField("c2paMetadataAvailable"), Phrase("maybe"))
+      val query = queryBuilderWithC2paAlias.makeQuery(List(condition)).asInstanceOf[BoolQuery]
+
+      query.must.size shouldBe 1
+      val phraseClause = query.must.head.asInstanceOf[MatchPhraseQuery]
+      phraseClause.field shouldBe "fileMetadata.c2pa.isAvailable"
+      phraseClause.value shouldBe "maybe"
+    }
+
+    it("fields with no matching alias or elasticsearch path still fall back to getFieldPath, unaffected by the new lookup") {
+      queryBuilderWithC2paAlias.resolveFieldPath("someUnrelatedField") shouldBe "someUnrelatedField"
     }
   }
 


### PR DESCRIPTION
## What does this change?

Some indexed fields are only ever written when a condition is `true`  — e.g.  `fileMetadata.c2pa.isAvailable` is only present at all when C2PA metadata was detected on an image (for reasoning, see https://github.com/guardian/grid/pull/4914); there's no explicit `false`. Users are given a  `true / false` search-hint dropdown for these fields (e.g.  `c2paMetadataAvailable:true / :false` ), but a literal  `:false` term query could never match anything, since  `false` is never actually indexed — it's only ever implied by the field being absent. That made  `:false` misleadingly return zero results instead of "all images without this field".

To address this:
* Added a  `matchViaExistence`  flag to `FieldAlias`, settable in  `common.conf`. When set:
  * `alias:true`  → rewritten as an exists query on the field's underlying Elasticsearch path
  * `alias:false`  → rewritten as a not-exists query ( bool.must_not(exists) )
* This is handled in `QueryBuilder.makeQueryBit`, which checks `isMatchViaExistence`  and, for boolean-looking phrase/word values on such fields, builds the `exists/not-exists` query instead of the normal literal  `matchQuery`/ `matchPhraseQuery`. Non-boolean values on the same field still fall through to a normal literal match.
* Also extended field lookup ( `resolveFieldPath / isMatchViaExistence` ) so a search can use either the friendly alias (e.g. `c2paMetadataAvailable`) or the raw Elasticsearch path (`fileMetadata.c2pa.isAvailable`) interchangeably — previously only the alias worked.


## How should a reviewer test this change?

* In your local `~/.grid/common.conf`, add:
```
field.aliases = [
  {
    elasticsearchPath = "fileMetadata.c2pa.isAvailable"
    alias = "c2paMetadataAvailable"
    label = "C2PA Metadata Available"
    displaySearchHint = true
    displayInAdditionalMetadata = true
    searchHintOptions = [ "true", "false" ]
    matchViaExistence = true
  }
]
```
* Start up the Grid locally
* You should now be able to search with: `c2paMetadataAvailable: false` and `+fileMetadata.c2pa.isAvailable:false`

<img width="1110" height="572" alt="false search" src="https://github.com/user-attachments/assets/29c7ac6f-4170-48a5-a235-2a5a3fa69e6f" />
<img width="1110" height="572" alt="false search 2" src="https://github.com/user-attachments/assets/dfed56f4-516b-49aa-807e-09f69e639379" />




## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218249327946580