### PR TITLE
Make expandable image metadata group arrows consistent with usages and collections

### DIFF
--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.css
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.css
@@ -12,3 +12,6 @@
     justify-content: flex-start;
 }
 
+.gr-display-crops + dd {
+    width: 100%;
+}

--- a/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
+++ b/kahuna/public/js/components/gr-display-crops/gr-display-crops.html
@@ -1,10 +1,10 @@
 <div class="image-info">
-    <dl class="image-info__group image-info__wrap" ng-if="ctrl.crops.length > 0">
+    <dl class="image-info__group image-info__wrap image-info__group--expandable" ng-if="ctrl.crops.length > 0">
         <div class="gr-display-crops">
             <button class="gr-display-crops"
                     ng-click="ctrl.showCrops = !ctrl.showCrops">
-                <span ng-hide="ctrl.showCrops">▸ Show</span>
-                <span ng-show="ctrl.showCrops">▾ Hide</span>
+                <span ng-hide="ctrl.showCrops"><gr-icon>chevron_right</gr-icon> Show</span>
+                <span ng-show="ctrl.showCrops"><gr-icon>expand_more</gr-icon> Hide</span>
                 crops
             </button>
         </div>

--- a/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
+++ b/kahuna/public/js/components/gr-image-metadata/gr-image-metadata.html
@@ -735,12 +735,12 @@
     </dl>
     </div>
 
-    <div ng-if="ctrl.singleImage && !ctrl.isAdditionalMetadataEmpty()" class="image-info__group image-info__group--full-metadata" role="region" aria-label="Additional metadata">
+    <div ng-if="ctrl.singleImage && !ctrl.isAdditionalMetadataEmpty()" class="image-info__group image-info__group--full-metadata image-info__group--expandable" role="region" aria-label="Additional metadata">
         <button class="metadata-reveal"
                 ng-click="ctrl.showMetadataSection('additionalMetadata')"
                 aria-label="{{ctrl.isMetadataSectionHidden('additionalMetadata') ? 'Show' : 'Hide'}} additional metadata section">
-            <span ng-show="ctrl.isMetadataSectionHidden('additionalMetadata')">▸ Show</span>
-            <span ng-hide="ctrl.isMetadataSectionHidden('additionalMetadata')">▾ Hide</span>
+            <span ng-show="ctrl.isMetadataSectionHidden('additionalMetadata')"><gr-icon>chevron_right</gr-icon> Show</span>
+            <span ng-hide="ctrl.isMetadataSectionHidden('additionalMetadata')"><gr-icon>expand_more</gr-icon> Hide</span>
             additional metadata
         </button>
 

--- a/kahuna/public/stylesheets/main.css
+++ b/kahuna/public/stylesheets/main.css
@@ -2202,6 +2202,13 @@ FIXME: what to do with touch devices
     position: relative;
 }
 
+.image-info__group--expandable {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+}
+
 .image-info__title {
     color: #eee;
 }


### PR DESCRIPTION
## What does this change?

* Use the same chevron for expandable image metadata group as usages and collections
* Fix lack of padding between group title and group content

<img width="295" height="520" alt="Screenshot 2026-09-10 at 12 37 27" src="https://github.com/user-attachments/assets/f254cdff-94df-489c-937f-87145fea5a0e" />



## Tested? Documented?
- [x] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
