### PR TITLE
Use a date time parser for checking dates

### DIFF
--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/DateTimeUtils.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/DateTimeUtils.scala
@@ -3,8 +3,10 @@ package com.gu.mediaservice.lib
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
 import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
 
 import java.time.temporal.ChronoUnit
+import java.util.Locale
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scala.util.Try
 
@@ -29,4 +31,35 @@ object DateTimeUtils {
       nowRoundedDownToTheHour plusSeconds (interval mul numberOfIntervals).toSeconds
     ).millis
   }
+}
+
+object PartialDate {
+  private val formats = List(
+    ("d MMMM, yyyy", true),
+    ("d MMM, yyyy", true),
+    ("d MMMM yyyy", true),
+    ("d MMM yyyy", true),
+    ("d MMMM", false),
+    ("d MMM", false)
+  ).map { case (pattern, hasYear) =>
+    DateTimeFormat.forPattern(pattern).withLocale(Locale.ENGLISH) -> hasYear
+  }
+
+  def parse(value: String): Option[PartialDate] =
+    formats.view.flatMap { case (formatter, hasYear) =>
+      Try(formatter.parseDateTime(value.trim)).toOption.map { date =>
+        PartialDate(
+          day = date.getDayOfMonth,
+          month = date.getMonthOfYear,
+          year = Option.when(hasYear)(date.getYear)
+        )
+      }
+    }.headOption
+}
+
+case class PartialDate(day: Int, month: Int, year: Option[Int]) {
+  def matches(timestamp: DateTime): Boolean =
+    Math.abs(timestamp.getDayOfMonth - day) <= 1 &&
+      timestamp.getMonthOfYear == month &&
+      year.forall(_ == timestamp.getYear)
 }

--- a/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
+++ b/common-lib/src/main/scala/com/gu/mediaservice/lib/cleanup/SupplierProcessors.scala
@@ -1,5 +1,6 @@
 package com.gu.mediaservice.lib.cleanup
 
+import com.gu.mediaservice.lib.PartialDate
 import com.gu.mediaservice.lib.config.UsageRightsConfigProvider
 import com.gu.mediaservice.lib.metadata.UsageRightsMetadataMapper
 import com.gu.mediaservice.model._
@@ -379,15 +380,6 @@ object GettyXmpParser extends ImageProcessor {
   // Matches: "LOC1, LOC2 - MONTH DAY:" or "LOC1, LOC2 - MONTH DAY, YEAR:" or "LOC1, LOC2 - MON DAY, YEAR - "
   private val LocationDatePrefix = """(?i)^([^,]+),\s+(.+?)\s+-\s+([A-Za-z]+)\s+(\d{1,2})(?:,\s*(\d{4}))?\s*(?:\:\s*|-\s+)(.*)$""".r
 
-  private val monthNumbers: Map[String, Int] = Map(
-    "january" -> 1, "jan" -> 1, "february" -> 2, "feb" -> 2,
-    "march" -> 3, "mar" -> 3, "april" -> 4, "apr" -> 4,
-    "may" -> 5, "june" -> 6, "jun" -> 6, "july" -> 7, "jul" -> 7,
-    "august" -> 8, "aug" -> 8, "september" -> 9, "sep" -> 9, "sept" -> 9,
-    "october" -> 10, "oct" -> 10, "november" -> 11, "nov" -> 11,
-    "december" -> 12, "dec" -> 12
-  )
-
   /**
     * Remove the leading "LOCATION1, LOCATION2 - MONTH DAY[, YEAR](:|−) " prefix from the description
     * when at least one of the two location parts matches any location metadata field (case-insensitive)
@@ -405,17 +397,8 @@ object GettyXmpParser extends ImageProcessor {
         caseInsensitiveExists(locationFields, loc2)
     }
 
-  private def doesDateMatch(dateTaken: Option[DateTime], monthStr: String, day: Int, yearOpt: Option[Int]): Boolean = {
-    (for {
-      dt <- dateTaken
-      month <- monthNumbers.get(monthStr)
-    } yield {
-      // Allow ±1 day for timezone differences, but only within the same month
-      val monthMatch = dt.getMonthOfYear == month
-      val dayMatch = Math.abs(dt.getDayOfMonth - day) <= 1
-      val yearMatch = yearOpt.forall(_ == dt.getYear)
-      monthMatch && dayMatch && yearMatch
-    }).getOrElse(false)
+  private def doesDateMatch(dateTaken: Option[DateTime], partialDate: Option[PartialDate]): Boolean = {
+    dateTaken.exists(dt => partialDate.exists(pd => pd.matches(dt)))
   }
 
   private def prefixLocationToRetain(locationFields: List[String], loc1: String) = {
@@ -434,14 +417,11 @@ object GettyXmpParser extends ImageProcessor {
       case LocationDatePrefix(location1, location2, month, dayOfMonth, year, rest) =>
         val loc1 = location1.trim
         val loc2 = location2.trim
-        val monthStr = month.toLowerCase
-        val day = dayOfMonth.toInt
         val locationFields = List(metadata.subLocation, metadata.city, metadata.state, metadata.country).flatten
-        val yearOpt = Option(year).map(_.toInt)
         for {
-          day <- Option(day)
+          _ <- Option(dayOfMonth)
           if doesLocalMatch(locationFields, loc1, loc2)
-          if doesDateMatch(metadata.dateTaken, monthStr, day, yearOpt)
+          if doesDateMatch(metadata.dateTaken, PartialDate.parse(s"$dayOfMonth $month ${Option(year).getOrElse("")}"))
         } yield {
           prefixLocationToRetain(locationFields, loc1)
             .map(prefix => s"$prefix $rest")


### PR DESCRIPTION
## What does this change?
This uses date time parsing so that we can check the equivanlence of dates that way, rather than using string and int matches. 
## How should a reviewer test this change?

<!-- Detailed steps will make this change easier to review. -->

## How can success be measured?

## Who should look at this?
<!-- Reach the team with @guardian/digital-cms -->

## Tested? Documented?
- [ ] locally by committer
- [ ] locally by Guardian reviewer
- [ ] on the Guardian's TEST environment
- [ ] relevant documentation added or amended (if needed)
